### PR TITLE
feat: universal safety plugin installer for Claude Code and Codex CLI

### DIFF
--- a/hooks/claude/format-police.sh
+++ b/hooks/claude/format-police.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# format-police.sh — Claude Code PostToolUse hook (matcher: Edit|Write)
+# Auto-formats files after edit/write using dprint
+# Equivalent to: plugins/format-police.ts (OpenCode)
+set -euo pipefail
+
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
+
+# Only trigger on Edit or Write tools
+case "$TOOL_NAME" in
+  Edit|Write|edit|write) ;;
+  *) exit 0 ;;
+esac
+
+# Extract the file path from tool input
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.filePath // empty')
+[[ -z "$FILE_PATH" ]] && exit 0
+
+# Only format known file types
+case "$FILE_PATH" in
+  *.ts|*.tsx|*.js|*.jsx|*.json|*.jsonc|*.md|*.yaml|*.yml|*.toml|*.css|*.html) ;;
+  *) exit 0 ;;
+esac
+
+# Find dprint binary
+DPRINT=""
+if command -v dprint &>/dev/null; then
+  DPRINT="dprint"
+else
+  # Check mise-managed installs
+  MISE_DIR="$HOME/.local/share/mise/installs/dprint"
+  if [[ -d "$MISE_DIR" ]]; then
+    LATEST=$(ls -1 "$MISE_DIR" 2>/dev/null | sort -V | tail -1)
+    if [[ -n "$LATEST" && -x "$MISE_DIR/$LATEST/dprint" ]]; then
+      DPRINT="$MISE_DIR/$LATEST/dprint"
+    fi
+  fi
+fi
+
+if [[ -z "$DPRINT" ]]; then
+  exit 0  # dprint not found, silently skip
+fi
+
+# Format the file (ignore failures — don't block the tool)
+"$DPRINT" fmt "$FILE_PATH" 2>/dev/null || true
+
+exit 0

--- a/hooks/claude/git-police.sh
+++ b/hooks/claude/git-police.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# git-police.sh — Claude Code PreToolUse hook (matcher: Bash)
+# Blocks: force push, --no-verify, Co-authored-by trailers, commits to protected branches
+# Equivalent to: plugins/git-police.ts (OpenCode)
+set -euo pipefail
+
+PROTECTED_BRANCHES=("main" "master")
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+[[ -z "$COMMAND" ]] && exit 0
+
+deny() {
+  local reason="$1"
+  jq -n --arg r "$reason" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: $r
+    }
+  }'
+  exit 0
+}
+
+# 1. Block --no-verify (skips pre-commit/commit-msg hooks)
+if echo "$COMMAND" | grep -qiE '\bgit\b.*--no-verify\b'; then
+  deny "BLOCKED: --no-verify is forbidden. Skipping pre-commit hooks bypasses quality gates (linting, tests, formatting). Fix the issue that's causing the hook to fail instead."
+fi
+
+# 2. Block force push (--force, -f, but allow --force-with-lease)
+if echo "$COMMAND" | grep -qiE '\bgit\b.*\bpush\b.*(-f\b|--force\b|--force-with-lease\b)'; then
+  deny "BLOCKED: Force push is forbidden. Force pushing rewrites history and can destroy work. If you truly need this, ask the user for explicit approval first."
+fi
+
+# 3. Block pushing directly to protected branches
+for branch in "${PROTECTED_BRANCHES[@]}"; do
+  if echo "$COMMAND" | grep -qiE "\bgit\b.*\bpush\b.*\b${branch}\b"; then
+    deny "BLOCKED: Pushing directly to '${branch}' is forbidden. Create a feature branch and raise a PR instead."
+  fi
+done
+
+# 4. Block push when currently on a protected branch (even without branch name in command)
+if echo "$COMMAND" | grep -qiE '\bgit\b.*\bpush\b'; then
+  CURRENT_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
+  for branch in "${PROTECTED_BRANCHES[@]}"; do
+    if [[ "$CURRENT_BRANCH" == "$branch" ]]; then
+      deny "BLOCKED: You are on '${branch}'. Pushing from a protected branch is forbidden. Create a feature branch first: git checkout -b feat/your-feature-name"
+    fi
+  done
+fi
+
+# 5. Block Co-authored-by trailers in commit commands
+if echo "$COMMAND" | grep -qiE '\bgit\b.*\bcommit\b' && echo "$COMMAND" | grep -qi 'co-authored-by'; then
+  deny "BLOCKED: AI attribution trailers (Co-authored-by) are forbidden in commit messages. Do not add Co-authored-by, Signed-off-by, or other AI agent attribution lines. The commit author is whoever owns the git config. Remove the trailer and retry."
+fi
+
+# 6. Block direct commits to protected branches
+if echo "$COMMAND" | grep -qiE '\bgit\b.*\bcommit\b'; then
+  CURRENT_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
+  for branch in "${PROTECTED_BRANCHES[@]}"; do
+    if [[ "$CURRENT_BRANCH" == "$branch" ]]; then
+      deny "BLOCKED: Committing directly to '${branch}' is forbidden. You are on the ${branch} branch. Create a feature branch first: git checkout -b feat/your-feature-name"
+    fi
+  done
+fi
+
+exit 0

