### PR TITLE
feat(codex): add stale branch prompt rules for Codex CLI

### DIFF
--- a/policies/git-police.rules
+++ b/policies/git-police.rules
@@ -1,0 +1,18 @@
+
+# ── STALE BRANCH PROTECTION ──────────────────────────────────────────────────
+# Codex prefix_rule cannot run git fetch to check staleness, so we prompt
+# the user to confirm they have pulled latest before creating a new branch.
+
+prefix_rule(
+    pattern = ["git", "checkout", "-b"],
+    decision = "prompt",
+    justification = "Creating a new branch. Ensure your current branch is up to date with origin first: run 'git pull' before branching to avoid working on stale code.",
+    match     = ["git checkout -b feat/new-feature", "git checkout -b fix/bug"],
+)
+
+prefix_rule(
+    pattern = ["git", "switch", "-c"],
+    decision = "prompt",
+    justification = "Creating a new branch. Ensure your current branch is up to date with origin first: run 'git pull' before branching to avoid working on stale code.",
+    match     = ["git switch -c feat/new-feature", "git switch -c fix/bug"],
+)


### PR DESCRIPTION
## Summary

Adds stale branch protection for Codex CLI. Since Codex `prefix_rule` cannot execute shell commands (no git fetch/rev-parse), these use the `prompt` decision to remind users to pull before creating branches.

## Changes

- `policies/git-police.rules`: Added prompt rules for `git checkout -b` and `git switch -c`

## Limitation

Unlike the bash hook (blocks with behind count) and TS plugin (throws with behind count), Codex can only prompt — it cannot programmatically check staleness.