### PR TITLE
feat: add pkg-police and coding-police across all platforms

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -12,3 +12,29 @@ git-police:
     #   allowed-repos:
     #     - brain
     #     - my-notes
+
+coding-police:
+  # Maximum lines per file before warning to split.
+  max-file-lines: 1000
+
+  # Maximum lines per function/method before warning to decompose.
+  max-function-lines: 100
+
+  # Minimum identical consecutive lines to flag as duplicate code.
+  min-duplicate-lines: 6
+
+  # Maximum exports per file before warning about single responsibility.
+  max-exports-per-file: 15
+
+  # File path patterns to exclude from checks.
+  exclude-patterns: []
+  # Example:
+  #   exclude-patterns:
+  #     - generated/
+  #     - __snapshots__/
+
+pkg-police:
+  # Set to false to disable bun enforcement (allows npm/npx/yarn/pnpm).
+  enabled: true
+  # Example:
+  #   enabled: false

--- a/hooks/claude/coding-police.sh
+++ b/hooks/claude/coding-police.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+# coding-police.sh — Claude Code PostToolUse hook (matcher: Edit|Write)
+# Enforces: DRY code, modular files (<1000 lines), short functions, single responsibility
+# Equivalent to: plugins/coding-police.ts (OpenCode)
+set -euo pipefail
+
+# ── Configuration ───────────────────────────────────────────────────────────
+AGENTKIT_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/agentkit/config.yaml"
+
+MAX_FILE_LINES=1000
+MAX_FUNCTION_LINES=100
+MIN_DUPLICATE_LINES=6
+MAX_EXPORTS_PER_FILE=15
+
+load_config() {
+  [[ -f "$AGENTKIT_CONFIG" ]] || return 0
+  local section
+  section=$(sed -n '/^coding-police:/,/^[^ ]/p' "$AGENTKIT_CONFIG" | head -n -1)
+  [[ -z "$section" ]] && return 0
+
+  local val
+  val=$(echo "$section" | grep -oP 'max-file-lines:\s*\K\d+' || true)
+  [[ -n "$val" ]] && MAX_FILE_LINES="$val"
+
+  val=$(echo "$section" | grep -oP 'max-function-lines:\s*\K\d+' || true)
+  [[ -n "$val" ]] && MAX_FUNCTION_LINES="$val"
+
+  val=$(echo "$section" | grep -oP 'min-duplicate-lines:\s*\K\d+' || true)
+  [[ -n "$val" ]] && MIN_DUPLICATE_LINES="$val"
+
+  val=$(echo "$section" | grep -oP 'max-exports-per-file:\s*\K\d+' || true)
+  [[ -n "$val" ]] && MAX_EXPORTS_PER_FILE="$val"
+}
+load_config
+
+# ── Input parsing ───────────────────────────────────────────────────────────
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
+
+# Only trigger on Edit or Write tools
+case "$TOOL_NAME" in
+  Edit|Write|edit|write) ;;
+  *) exit 0 ;;
+esac
+
+# Extract the file path from tool input
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.filePath // empty')
+[[ -z "$FILE_PATH" ]] && exit 0
+
+# Only check code files
+case "$FILE_PATH" in
+  *.ts|*.tsx|*.js|*.jsx|*.py|*.rb|*.go|*.rs|*.java|*.kt|*.cs|*.cpp|*.c|*.h|*.hpp|*.swift|*.scala|*.vue|*.svelte) ;;
+  *) exit 0 ;;
+esac
+
+# Skip generated/lock files
+case "$FILE_PATH" in
+  *.lock|*.min.*|*.generated.*|*.snap|*.d.ts|package-lock.json|yarn.lock|pnpm-lock.yaml)
+    exit 0 ;;
+esac
+
+[[ -f "$FILE_PATH" ]] || exit 0
+
+VIOLATIONS=()
+
+# ── Check 1: File length ───────────────────────────────────────────────────
+check_file_length() {
+  local line_count
+  line_count=$(wc -l < "$FILE_PATH")
+  if (( line_count > MAX_FILE_LINES )); then
+    local excess=$(( line_count - MAX_FILE_LINES ))
+    VIOLATIONS+=("FILE TOO LONG: ${line_count} lines (limit: ${MAX_FILE_LINES}, over by ${excess}). Split this file into smaller modules grouped by functionality. Identify logical boundaries (types, helpers, handlers, constants) and extract them.")
+  fi
+}
+
+# ── Check 2: Function lengths ──────────────────────────────────────────────
+check_function_lengths() {
+  # Use awk to find function definitions and track brace depth
+  local long_funcs
+  long_funcs=$(awk -v max="$MAX_FUNCTION_LINES" '
+    # Match function starts for TS/JS/Go/Rust/Java/C
+    /^[[:space:]]*(export[[:space:]]+)?(async[[:space:]]+)?function[[:space:]]+[a-zA-Z_]/ ||
+    /^[[:space:]]*(export[[:space:]]+)?(const|let|var)[[:space:]]+[a-zA-Z_][a-zA-Z0-9_]*[[:space:]]*=[[:space:]]*(async[[:space:]]*)?\(/ ||
+    /^[[:space:]]*(pub[[:space:]]+)?(async[[:space:]]+)?fn[[:space:]]+[a-zA-Z_]/ ||
+    /^[[:space:]]*func[[:space:]]+(\([^)]*\)[[:space:]]+)?[a-zA-Z_]/ {
+      if (in_func && depth == 0) {
+        len = NR - func_start
+        if (len > max) {
+          printf "LONG FUNCTION: `%s` is %d lines (limit: %d, starts at line %d). Break it into smaller helper functions.\n", func_name, len, max, func_start
+        }
+      }
+      # Extract function name
+      name = $0
+      gsub(/^[[:space:]]*(export[[:space:]]+)?(async[[:space:]]+)?(pub[[:space:]]+)?/, "", name)
+      gsub(/^(function|fn|func|const|let|var)[[:space:]]+/, "", name)
+      gsub(/(\([^)]*\)[[:space:]]+)?/, "", name)  # Go receiver
+      gsub(/[[:space:]]*[=({:.].*/, "", name)
+      func_name = name
+      func_start = NR
+      depth = 0
+      in_func = 1
+    }
+
+    # Also match Python def
+    /^[[:space:]]*(async[[:space:]]+)?def[[:space:]]+[a-zA-Z_]/ {
+      if (in_func && depth == 0 && NR > func_start) {
+        len = NR - func_start
+        if (len > max) {
+          printf "LONG FUNCTION: `%s` is %d lines (limit: %d, starts at line %d). Break it into smaller helper functions.\n", func_name, len, max, func_start
+        }
+      }
+      name = $0
+      gsub(/^[[:space:]]*(async[[:space:]]+)?def[[:space:]]+/, "", name)
+      gsub(/[[:space:]]*\(.*/, "", name)
+      func_name = name
+      func_start = NR
+      depth = 0
+      in_func = 1
+    }
+
+    in_func {
+      n = split($0, chars, "")
+      for (i = 1; i <= n; i++) {
+        if (chars[i] == "{") depth++
+        if (chars[i] == "}") depth--
+      }
+      if (depth <= 0 && NR > func_start && index($0, "}") > 0) {
+        len = NR - func_start + 1
+        if (len > max) {
+          printf "LONG FUNCTION: `%s` is %d lines (limit: %d, starts at line %d). Break it into smaller helper functions.\n", func_name, len, max, func_start
+        }
+        in_func = 0
+      }
+    }
+
+    END {
+      if (in_func && depth == 0) {
+        len = NR - func_start
+        if (len > max) {
+          printf "LONG FUNCTION: `%s` is %d lines (limit: %d, starts at line %d). Break it into smaller helper functions.\n", func_name, len, max, func_start
+        }
+      }
+    }
+  ' "$FILE_PATH" 2>/dev/null || true)
+
+  while IFS= read -r line; do
+    if [[ -n "$line" ]]; then VIOLATIONS+=("$line"); fi
+  done <<< "$long_funcs"
+}
+
+# ── Check 3: Duplicate code blocks ─────────────────────────────────────────
+check_duplicate_blocks() {
+  # Normalise: strip comments, blank lines, imports, then find repeated blocks
+  local dupes
+  dupes=$(awk -v min="$MIN_DUPLICATE_LINES" '
+    BEGIN { idx = 0 }
+    {
+      line = $0
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
+
+      # Skip blank, comments, imports, single-char structural lines
+      if (line == "") next
+      if (line ~ /^\/\//) next
+      if (line ~ /^#/) next
+      if (line ~ /^\*/) next
+      if (line ~ /^\/\*/) next
+      if (line ~ /^\*\//) next
+      if (line ~ /^(import|from|require|use |using )/) next
+      if (line ~ /^[{}()\[\];,]$/) next
+
+      idx++
+      norm[idx] = line
+      orig[idx] = NR
+    }
+    END {
+      for (i = 1; i <= idx - min + 1; i++) {
+        block = ""
+        for (k = 0; k < min; k++) {
+          block = block norm[i + k] "\n"
+        }
+
+        if (block in seen) {
+          first = seen[block]
+          key = first ":" orig[i]
+          if (!(key in reported)) {
+            reported[key] = 1
+            printf "DUPLICATE CODE: %d+ line block duplicated at lines %d and %d. Extract into a shared function to keep code DRY.\n", min, first, orig[i]
+          }
+        } else {
+          seen[block] = orig[i]
+        }
+      }
+    }
+  ' "$FILE_PATH" 2>/dev/null || true)
+
+  while IFS= read -r line; do
+    if [[ -n "$line" ]]; then VIOLATIONS+=("$line"); fi
+  done <<< "$dupes"
+}
+
+# ── Check 4: Export count (TS/JS only) ──────────────────────────────────────
+check_export_count() {
+  case "$FILE_PATH" in
+    *.ts|*.tsx|*.js|*.jsx) ;;
+    *) return 0 ;;
+  esac
+
+  local count
+  count=$(grep -cE '^\s*export\s+(default\s+)?(function|class|const|let|var|type|interface|enum|async)' "$FILE_PATH" 2>/dev/null || true)
+  count=${count:-0}
+  if (( count > MAX_EXPORTS_PER_FILE )); then
+    VIOLATIONS+=("TOO MANY EXPORTS: ${count} exports in this file (limit: ${MAX_EXPORTS_PER_FILE}). This suggests the file has multiple responsibilities. Group related exports into separate modules (e.g., types.ts, helpers.ts, constants.ts).")
+  fi
+}
+
+# ── Run all checks ──────────────────────────────────────────────────────────
+check_file_length
+check_function_lengths
+check_duplicate_blocks
+check_export_count
+
+# ── Output violations ──────────────────────────────────────────────────────
+if (( ${#VIOLATIONS[@]} > 0 )); then
+  {
+    echo ""
+    echo "CODING STANDARDS VIOLATION (coding-police)"
+    echo "=================================================="
+    for i in "${!VIOLATIONS[@]}"; do
+      echo "$(( i + 1 )). ${VIOLATIONS[$i]}"
+      echo ""
+    done
+    echo "REQUIRED ACTIONS:"
+    echo "- Keep code DRY: extract duplicated logic into shared functions."
+    echo "- Keep files modular: split files exceeding ${MAX_FILE_LINES} lines by functionality."
+    echo "- Keep functions focused: break functions over ${MAX_FUNCTION_LINES} lines into composable helpers."
+    echo "- Apply Single Responsibility: each file should have one clear purpose."
+    echo ""
+    echo "Fix these violations before proceeding."
+  } >&2
+fi
+
+exit 0

--- a/hooks/claude/pkg-police.sh
+++ b/hooks/claude/pkg-police.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# pkg-police.sh — Claude Code PreToolUse hook (matcher: Bash)
+# Blocks: npm, npx, yarn, pnpm commands — enforces bun as package manager
+# Equivalent to: plugins/pkg-police.ts (OpenCode)
+set -euo pipefail
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+[[ -z "$COMMAND" ]] && exit 0
+
+deny() {
+  local reason="$1"
+  jq -n --arg r "$reason" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: $r
+    }
+  }'
+  exit 0
+}
+
+# Check for npm commands (install, run, test, exec, create, init, publish, ci)
+if echo "$COMMAND" | grep -qiE '\bnpm\s+(install|i|ci|run|test|init|publish|exec|create)\b'; then
+  SUBCMD=$(echo "$COMMAND" | grep -oiE '\bnpm\s+\w+' | head -1)
+  deny "BLOCKED: '${SUBCMD}' is not allowed. Use bun instead. Mapping: npm install → bun install, npm run → bun run, npm test → bun test, npm init → bun init, npx → bunx. Override: user explicitly requests npm."
+fi
+
+# Check for npx
+if echo "$COMMAND" | grep -qiE '\bnpx\s+'; then
+  deny "BLOCKED: 'npx' is not allowed. Use 'bunx' instead. Example: npx tsc → bunx tsc. Override: user explicitly requests npx."
+fi
+
+# Check for yarn
+if echo "$COMMAND" | grep -qiE '\byarn(\s+|$)'; then
+  deny "BLOCKED: 'yarn' is not allowed. Use bun instead. Mapping: yarn → bun install, yarn add → bun add, yarn run → bun run. Override: user explicitly requests yarn."
+fi
+
+# Check for pnpm
+if echo "$COMMAND" | grep -qiE '\bpnpm(\s+|$)'; then
+  deny "BLOCKED: 'pnpm' is not allowed. Use bun instead. Mapping: pnpm install → bun install, pnpm add → bun add, pnpm run → bun run. Override: user explicitly requests pnpm."
+fi
+
+exit 0

--- a/hooks/claude/settings.json
+++ b/hooks/claude/settings.json
@@ -15,6 +15,12 @@
             "command": "$HOME/.claude/hooks/kubectl-police.sh",
             "timeout": 10,
             "statusMessage": "kubectl-police: checking Kargo safety..."
+          },
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/pkg-police.sh",
+            "timeout": 10,
+            "statusMessage": "pkg-police: enforcing bun as package manager..."
           }
         ]
       }
@@ -27,6 +33,12 @@
             "type": "command",
             "command": "$HOME/.claude/hooks/format-police.sh",
             "timeout": 15
+          },
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/coding-police.sh",
+            "timeout": 15,
+            "statusMessage": "coding-police: checking coding standards..."
           }
         ]
       }