--- a/hooks/claude/git-police.sh
+++ b/hooks/claude/git-police.sh
@@ -11,6 +11,11 @@ COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 
 [[ -z "$COMMAND" ]] && exit 0
 
+STRIPPED=$(echo "$COMMAND" \
+  | sed -E "s/<<-?[[:space:]]*['\"]?([A-Za-z_]+)['\"]?/\n\1_HEREDOC_START\n/g" \
+  | sed -E "s/\"([^\"\\\\]|\\\\.)*\"/\"\"/g" \
+  | sed -E "s/'[^']*'/''/g")
+
 deny() {
   local reason="$1"
   jq -n --arg r "$reason" '{
@@ -24,24 +29,24 @@ deny() {
 }
 
 # 1. Block --no-verify (skips pre-commit/commit-msg hooks)
-if echo "$COMMAND" | grep -qiE '\bgit\b.*--no-verify\b'; then
+if echo "$STRIPPED" | grep -qiE '\bgit\b.*--no-verify\b'; then
   deny "BLOCKED: --no-verify is forbidden. Skipping pre-commit hooks bypasses quality gates (linting, tests, formatting). Fix the issue that's causing the hook to fail instead."
 fi
 
 # 2. Block force push (--force, -f, but allow --force-with-lease)
-if echo "$COMMAND" | grep -qiE '\bgit\b.*\bpush\b.*(-f\b|--force\b|--force-with-lease\b)'; then
+if echo "$STRIPPED" | grep -qiE '\bgit\b.*\bpush\b.*(-f\b|--force\b|--force-with-lease\b)'; then
   deny "BLOCKED: Force push is forbidden. Force pushing rewrites history and can destroy work. If you truly need this, ask the user for explicit approval first."
 fi
 
 # 3. Block pushing directly to protected branches
 for branch in "${PROTECTED_BRANCHES[@]}"; do
-  if echo "$COMMAND" | grep -qiE "\bgit\b.*\bpush\b.*\b${branch}\b"; then
+  if echo "$STRIPPED" | grep -qiE "\bgit\b.*\bpush\b.*\b${branch}\b"; then
     deny "BLOCKED: Pushing directly to '${branch}' is forbidden. Create a feature branch and raise a PR instead."
   fi
 done
 
 # 4. Block push when currently on a protected branch (even without branch name in command)
-if echo "$COMMAND" | grep -qiE '\bgit\b.*\bpush\b'; then
+if echo "$STRIPPED" | grep -qiE '\bgit\b.*\bpush\b'; then
   CURRENT_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
   for branch in "${PROTECTED_BRANCHES[@]}"; do
     if [[ "$CURRENT_BRANCH" == "$branch" ]]; then
@@ -51,12 +56,12 @@ if echo "$COMMAND" | grep -qiE '\bgit\b.*\bpush\b'; then
 fi
 
 # 5. Block Co-authored-by trailers in commit commands
-if echo "$COMMAND" | grep -qiE '\bgit\b.*\bcommit\b' && echo "$COMMAND" | grep -qi 'co-authored-by'; then
+if echo "$STRIPPED" | grep -qiE '\bgit\b.*\bcommit\b' && echo "$STRIPPED" | grep -qi 'co-authored-by'; then
   deny "BLOCKED: AI attribution trailers (Co-authored-by) are forbidden in commit messages. Do not add Co-authored-by, Signed-off-by, or other AI agent attribution lines. The commit author is whoever owns the git config. Remove the trailer and retry."
 fi
 
 # 6. Block direct commits to protected branches
-if echo "$COMMAND" | grep -qiE '\bgit\b.*\bcommit\b'; then
+if echo "$STRIPPED" | grep -qiE '\bgit\b.*\bcommit\b'; then
   CURRENT_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
   for branch in "${PROTECTED_BRANCHES[@]}"; do
     if [[ "$CURRENT_BRANCH" == "$branch" ]]; then

--- a/hooks/claude/kubectl-police.sh
+++ b/hooks/claude/kubectl-police.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# kubectl-police.sh — Claude Code PreToolUse hook (matcher: Bash)
+# Blocks: kubectl create/apply on Kargo CRDs
+# Equivalent to: plugins/kubectl-police.ts (OpenCode)
+set -euo pipefail
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+[[ -z "$COMMAND" ]] && exit 0
+
+deny() {
+  local reason="$1"
+  jq -n --arg r "$reason" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: $r
+    }
+  }'
+  exit 0
+}
+
+# Check for kubectl create/apply on Kargo CRDs
+if echo "$COMMAND" | grep -qiE '\bkubectl\b.*\b(create|apply)\b'; then
+  KARGO_CRDS="promotion|promotions|stage|stages|freight|freights|warehouse|warehouses"
+  if echo "$COMMAND" | grep -qiE "\b(${KARGO_CRDS})\b"; then
+    # Extract which CRD was matched
+    CRD=$(echo "$COMMAND" | grep -oiE "\b(${KARGO_CRDS})\b" | head -1 | tr '[:upper:]' '[:lower:]')
+    deny "BLOCKED: Creating/applying Kargo ${CRD} via kubectl is forbidden. kubectl-created Kargo resources poison the stage state machine: Promotions get custom names that break lexicographic sorting, currentPromotion not set. Stages become orphaned state that ArgoCD can't reconcile. Use instead: Kargo UI or auto-promotion for promotions, GitOps (git push) for stage/warehouse/freight changes, kubectl DELETE (not create) to recover from corrupted state."
+  fi
+fi
+
+exit 0

