### PR TITLE
fix(git-police): close attribution leak; broaden patterns

### DIFF
--- a/hooks/claude/git-police.sh
+++ b/hooks/claude/git-police.sh
@@ -87,9 +87,12 @@ if echo "$STRIPPED" | grep -qiE '\bgit\b.*\bpush\b'; then
 	done
 fi
 
-# 5. Block Co-authored-by trailers in commit commands
-if echo "$STRIPPED" | grep -qiE '\bgit\b.*\bcommit\b' && echo "$TOOL_INPUT" | grep -qi 'co-authored-by'; then
-	deny "BLOCKED: AI attribution trailers (Co-authored-by) are forbidden in commit messages. Do not add Co-authored-by, Signed-off-by, or other AI agent attribution lines. The commit author is whoever owns the git config. Remove the trailer and retry."
+# 5. Block AI attribution trailers / signatures in commit commands.
+#    $INPUT is the full PreToolUse JSON payload from stdin; the previous
+#    version referenced an undefined $TOOL_INPUT and silently never matched.
+if echo "$STRIPPED" | grep -qiE '\bgit\b.*\bcommit\b' \
+	&& echo "$INPUT" | grep -qiE 'co-authored-by|generated with \[claude code\]|🤖 generated|claude\.ai/code|noreply@anthropic\.com'; then
+	deny "BLOCKED: AI attribution in commit messages is forbidden. Do not add Co-authored-by, Signed-off-by, '🤖 Generated with [Claude Code]', claude.ai/code links, noreply@anthropic.com co-authors, or any other AI agent attribution. The commit author is whoever owns the git config. Remove the attribution and retry."
 fi
 
 # 6. Block direct commits to protected branches

--- a/plugins/git-police.ts
+++ b/plugins/git-police.ts
@@ -198,11 +198,17 @@ export default async function gitPolice(ctx: PluginInput) {
           );
         }
 
-        if (/co-authored-by/i.test(command)) {
+        if (
+          /co-authored-by|generated with \[claude code\]|🤖 generated|claude\.ai\/code|noreply@anthropic\.com/i.test(
+            command,
+          )
+        ) {
           throw new Error(
-            `BLOCKED: AI attribution trailers (Co-authored-by) are forbidden in commit messages.\n` +
-              `Do not add Co-authored-by, Signed-off-by, or other AI agent attribution lines.\n` +
-              `The commit author is whoever owns the git config. Remove the trailer and retry.`,
+            `BLOCKED: AI attribution in commit messages is forbidden.\n` +
+              `Do not add Co-authored-by, Signed-off-by, '🤖 Generated with [Claude Code]',\n` +
+              `claude.ai/code links, noreply@anthropic.com co-authors, or any other AI\n` +
+              `agent attribution. The commit author is whoever owns the git config.\n` +
+              `Remove the attribution and retry.`,
           );
         }
       }

--- a/tests/git-police.test.ts
+++ b/tests/git-police.test.ts
@@ -62,6 +62,9 @@ describe('git-police', () => {
     const commands = [
       'git commit -m "fix stuff\n\nCo-authored-by: Claude <claude@anthropic.com>"',
       'git commit -m "fix\n\nCo-Authored-By: GPT"',
+      'git commit -m "fix\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)"',
+      'git commit -m "fix\n\nGenerated with [Claude Code](https://claude.ai/code)"',
+      'git commit -m "fix\n\nCo-Authored-By: Claude <noreply@anthropic.com>"',
     ];
 
     for (const cmd of commands) {


### PR DESCRIPTION
## Summary

Two bugs let AI attribution slip through into commits:

1. The bash hook's commit-attribution check referenced an undefined `$TOOL_INPUT` variable instead of the `$INPUT` payload it actually reads from stdin, so the rule silently never matched. (Hit this in practice — committed two PRs with AI trailers despite the hook being installed.)
2. The pattern only looked for `co-authored-by`. Claude Code's default commit-message footer also includes a `🤖 Generated with [Claude Code]` line, a `claude.ai/code` URL, and frequently a `noreply@anthropic.com` co-author. None of those triggered the rule.

This PR fixes the typo, broadens the regex (in both the bash hook and the OpenCode TypeScript plugin), and adds tests for the new patterns.

After this lands, run `./install.sh --global` to refresh the local copy at `~/.claude/hooks/git-police.sh`.

## Test plan

- [x] `bun test tests/git-police.test.ts` — 29 pass
- [x] Manual: piping a fake `tool_input` JSON with each blocked pattern through `bash hooks/claude/git-police.sh` returns a `permissionDecision: "deny"` for each
- [x] Manual: a normal `git push origin <branch>` still passes; `git status`, `git diff`, etc. unaffected