### PR TITLE
feat(comment-police): rule + plugin to flag low-value comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,22 +17,24 @@ Reusable AI agent skills, rules, plugins, hooks, and tools for OpenCode, Claude 
 
 ### Rules (auto-loaded by file glob match)
 
-| Rule                     | Glob                    | Description                                                        |
-| ------------------------ | ----------------------- | ------------------------------------------------------------------ |
-| **consent-protocol**     | `**/*`                  | Stop after asking a question -- never act and ask in the same turn |
-| **credential-bootstrap** | `gitops/**/*.yaml`      | OpenBao + ESO credential bootstrap pattern for GitOps apps         |
-| **coding-standards**     | `**/*.{ts,py,go,rs...}` | Enforces DRY, modularity, and focused functions proactively        |
+| Rule                     | Glob                                            | Description                                                        |
+| ------------------------ | ----------------------------------------------- | ------------------------------------------------------------------ |
+| **consent-protocol**     | `**/*`                                          | Stop after asking a question -- never act and ask in the same turn |
+| **credential-bootstrap** | `gitops/**/*.yaml`                              | OpenBao + ESO credential bootstrap pattern for GitOps apps         |
+| **coding-standards**     | `**/*.{ts,py,go,rs...}`                         | Enforces DRY, modularity, and focused functions proactively        |
+| **comment-discipline**   | `**/*.{ts,py,go,rs,sh,yaml,toml,Dockerfile...}` | Default to no comments; only WHY when non-obvious                  |
 
 ### Plugins (OpenCode only -- runtime hooks)
 
-| Plugin                | Description                                                                                        |
-| --------------------- | -------------------------------------------------------------------------------------------------- |
-| **version-police.ts** | Auto-checks Helm/npm/Cargo dependency versions on file write                                       |
-| **format-police.ts**  | Auto-formats files on write using dprint                                                           |
-| **kubectl-police.ts** | Blocks kubectl create/apply for Kargo CRDs (unconditionally)                                       |
-| **git-police.ts**     | Blocks commits to main/master, force push, --no-verify, AI attribution, push to protected branches |
-| **coding-police.ts**  | Enforces DRY code, modular files (<1000 lines), short functions, and single responsibility         |
-| **pkg-police.ts**     | Enforces bun as package manager — blocks npm, npx, yarn, pnpm commands                             |
+| Plugin                | Description                                                                                                              |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| **version-police.ts** | Auto-checks Helm/npm/Cargo dependency versions on file write                                                             |
+| **format-police.ts**  | Auto-formats files on write using dprint                                                                                 |
+| **kubectl-police.ts** | Blocks kubectl create/apply for Kargo CRDs (unconditionally)                                                             |
+| **git-police.ts**     | Blocks commits to main/master, force push, --no-verify, AI attribution, push to protected branches                       |
+| **coding-police.ts**  | Enforces DRY code, modular files (<1000 lines), short functions, and single responsibility                               |
+| **comment-police.ts** | Warns on long comment blocks, tutorial-style file headers, PR/plan/closes-#N references, and high comment-to-code ratios |
+| **pkg-police.ts**     | Enforces bun as package manager — blocks npm, npx, yarn, pnpm commands                                                   |
 
 ### Hooks (Claude Code -- PreToolUse / PostToolUse)
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -38,3 +38,31 @@ pkg-police:
   enabled: true
   # Example:
   #   enabled: false
+
+comment-police:
+  # Maximum lines in a single body comment block before warning.
+  max-block-lines: 6
+
+  # Maximum lines in a top-of-file comment header before warning.
+  # ("Tutorial-style" headers belong in the README, not in the file.)
+  max-header-lines: 10
+
+  # Maximum comment-to-(comment+code) line ratio per file before warning.
+  max-comment-ratio: 0.3
+
+  # Regex patterns flagged as rotting references (PR / plan / commit
+  # references belong in the PR description / commit message, not in code).
+  forbidden-patterns:
+    - 'Plan-?\d+'
+    - 'PR\s*#?\d+'
+    - 'closes\s*#\d+'
+    - 'fixes\s*#\d+'
+    - 'TODO[: ]+(for|after|once)\b'
+    - 'as part of (this|the) (PR|MR|fix)'
+
+  # File path patterns to exclude from checks.
+  exclude-patterns: []
+  # Example:
+  #   exclude-patterns:
+  #     - vendor/
+  #     - generated/