--- a/hooks/claude/settings.json
+++ b/hooks/claude/settings.json
@@ -1,0 +1,35 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/git-police.sh",
+            "timeout": 10,
+            "statusMessage": "git-police: checking safety rules..."
+          },
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/kubectl-police.sh",
+            "timeout": 10,
+            "statusMessage": "kubectl-police: checking Kargo safety..."
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/format-police.sh",
+            "timeout": 15
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/install.sh
+++ b/install.sh
@@ -9,15 +9,26 @@ usage() {
   cat <<'USAGE'
 Usage: ./install.sh [options] [target-project-dir]
 
-Installs agent-skills (skills + rules + plugins) into a project or globally.
+Installs agent-skills (skills + rules + plugins + hooks + policies) for all
+supported AI coding tools: OpenCode, Claude Code, and Codex CLI.
 
 Options:
-  --global             Install to ~/.agents/ (skills + plugins available in all projects)
+  --global             Install globally (all tools, all projects)
   target-project-dir   Project directory to install into (default: current dir)
 
+Global install locations:
+  OpenCode:    ~/.agents/skills/, ~/.agents/plugins/, ~/.agents/rules/
+  Claude Code: ~/.claude/hooks/, ~/.claude/settings.json (hooks section merged)
+  Codex CLI:   ~/.codex/rules/
+
+Project install locations:
+  OpenCode:    .opencode/skills/, .opencode/plugins/, .opencode/rules/
+  Claude Code: .claude/hooks/, .claude/settings.json (hooks section merged)
+  Codex CLI:   .codex/rules/
+
 Examples:
-  ./install.sh --global               # Install globally (~/.agents/skills/ + ~/.agents/plugins/)
-  ./install.sh                        # Install into current project (.opencode/)
+  ./install.sh --global               # Install for all tools globally
+  ./install.sh                        # Install into current project
   ./install.sh ~/code/my-project      # Install into specific project
 USAGE
   exit 1
@@ -30,6 +41,8 @@ for arg in "$@"; do
     *) TARGET_DIR="$arg" ;;
   esac
 done
