### PR TITLE
chore: rename to agentkit + add git-police repo allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# agent-skills
+# agentkit
 
-Reusable AI agent skills, rules, and plugins for OpenCode, Claude Code, and other AI coding agents.
+Reusable AI agent skills, rules, plugins, hooks, and tools for OpenCode, Claude Code, and other AI coding agents.
 
 ## What's Included
 
@@ -35,7 +35,7 @@ Reusable AI agent skills, rules, and plugins for OpenCode, Claude Code, and othe
 ### Option 1: skills.sh CLI (skills only, all agents)
 
 ```bash
-npx skills add developerinlondon/agent-skills
+npx skills add developerinlondon/agentkit
 ```
 
 This installs SKILL.md files for your AI agent (Claude Code, OpenCode, Cursor, etc.).
@@ -43,8 +43,8 @@ This installs SKILL.md files for your AI agent (Claude Code, OpenCode, Cursor, e
 ### Option 2: Install globally (all projects)
 
 ```bash
-git clone git@github.com:developerinlondon/agent-skills.git
-./agent-skills/install.sh --global
+git clone git@github.com:developerinlondon/agentkit.git
+./agentkit/install.sh --global
 ```
 
 Installs skills to `~/.agents/skills/`, rules to `~/.agents/rules/`, plugins to
@@ -55,7 +55,7 @@ to add).
 ### Option 3: Install into a specific project
 
 ```bash
-./agent-skills/install.sh /path/to/your/project
+./agentkit/install.sh /path/to/your/project
 ```
 
 Copies skills, rules, and plugins into the project's `.opencode/` directory.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,25 @@ cp plugins/version-police.ts your-project/.opencode/plugins/
 |------|-------------|
 | **fix-ascii-boxes.py** | Fixes ASCII box-drawing alignment in markdown files, handles nested boxes inside-out |
 
+## Configuration
+
+Agentkit uses a YAML config file at `~/.config/agentkit/config.yaml` (respects `XDG_CONFIG_HOME`).
+The installer creates a default config from `config.example.yaml` on first run.
+
+```yaml
+git-police:
+  branch-protection:
+    allowed-repos:
+      - brain
+      - my-notes
+```
+
+### git-police.branch-protection.allowed-repos
+
+Repos listed here are exempt from branch protection rules (direct commits/pushes to main/master
+are allowed). Use the repo name (e.g. `brain`) or `owner/name` (e.g. `myorg/brain`). Partial
+matches are supported.
+
 ## gitops-master Setup
 
 The gitops-master skill needs to know your cluster environment. Create a `.gitops-config.yaml` in
@@ -118,6 +137,9 @@ These poison the Kargo stage state machine when created via kubectl. Read-only c
 - `--no-verify` flag -- bypasses pre-commit hooks and quality gates
 - AI attribution trailers (`Co-authored-by`) in commit messages
 - Push directly to protected branches -- must use PRs