--- a/plugins/coding-police.ts
+++ b/plugins/coding-police.ts
@@ -1,0 +1,363 @@
+import type { PluginInput } from '@opencode-ai/plugin';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import path from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+interface CodingPoliceConfig {
+  maxFileLines: number;
+  maxFunctionLines: number;
+  minDuplicateLines: number;
+  maxExportsPerFile: number;
+  excludePatterns: string[];
+}
+
+const DEFAULTS: CodingPoliceConfig = {
+  maxFileLines: 1000,
+  maxFunctionLines: 100,
+  minDuplicateLines: 6,
+  maxExportsPerFile: 15,
+  excludePatterns: [],
+};
+
+const CODE_FILE =
+  /\.(ts|tsx|js|jsx|py|rb|go|rs|java|kt|cs|cpp|c|h|hpp|swift|scala|vue|svelte)$/;
+
+// Files that are legitimately long (auto-generated, lockfiles, etc.)
+const SKIP_FILES =
+  /\.(lock|min\.\w+|generated\.\w+|snap|d\.ts)$|package-lock\.json|yarn\.lock|pnpm-lock\.yaml/;
+
+function getAgentkitConfigPath(): string {
+  const xdg = process.env.XDG_CONFIG_HOME || join(homedir(), '.config');
+  return join(xdg, 'agentkit', 'config.yaml');
+}
+
+/**
+ * Lightweight YAML parser for the coding-police section.
+ * Follows the same hand-rolled approach as git-police to avoid deps.
+ */
+export function loadConfig(): CodingPoliceConfig {
+  try {
+    const content = readFileSync(getAgentkitConfigPath(), 'utf-8');
+    const lines = content.split('\n');
+    let inSection = false;
+    const sectionLines: string[] = [];
+
+    for (const line of lines) {
+      if (/^coding-police:/.test(line)) {
+        inSection = true;
+        continue;
+      }
+      if (inSection) {
+        if (/^\S/.test(line)) break;
+        sectionLines.push(line);
+      }
+    }
+
+    if (sectionLines.length === 0) return { ...DEFAULTS };
+
+    const section = sectionLines.join('\n');
+
+    const maxFile = section.match(/max-file-lines:\s*(\d+)/);
+    const maxFunc = section.match(/max-function-lines:\s*(\d+)/);
+    const minDup = section.match(/min-duplicate-lines:\s*(\d+)/);
+    const maxExp = section.match(/max-exports-per-file:\s*(\d+)/);
+
+    const excludeMatch = section.match(
+      /exclude-patterns:\s*\n((?:\s*-\s*.+\n?)*)/,
+    );
+    const excludes = excludeMatch
+      ? [...excludeMatch[1].matchAll(/^\s*-\s+(.+)$/gm)].map((m) =>
+          m[1].trim(),
+        )
+      : [];
+
+    return {
+      maxFileLines: maxFile ? parseInt(maxFile[1], 10) : DEFAULTS.maxFileLines,
+      maxFunctionLines: maxFunc
+        ? parseInt(maxFunc[1], 10)
+        : DEFAULTS.maxFunctionLines,
+      minDuplicateLines: minDup
+        ? parseInt(minDup[1], 10)
+        : DEFAULTS.minDuplicateLines,
+      maxExportsPerFile: maxExp
+        ? parseInt(maxExp[1], 10)
+        : DEFAULTS.maxExportsPerFile,
+      excludePatterns: excludes.length > 0 ? excludes : DEFAULTS.excludePatterns,
+    };
+  } catch {
+    return { ...DEFAULTS };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Checks
+// ---------------------------------------------------------------------------
+
+/**
+ * Check 1: File length — files over the threshold must be split.
+ */
+export function checkFileLength(
+  lines: string[],
+  maxLines: number,
+): string | null {
+  if (lines.length <= maxLines) return null;
+
+  const excess = lines.length - maxLines;
+  return (
+    `FILE TOO LONG: ${lines.length} lines (limit: ${maxLines}, over by ${excess}).\n` +
+    `  Split this file into smaller modules grouped by functionality.\n` +
+    `  Identify logical boundaries (types, helpers, handlers, constants) and extract them.`
+  );
+}
+
+/**
+ * Check 2: Function/method length — long functions violate modularity.
+ *
+ * Detects functions in: TypeScript/JavaScript, Python, Go, Rust, Java/Kotlin/C#.
+ * Returns warnings for every function exceeding the threshold.
+ */
+export function checkFunctionLengths(
+  lines: string[],
+  maxLines: number,
+): string[] {
+  const warnings: string[] = [];
+
+  // Pattern: opening of a function (not perfect, but good enough for LLM guidance)
+  const funcStartPatterns = [
+    // TS/JS: function name(, async function, arrow assigned, method
+    /^\s*(?:export\s+)?(?:async\s+)?function\s+(\w+)/,
+    /^\s*(?:export\s+)?(?:const|let|var)\s+(\w+)\s*=\s*(?:async\s+)?\(/,
+    /^\s*(?:public|private|protected|static|async|\s)*(\w+)\s*\([^)]*\)\s*(?::\s*\S+)?\s*\{/,
+    // Python: def name(
+    /^\s*(?:async\s+)?def\s+(\w+)\s*\(/,
+    // Go: func name(  or func (receiver) name(
+    /^\s*func\s+(?:\([^)]*\)\s+)?(\w+)\s*\(/,
+    // Rust: fn name(
+    /^\s*(?:pub\s+)?(?:async\s+)?fn\s+(\w+)/,
+  ];
+
+  let currentFunc: { name: string; startLine: number } | null = null;
+  let braceDepth = 0;
+  let indentBaseline = -1;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    // Try to match a function start
+    if (!currentFunc) {
+      for (const pattern of funcStartPatterns) {
+        const match = line.match(pattern);
+        if (match) {
+          currentFunc = { name: match[1], startLine: i + 1 };
+          braceDepth = 0;
+          indentBaseline = line.search(/\S/);
+          break;
+        }
+      }
+    }
+
+    if (currentFunc) {
+      // Track brace depth for brace-based languages
+      for (const ch of line) {
+        if (ch === '{') braceDepth++;
+        if (ch === '}') braceDepth--;
+      }
+
+      // Function ends when brace depth returns to 0, or when we hit a
+      // dedented non-blank line (Python-style)
+      const isEnd =
+        (braceDepth <= 0 && i > currentFunc.startLine - 1 && line.includes('}')) ||
+        (indentBaseline >= 0 &&
+          i > currentFunc.startLine &&
+          line.trim() !== '' &&
+          !line.match(/^\s*#/) &&
+          line.search(/\S/) <= indentBaseline &&
+          !line.match(/^\s*[})\]]/));
+
+      if (isEnd || i === lines.length - 1) {
+        const length = i - currentFunc.startLine + 2;
+        if (length > maxLines) {
+          warnings.push(
+            `LONG FUNCTION: \`${currentFunc.name}\` is ${length} lines (limit: ${maxLines}, starts at line ${currentFunc.startLine}).` +
+              ` Break it into smaller helper functions.`,
+          );
+        }
+        currentFunc = null;
+        braceDepth = 0;
+      }
+    }
+  }
+
+  return warnings;
+}
+
+/**
+ * Check 3: Duplicate code blocks — finds repeated sequences of non-trivial lines.
+ *
+ * Normalises whitespace and skips blank/comment lines before comparison.
+ * Returns warnings when identical blocks of `minLines` or more are found.
+ */
+export function checkDuplicateBlocks(
+  lines: string[],
+  minLines: number,
+): string[] {
+  const warnings: string[] = [];
+
+  // Normalise: trim, skip blank lines, single-line comments, import/require
+  const normalised: { text: string; originalLine: number }[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
+    if (
+      trimmed === '' ||
+      trimmed.startsWith('//') ||
+      trimmed.startsWith('#') ||
+      trimmed.startsWith('*') ||
+      trimmed.startsWith('/*') ||
+      trimmed.startsWith('*/') ||
+      /^(import|from|require|use |using )/.test(trimmed) ||
+      /^[{}()\[\];,]$/.test(trimmed)
+    ) {
+      continue;
+    }
+    normalised.push({ text: trimmed, originalLine: i + 1 });
+  }
+
+  // Sliding window: hash blocks of `minLines` normalised lines
+  const seen = new Map<string, number>(); // hash -> first occurrence original line
+  const reported = new Set<string>();
+
+  for (let i = 0; i <= normalised.length - minLines; i++) {
+    const block = normalised
+      .slice(i, i + minLines)
+      .map((l) => l.text)
+      .join('\n');
+
+    if (seen.has(block)) {
+      const firstLine = seen.get(block)!;
+      const dupeLine = normalised[i].originalLine;
+      const key = `${firstLine}:${dupeLine}`;
+
+      if (!reported.has(key)) {
+        reported.add(key);
+        warnings.push(
+          `DUPLICATE CODE: ${minLines}+ line block duplicated at lines ${firstLine} and ${dupeLine}.` +
+            ` Extract into a shared function to keep code DRY.`,
+        );
+      }
+    } else {
+      seen.set(block, normalised[i].originalLine);
+    }
+  }
+
+  return warnings;
+}
+
+/**
+ * Check 4: Export count — too many exports means the file has too many responsibilities.
+ */
+export function checkExportCount(
+  lines: string[],
+  maxExports: number,
+): string | null {
+  let count = 0;
+  for (const line of lines) {
+    if (/^\s*export\s+(default\s+)?(?:function|class|const|let|var|type|interface|enum|async)/.test(line)) {
+      count++;
+    }
+  }
+
+  if (count > maxExports) {
+    return (
+      `TOO MANY EXPORTS: ${count} exports in this file (limit: ${maxExports}).\n` +
+      `  This suggests the file has multiple responsibilities.\n` +
+      `  Group related exports into separate modules (e.g., types.ts, helpers.ts, constants.ts).`
+    );
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Plugin entry point
+// ---------------------------------------------------------------------------
+
+export default async function codingPolice(ctx: PluginInput) {
+  const config = loadConfig();
+
+  return {
+    'tool.execute.after': async (
+      input: { tool: string; sessionID: string; callID: string },
+      output: { title: string; output: string; metadata: unknown },
+    ) => {
+      const toolName = input.tool?.toLowerCase();
+      if (toolName !== 'edit' && toolName !== 'write') return;
+
+      const relativePath = output.title;
+      if (!relativePath) return;
+
+      // Only check code files
+      if (!CODE_FILE.test(relativePath)) return;
+      // Skip generated/lock files
+      if (SKIP_FILES.test(relativePath)) return;
+      // Check exclusion patterns from config
+      if (
+        config.excludePatterns.some((pattern) => relativePath.includes(pattern))
+      ) {
+        return;
+      }
+
+      const absPath = path.isAbsolute(relativePath)
+        ? relativePath
+        : path.resolve(ctx.worktree, relativePath);
+
+      let content: string;
+      try {
+        content = readFileSync(absPath, 'utf-8');
+      } catch {
+        return;
+      }
+
+      const lines = content.split('\n');
+      const violations: string[] = [];
+
+      // Check 1: File length
+      const lengthWarning = checkFileLength(lines, config.maxFileLines);
+      if (lengthWarning) violations.push(lengthWarning);
+
+      // Check 2: Function lengths
+      const funcWarnings = checkFunctionLengths(lines, config.maxFunctionLines);
+      violations.push(...funcWarnings);
+
+      // Check 3: Duplicate code blocks
+      const dupeWarnings = checkDuplicateBlocks(lines, config.minDuplicateLines);
+      violations.push(...dupeWarnings);
+
+      // Check 4: Export count (TS/JS only)
+      if (/\.(ts|tsx|js|jsx)$/.test(relativePath)) {
+        const exportWarning = checkExportCount(lines, config.maxExportsPerFile);
+        if (exportWarning) violations.push(exportWarning);
+      }
+
+      if (violations.length === 0) return;
+
+      output.output +=
+        `\n\n` +
+        `CODING STANDARDS VIOLATION (coding-police)\n` +
+        `${'='.repeat(50)}\n` +
+        violations.map((v, i) => `${i + 1}. ${v}`).join('\n\n') +
+        `\n\n` +
+        `REQUIRED ACTIONS:\n` +
+        `- Keep code DRY: extract duplicated logic into shared functions.\n` +
+        `- Keep files modular: split files exceeding ${config.maxFileLines} lines by functionality.\n` +
+        `- Keep functions focused: break functions over ${config.maxFunctionLines} lines into composable helpers.\n` +
+        `- Apply Single Responsibility: each file should have one clear purpose.\n` +
+        `\n` +
+        `Fix these violations before proceeding.`;
+    },
+  };
+}

--- a/plugins/pkg-police.ts
+++ b/plugins/pkg-police.ts
@@ -1,0 +1,87 @@
+import type { PluginInput } from '@opencode-ai/plugin';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+/**
+ * Blocked package manager commands and their bun equivalents.
+ *
+ * Pattern: regex matching the forbidden command invocation.
+ * Replacement: human-readable bun equivalent for the error message.
+ */
+const BLOCKED_COMMANDS: Array<{ pattern: RegExp; tool: string; replacement: string }> = [
+  { pattern: /\bnpm\s+install\b/i, tool: 'npm install', replacement: 'bun install' },
+  { pattern: /\bnpm\s+i\b/i, tool: 'npm i', replacement: 'bun install' },
+  { pattern: /\bnpm\s+ci\b/i, tool: 'npm ci', replacement: 'bun install --frozen-lockfile' },
+  { pattern: /\bnpm\s+run\b/i, tool: 'npm run', replacement: 'bun run' },
+  { pattern: /\bnpm\s+test\b/i, tool: 'npm test', replacement: 'bun test' },
+  { pattern: /\bnpm\s+init\b/i, tool: 'npm init', replacement: 'bun init' },
+  { pattern: /\bnpm\s+publish\b/i, tool: 'npm publish', replacement: 'bun publish' },
+  { pattern: /\bnpm\s+exec\b/i, tool: 'npm exec', replacement: 'bunx' },
+  { pattern: /\bnpm\s+create\b/i, tool: 'npm create', replacement: 'bun create' },
+  { pattern: /\bnpx\s+/i, tool: 'npx', replacement: 'bunx' },
+  { pattern: /\byarn\s+/i, tool: 'yarn', replacement: 'bun' },
+  { pattern: /\byarn$/im, tool: 'yarn', replacement: 'bun install' },
+  { pattern: /\bpnpm\s+/i, tool: 'pnpm', replacement: 'bun' },
+  { pattern: /\bpnpm$/im, tool: 'pnpm', replacement: 'bun install' },
+];
+
+function getAgentkitConfigPath(): string {
+  const xdg = process.env.XDG_CONFIG_HOME || join(homedir(), '.config');
+  return join(xdg, 'agentkit', 'config.yaml');
+}
+
+function isDisabled(): boolean {
+  try {
+    const content = readFileSync(getAgentkitConfigPath(), 'utf-8');
+    // Simple YAML check: pkg-police:\n  enabled: false
+    if (/pkg-police:\s*\n\s+enabled:\s*false/i.test(content)) return true;
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+function detectBlockedPkgManager(command: string): string | null {
+  for (const { pattern, tool, replacement } of BLOCKED_COMMANDS) {
+    if (pattern.test(command)) {
+      return (
+        `BLOCKED: '${tool}' is not allowed. Use bun instead.\n` +
+        `\n` +
+        `Replace with: ${replacement}\n` +
+        `\n` +
+        `Quick reference:\n` +
+        `  npm install / yarn / pnpm install  →  bun install\n` +
+        `  npm install <pkg>                  →  bun add <pkg>\n` +
+        `  npm run <script>                   →  bun run <script>\n` +
+        `  npx <cmd>                          →  bunx <cmd>\n` +
+        `  npm test                           →  bun test\n` +
+        `\n` +
+        `Override: set pkg-police.enabled: false in agentkit config,\n` +
+        `or user explicitly requests a different package manager.`
+      );
+    }
+  }
+  return null;
+}
+
+export default async function pkgPolice(_ctx: PluginInput) {
+  return {
+    'tool.execute.before': async (
+      input: { tool: string; sessionID: string; callID: string },
+      output: { args: Record<string, unknown> },
+    ): Promise<void> => {
+      const toolName = input.tool?.toLowerCase();
+      if (toolName !== 'bash') return;
+      if (isDisabled()) return;
+
+      const command = output.args.command as string | undefined;
+      if (!command) return;
+
+      const error = detectBlockedPkgManager(command);
+      if (error) {
+        throw new Error(error);
+      }
+    },
+  };
+}

--- a/policies/codex/coding-police.rules
+++ b/policies/codex/coding-police.rules
@@ -1,0 +1,62 @@
+# coding-police.rules — Codex CLI exec policy
+# Enforces: DRY code, modular files (<1000 lines), short functions, single responsibility
+# Equivalent to: plugins/coding-police.ts (OpenCode), hooks/claude/coding-police.sh (Claude Code)
+#
+# NOTE: Codex prefix_rule() can only match command-line tokens (pre-exec).
+# File-content checks (line count, function length, duplicates, export count) are
+# enforced at runtime by the OpenCode plugin and Claude Code hook.
+#
+# The rules below catch bash-level patterns that commonly produce files violating
+# coding standards (e.g., writing large code blocks via heredocs or redirects).
+#
+# ─── CODING STANDARDS (for agent reference) ──────────────────────────────────
+#
+# 1. FILE LENGTH: No single file should exceed 1000 lines.
+#    Split into smaller modules grouped by functionality (types, helpers,
+#    handlers, constants).
+#
+# 2. FUNCTION LENGTH: No single function should exceed 100 lines.
+#    Break large functions into smaller, focused helper functions.
+#
+# 3. DRY (Don't Repeat Yourself): Never duplicate code blocks of 6+ lines.
+#    Extract repeated logic into shared functions or modules.
+#
+# 4. SINGLE RESPONSIBILITY: Each file should have one clear purpose.
+#    If a file has more than 15 exports, it likely has too many responsibilities.
+#
+# 5. MODULARIZATION: Group related code into cohesive modules.
+#    Prefer many small files over few large files.
+
+# ── LARGE HEREDOC WRITES ───────────────────────────────────────────────────
+# Prompt when writing code via heredoc to a code file — these often produce
+# oversized files that violate the 1000-line limit.
+
+prefix_rule(
+    pattern = ["cat", "<<"],
+    decision = "prompt",
+    justification = "Writing code via heredoc can easily produce oversized files. Coding standards require: max 1000 lines per file, max 100 lines per function, no duplicated code blocks. Ensure the output file stays within limits and code is modular.",
+    match = ["cat << 'EOF' > app.ts", "cat <<EOF > handler.py"],
+    not_match = ["cat README.md", "cat /etc/hosts"],
+)
+
+# ── TEE TO CODE FILES ──────────────────────────────────────────────────────
+# Prompt when using tee to write code — same risk as heredocs.
+
+prefix_rule(
+    pattern = ["tee"],
+    decision = "prompt",
+    justification = "Writing code via tee can produce oversized files. Coding standards require: max 1000 lines per file, max 100 lines per function, no duplicated code blocks. Ensure the output stays modular.",
+    match = ["tee src/handler.ts", "tee -a lib/utils.py"],
+    not_match = ["tee /tmp/log.txt"],
+)
+
+# ── APPEND REDIRECTION TO CODE FILES ──────────────────────────────────────
+# Prompt when appending to code files — risk of growing files beyond limits.
+
+prefix_rule(
+    pattern = ["bash", "-c"],
+    decision = "prompt",
+    justification = "Running bash -c with code generation may produce large files. Coding standards require: max 1000 lines per file, max 100 lines per function, no duplicated code blocks, no more than 15 exports per file. Verify the result stays modular.",
+    match = ["bash -c 'cat << EOF >> app.ts'"],
+    not_match = ["bash -c 'echo hello'"],
+)

--- a/policies/codex/pkg-police.rules
+++ b/policies/codex/pkg-police.rules
@@ -1,0 +1,66 @@
+# pkg-police.rules — Codex CLI exec policy
+# Blocks: npm, npx, yarn, pnpm commands — enforces bun as package manager
+# Equivalent to: plugins/pkg-police.ts (OpenCode), hooks/claude/pkg-police.sh (Claude Code)
+
+# ── PACKAGE MANAGER ENFORCEMENT ─────────────────────────────────────────────
+# All JavaScript/TypeScript package management must use bun.
+# npm, npx, yarn, and pnpm are blocked unless the user explicitly overrides.
+
+prefix_rule(
+    pattern = ["npm", ["install", "i", "ci", "run", "test", "init", "publish", "exec", "create"]],
+    decision = "forbidden",
+    justification = "npm is not allowed. Use bun instead: npm install → bun install, npm run → bun run, npm test → bun test.",
+    match = [
+        "npm install",
+        "npm i express",
+        "npm run build",
+        "npm test",
+        "npm ci",
+    ],
+    not_match = [
+        "bun install",
+        "bun run build",
+    ],
+)
+
+prefix_rule(
+    pattern = ["npx"],
+    decision = "forbidden",
+    justification = "npx is not allowed. Use bunx instead: npx tsc → bunx tsc.",
+    match = [
+        "npx tsc --noEmit",
+        "npx expo export",
+    ],
+    not_match = [
+        "bunx tsc --noEmit",
+        "bunx expo export",
+    ],
+)
+
+prefix_rule(
+    pattern = ["yarn"],
+    decision = "forbidden",
+    justification = "yarn is not allowed. Use bun instead: yarn → bun install, yarn add → bun add.",
+    match = [
+        "yarn install",
+        "yarn add react",
+    ],
+    not_match = [
+        "bun install",
+        "bun add react",
+    ],
+)
+
+prefix_rule(
+    pattern = ["pnpm"],
+    decision = "forbidden",
+    justification = "pnpm is not allowed. Use bun instead: pnpm install → bun install, pnpm add → bun add.",
+    match = [
+        "pnpm install",
+        "pnpm add react",
+    ],
+    not_match = [
+        "bun install",
+        "bun add react",
+    ],
+)

--- a/rules/coding-standards.md
+++ b/rules/coding-standards.md
@@ -1,0 +1,37 @@
+---
+globs: "**/*.{ts,tsx,js,jsx,py,rb,go,rs,java,kt,cs,cpp,c,h,hpp,swift,scala,vue,svelte}"
+---
+
+# Coding Standards (Coding Police)
+
+Enforce these standards proactively to ensure the codebase remains modular, DRY, and maintainable.
+
+## 1. Modularize by Default
+
+- **File Length Limit**: No single file should exceed **1000 lines**.
+- If a file grows beyond this limit, split it into smaller modules based on functionality (e.g., `types.ts`, `helpers.ts`, `constants.ts`, `handlers.ts`).
+- Prefer a directory of small files over one large monolithic file.
+
+## 2. Keep Functions Focused
+
+- **Function Length Limit**: No single function or method should exceed **100 lines**.
+- Large functions are harder to test and reason about. Decompose them into small, composable helper functions.
+- Each function should do exactly one thing.
+
+## 3. DRY (Don't Repeat Yourself)
+
+- **Zero Tolerance for Duplication**: Never copy-paste logic.
+- If you find yourself writing the same **6+ lines** of code in two places, extract them into a shared function or utility module.
+- Duplication is a major source of maintenance debt.
+
+## 4. Single Responsibility
+
+- **Export Limit**: In TypeScript/JavaScript, a single file should ideally have no more than **15 exports**.
+- Too many exports usually indicate that a file has multiple responsibilities.
+- Split files with excessive exports into focused modules.
+
+## 5. Implementation Strategy
+
+- Plan your file structure **before** writing large amounts of code.
+- If you realize a feature requires 1000+ lines, create the directory structure and multiple files from the start.
+- Do not wait for the "Coding Police" plugin to warn you — modularity should be built-in.

--- a/tests/coding-police.test.ts
+++ b/tests/coding-police.test.ts
@@ -1,0 +1,326 @@
+import { describe, test, expect } from 'bun:test';
+import codingPolice, {
+  checkFileLength,
+  checkFunctionLengths,
+  checkDuplicateBlocks,
+  checkExportCount,
+} from '../plugins/coding-police';
+
+// ---------------------------------------------------------------------------
+// Mock context (matches pattern from other police tests)
+// ---------------------------------------------------------------------------
+
+const mockCtx = {
+  client: {},
+  project: {},
+  directory: '/tmp',
+  worktree: '/tmp',
+  serverUrl: new URL('http://localhost'),
+  $: {},
+} as any;
+
+// ---------------------------------------------------------------------------
+// Helper: generate lines
+// ---------------------------------------------------------------------------
+
+function generateLines(count: number, template = 'const x = 1;'): string[] {
+  return Array.from({ length: count }, (_, i) => `${template} // line ${i + 1}`);
+}
+
+// ---------------------------------------------------------------------------
+// Check 1: File length
+// ---------------------------------------------------------------------------
+
+describe('checkFileLength', () => {
+  test('returns null for files under limit', () => {
+    const lines = generateLines(500);
+    expect(checkFileLength(lines, 1000)).toBeNull();
+  });
+
+  test('returns null for files exactly at limit', () => {
+    const lines = generateLines(1000);
+    expect(checkFileLength(lines, 1000)).toBeNull();
+  });
+
+  test('returns warning for files over limit', () => {
+    const lines = generateLines(1050);
+    const result = checkFileLength(lines, 1000);
+    expect(result).not.toBeNull();
+    expect(result).toContain('FILE TOO LONG');
+    expect(result).toContain('1050 lines');
+    expect(result).toContain('limit: 1000');
+    expect(result).toContain('over by 50');
+  });
+
+  test('returns warning with correct excess count', () => {
+    const lines = generateLines(1500);
+    const result = checkFileLength(lines, 1000);
+    expect(result).toContain('over by 500');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Check 2: Function lengths
+// ---------------------------------------------------------------------------
+
+describe('checkFunctionLengths', () => {
+  test('returns empty for short functions', () => {
+    const code = [
+      'function shortFunc() {',
+      '  const a = 1;',
+      '  return a;',
+      '}',
+    ];
+    expect(checkFunctionLengths(code, 100)).toEqual([]);
+  });
+
+  test('detects long named functions', () => {
+    const body = Array.from({ length: 120 }, (_, i) => `  const x${i} = ${i};`);
+    const code = ['function longFunc() {', ...body, '}'];
+    const warnings = checkFunctionLengths(code, 100);
+    expect(warnings.length).toBeGreaterThan(0);
+    expect(warnings[0]).toContain('longFunc');
+    expect(warnings[0]).toContain('LONG FUNCTION');
+  });
+
+  test('detects long async functions', () => {
+    const body = Array.from({ length: 110 }, (_, i) => `  await fetch(${i});`);
+    const code = ['async function fetchAll() {', ...body, '}'];
+    const warnings = checkFunctionLengths(code, 100);
+    expect(warnings.length).toBeGreaterThan(0);
+    expect(warnings[0]).toContain('fetchAll');
+  });
+
+  test('detects long exported functions', () => {
+    const body = Array.from({ length: 110 }, (_, i) => `  const x${i} = ${i};`);
+    const code = ['export function bigExport() {', ...body, '}'];
+    const warnings = checkFunctionLengths(code, 100);
+    expect(warnings.length).toBeGreaterThan(0);
+    expect(warnings[0]).toContain('bigExport');
+  });
+
+  test('detects long Python functions', () => {
+    const body = Array.from({ length: 110 }, (_, i) => `    x${i} = ${i}`);
+    const code = ['def long_python_func():', ...body, '', 'def next_func():'];
+    const warnings = checkFunctionLengths(code, 100);
+    expect(warnings.length).toBeGreaterThan(0);
+    expect(warnings[0]).toContain('long_python_func');
+  });
+
+  test('detects long Go functions', () => {
+    const body = Array.from({ length: 110 }, (_, i) => `  x := ${i}`);
+    const code = ['func longGoFunc() error {', ...body, '}'];
+    const warnings = checkFunctionLengths(code, 100);
+    expect(warnings.length).toBeGreaterThan(0);
+    expect(warnings[0]).toContain('longGoFunc');
+  });
+
+  test('detects long Rust functions', () => {
+    const body = Array.from({ length: 110 }, (_, i) => `    let x${i} = ${i};`);
+    const code = ['pub async fn long_rust_fn() -> Result<()> {', ...body, '}'];
+    const warnings = checkFunctionLengths(code, 100);
+    expect(warnings.length).toBeGreaterThan(0);
+    expect(warnings[0]).toContain('long_rust_fn');
+  });
+
+  test('ignores short functions among long ones', () => {
+    const shortBody = ['  return 1;'];
+    const longBody = Array.from({ length: 110 }, (_, i) => `  const x${i} = ${i};`);
+    const code = [
+      'function short() {',
+      ...shortBody,
+      '}',
+      'function long() {',
+      ...longBody,
+      '}',
+    ];
+    const warnings = checkFunctionLengths(code, 100);
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toContain('long');
+    expect(warnings[0]).not.toContain('short');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Check 3: Duplicate code blocks
+// ---------------------------------------------------------------------------
+
+describe('checkDuplicateBlocks', () => {
+  test('returns empty when no duplicates', () => {
+    const code = [
+      'const a = 1;',
+      'const b = 2;',
+      'const c = 3;',
+      'const d = 4;',
+      'const e = 5;',
+      'const f = 6;',
+      'const g = 7;',
+    ];
+    expect(checkDuplicateBlocks(code, 6)).toEqual([]);
+  });
+
+  test('detects duplicated blocks', () => {
+    const block = [
+      'const x = getUser();',
+      'const y = validate(x);',
+      'const z = transform(y);',
+      'await save(z);',
+      'logger.info("done");',
+      'return z;',
+    ];
+    const code = [
+      'function handler1() {',
+      ...block,
+      '}',
+      '',
+      'function handler2() {',
+      ...block,
+      '}',
+    ];
+    const warnings = checkDuplicateBlocks(code, 6);
+    expect(warnings.length).toBeGreaterThan(0);
+    expect(warnings[0]).toContain('DUPLICATE CODE');
+    expect(warnings[0]).toContain('DRY');
+  });
+
+  test('ignores duplicate blank lines and comments', () => {
+    const code = [
+      '// comment',
+      '',
+      '// comment',
+      '',
+      '// comment',
+      '',
+      '// comment',
+      '',
+      '// another',
+      '',
+      '// another',
+      '',
+    ];
+    expect(checkDuplicateBlocks(code, 6)).toEqual([]);
+  });
+
+  test('ignores duplicate import lines', () => {
+    const code = [
+      "import { a } from 'a';",
+      "import { b } from 'b';",
+      "import { c } from 'c';",
+      "import { d } from 'd';",
+      "import { e } from 'e';",
+      "import { f } from 'f';",
+      '',
+      "import { a } from 'a';",
+      "import { b } from 'b';",
+      "import { c } from 'c';",
+      "import { d } from 'd';",
+      "import { e } from 'e';",
+      "import { f } from 'f';",
+    ];
+    expect(checkDuplicateBlocks(code, 6)).toEqual([]);
+  });
+
+  test('respects minLines threshold', () => {
+    const block = ['const a = 1;', 'const b = 2;', 'const c = 3;'];
+    const code = [...block, '', ...block];
+    // Block is 3 lines, threshold is 6 — should not trigger
+    expect(checkDuplicateBlocks(code, 6)).toEqual([]);
+    // Block is 3 lines, threshold is 3 — should trigger
+    const warnings = checkDuplicateBlocks(code, 3);
+    expect(warnings.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Check 4: Export count
+// ---------------------------------------------------------------------------
+
+describe('checkExportCount', () => {
+  test('returns null for few exports', () => {
+    const code = [
+      'export function a() {}',
+      'export function b() {}',
+      'export const c = 1;',
+    ];
+    expect(checkExportCount(code, 15)).toBeNull();
+  });
+
+  test('returns warning when exports exceed limit', () => {
+    const code = Array.from(
+      { length: 20 },
+      (_, i) => `export function fn${i}() {}`,
+    );
+    const result = checkExportCount(code, 15);
+    expect(result).not.toBeNull();
+    expect(result).toContain('TOO MANY EXPORTS');
+    expect(result).toContain('20 exports');
+    expect(result).toContain('limit: 15');
+  });
+
+  test('counts different export types', () => {
+    const code = [
+      'export function a() {}',
+      'export const b = 1;',
+      'export let c = 2;',
+      'export var d = 3;',
+      'export class E {}',
+      'export interface F {}',
+      'export type G = string;',
+      'export enum H {}',
+      'export async function i() {}',
+      'export default function j() {}',
+    ];
+    // 10 exports, limit 5 — should warn
+    const result = checkExportCount(code, 5);
+    expect(result).not.toBeNull();
+    expect(result).toContain('10 exports');
+  });
+
+  test('does not count non-export lines', () => {
+    const code = [
+      'function internal() {}',
+      'const local = 1;',
+      '// export function commented() {}',
+      'export function onlyOne() {}',
+    ];
+    expect(checkExportCount(code, 15)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Plugin integration (hook wiring)
+// ---------------------------------------------------------------------------
+
+describe('coding-police plugin', () => {
+  test('ignores non-edit/write tools', async () => {
+    const hooks = await codingPolice(mockCtx);
+    const input = { tool: 'bash', sessionID: 'test', callID: 'test' };
+    const output = { title: 'foo.ts', output: 'done', metadata: {} };
+    await hooks['tool.execute.after']!(input, output);
+    expect(output.output).toBe('done');
+  });
+
+  test('ignores non-code files', async () => {
+    const hooks = await codingPolice(mockCtx);
+    const input = { tool: 'write', sessionID: 'test', callID: 'test' };
+    const output = { title: 'readme.md', output: 'done', metadata: {} };
+    await hooks['tool.execute.after']!(input, output);
+    expect(output.output).toBe('done');
+  });
+
+  test('ignores generated/lock files', async () => {
+    const hooks = await codingPolice(mockCtx);
+    const input = { tool: 'write', sessionID: 'test', callID: 'test' };
+    const output = { title: 'types.d.ts', output: 'done', metadata: {} };
+    await hooks['tool.execute.after']!(input, output);
+    expect(output.output).toBe('done');
+  });
+
+  test('ignores lock files', async () => {
+    const hooks = await codingPolice(mockCtx);
+    const input = { tool: 'edit', sessionID: 'test', callID: 'test' };
+    const output = { title: 'package-lock.json', output: 'done', metadata: {} };
+    await hooks['tool.execute.after']!(input, output);
+    expect(output.output).toBe('done');
+  });
+});


### PR DESCRIPTION
## Summary

- **pkg-police**: Enforces `bun` as the default JS/TS package manager — blocks `npm`, `npx`, `yarn`, `pnpm` with actionable bun equivalents in error messages
- **coding-police**: Enforces file size (<1000 lines), function length (<100 lines), DRY (6+ duplicate lines), and export count (<15) limits
- Both available on all three platforms: OpenCode plugin, Claude Code hook, Codex CLI policy

## Files

| File | Description |
|------|-------------|
| `plugins/pkg-police.ts` | OpenCode `tool.execute.before` plugin |
| `hooks/claude/pkg-police.sh` | Claude Code PreToolUse hook |
| `policies/codex/pkg-police.rules` | Codex CLI exec policy |
| `plugins/coding-police.ts` | OpenCode `tool.execute.after` plugin |
| `hooks/claude/coding-police.sh` | Claude Code PostToolUse hook |
| `policies/codex/coding-police.rules` | Codex CLI exec policy |
| `rules/coding-standards.md` | Auto-loaded rule for code files |
| `tests/coding-police.test.ts` | Tests for coding-police |
| `config.example.yaml` | Added `pkg-police` and `coding-police` config sections |
| `hooks/claude/settings.json` | Registered both hooks |
| `README.md` | Updated all tables and added detailed docs |

## Config

```yaml
pkg-police:
  enabled: true  # set false to disable bun enforcement

coding-police:
  max-file-lines: 1000
  max-function-lines: 100
  min-duplicate-lines: 6
  max-exports-per-file: 15
```