--- a/plugins/comment-police.ts
+++ b/plugins/comment-police.ts
@@ -1,0 +1,255 @@
+import type { PluginInput } from '@opencode-ai/plugin';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import path from 'node:path';
+
+interface CommentPoliceConfig {
+  maxBlockLines: number;
+  maxHeaderLines: number;
+  maxCommentRatio: number;
+  forbiddenPatterns: string[];
+  excludePatterns: string[];
+}
+
+const DEFAULTS: CommentPoliceConfig = {
+  maxBlockLines: 6,
+  maxHeaderLines: 10,
+  maxCommentRatio: 0.3,
+  forbiddenPatterns: [
+    'Plan-?\\d+',
+    'plan \\d',
+    'PR\\s*#?\\d+',
+    'closes\\s*#\\d+',
+    'fixes\\s*#\\d+',
+    'TODO[: ]+(for|after|once)\\b',
+    'for the v\\d',
+    'added (when|for) (we|the)',
+    'as part of (this|the) (PR|MR|fix)',
+    'see (issue|ticket|PR|MR)',
+  ],
+  excludePatterns: [],
+};
+
+const TARGET_FILE =
+  /\.(ts|tsx|js|jsx|py|rb|go|rs|java|kt|cs|cpp|c|h|hpp|swift|scala|vue|svelte|sh|bash|yaml|yml|toml)$|Dockerfile(\..+)?$/;
+
+const SKIP_FILES =
+  /\.(lock|min\.\w+|generated\.\w+|snap|d\.ts)$|package-lock\.json|yarn\.lock|pnpm-lock\.yaml/;
+
+function configPath(): string {
+  const xdg = process.env.XDG_CONFIG_HOME || join(homedir(), '.config');
+  return join(xdg, 'agentkit', 'config.yaml');
+}
+
+export function loadConfig(): CommentPoliceConfig {
+  try {
+    const content = readFileSync(configPath(), 'utf-8');
+    const lines = content.split('\n');
+    let inSection = false;
+    const sectionLines: string[] = [];
+    for (const line of lines) {
+      if (/^comment-police:/.test(line)) {
+        inSection = true;
+        continue;
+      }
+      if (inSection) {
+        if (/^\S/.test(line)) break;
+        sectionLines.push(line);
+      }
+    }
+    if (sectionLines.length === 0) return { ...DEFAULTS };
+    const section = sectionLines.join('\n');
+
+    const block = section.match(/max-block-lines:\s*(\d+)/);
+    const header = section.match(/max-header-lines:\s*(\d+)/);
+    const ratio = section.match(/max-comment-ratio:\s*([0-9.]+)/);
+    const forbiddenMatch = section.match(
+      /forbidden-patterns:\s*\n((?:\s*-\s*.+\n?)*)/,
+    );
+    const forbidden = forbiddenMatch
+      ? [...forbiddenMatch[1].matchAll(/^\s*-\s+(.+)$/gm)].map((m) =>
+          m[1].trim().replace(/^["']|["']$/g, ''),
+        )
+      : DEFAULTS.forbiddenPatterns;
+    const excludeMatch = section.match(
+      /exclude-patterns:\s*\n((?:\s*-\s*.+\n?)*)/,
+    );
+    const excludes = excludeMatch
+      ? [...excludeMatch[1].matchAll(/^\s*-\s+(.+)$/gm)].map((m) =>
+          m[1].trim(),
+        )
+      : DEFAULTS.excludePatterns;
+
+    return {
+      maxBlockLines: block ? parseInt(block[1], 10) : DEFAULTS.maxBlockLines,
+      maxHeaderLines: header
+        ? parseInt(header[1], 10)
+        : DEFAULTS.maxHeaderLines,
+      maxCommentRatio: ratio
+        ? parseFloat(ratio[1])
+        : DEFAULTS.maxCommentRatio,
+      forbiddenPatterns: forbidden,
+      excludePatterns: excludes,
+    };
+  } catch {
+    return { ...DEFAULTS };
+  }
+}
+
+// Map a file extension to the line-comment marker(s) it uses. Block-comment
+// detection (`/* */`, `=begin/=end`) is handled separately below.
+function lineCommentMarkers(filename: string): RegExp {
+  if (/\.(py|rb|sh|bash|yaml|yml|toml)$|Dockerfile/.test(filename)) {
+    return /^\s*#(?!!)/;
+  }
+  if (/\.(ts|tsx|js|jsx|go|rs|java|kt|cs|cpp|c|h|hpp|swift|scala)$/.test(filename)) {
+    return /^\s*\/\//;
+  }
+  if (/\.(vue|svelte)$/.test(filename)) {
+    // HTML-style comments inside templates; line `//` inside scripts.
+    return /^\s*(\/\/|<!--)/;
+  }
+  return /^\s*(\/\/|#)/;
+}
+
+interface CommentBlock {
+  startLine: number; // 1-indexed
+  lines: string[];
+}
+
+export function findCommentBlocks(
+  source: string[],
+  marker: RegExp,
+): CommentBlock[] {
+  const blocks: CommentBlock[] = [];
+  let current: CommentBlock | null = null;
+  for (let i = 0; i < source.length; i++) {
+    if (marker.test(source[i])) {
+      if (!current) current = { startLine: i + 1, lines: [] };
+      current.lines.push(source[i]);
+    } else if (current) {
+      blocks.push(current);
+      current = null;
+    }
+  }
+  if (current) blocks.push(current);
+  return blocks;
+}
+
+export function commentLineCount(source: string[], marker: RegExp): number {
+  return source.filter((l) => marker.test(l)).length;
+}
+
+export function codeLineCount(source: string[], marker: RegExp): number {
+  return source.filter((l) => l.trim() !== '' && !marker.test(l)).length;
+}
+
+export function checkBlocks(
+  blocks: CommentBlock[],
+  maxBlockLines: number,
+  maxHeaderLines: number,
+  forbidden: RegExp[],
+): string[] {
+  const warnings: string[] = [];
+  for (const b of blocks) {
+    const isHeader = b.startLine <= 3;
+    const limit = isHeader ? maxHeaderLines : maxBlockLines;
+    if (b.lines.length > limit) {
+      warnings.push(
+        `${isHeader ? 'tutorial-style file header' : 'long comment block'} at line ${b.startLine}: ${b.lines.length} lines (limit: ${limit})`,
+      );
+    }
+    const text = b.lines.join('\n');
+    for (const pat of forbidden) {
+      const m = text.match(pat);
+      if (m) {
+        warnings.push(
+          `comment block at line ${b.startLine} contains a rotting reference: \`${m[0]}\` — move it to the PR description / commit message`,
+        );
+        break;
+      }
+    }
+  }
+  return warnings;
+}
+
+export function checkRatio(
+  source: string[],
+  marker: RegExp,
+  maxRatio: number,
+): string | null {
+  const code = codeLineCount(source, marker);
+  const comments = commentLineCount(source, marker);
+  if (code === 0) return null;
+  const ratio = comments / (code + comments);
+  if (ratio > maxRatio) {
+    return `comment-to-code ratio ${(ratio * 100).toFixed(0)}% exceeds ${(maxRatio * 100).toFixed(0)}% (${comments} comment lines vs ${code} code lines)`;
+  }
+  return null;
+}
+
+export const CommentPolice = {
+  name: 'comment-police',
+  hooks: ({ ctx }: PluginInput) => {
+    return {
+      'tool.execute.after': async (
+        input: { tool: string },
+        output: { title?: string; output?: string },
+      ) => {
+        if (!['edit', 'write'].includes(input.tool)) return;
+        const rel = output.title;
+        if (!rel) return;
+        if (!TARGET_FILE.test(rel)) return;
+        if (SKIP_FILES.test(rel)) return;
+
+        const config = loadConfig();
+        if (config.excludePatterns.some((p) => rel.includes(p))) return;
+
+        const abs = path.isAbsolute(rel)
+          ? rel
+          : path.resolve(ctx.worktree, rel);
+        let content: string;
+        try {
+          content = readFileSync(abs, 'utf-8');
+        } catch {
+          return;
+        }
+        const lines = content.split('\n');
+        const marker = lineCommentMarkers(rel);
+        const blocks = findCommentBlocks(lines, marker);
+        const forbidden = config.forbiddenPatterns.map(
+          (p) => new RegExp(p, 'i'),
+        );
+
+        const warnings: string[] = [];
+        warnings.push(
+          ...checkBlocks(
+            blocks,
+            config.maxBlockLines,
+            config.maxHeaderLines,
+            forbidden,
+          ),
+        );
+        const ratioWarning = checkRatio(
+          lines,
+          marker,
+          config.maxCommentRatio,
+        );
+        if (ratioWarning) warnings.push(ratioWarning);
+
+        if (warnings.length === 0) return;
+
+        output.output =
+          (output.output ?? '') +
+          `\n\nCOMMENT DISCIPLINE (comment-police)\n` +
+          `${'='.repeat(50)}\n` +
+          warnings.map((w, i) => `${i + 1}. ${w}`).join('\n\n') +
+          `\n\n` +
+          `Default to no comments. Add only when WHY is non-obvious and removing the comment would confuse a future reader without conversation context. PR description / commit message is the durable home for "why this change was made". See agentkit rules/comment-discipline.md.`;
+      },
+    };
+  },
+};
+
+export default CommentPolice;

--- a/rules/comment-discipline.md
+++ b/rules/comment-discipline.md
@@ -1,0 +1,59 @@
+---
+globs: "**/*.{ts,tsx,js,jsx,py,rb,go,rs,java,kt,cs,cpp,c,h,hpp,swift,scala,vue,svelte,sh,bash,yaml,yml,toml,Dockerfile,Dockerfile.*}"
+---
+
+# Comment Discipline (Comment Police)
+
+Default to writing **no comments**. Add one only when the WHY is non-obvious and removing it would confuse a future reader without conversation context. Bad comments rot, lie, and bloat the codebase.
+
+## 1. Forbidden Patterns (the comment police flags these)
+
+- **Multi-paragraph rationale blocks** above functions, jobs, steps. The PR description / commit message is where rationale lives.
+- **References to the current PR / task / commit / plan**: `closes #N`, `Plan-15 slice 2`, `for the v0.14.0 flow`, `added when we did X`. These rot the moment the surrounding code changes.
+- **WHAT-narration**: comments that re-state what the code clearly does (`# call API`, `// loop over items`, `# release jobs run after binaries succeed`).
+- **Tutorial-style top-of-file headers** longer than ~10 lines describing how to use the file. README / docs are the right home.
+- **Documenting default values** that are visible two lines below.
+- **Step-by-step narratives** ("first we do X, then Y, then Z") inside functions that already have those exact steps.
+
+## 2. What's Worth Keeping
+
+A comment passes the bar if all of these hold:
+
+- The WHY is genuinely non-obvious from the code
+- Removing it would confuse a future reader without conversation context
+- The information is durable (won't rot when surrounding code changes)
+- It's about ONE of: hidden constraint, subtle invariant, workaround for a specific external bug, behavior that would surprise
+
+Examples that pass:
+
+```rust
+// PG's `CREATE SCHEMA IF NOT EXISTS` races across processes — the
+// catalog insert happens before the existence check. Catch 23505 here.
+```
+
+```yaml
+# musl-tools must be apt-installed because dtolnay/rust-toolchain
+# doesn't pull cross-compile system deps.
+```
+
+```ts
+// Docker doesn't expand ARG inside `--from`; we use a picker stage.
+```
+
+Examples that fail:
+
+```rust
+// Plan-15 slice 2 lifted the workflow-API auth gate to the engine layer.
+// Now release jobs run after binaries; we removed the bumped gate.
+// See PR #77 for the rationale on why we picked the artifact-download path.
+```
+
+(Three sins: PR reference, narrating WHAT changed, WHY belongs in commit.)
+
+## 3. Implementation Strategy
+
+- **Write code first, comments last** (or never). After writing a function, ask "would deleting every comment in this function leave it confusing?" If no, delete them.
+- **If you're explaining the code, fix the code instead.** Rename the variable, extract a helper, restructure — most "needed" comments mean the code isn't reading clearly.
+- **PR description / commit message is the durable home** for _why this change was made_. Don't duplicate that into the code.
+- **Comment-to-code ratio** in any single file edit should generally stay below ~30%. The comment police plugin will warn above that on writes.
+- Don't wait for the comment police plugin to warn — discipline is built-in, not retro-fitted.

--- a/tests/comment-police.test.ts
+++ b/tests/comment-police.test.ts
@@ -1,0 +1,142 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  findCommentBlocks,
+  commentLineCount,
+  codeLineCount,
+  checkBlocks,
+  checkRatio,
+} from '../plugins/comment-police';
+
+const TS = /^\s*\/\//;
+const PY = /^\s*#(?!!)/;
+
+describe('findCommentBlocks', () => {
+  test('groups consecutive line comments', () => {
+    const src = ['// a', '// b', '// c', 'const x = 1;', '// d'];
+    const blocks = findCommentBlocks(src, TS);
+    expect(blocks.length).toBe(2);
+    expect(blocks[0].lines.length).toBe(3);
+    expect(blocks[0].startLine).toBe(1);
+    expect(blocks[1].lines.length).toBe(1);
+    expect(blocks[1].startLine).toBe(5);
+  });
+
+  test('returns empty array when no comments', () => {
+    const src = ['const x = 1;', 'const y = 2;'];
+    expect(findCommentBlocks(src, TS)).toEqual([]);
+  });
+
+  test('handles trailing comment block', () => {
+    const src = ['const x = 1;', '// trailing', '// trailing'];
+    const blocks = findCommentBlocks(src, TS);
+    expect(blocks.length).toBe(1);
+    expect(blocks[0].lines.length).toBe(2);
+  });
+});
+
+describe('checkBlocks', () => {
+  const blockOf = (n: number, startLine: number) => ({
+    startLine,
+    lines: Array.from({ length: n }, (_, i) => `// line ${i}`),
+  });
+
+  test('warns on long body block', () => {
+    const warnings = checkBlocks([blockOf(7, 30)], 6, 10, []);
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toContain('long comment block');
+    expect(warnings[0]).toContain('line 30');
+  });
+
+  test('does not warn on body block within limit', () => {
+    expect(checkBlocks([blockOf(6, 30)], 6, 10, [])).toEqual([]);
+  });
+
+  test('warns on tutorial header (block within first 3 lines)', () => {
+    const warnings = checkBlocks([blockOf(11, 1)], 6, 10, []);
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toContain('tutorial-style file header');
+  });
+
+  test('header threshold is more permissive than body', () => {
+    expect(checkBlocks([blockOf(10, 1)], 6, 10, [])).toEqual([]);
+    const w = checkBlocks([blockOf(7, 5)], 6, 10, []);
+    expect(w.length).toBe(1);
+    expect(w[0]).toContain('long comment block');
+  });
+
+  test('flags rotting reference patterns (PR / plan / closes)', () => {
+    const block = {
+      startLine: 5,
+      lines: ['// closes #76 — wires the auth gate'],
+    };
+    const warnings = checkBlocks([block], 6, 10, [/closes\s*#\d+/i]);
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toContain('rotting reference');
+    expect(warnings[0]).toContain('closes #76');
+  });
+
+  test('only flags first matching forbidden pattern per block', () => {
+    const block = {
+      startLine: 5,
+      lines: ['// closes #1', '// see PR #2'],
+    };
+    const warnings = checkBlocks([block], 6, 10, [
+      /closes\s*#\d/i,
+      /PR\s*#\d/i,
+    ]);
+    expect(warnings.length).toBe(1);
+  });
+});
+
+describe('checkRatio', () => {
+  test('returns null for empty file', () => {
+    expect(checkRatio([], TS, 0.3)).toBeNull();
+  });
+
+  test('returns null when ratio is under threshold', () => {
+    const src = [
+      '// a',
+      'const a = 1;',
+      'const b = 2;',
+      'const c = 3;',
+      'const d = 4;',
+    ];
+    expect(checkRatio(src, TS, 0.3)).toBeNull();
+  });
+
+  test('warns when comments dominate', () => {
+    const src = [
+      '// 1',
+      '// 2',
+      '// 3',
+      '// 4',
+      '// 5',
+      '// 6',
+      'const x = 1;',
+    ];
+    const warning = checkRatio(src, TS, 0.3);
+    expect(warning).not.toBeNull();
+    expect(warning).toContain('exceeds 30%');
+    expect(warning).toContain('6 comment lines vs 1 code lines');
+  });
+
+  test('python comments via the # marker', () => {
+    const src = [
+      '# header',
+      '# header',
+      '# header',
+      '# header',
+      'x = 1',
+    ];
+    const warning = checkRatio(src, PY, 0.3);
+    expect(warning).not.toBeNull();
+  });
+});
+
+describe('commentLineCount + codeLineCount', () => {
+  test('counts each separately, ignoring blank lines for code', () => {
+    const src = ['// a', '', 'const x = 1;', 'const y = 2;', '// b'];
+    expect(commentLineCount(src, TS)).toBe(2);
+    expect(codeLineCount(src, TS)).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the comment-discipline rule + comment-police plugin pair (matching the existing rules/coding-standards + plugins/coding-police pattern). Catches the over-commenting habit before it bloats the codebase.

## What's flagged

| Signal | Default threshold | Why |
|---|---|---|
| Body comment block > N lines | 6 | Long blocks usually narrate WHAT instead of WHY |
| Top-of-file header > N lines | 10 | Tutorial-style headers belong in README, not the file |
| Comment-to-code ratio > X | 30% | Single-edit signal that explanation has overrun the change |
| Pattern `Plan-N`, `PR #N`, `closes #N`, `as part of this PR`, etc. | enabled | Rotting references — PR description / commit message is the durable home |

All thresholds and patterns configurable via `~/.config/agentkit/config.yaml`. Soft warnings — never blocks — since semantic comment-quality is hard to judge automatically and false positives would be expensive.

## Files

- `rules/comment-discipline.md` — declarative rule, glob-loaded into agent context for code files
- `plugins/comment-police.ts` — OpenCode plugin, runs PreToolUse on edit/write
- `tests/comment-police.test.ts` — 14 unit tests covering block detection, ratio math, forbidden patterns, header vs body thresholds
- `config.example.yaml` — `comment-police:` section with annotated defaults
- `README.md` — listed in the Rules and Plugins tables

## Test plan

- [x] `bun test tests/comment-police.test.ts` → 14 pass / 0 fail
- [x] Pattern coverage: block length, header threshold, rotting reference detection, single-flag-per-block, ratio math, language-specific markers (`//` vs `#`)
- [ ] Manual smoke test once installed: write a file with a long block comment containing `closes #76`, expect a warning in agent output