### PR TITLE
fix(codex): resolve policy parse errors and incorrect rules

### DIFF
--- a/policies/codex/coding-police.rules
+++ b/policies/codex/coding-police.rules
@@ -35,7 +35,7 @@ prefix_rule(
     pattern = ["cat", "<<"],
     decision = "prompt",
     justification = "Writing code via heredoc can easily produce oversized files. Coding standards require: max 1000 lines per file, max 100 lines per function, no duplicated code blocks. Ensure the output file stays within limits and code is modular.",
-    match = ["cat << 'EOF' > app.ts", "cat <<EOF > handler.py"],
+    match = ["cat << 'EOF' > app.ts", "cat << EOF > handler.py"],
     not_match = ["cat README.md", "cat /etc/hosts"],
 )
 
@@ -47,7 +47,6 @@ prefix_rule(
     decision = "prompt",
     justification = "Writing code via tee can produce oversized files. Coding standards require: max 1000 lines per file, max 100 lines per function, no duplicated code blocks. Ensure the output stays modular.",
     match = ["tee src/handler.ts", "tee -a lib/utils.py"],
-    not_match = ["tee /tmp/log.txt"],
 )
 
 # ── APPEND REDIRECTION TO CODE FILES ──────────────────────────────────────
@@ -58,5 +57,4 @@ prefix_rule(
     decision = "prompt",
     justification = "Running bash -c with code generation may produce large files. Coding standards require: max 1000 lines per file, max 100 lines per function, no duplicated code blocks, no more than 15 exports per file. Verify the result stays modular.",
     match = ["bash -c 'cat << EOF >> app.ts'"],
-    not_match = ["bash -c 'echo hello'"],
 )

--- a/policies/codex/git-police.rules
+++ b/policies/codex/git-police.rules
@@ -7,7 +7,7 @@
 prefix_rule(
     pattern = ["git", "push", "--force"],
     decision = "forbidden",
-    justification = "Force push is prohibited. Use --force-with-lease to avoid overwriting others' work.",
+    justification = "Force push is prohibited. It rewrites remote history and can destroy others' work.",
     match     = ["git push --force", "git push --force origin main"],
     not_match = ["git push", "git push origin main"],
 )
@@ -15,9 +15,15 @@ prefix_rule(
 prefix_rule(
     pattern = ["git", "push", "-f"],
     decision = "forbidden",
-    justification = "Force push (-f) is prohibited. Use --force-with-lease.",
+    justification = "Force push (-f) is prohibited. It rewrites remote history and can destroy others' work.",
     match     = ["git push -f", "git push -f origin main"],
     not_match = ["git push origin main"],
+)
+
+prefix_rule(
+    pattern = ["git", "push", "--force-with-lease"],
+    decision = "forbidden",
+    justification = "Force push with lease is forbidden. It still rewrites remote history.",
 )
 
 # ── SKIP HOOKS (--no-verify) ─────────────────────────────────────────────────
@@ -48,12 +54,6 @@ prefix_rule(
     justification = "-n (--no-verify) bypasses hooks. Fix the hook failure instead.",
 )
 
-prefix_rule(
-    pattern = ["git", "push", "-n"],
-    decision = "forbidden",
-    justification = "-n (--no-verify) bypasses hooks. Fix the hook failure instead.",
-)
-
 # ── DIRECT PUSH TO PROTECTED BRANCHES ────────────────────────────────────────
 
 prefix_rule(
@@ -61,7 +61,6 @@ prefix_rule(
     decision = "forbidden",
     justification = "Direct push to protected branches is prohibited. Open a PR instead.",
     match     = ["git push origin main", "git push origin master", "git push upstream main"],
-    not_match = ["git push origin feature/my-branch"],
 )
 
 prefix_rule(
@@ -79,7 +78,6 @@ prefix_rule(
     decision = "prompt",
     justification = "Bare 'git push' may push a protected branch. Confirm you are NOT on main/master before proceeding.",
     match     = ["git push"],
-    not_match = ["git push origin feature/my-branch"],
 )
 
 # ── AMEND PUSHED COMMITS ─────────────────────────────────────────────────────
@@ -107,9 +105,6 @@ prefix_rule(
     decision = "prompt",
     justification = "git clean permanently deletes untracked files/directories.",
 )
-
-
-
 
 # ── STALE BRANCH PROTECTION ──────────────────────────────────────────────────
 # Codex prefix_rule cannot run git fetch to check staleness, so we prompt


### PR DESCRIPTION
## Summary

All Codex CLI `.rules` files were completely broken — Codex threw parse errors at startup and none of the policies loaded. Fixed all load-time assertion failures.

## Bugs Fixed

### coding-police.rules
- `cat <<EOF > handler.py` shlex tokenization fix — needs space between `<<` and `EOF`
- Removed invalid `not_match` entries for `tee` and `bash -c` rules — prefix rules match everything starting with those tokens

### git-police.rules
- **Removed `git push -n` rule** — `-n` means `--dry-run` for push, not the skip-hooks flag
- **Removed broken `not_match` assertions** — prefix `["git", "push"]` matches ALL git push commands
- **Added `--force-with-lease` forbidden rule** — was blocked in bash/TS but missing from Codex
- **Fixed force push justification** — no longer recommends a method that is also blocked

### kubectl-police.rules & pkg-police.rules
- Verified clean — no changes needed

## Validation
`codex exec --ephemeral "echo hello"` now loads all rules without errors.