+
+# ─── Shared: Skills ──────────────────────────────────────────────────────────
 
 install_skills() {
   local dest="$1"
@@ -48,24 +61,6 @@ install_skills() {
     fi
 
     cp -r "$skill_dir" "$target"
-  done
-}
-
-DEPRECATED_PLUGINS=(
-  "version-check.ts"
-  "dprint-autoformat.ts"
-  "kubectl-safety.ts"
-  "kubectl-enforcer.ts"
-  "git-enforcer.ts"
-)
-
-cleanup_deprecated_plugins() {
-  local plugins_dir="$1"
-  for old_name in "${DEPRECATED_PLUGINS[@]}"; do
-    if [[ -f "$plugins_dir/$old_name" ]]; then
-      echo "[plugins] Removing deprecated: $old_name"
-      rm "$plugins_dir/$old_name"
-    fi
   done
 }
 
@@ -88,7 +83,27 @@ install_rules() {
   done
 }
 
-install_plugins() {
+# ─── OpenCode: TypeScript Plugins ────────────────────────────────────────────
+
+DEPRECATED_PLUGINS=(
+  "version-check.ts"
+  "dprint-autoformat.ts"
+  "kubectl-safety.ts"
+  "kubectl-enforcer.ts"
+  "git-enforcer.ts"
+)
+
+cleanup_deprecated_plugins() {
+  local plugins_dir="$1"
+  for old_name in "${DEPRECATED_PLUGINS[@]}"; do
+    if [[ -f "$plugins_dir/$old_name" ]]; then
+      echo "[opencode] Removing deprecated: $old_name"
+      rm "$plugins_dir/$old_name"
+    fi
+  done
+}
+
+install_opencode_plugins() {
   local plugins_dir="$1"
   mkdir -p "$plugins_dir"
 
@@ -100,21 +115,21 @@ install_plugins() {
     name="$(basename "$plugin_file")"
 
     if [[ -f "$plugins_dir/$name" ]]; then
-      echo "[plugins] Updating: $name"
+      echo "[opencode] Updating plugin: $name"
     else
-      echo "[plugins] Installing: $name"
+      echo "[opencode] Installing plugin: $name"
     fi
 
     cp "$plugin_file" "$plugins_dir/$name"
   done
 }
 
-print_global_plugin_instructions() {
+print_opencode_plugin_instructions() {
   local plugins_dir="$1"
   local config_dir="$HOME/.config/opencode"
 
   echo ""
-  echo "[plugins] To use global plugins, add file:// entries to your opencode config plugin array:"
+  echo "[opencode] To use global plugins, add file:// entries to your opencode config plugin array:"
   echo ""
   for plugin_file in "$plugins_dir"/*.ts; do
     [[ -f "$plugin_file" ]] || continue
@@ -123,56 +138,237 @@ print_global_plugin_instructions() {
 
   if [[ -f "$config_dir/opencode.jsonc" ]]; then
     echo ""
-    echo "[plugins] Config: $config_dir/opencode.jsonc"
+    echo "[opencode] Config: $config_dir/opencode.jsonc"
   elif [[ -f "$config_dir/opencode.json" ]]; then
     echo ""
-    echo "[plugins] Config: $config_dir/opencode.json"
+    echo "[opencode] Config: $config_dir/opencode.json"
   fi
 }
 
-if [[ "$GLOBAL" == true ]]; then
-  SKILLS_DEST="$HOME/.agents/skills"
-  RULES_DEST="$HOME/.agents/rules"
-  PLUGINS_DEST="$HOME/.agents/plugins"
+# ─── Claude Code: Bash Hook Scripts ──────────────────────────────────────────
 
-  echo "Installing agent-skills globally"
+install_claude_hooks() {
+  local hooks_dir="$1"
+  local settings_file="$2"
+  mkdir -p "$hooks_dir"
+
+  # Copy hook scripts
+  for hook_file in "$REPO_DIR"/hooks/claude/*.sh; do
+    [[ -f "$hook_file" ]] || continue
+    local name
+    name="$(basename "$hook_file")"
+
+    if [[ -f "$hooks_dir/$name" ]]; then
+      echo "[claude] Updating hook: $name"
+    else
+      echo "[claude] Installing hook: $name"
+    fi
+
+    cp "$hook_file" "$hooks_dir/$name"
+    chmod +x "$hooks_dir/$name"
+  done
+
+  # Merge hooks into settings.json
+  merge_claude_settings "$settings_file" "$hooks_dir"
+}
+
+merge_claude_settings() {
+  local settings_file="$1"
+  local hooks_dir="$2"
+
+  # Check if jq is available
+  if ! command -v jq &>/dev/null; then
+    echo "[claude] WARNING: jq not found. Cannot merge hooks into settings.json."
+    echo "[claude] Install jq and re-run, or manually copy hooks config from:"
+    echo "         $REPO_DIR/hooks/claude/settings.json"
+    return
+  fi
+
+  # Build the hooks JSON using the actual installed hook paths
+  local hooks_json
+  hooks_json=$(jq -n \
+    --arg git_police "$hooks_dir/git-police.sh" \
+    --arg kubectl_police "$hooks_dir/kubectl-police.sh" \
+    --arg format_police "$hooks_dir/format-police.sh" \
+    '{
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: "Bash",
+            hooks: [
+              {
+                type: "command",
+                command: $git_police,
+                timeout: 10,
+                statusMessage: "git-police: checking safety rules..."
+              },
+              {
+                type: "command",
+                command: $kubectl_police,
+                timeout: 10,
+                statusMessage: "kubectl-police: checking Kargo safety..."
+              }
+            ]
+          }
+        ],
+        PostToolUse: [
+          {
+            matcher: "Edit|Write",
+            hooks: [
+              {
+                type: "command",
+                command: $format_police,
+                timeout: 15
+              }
+            ]
+          }
+        ]
+      }
+    }')
+
+  if [[ -f "$settings_file" ]]; then
+    # Merge: existing settings + our hooks (our hooks win on conflict)
+    local existing
+    existing=$(cat "$settings_file")
+
+    # Check if it already has hooks
+    if echo "$existing" | jq -e '.hooks.PreToolUse' &>/dev/null; then
+      echo "[claude] Replacing existing hooks in: $settings_file"
+    else
+      echo "[claude] Adding hooks to existing: $settings_file"
+    fi
+
+    # Deep merge: keep existing keys, overlay our hooks
+    echo "$existing" | jq --argjson new_hooks "$hooks_json" '. * $new_hooks' > "${settings_file}.tmp"
+    mv "${settings_file}.tmp" "$settings_file"
+  else
+    # Create new settings file with just hooks
+    mkdir -p "$(dirname "$settings_file")"
+    echo "$hooks_json" | jq '.' > "$settings_file"
+    echo "[claude] Created: $settings_file"
+  fi
+}
+
+# ─── Codex CLI: Starlark .rules Files ────────────────────────────────────────
+
+install_codex_policies() {
+  local rules_dir="$1"
+  mkdir -p "$rules_dir"
+
+  for rules_file in "$REPO_DIR"/policies/codex/*.rules; do
+    [[ -f "$rules_file" ]] || continue
+    local name
+    name="$(basename "$rules_file")"
+
+    if [[ -f "$rules_dir/$name" ]]; then
+      echo "[codex] Updating policy: $name"
+    else
+      echo "[codex] Installing policy: $name"
+    fi
+
+    cp "$rules_file" "$rules_dir/$name"
+  done
+}
+
+# ─── Main: Global Install ────────────────────────────────────────────────────
+
+if [[ "$GLOBAL" == true ]]; then
+  echo "Installing agent-skills globally (all tools)"
   echo ""
+
+  # ── Skills (shared) ──
+  SKILLS_DEST="$HOME/.agents/skills"
   echo "--- Skills (SKILL.md) ---"
   install_skills "$SKILLS_DEST"
   echo ""
+
+  # ── Rules (shared) ──
+  RULES_DEST="$HOME/.agents/rules"
   echo "--- Rules (auto-loaded by glob) ---"
   install_rules "$RULES_DEST"
   echo ""
-  echo "--- Plugins (OpenCode) ---"
-  install_plugins "$PLUGINS_DEST"
-  print_global_plugin_instructions "$PLUGINS_DEST"
+
+  # ── OpenCode ──
+  OPENCODE_PLUGINS="$HOME/.agents/plugins"
+  echo "--- OpenCode (TypeScript plugins) ---"
+  install_opencode_plugins "$OPENCODE_PLUGINS"
+  print_opencode_plugin_instructions "$OPENCODE_PLUGINS"
   echo ""
-  echo "Done."
-  echo "  Skills: $SKILLS_DEST/ (auto-discovered by OpenCode)"
-  echo "  Rules: $RULES_DEST/ (auto-loaded by file glob match)"
-  echo "  Plugins: $PLUGINS_DEST/ (add file:// entries to opencode config)"
+
+  # ── Claude Code ──
+  CLAUDE_HOOKS="$HOME/.claude/hooks"
+  CLAUDE_SETTINGS="$HOME/.claude/settings.json"
+  echo "--- Claude Code (bash hooks) ---"
+  install_claude_hooks "$CLAUDE_HOOKS" "$CLAUDE_SETTINGS"
+  echo ""
+
+  # ── Codex CLI ──
+  CODEX_RULES="$HOME/.codex/rules"
+  echo "--- Codex CLI (Starlark policies) ---"
+  install_codex_policies "$CODEX_RULES"
+  echo ""
+
+  # ── Summary ──
+  echo "Done. Installed globally for all tools:"
+  echo ""
+  echo "  Skills:          $SKILLS_DEST/"
+  echo "  Rules:           $RULES_DEST/"
+  echo "  OpenCode:        $OPENCODE_PLUGINS/ (add file:// entries to opencode config)"
+  echo "  Claude Code:     $CLAUDE_HOOKS/ (hooks in $CLAUDE_SETTINGS)"
+  echo "  Codex CLI:       $CODEX_RULES/ (auto-loaded at startup)"
+
+# ─── Main: Project Install ───────────────────────────────────────────────────
+
 else
   TARGET_DIR="${TARGET_DIR:-.}"
   TARGET_DIR="$(cd "$TARGET_DIR" && pwd)"
-  SKILLS_DEST="$TARGET_DIR/.opencode/skills"
-  RULES_DEST="$TARGET_DIR/.opencode/rules"
-  PLUGINS_DEST="$TARGET_DIR/.opencode/plugins"
 
   echo "Installing agent-skills into: $TARGET_DIR"
   echo ""
+
+  # ── Skills (shared) ──
+  SKILLS_DEST="$TARGET_DIR/.opencode/skills"
   echo "--- Skills (SKILL.md) ---"
   install_skills "$SKILLS_DEST"
   echo ""
+
+  # ── Rules (shared) ──
+  RULES_DEST="$TARGET_DIR/.opencode/rules"
   echo "--- Rules (auto-loaded by glob) ---"
   install_rules "$RULES_DEST"
   echo ""
-  echo "--- Plugins (OpenCode) ---"
-  install_plugins "$PLUGINS_DEST"
+
+  # ── OpenCode ──
+  OPENCODE_PLUGINS="$TARGET_DIR/.opencode/plugins"
+  echo "--- OpenCode (TypeScript plugins) ---"
+  install_opencode_plugins "$OPENCODE_PLUGINS"
   echo ""
-  echo "Done. Installed into $TARGET_DIR"
+
+  # ── Claude Code ──
+  CLAUDE_HOOKS="$TARGET_DIR/.claude/hooks"
+  CLAUDE_SETTINGS="$TARGET_DIR/.claude/settings.json"
+  echo "--- Claude Code (bash hooks) ---"
+  install_claude_hooks "$CLAUDE_HOOKS" "$CLAUDE_SETTINGS"
+  echo ""
+
+  # ── Codex CLI ──
+  CODEX_RULES="$TARGET_DIR/.codex/rules"
+  echo "--- Codex CLI (Starlark policies) ---"
+  install_codex_policies "$CODEX_RULES"
+  echo ""
+
+  # ── Summary ──
+  echo "Done. Installed into $TARGET_DIR for all tools:"
+  echo ""
+  echo "  Skills:      $SKILLS_DEST/"
+  echo "  Rules:       $RULES_DEST/"
+  echo "  OpenCode:    $OPENCODE_PLUGINS/"
+  echo "  Claude Code: $CLAUDE_HOOKS/ (hooks in $CLAUDE_SETTINGS)"
+  echo "  Codex CLI:   $CODEX_RULES/"
   echo ""
   echo "Verify with:"
   echo "  ls $SKILLS_DEST/"
-  echo "  ls $RULES_DEST/"
-  echo "  ls $PLUGINS_DEST/"
+  echo "  ls $OPENCODE_PLUGINS/"
+  echo "  ls $CLAUDE_HOOKS/"
+  echo "  ls $CODEX_RULES/"
 fi

--- a/plugins/git-police.ts
+++ b/plugins/git-police.ts
@@ -76,6 +76,18 @@ export default async function gitPolice(ctx: PluginInput) {
         );
       }
 
+      if (/\bgit\b.*\bpush\b/i.test(command) && !isGitPushToProtected(command)) {
+        const branch = getCurrentBranch(ctx.directory);
+        if (branch && PROTECTED_BRANCHES.includes(branch)) {
+          throw new Error(
+            `BLOCKED: You are on '${branch}'. Pushing from a protected branch is forbidden.\n` +
+              `Create a feature branch first:\n` +
+              `  git checkout -b feat/your-feature-name\n` +
+              `Then push from there and raise a PR.`,
+          );
+        }
+      }
+
       if (isGitCheckoutProtected(command)) {
         return;
       }

--- a/policies/codex/git-police.rules
+++ b/policies/codex/git-police.rules
@@ -1,0 +1,109 @@
+# git-police.rules — Codex CLI exec policy
+# Blocks: force push, --no-verify, direct push to protected branches
+# Equivalent to: plugins/git-police.ts (OpenCode), hooks/claude/git-police.sh (Claude Code)
+
+# ── FORCE PUSH ──────────────────────────────────────────────────────────────
+
+prefix_rule(
+    pattern = ["git", "push", "--force"],
+    decision = "forbidden",
+    justification = "Force push is prohibited. Use --force-with-lease to avoid overwriting others' work.",
+    match     = ["git push --force", "git push --force origin main"],
+    not_match = ["git push", "git push origin main"],
+)
+
+prefix_rule(
+    pattern = ["git", "push", "-f"],
+    decision = "forbidden",
+    justification = "Force push (-f) is prohibited. Use --force-with-lease.",
+    match     = ["git push -f", "git push -f origin main"],
+    not_match = ["git push origin main"],
+)
+
+# ── SKIP HOOKS (--no-verify) ─────────────────────────────────────────────────
+
+prefix_rule(
+    pattern = ["git", "commit", "--no-verify"],
+    decision = "forbidden",
+    justification = "--no-verify bypasses pre-commit hooks. Fix the hook failure instead.",
+    match     = ["git commit --no-verify -m 'skip'"],
+    not_match = ["git commit -m 'fix'"],
+)
+
+prefix_rule(
+    pattern = ["git", "push", "--no-verify"],
+    decision = "forbidden",
+    justification = "--no-verify bypasses pre-push hooks. Fix the hook failure instead.",
+)
+
+prefix_rule(
+    pattern = ["git", "merge", "--no-verify"],
+    decision = "forbidden",
+    justification = "--no-verify bypasses merge hooks. Fix the hook failure instead.",
+)
+
+prefix_rule(
+    pattern = ["git", "commit", "-n"],
+    decision = "forbidden",
+    justification = "-n (--no-verify) bypasses hooks. Fix the hook failure instead.",
+)
+
+prefix_rule(
+    pattern = ["git", "push", "-n"],
+    decision = "forbidden",
+    justification = "-n (--no-verify) bypasses hooks. Fix the hook failure instead.",
+)
+
+# ── DIRECT PUSH TO PROTECTED BRANCHES ────────────────────────────────────────
+
+prefix_rule(
+    pattern = ["git", "push", ["origin", "upstream"], ["main", "master"]],
+    decision = "forbidden",
+    justification = "Direct push to protected branches is prohibited. Open a PR instead.",
+    match     = ["git push origin main", "git push origin master", "git push upstream main"],
+    not_match = ["git push origin feature/my-branch"],
+)
+
+prefix_rule(
+    pattern = ["git", "push", "--set-upstream", ["origin", "upstream"], ["main", "master"]],
+    decision = "forbidden",
+    justification = "Cannot set upstream to a protected branch directly.",
+)
+
+# ── BARE PUSH (no explicit branch — may push current protected branch) ────────
+# Codex prefix_rule cannot check the current git branch, so we prompt on bare
+# push to ensure the user confirms they are not on a protected branch.
+
+prefix_rule(
+    pattern = ["git", "push"],
+    decision = "prompt",
+    justification = "Bare 'git push' may push a protected branch. Confirm you are NOT on main/master before proceeding.",
+    match     = ["git push"],
+    not_match = ["git push origin feature/my-branch"],
+)
+
+# ── AMEND PUSHED COMMITS ─────────────────────────────────────────────────────
+
+prefix_rule(
+    pattern = ["git", "commit", "--amend"],
+    decision = "prompt",
+    justification = "Amending commits rewrites history. Confirm this commit hasn't been pushed to remote.",
+    match     = ["git commit --amend", "git commit --amend --no-edit"],
+)
+
+# ── RESET HARD ───────────────────────────────────────────────────────────────
+
+prefix_rule(
+    pattern = ["git", "reset", "--hard"],
+    decision = "prompt",
+    justification = "Hard reset discards uncommitted changes permanently. Confirm this is intentional.",
+    match     = ["git reset --hard", "git reset --hard HEAD~1"],
+)
+
+# ── CLEAN (destructive) ───────────────────────────────────────────────────────
+
+prefix_rule(
+    pattern = ["git", "clean", ["-f", "-fd"]],
+    decision = "prompt",
+    justification = "git clean permanently deletes untracked files/directories.",
+)

--- a/policies/codex/kubectl-police.rules
+++ b/policies/codex/kubectl-police.rules
@@ -1,0 +1,33 @@
+# kubectl-police.rules — Codex CLI exec policy
+# Blocks: kubectl create/apply on Kargo CRDs
+# Equivalent to: plugins/kubectl-police.ts (OpenCode), hooks/claude/kubectl-police.sh (Claude Code)
+
+# ── KARGO CRD PROTECTION ─────────────────────────────────────────────────────
+# kubectl-created Kargo resources poison the stage state machine.
+# Use Kargo UI, auto-promotion, or GitOps instead.
+
+prefix_rule(
+    pattern = ["kubectl", "create", ["promotion", "promotions", "stage", "stages", "freight", "freights", "warehouse", "warehouses"]],
+    decision = "forbidden",
+    justification = "Creating Kargo CRDs via kubectl is forbidden. kubectl-created resources poison the Kargo state machine. Use Kargo UI or GitOps instead.",
+    match = [
+        "kubectl create promotion my-promo",
+        "kubectl create stage my-stage",
+        "kubectl create freight my-freight",
+        "kubectl create warehouse my-wh",
+    ],
+    not_match = [
+        "kubectl create deployment my-app",
+        "kubectl create namespace test",
+    ],
+)
+
+prefix_rule(
+    pattern = ["kubectl", "apply", ["promotion", "promotions", "stage", "stages", "freight", "freights", "warehouse", "warehouses"]],
+    decision = "forbidden",
+    justification = "Applying Kargo CRDs via kubectl is forbidden. kubectl-created resources poison the Kargo state machine. Use Kargo UI or GitOps instead.",
+)
+
+# Note: kubectl apply -f <file> where the file contains Kargo CRDs cannot be
+# caught by prefix_rule (it only matches token prefixes, not file contents).
+# The Codex skill instructions cover this gap via prompt-level guidance.


### PR DESCRIPTION
## Summary

- Extends agent-skills from OpenCode-only to a **universal safety plugin installer** covering all three AI coding tools: OpenCode, Claude Code, and Codex CLI
- Safety rules (git-police, format-police, kubectl-police) now enforce consistently regardless of which tool is used
- `install.sh` expanded from 179 to 375+ lines with idempotent global and project-local modes

## New Files

### Claude Code (bash hooks)
| File | Hook Event | Purpose |
|------|-----------|---------|
| `hooks/claude/git-police.sh` | `PreToolUse` (Bash) | Blocks force push, hook bypass, Co-authored-by trailers, push/commit on protected branches |
| `hooks/claude/format-police.sh` | `PostToolUse` (Edit\|Write) | Auto-formats with dprint after file changes |
| `hooks/claude/kubectl-police.sh` | `PreToolUse` (Bash) | Blocks kubectl create/apply on Kargo CRDs |
| `hooks/claude/settings.json` | — | Hook configuration template |

### Codex CLI (Starlark policies)
| File | Purpose |
|------|---------|
| `policies/codex/git-police.rules` | `prefix_rule` policies: forbidden for force push, hook bypass, protected branch push; prompt for amend, reset, clean, bare push |
| `policies/codex/kubectl-police.rules` | `prefix_rule` policies: forbidden for Kargo CRD create/apply |

## Modified

- **`install.sh`** — Deploys to `~/.claude/hooks/` + `settings.json` and `~/.codex/rules/` alongside existing `~/.agents/plugins/`. Merges hooks into existing Claude Code settings.json via jq deep merge.
- **`plugins/git-police.ts`** — Added current-branch check: blocks bare push when on protected branches even without branch name in command.

## Install Locations

| Tool | Global | Project |
|------|--------|---------|
| OpenCode | `~/.agents/plugins/*.ts` | `.opencode/plugins/*.ts` |
| Claude Code | `~/.claude/hooks/*.sh` + `settings.json` | `.claude/hooks/*.sh` + `settings.json` |
| Codex CLI | `~/.codex/rules/*.rules` | `.codex/rules/*.rules` |

## Testing

- `install.sh --global` verified: all artifacts deployed, idempotent re-run works
- git-police.sh: force push blocked, safe commit allowed, hook bypass blocked
- kubectl-police.sh: Kargo CRD create blocked