+
+Repos listed in `git-police.branch-protection.allowed-repos` in your config are exempt from branch
+protection rules. See [Configuration](#configuration).
 
 ## Rules
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,0 +1,14 @@
+# Agentkit Configuration
+# Copy to: ~/.config/agentkit/config.yaml
+# XDG_CONFIG_HOME is respected if set.
+
+git-police:
+  branch-protection:
+    # Repos where direct commits/pushes to main/master are allowed.
+    # Use the repo name (e.g. "brain") or owner/name (e.g. "myorg/brain").
+    # Partial matches are supported — "brain" matches "myorg/brain".
+    allowed-repos: []
+    # Example:
+    #   allowed-repos:
+    #     - brain
+    #     - my-notes

--- a/hooks/claude/git-police.sh
+++ b/hooks/claude/git-police.sh
@@ -5,19 +5,43 @@
 set -euo pipefail
 
 PROTECTED_BRANCHES=("main" "master")
-ALLOWED_REPOS=("brain" "deepbrain/brain")
+AGENTKIT_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/agentkit/config.yaml"
 
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 
 [[ -z "$COMMAND" ]] && exit 0
 
-REPO_NAME=$(git remote get-url origin 2>/dev/null | sed -E 's|.*[:/]([^/]+/[^/]+?)(\.git)?$|\1|' || echo "")
-for allowed in "${ALLOWED_REPOS[@]}"; do
-	if [[ "$REPO_NAME" == *"$allowed"* ]]; then
-		exit 0
-	fi
-done
+load_allowed_repos() {
+	[[ -f "$AGENTKIT_CONFIG" ]] || return
+	local in_section=false
+	while IFS= read -r line; do
+		if [[ "$line" =~ ^[[:space:]]*branch-protection: ]]; then
+			in_section=true
+			continue
+		fi
+		if [[ "$in_section" == true && "$line" =~ ^[[:space:]]*allowed-repos: ]]; then
+			continue
+		fi
+		if [[ "$in_section" == true && "$line" =~ ^[[:space:]]*-[[:space:]]+(.*) ]]; then
+			ALLOWED_REPOS+=("${BASH_REMATCH[1]}")
+		elif [[ "$in_section" == true && ! "$line" =~ ^[[:space:]] ]]; then
+			break
+		fi
+	done < <(sed -n '/^git-police:/,/^[^ ]/p' "$AGENTKIT_CONFIG")
+}
+
+ALLOWED_REPOS=()
+load_allowed_repos
+
+if [[ ${#ALLOWED_REPOS[@]} -gt 0 ]]; then
+	REPO_NAME=$(git remote get-url origin 2>/dev/null | sed -E 's|.*[:/]([^/]+/[^/]+?)(\.git)?$|\1|' || echo "")
+	for allowed in "${ALLOWED_REPOS[@]}"; do
+		if [[ "$REPO_NAME" == *"$allowed"* ]]; then
+			exit 0
+		fi
+	done
+fi
 
 STRIPPED=$(echo "$COMMAND" |
 	sed -E "s/<<-?[[:space:]]*['\"]?([A-Za-z_]+)['\"]?/\n\1_HEREDOC_START\n/g" |
@@ -25,57 +49,57 @@ STRIPPED=$(echo "$COMMAND" |
 	sed -E "s/'[^']*'/''/g")
 
 deny() {
-  local reason="$1"
-  jq -n --arg r "$reason" '{
+	local reason="$1"
+	jq -n --arg r "$reason" '{
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
       permissionDecision: "deny",
       permissionDecisionReason: $r
     }
   }'
-  exit 0
+	exit 0
 }
 
 # 1. Block --no-verify (skips pre-commit/commit-msg hooks)
 if echo "$STRIPPED" | grep -qiE '\bgit\b.*--no-verify\b'; then
-  deny "BLOCKED: --no-verify is forbidden. Skipping pre-commit hooks bypasses quality gates (linting, tests, formatting). Fix the issue that's causing the hook to fail instead."
+	deny "BLOCKED: --no-verify is forbidden. Skipping pre-commit hooks bypasses quality gates (linting, tests, formatting). Fix the issue that's causing the hook to fail instead."
 fi
 
 # 2. Block force push (--force, -f, but allow --force-with-lease)
 if echo "$STRIPPED" | grep -qiE '\bgit\b.*\bpush\b.*(-f\b|--force\b|--force-with-lease\b)'; then
-  deny "BLOCKED: Force push is forbidden. Force pushing rewrites history and can destroy work. If you truly need this, ask the user for explicit approval first."
+	deny "BLOCKED: Force push is forbidden. Force pushing rewrites history and can destroy work. If you truly need this, ask the user for explicit approval first."
 fi
 
 # 3. Block pushing directly to protected branches
 for branch in "${PROTECTED_BRANCHES[@]}"; do
-  if echo "$STRIPPED" | grep -qiE "\bgit\b.*\bpush\b.*\b${branch}\b"; then
-    deny "BLOCKED: Pushing directly to '${branch}' is forbidden. Create a feature branch and raise a PR instead."
-  fi
+	if echo "$STRIPPED" | grep -qiE "\bgit\b.*\bpush\b.*\b${branch}\b"; then
+		deny "BLOCKED: Pushing directly to '${branch}' is forbidden. Create a feature branch and raise a PR instead."
+	fi
 done
 
 # 4. Block push when currently on a protected branch (even without branch name in command)
 if echo "$STRIPPED" | grep -qiE '\bgit\b.*\bpush\b'; then
-  CURRENT_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
-  for branch in "${PROTECTED_BRANCHES[@]}"; do
-    if [[ "$CURRENT_BRANCH" == "$branch" ]]; then
-      deny "BLOCKED: You are on '${branch}'. Pushing from a protected branch is forbidden. Create a feature branch first: git checkout -b feat/your-feature-name"
-    fi
-  done
+	CURRENT_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
+	for branch in "${PROTECTED_BRANCHES[@]}"; do
+		if [[ "$CURRENT_BRANCH" == "$branch" ]]; then
+			deny "BLOCKED: You are on '${branch}'. Pushing from a protected branch is forbidden. Create a feature branch first: git checkout -b feat/your-feature-name"
+		fi
+	done
 fi
 
 # 5. Block Co-authored-by trailers in commit commands
 if echo "$STRIPPED" | grep -qiE '\bgit\b.*\bcommit\b' && echo "$STRIPPED" | grep -qi 'co-authored-by'; then
-  deny "BLOCKED: AI attribution trailers (Co-authored-by) are forbidden in commit messages. Do not add Co-authored-by, Signed-off-by, or other AI agent attribution lines. The commit author is whoever owns the git config. Remove the trailer and retry."
+	deny "BLOCKED: AI attribution trailers (Co-authored-by) are forbidden in commit messages. Do not add Co-authored-by, Signed-off-by, or other AI agent attribution lines. The commit author is whoever owns the git config. Remove the trailer and retry."
 fi
 
 # 6. Block direct commits to protected branches
 if echo "$STRIPPED" | grep -qiE '\bgit\b.*\bcommit\b'; then
-  CURRENT_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
-  for branch in "${PROTECTED_BRANCHES[@]}"; do
-    if [[ "$CURRENT_BRANCH" == "$branch" ]]; then
-      deny "BLOCKED: Committing directly to '${branch}' is forbidden. You are on the ${branch} branch. Create a feature branch first: git checkout -b feat/your-feature-name"
-    fi
-  done
+	CURRENT_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
+	for branch in "${PROTECTED_BRANCHES[@]}"; do
+		if [[ "$CURRENT_BRANCH" == "$branch" ]]; then
+			deny "BLOCKED: Committing directly to '${branch}' is forbidden. You are on the ${branch} branch. Create a feature branch first: git checkout -b feat/your-feature-name"
+		fi
+	done
 fi
 
 exit 0

--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,7 @@ usage() {
   cat <<'USAGE'
 Usage: ./install.sh [options] [target-project-dir]
 
-Installs agent-skills (skills + rules + plugins + hooks + policies) for all
+Installs agentkit (skills + rules + plugins + hooks + tools + policies) for all
 supported AI coding tools: OpenCode, Claude Code, and Codex CLI.
 
 Options:
@@ -295,7 +295,7 @@ install_codex_policies() {
 # ─── Main: Global Install ────────────────────────────────────────────────────
 
 if [[ "$GLOBAL" == true ]]; then
-  echo "Installing agent-skills globally (all tools)"
+	echo "Installing agentkit globally (all tools)"
   echo ""
 
   # ── Skills (shared) ──
@@ -350,7 +350,7 @@ else
   TARGET_DIR="${TARGET_DIR:-.}"
   TARGET_DIR="$(cd "$TARGET_DIR" && pwd)"
 
-  echo "Installing agent-skills into: $TARGET_DIR"
+	echo "Installing agentkit into: $TARGET_DIR"
   echo ""
 
   # ── Skills (shared) ──

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@ GLOBAL=false
 TARGET_DIR=""
 
 usage() {
-  cat <<'USAGE'
+	cat <<'USAGE'
 Usage: ./install.sh [options] [target-project-dir]
 
 Installs agentkit (skills + rules + plugins + hooks + tools + policies) for all
@@ -31,166 +31,166 @@ Examples:
   ./install.sh                        # Install into current project
   ./install.sh ~/code/my-project      # Install into specific project
 USAGE
-  exit 1
+	exit 1
 }
 
 for arg in "$@"; do
-  case "$arg" in
-    -h|--help) usage ;;
-    --global) GLOBAL=true ;;
-    *) TARGET_DIR="$arg" ;;
-  esac
+	case "$arg" in
+	-h | --help) usage ;;
+	--global) GLOBAL=true ;;
+	*) TARGET_DIR="$arg" ;;
+	esac
 done
 
 # ─── Shared: Skills ──────────────────────────────────────────────────────────
 
 install_skills() {
-  local dest="$1"
-  mkdir -p "$dest"
+	local dest="$1"
+	mkdir -p "$dest"
 
-  for skill_dir in "$REPO_DIR"/skills/*/; do
-    local skill_name
-    skill_name="$(basename "$skill_dir")"
-    local target="$dest/$skill_name"
+	for skill_dir in "$REPO_DIR"/skills/*/; do
+		local skill_name
+		skill_name="$(basename "$skill_dir")"
+		local target="$dest/$skill_name"
 
-    if [[ -d "$target" ]]; then
-      echo "[skills] Updating: $skill_name"
-      rm -rf "$target"
-    else
-      echo "[skills] Installing: $skill_name"
-    fi
+		if [[ -d "$target" ]]; then
+			echo "[skills] Updating: $skill_name"
+			rm -rf "$target"
+		else
+			echo "[skills] Installing: $skill_name"
+		fi
 
-    cp -r "$skill_dir" "$target"
-  done
+		cp -r "$skill_dir" "$target"
+	done
 }
 
 install_rules() {
-  local dest="$1"
-  mkdir -p "$dest"
+	local dest="$1"
+	mkdir -p "$dest"
 
-  for rule_file in "$REPO_DIR"/rules/*.md; do
-    [[ -f "$rule_file" ]] || continue
-    local name
-    name="$(basename "$rule_file")"
+	for rule_file in "$REPO_DIR"/rules/*.md; do
+		[[ -f "$rule_file" ]] || continue
+		local name
+		name="$(basename "$rule_file")"
 
-    if [[ -f "$dest/$name" ]]; then
-      echo "[rules] Updating: $name"
-    else
-      echo "[rules] Installing: $name"
-    fi
+		if [[ -f "$dest/$name" ]]; then
+			echo "[rules] Updating: $name"
+		else
+			echo "[rules] Installing: $name"
+		fi
 
-    cp "$rule_file" "$dest/$name"
-  done
+		cp "$rule_file" "$dest/$name"
+	done
 }
 
 # ─── OpenCode: TypeScript Plugins ────────────────────────────────────────────
 
 DEPRECATED_PLUGINS=(
-  "version-check.ts"
-  "dprint-autoformat.ts"
-  "kubectl-safety.ts"
-  "kubectl-enforcer.ts"
-  "git-enforcer.ts"
+	"version-check.ts"
+	"dprint-autoformat.ts"
+	"kubectl-safety.ts"
+	"kubectl-enforcer.ts"
+	"git-enforcer.ts"
 )
 
 cleanup_deprecated_plugins() {
-  local plugins_dir="$1"
-  for old_name in "${DEPRECATED_PLUGINS[@]}"; do
-    if [[ -f "$plugins_dir/$old_name" ]]; then
-      echo "[opencode] Removing deprecated: $old_name"
-      rm "$plugins_dir/$old_name"
-    fi
-  done
+	local plugins_dir="$1"
+	for old_name in "${DEPRECATED_PLUGINS[@]}"; do
+		if [[ -f "$plugins_dir/$old_name" ]]; then
+			echo "[opencode] Removing deprecated: $old_name"
+			rm "$plugins_dir/$old_name"
+		fi
+	done
 }
 
 install_opencode_plugins() {
-  local plugins_dir="$1"
-  mkdir -p "$plugins_dir"
+	local plugins_dir="$1"
+	mkdir -p "$plugins_dir"
 
-  cleanup_deprecated_plugins "$plugins_dir"
+	cleanup_deprecated_plugins "$plugins_dir"
 
-  for plugin_file in "$REPO_DIR"/plugins/*.ts; do
-    [[ -f "$plugin_file" ]] || continue
-    local name
-    name="$(basename "$plugin_file")"
+	for plugin_file in "$REPO_DIR"/plugins/*.ts; do
+		[[ -f "$plugin_file" ]] || continue
+		local name
+		name="$(basename "$plugin_file")"
 
-    if [[ -f "$plugins_dir/$name" ]]; then
-      echo "[opencode] Updating plugin: $name"
-    else
-      echo "[opencode] Installing plugin: $name"
-    fi
+		if [[ -f "$plugins_dir/$name" ]]; then
+			echo "[opencode] Updating plugin: $name"
+		else
+			echo "[opencode] Installing plugin: $name"
+		fi
 
-    cp "$plugin_file" "$plugins_dir/$name"
-  done
+		cp "$plugin_file" "$plugins_dir/$name"
+	done
 }
 
 print_opencode_plugin_instructions() {
-  local plugins_dir="$1"
-  local config_dir="$HOME/.config/opencode"
+	local plugins_dir="$1"
+	local config_dir="$HOME/.config/opencode"
 
-  echo ""
-  echo "[opencode] To use global plugins, add file:// entries to your opencode config plugin array:"
-  echo ""
-  for plugin_file in "$plugins_dir"/*.ts; do
-    [[ -f "$plugin_file" ]] || continue
-    echo "  \"file://$plugin_file\""
-  done
+	echo ""
+	echo "[opencode] To use global plugins, add file:// entries to your opencode config plugin array:"
+	echo ""
+	for plugin_file in "$plugins_dir"/*.ts; do
+		[[ -f "$plugin_file" ]] || continue
+		echo "  \"file://$plugin_file\""
+	done
 
-  if [[ -f "$config_dir/opencode.jsonc" ]]; then
-    echo ""
-    echo "[opencode] Config: $config_dir/opencode.jsonc"
-  elif [[ -f "$config_dir/opencode.json" ]]; then
-    echo ""
-    echo "[opencode] Config: $config_dir/opencode.json"
-  fi
+	if [[ -f "$config_dir/opencode.jsonc" ]]; then
+		echo ""
+		echo "[opencode] Config: $config_dir/opencode.jsonc"
+	elif [[ -f "$config_dir/opencode.json" ]]; then
+		echo ""
+		echo "[opencode] Config: $config_dir/opencode.json"
+	fi
 }
 
 # ─── Claude Code: Bash Hook Scripts ──────────────────────────────────────────
 
 install_claude_hooks() {
-  local hooks_dir="$1"
-  local settings_file="$2"
-  mkdir -p "$hooks_dir"
+	local hooks_dir="$1"
+	local settings_file="$2"
+	mkdir -p "$hooks_dir"
 
-  # Copy hook scripts
-  for hook_file in "$REPO_DIR"/hooks/claude/*.sh; do
-    [[ -f "$hook_file" ]] || continue
-    local name
-    name="$(basename "$hook_file")"
+	# Copy hook scripts
+	for hook_file in "$REPO_DIR"/hooks/claude/*.sh; do
+		[[ -f "$hook_file" ]] || continue
+		local name
+		name="$(basename "$hook_file")"
 
-    if [[ -f "$hooks_dir/$name" ]]; then
-      echo "[claude] Updating hook: $name"
-    else
-      echo "[claude] Installing hook: $name"
-    fi
+		if [[ -f "$hooks_dir/$name" ]]; then
+			echo "[claude] Updating hook: $name"
+		else
+			echo "[claude] Installing hook: $name"
+		fi
 
-    cp "$hook_file" "$hooks_dir/$name"
-    chmod +x "$hooks_dir/$name"
-  done
+		cp "$hook_file" "$hooks_dir/$name"
+		chmod +x "$hooks_dir/$name"
+	done
 
-  # Merge hooks into settings.json
-  merge_claude_settings "$settings_file" "$hooks_dir"
+	# Merge hooks into settings.json
+	merge_claude_settings "$settings_file" "$hooks_dir"
 }
 
 merge_claude_settings() {
-  local settings_file="$1"
-  local hooks_dir="$2"
+	local settings_file="$1"
+	local hooks_dir="$2"
 
-  # Check if jq is available
-  if ! command -v jq &>/dev/null; then
-    echo "[claude] WARNING: jq not found. Cannot merge hooks into settings.json."
-    echo "[claude] Install jq and re-run, or manually copy hooks config from:"
-    echo "         $REPO_DIR/hooks/claude/settings.json"
-    return
-  fi
+	# Check if jq is available
+	if ! command -v jq &>/dev/null; then
+		echo "[claude] WARNING: jq not found. Cannot merge hooks into settings.json."
+		echo "[claude] Install jq and re-run, or manually copy hooks config from:"
+		echo "         $REPO_DIR/hooks/claude/settings.json"
+		return
+	fi
 
-  # Build the hooks JSON using the actual installed hook paths
-  local hooks_json
-  hooks_json=$(jq -n \
-    --arg git_police "$hooks_dir/git-police.sh" \
-    --arg kubectl_police "$hooks_dir/kubectl-police.sh" \
-    --arg format_police "$hooks_dir/format-police.sh" \
-    '{
+	# Build the hooks JSON using the actual installed hook paths
+	local hooks_json
+	hooks_json=$(jq -n \
+		--arg git_police "$hooks_dir/git-police.sh" \
+		--arg kubectl_police "$hooks_dir/kubectl-police.sh" \
+		--arg format_police "$hooks_dir/format-police.sh" \
+		'{
       hooks: {
         PreToolUse: [
           {
@@ -226,27 +226,27 @@ merge_claude_settings() {
       }
     }')
 
-  if [[ -f "$settings_file" ]]; then
-    # Merge: existing settings + our hooks (our hooks win on conflict)
-    local existing
-    existing=$(cat "$settings_file")
+	if [[ -f "$settings_file" ]]; then
+		# Merge: existing settings + our hooks (our hooks win on conflict)
+		local existing
+		existing=$(cat "$settings_file")
 
-    # Check if it already has hooks
-    if echo "$existing" | jq -e '.hooks.PreToolUse' &>/dev/null; then
-      echo "[claude] Replacing existing hooks in: $settings_file"
-    else
-      echo "[claude] Adding hooks to existing: $settings_file"
-    fi
+		# Check if it already has hooks
+		if echo "$existing" | jq -e '.hooks.PreToolUse' &>/dev/null; then
+			echo "[claude] Replacing existing hooks in: $settings_file"
+		else
+			echo "[claude] Adding hooks to existing: $settings_file"
+		fi
 
-    # Deep merge: keep existing keys, overlay our hooks
-    echo "$existing" | jq --argjson new_hooks "$hooks_json" '. * $new_hooks' > "${settings_file}.tmp"
-    mv "${settings_file}.tmp" "$settings_file"
-  else
-    # Create new settings file with just hooks
-    mkdir -p "$(dirname "$settings_file")"
-    echo "$hooks_json" | jq '.' > "$settings_file"
-    echo "[claude] Created: $settings_file"
-  fi
+		# Deep merge: keep existing keys, overlay our hooks
+		echo "$existing" | jq --argjson new_hooks "$hooks_json" '. * $new_hooks' >"${settings_file}.tmp"
+		mv "${settings_file}.tmp" "$settings_file"
+	else
+		# Create new settings file with just hooks
+		mkdir -p "$(dirname "$settings_file")"
+		echo "$hooks_json" | jq '.' >"$settings_file"
+		echo "[claude] Created: $settings_file"
+	fi
 }
 
 # ─── Standalone Tools (Python/Bash scripts) ──────────────────────────────────
@@ -274,134 +274,156 @@ install_tools() {
 # ─── Codex CLI: Starlark .rules Files ────────────────────────────────────────
 
 install_codex_policies() {
-  local rules_dir="$1"
-  mkdir -p "$rules_dir"
+	local rules_dir="$1"
+	mkdir -p "$rules_dir"
 
-  for rules_file in "$REPO_DIR"/policies/codex/*.rules; do
-    [[ -f "$rules_file" ]] || continue
-    local name
-    name="$(basename "$rules_file")"
+	for rules_file in "$REPO_DIR"/policies/codex/*.rules; do
+		[[ -f "$rules_file" ]] || continue
+		local name
+		name="$(basename "$rules_file")"
 
-    if [[ -f "$rules_dir/$name" ]]; then
-      echo "[codex] Updating policy: $name"
-    else
-      echo "[codex] Installing policy: $name"
-    fi
+		if [[ -f "$rules_dir/$name" ]]; then
+			echo "[codex] Updating policy: $name"
+		else
+			echo "[codex] Installing policy: $name"
+		fi
 
-    cp "$rules_file" "$rules_dir/$name"
-  done
+		cp "$rules_file" "$rules_dir/$name"
+	done
+}
+
+# ─── User Config (~/.config/agentkit/) ───────────────────────────────────────
+
+install_config() {
+	local config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/agentkit"
+	local config_file="$config_dir/config.yaml"
+	mkdir -p "$config_dir"
+
+	if [[ -f "$config_file" ]]; then
+		echo "[config] Existing config preserved: $config_file"
+	else
+		cp "$REPO_DIR/config.example.yaml" "$config_file"
+		echo "[config] Created default config: $config_file"
+		echo "[config] Edit to customize: $config_file"
+	fi
 }
 
 # ─── Main: Global Install ────────────────────────────────────────────────────
 
 if [[ "$GLOBAL" == true ]]; then
 	echo "Installing agentkit globally (all tools)"
-  echo ""
+	echo ""
 
-  # ── Skills (shared) ──
-  SKILLS_DEST="$HOME/.agents/skills"
-  echo "--- Skills (SKILL.md) ---"
-  install_skills "$SKILLS_DEST"
-  echo ""
+	# ── Config ──
+	echo "--- Config ---"
+	install_config
+	echo ""
 
-  # ── Rules (shared) ──
-  RULES_DEST="$HOME/.agents/rules"
-  echo "--- Rules (auto-loaded by glob) ---"
-  install_rules "$RULES_DEST"
-  echo ""
+	# ── Skills (shared) ──
+	SKILLS_DEST="$HOME/.agents/skills"
+	echo "--- Skills (SKILL.md) ---"
+	install_skills "$SKILLS_DEST"
+	echo ""
 
-  # ── OpenCode ──
-  OPENCODE_PLUGINS="$HOME/.agents/plugins"
-  echo "--- OpenCode (TypeScript plugins) ---"
-  install_opencode_plugins "$OPENCODE_PLUGINS"
-  print_opencode_plugin_instructions "$OPENCODE_PLUGINS"
-  echo ""
+	# ── Rules (shared) ──
+	RULES_DEST="$HOME/.agents/rules"
+	echo "--- Rules (auto-loaded by glob) ---"
+	install_rules "$RULES_DEST"
+	echo ""
 
-  # ── Claude Code ──
-  CLAUDE_HOOKS="$HOME/.claude/hooks"
+	# ── OpenCode ──
+	OPENCODE_PLUGINS="$HOME/.agents/plugins"
+	echo "--- OpenCode (TypeScript plugins) ---"
+	install_opencode_plugins "$OPENCODE_PLUGINS"
+	print_opencode_plugin_instructions "$OPENCODE_PLUGINS"
+	echo ""
+
+	# ── Claude Code ──
+	CLAUDE_HOOKS="$HOME/.claude/hooks"
 	CLAUDE_TOOLS="$HOME/.claude/tools"
-  CLAUDE_SETTINGS="$HOME/.claude/settings.json"
-  echo "--- Claude Code (bash hooks) ---"
-  install_claude_hooks "$CLAUDE_HOOKS" "$CLAUDE_SETTINGS"
-  echo ""
+	CLAUDE_SETTINGS="$HOME/.claude/settings.json"
+	echo "--- Claude Code (bash hooks) ---"
+	install_claude_hooks "$CLAUDE_HOOKS" "$CLAUDE_SETTINGS"
+	echo ""
 	echo "--- Standalone tools ---"
 	install_tools "$CLAUDE_TOOLS"
 	echo ""
 
-  # ── Codex CLI ──
-  CODEX_RULES="$HOME/.codex/rules"
-  echo "--- Codex CLI (Starlark policies) ---"
-  install_codex_policies "$CODEX_RULES"
-  echo ""
+	# ── Codex CLI ──
+	CODEX_RULES="$HOME/.codex/rules"
+	echo "--- Codex CLI (Starlark policies) ---"
+	install_codex_policies "$CODEX_RULES"
+	echo ""
 
-  # ── Summary ──
-  echo "Done. Installed globally for all tools:"
-  echo ""
-  echo "  Skills:          $SKILLS_DEST/"
-  echo "  Rules:           $RULES_DEST/"
-  echo "  OpenCode:        $OPENCODE_PLUGINS/ (add file:// entries to opencode config)"
-  echo "  Claude Code:     $CLAUDE_HOOKS/ (hooks in $CLAUDE_SETTINGS)"
+	# ── Summary ──
+	echo "Done. Installed globally for all tools:"
+	echo ""
+	echo "  Config:          ${XDG_CONFIG_HOME:-$HOME/.config}/agentkit/config.yaml"
+	echo "  Skills:          $SKILLS_DEST/"
+	echo "  Rules:           $RULES_DEST/"
+	echo "  OpenCode:        $OPENCODE_PLUGINS/ (add file:// entries to opencode config)"
+	echo "  Claude Code:     $CLAUDE_HOOKS/ (hooks in $CLAUDE_SETTINGS)"
 	echo "  Tools:           $CLAUDE_TOOLS/"
-  echo "  Codex CLI:       $CODEX_RULES/ (auto-loaded at startup)"
+	echo "  Codex CLI:       $CODEX_RULES/ (auto-loaded at startup)"
 
 # ─── Main: Project Install ───────────────────────────────────────────────────
 
 else
-  TARGET_DIR="${TARGET_DIR:-.}"
-  TARGET_DIR="$(cd "$TARGET_DIR" && pwd)"
+	TARGET_DIR="${TARGET_DIR:-.}"
+	TARGET_DIR="$(cd "$TARGET_DIR" && pwd)"
 
 	echo "Installing agentkit into: $TARGET_DIR"
-  echo ""
+	echo ""
 
-  # ── Skills (shared) ──
-  SKILLS_DEST="$TARGET_DIR/.opencode/skills"
-  echo "--- Skills (SKILL.md) ---"
-  install_skills "$SKILLS_DEST"
-  echo ""
+	# ── Skills (shared) ──
+	SKILLS_DEST="$TARGET_DIR/.opencode/skills"
+	echo "--- Skills (SKILL.md) ---"
+	install_skills "$SKILLS_DEST"
+	echo ""
 
-  # ── Rules (shared) ──
-  RULES_DEST="$TARGET_DIR/.opencode/rules"
-  echo "--- Rules (auto-loaded by glob) ---"
-  install_rules "$RULES_DEST"
-  echo ""
+	# ── Rules (shared) ──
+	RULES_DEST="$TARGET_DIR/.opencode/rules"
+	echo "--- Rules (auto-loaded by glob) ---"
+	install_rules "$RULES_DEST"
+	echo ""
 
-  # ── OpenCode ──
-  OPENCODE_PLUGINS="$TARGET_DIR/.opencode/plugins"
-  echo "--- OpenCode (TypeScript plugins) ---"
-  install_opencode_plugins "$OPENCODE_PLUGINS"
-  echo ""
+	# ── OpenCode ──
+	OPENCODE_PLUGINS="$TARGET_DIR/.opencode/plugins"
+	echo "--- OpenCode (TypeScript plugins) ---"
+	install_opencode_plugins "$OPENCODE_PLUGINS"
+	echo ""
 
-  # ── Claude Code ──
-  CLAUDE_HOOKS="$TARGET_DIR/.claude/hooks"
+	# ── Claude Code ──
+	CLAUDE_HOOKS="$TARGET_DIR/.claude/hooks"
 	CLAUDE_TOOLS="$TARGET_DIR/.claude/tools"
-  CLAUDE_SETTINGS="$TARGET_DIR/.claude/settings.json"
-  echo "--- Claude Code (bash hooks) ---"
-  install_claude_hooks "$CLAUDE_HOOKS" "$CLAUDE_SETTINGS"
-  echo ""
+	CLAUDE_SETTINGS="$TARGET_DIR/.claude/settings.json"
+	echo "--- Claude Code (bash hooks) ---"
+	install_claude_hooks "$CLAUDE_HOOKS" "$CLAUDE_SETTINGS"
+	echo ""
 	echo "--- Standalone tools ---"
 	install_tools "$CLAUDE_TOOLS"
 	echo ""
 
-  # ── Codex CLI ──
-  CODEX_RULES="$TARGET_DIR/.codex/rules"
-  echo "--- Codex CLI (Starlark policies) ---"
-  install_codex_policies "$CODEX_RULES"
-  echo ""
+	# ── Codex CLI ──
+	CODEX_RULES="$TARGET_DIR/.codex/rules"
+	echo "--- Codex CLI (Starlark policies) ---"
+	install_codex_policies "$CODEX_RULES"
+	echo ""
 
-  # ── Summary ──
-  echo "Done. Installed into $TARGET_DIR for all tools:"
-  echo ""
-  echo "  Skills:      $SKILLS_DEST/"
-  echo "  Rules:       $RULES_DEST/"
-  echo "  OpenCode:    $OPENCODE_PLUGINS/"
-  echo "  Claude Code: $CLAUDE_HOOKS/ (hooks in $CLAUDE_SETTINGS)"
+	# ── Summary ──
+	echo "Done. Installed into $TARGET_DIR for all tools:"
+	echo ""
+	echo "  Skills:      $SKILLS_DEST/"
+	echo "  Rules:       $RULES_DEST/"
+	echo "  OpenCode:    $OPENCODE_PLUGINS/"
+	echo "  Claude Code: $CLAUDE_HOOKS/ (hooks in $CLAUDE_SETTINGS)"
 	echo "  Tools:       $CLAUDE_TOOLS/"
-  echo "  Codex CLI:   $CODEX_RULES/"
-  echo ""
-  echo "Verify with:"
-  echo "  ls $SKILLS_DEST/"
-  echo "  ls $OPENCODE_PLUGINS/"
-  echo "  ls $CLAUDE_HOOKS/"
+	echo "  Codex CLI:   $CODEX_RULES/"
+	echo ""
+	echo "Verify with:"
+	echo "  ls $SKILLS_DEST/"
+	echo "  ls $OPENCODE_PLUGINS/"
+	echo "  ls $CLAUDE_HOOKS/"
 	echo "  ls $CLAUDE_TOOLS/"
-  echo "  ls $CODEX_RULES/"
+	echo "  ls $CODEX_RULES/"
 fi

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "agentkit",
   "private": true,
   "scripts": {
     "test": "bun test"

--- a/plugins/git-police.ts
+++ b/plugins/git-police.ts
@@ -1,8 +1,42 @@
 import type { PluginInput } from '@opencode-ai/plugin';
 import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
 
 const PROTECTED_BRANCHES = ['main', 'master'];
-const ALLOWED_REPOS = ['brain', 'deepbrain/brain'];
+
+function getAgentkitConfigPath(): string {
+  const xdg = process.env.XDG_CONFIG_HOME || join(homedir(), '.config');
+  return join(xdg, 'agentkit', 'config.yaml');
+}
+
+function loadAllowedRepos(): string[] {
+  try {
+    const content = readFileSync(getAgentkitConfigPath(), 'utf-8');
+    const lines = content.split('\n');
+    let inGitPolice = false;
+    const sectionLines: string[] = [];
+    for (const line of lines) {
+      if (/^git-police:/.test(line)) {
+        inGitPolice = true;
+        continue;
+      }
+      if (inGitPolice) {
+        if (/^\S/.test(line)) break;
+        sectionLines.push(line);
+      }
+    }
+    const section = sectionLines.join('\n');
+    const bpMatch = section.match(
+      /branch-protection:\s*\n\s*allowed-repos:\s*\n((?:\s*-\s*.+\n?)*)/,
+    );
+    if (!bpMatch) return [];
+    return [...bpMatch[1].matchAll(/^\s*-\s+(.+)$/gm)].map((m) => m[1].trim());
+  } catch {
+    return [];
+  }
+}
 
 function getRepoName(cwd: string): string | null {
   const result = spawnSync('git', ['remote', 'get-url', 'origin'], {
@@ -17,9 +51,11 @@ function getRepoName(cwd: string): string | null {
 }
 
 function isAllowedRepo(cwd: string): boolean {
+  const allowedRepos = loadAllowedRepos();
+  if (allowedRepos.length === 0) return false;
   const repo = getRepoName(cwd);
   if (!repo) return false;
-  return ALLOWED_REPOS.some((allowed) => repo.includes(allowed));
+  return allowedRepos.some((allowed) => repo.includes(allowed));
 }
 
 function stripQuotedContent(command: string): string {


### PR DESCRIPTION
## Summary

- Rename all internal references from `agent-skills` to `agentkit` (README, install.sh, package.json)
- Add `name: "agentkit"` to package.json
- Add repo allowlist to git-police (bash hook + TypeScript plugin) — repos like `brain` that need direct-to-main push are exempted based on git remote URL matching