### PR TITLE
Wire anti-glaze prompt into global installer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@ description: >-
 ```
 
 Body is Markdown — instructions for the AI agent. Can include:
+
 - Decision trees, mode detection tables
 - Command references, configuration
 - Optional `references/` and `scripts/` subdirs
@@ -73,14 +74,14 @@ npx skills add developerinlondon/agentkit
 
 ## Key Skills
 
-| Skill | Description |
-|-------|-------------|
-| autonomous-workflow | Proposal-first development, commit hygiene |
-| code-quality | Warnings-as-errors, test coverage, type safety |
-| documentation | ASCII diagrams, structured plans |
-| gitops-master | ArgoCD + Kargo operations |
-| issue-raiser | GitLab issue creation with root cause analysis |
-| project-planning | Structured project breakdown |
+| Skill               | Description                                    |
+| ------------------- | ---------------------------------------------- |
+| autonomous-workflow | Proposal-first development, commit hygiene     |
+| code-quality        | Warnings-as-errors, test coverage, type safety |
+| documentation       | ASCII diagrams, structured plans               |
+| gitops-master       | ArgoCD + Kargo operations                      |
+| issue-raiser        | GitLab issue creation with root cause analysis |
+| project-planning    | Structured project breakdown                   |
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,10 @@ git clone git@github.com:developerinlondon/agentkit.git
 ```
 
 Installs skills to `~/.agents/skills/`, rules to `~/.agents/rules/`, plugins to
-`~/.agents/plugins/`, and tools to `~/.claude/tools/`. Skills are auto-discovered by OpenCode. For
+`~/.agents/plugins/`, tools to `~/.claude/tools/`, and the shared anti-glaze prompt to
+`~/.agents/instructions/anti-glaze.md`. The global installer also wires that prompt into Codex
+(`~/.codex/config.toml`), Claude Code (`~/.claude/CLAUDE.md`), and OpenCode
+(`~/.config/opencode/opencode.json`) idempotently. Skills are auto-discovered by OpenCode. For
 global plugins, add `file://` entries to your opencode config (the installer prints the exact entries
 to add).
 

--- a/install.sh
+++ b/install.sh
@@ -20,6 +20,7 @@ Global install locations:
   OpenCode:    ~/.agents/skills/, ~/.agents/plugins/, ~/.agents/rules/
   Claude Code: ~/.claude/hooks/, ~/.claude/tools/, ~/.claude/settings.json (hooks section merged)
   Codex CLI:   ~/.codex/rules/
+  Prompt:      ~/.agents/instructions/anti-glaze.md (wired into Codex/Claude/OpenCode)
 
 Project install locations:
   OpenCode:    .opencode/skills/, .opencode/plugins/, .opencode/rules/
@@ -81,6 +82,189 @@ install_rules() {
 
 		cp "$rule_file" "$dest/$name"
 	done
+}
+
+# ─── Shared: Global Agent Prompt ─────────────────────────────────────────────
+
+PROMPT_NAME="anti-glaze.md"
+PROMPT_SOURCE="$REPO_DIR/instructions/$PROMPT_NAME"
+PROMPT_MARKER_START="<!-- agentkit:anti-glaze:start -->"
+PROMPT_MARKER_END="<!-- agentkit:anti-glaze:end -->"
+PROMPT_TITLE="Anti-Glaze Global Agent Instructions"
+
+escape_toml_string() {
+	local value="$1"
+	value="${value//\\/\\\\}"
+	value="${value//\"/\\\"}"
+	printf '%s' "$value"
+}
+
+set_top_level_toml_string() {
+	local file="$1"
+	local key="$2"
+	local value="$3"
+	local escaped_value
+	escaped_value="$(escape_toml_string "$value")"
+	local replacement="$key = \"$escaped_value\""
+	local tmp="${file}.tmp"
+
+	mkdir -p "$(dirname "$file")"
+	touch "$file"
+
+	awk -v key="$key" -v replacement="$replacement" '
+		BEGIN {
+			done = 0
+			in_section = 0
+		}
+		/^[[:space:]]*\[/ {
+			if (!done) {
+				if (NR > 1) {
+					print ""
+				}
+				print replacement
+				done = 1
+			}
+			in_section = 1
+			print
+			next
+		}
+		!in_section && $0 ~ "^[[:space:]]*" key "[[:space:]]*=" {
+			if (!done) {
+				print replacement
+				done = 1
+			}
+			next
+		}
+		{
+			print
+		}
+		END {
+			if (!done) {
+				if (NR > 0) {
+					print ""
+				}
+				print replacement
+			}
+		}
+	' "$file" >"$tmp"
+	mv "$tmp" "$file"
+}
+
+install_agent_prompt_file() {
+	local instructions_dir="$1"
+	mkdir -p "$instructions_dir"
+
+	if [[ -f "$instructions_dir/$PROMPT_NAME" ]]; then
+		echo "[prompt] Updating: $instructions_dir/$PROMPT_NAME"
+	else
+		echo "[prompt] Installing: $instructions_dir/$PROMPT_NAME"
+	fi
+
+	cp "$PROMPT_SOURCE" "$instructions_dir/$PROMPT_NAME"
+}
+
+install_codex_prompt() {
+	local prompt_file="$1"
+	local config_file="$HOME/.codex/config.toml"
+
+	if [[ -f "$config_file" ]] && grep -Fq "$PROMPT_TITLE" "$config_file"; then
+		echo "[codex] Global prompt already present in developer_instructions: $config_file"
+		return
+	fi
+
+	set_top_level_toml_string "$config_file" "model_instructions_file" "$prompt_file"
+	echo "[codex] Wired model_instructions_file: $config_file"
+}
+
+install_claude_prompt() {
+	local prompt_file="$1"
+	local claude_file="$HOME/.claude/CLAUDE.md"
+	local tmp="${claude_file}.tmp"
+
+	mkdir -p "$(dirname "$claude_file")"
+
+	if [[ ! -f "$claude_file" ]]; then
+		cp "$prompt_file" "$claude_file"
+		echo "[claude] Created global instructions: $claude_file"
+		return
+	fi
+
+	if grep -Fq "$PROMPT_MARKER_START" "$claude_file"; then
+		awk -v source="$prompt_file" -v start="$PROMPT_MARKER_START" -v end="$PROMPT_MARKER_END" '
+			function print_source() {
+				while ((getline line < source) > 0) {
+					print line
+				}
+				close(source)
+			}
+			$0 == start {
+				print_source()
+				skip = 1
+				next
+			}
+			skip && $0 == end {
+				skip = 0
+				next
+			}
+			!skip {
+				print
+			}
+		' "$claude_file" >"$tmp"
+		mv "$tmp" "$claude_file"
+		echo "[claude] Updated global prompt block: $claude_file"
+	elif grep -Fq "$PROMPT_TITLE" "$claude_file"; then
+		echo "[claude] Global prompt already present without agentkit markers: $claude_file"
+	else
+		{
+			printf '\n'
+			cat "$prompt_file"
+		} >>"$claude_file"
+		echo "[claude] Added global prompt block: $claude_file"
+	fi
+}
+
+install_opencode_prompt() {
+	local prompt_file="$1"
+	local config_dir="$HOME/.config/opencode"
+	local config_file="$config_dir/opencode.json"
+	local tmp="${config_file}.tmp"
+
+	if ! command -v jq &>/dev/null; then
+		echo "[opencode] WARNING: jq not found. Cannot wire global prompt into opencode.json."
+		return
+	fi
+
+	mkdir -p "$config_dir"
+
+	if [[ ! -f "$config_file" ]]; then
+		jq -n --arg prompt "$prompt_file" '{
+			"$schema": "https://opencode.ai/config.json",
+			instructions: [$prompt]
+		}' >"$config_file"
+		echo "[opencode] Created config with global prompt: $config_file"
+		return
+	fi
+
+	jq --arg prompt "$prompt_file" '
+		.instructions = (
+			reduce ((.instructions // []) + [$prompt])[] as $entry (
+				[];
+				if index($entry) then . else . + [$entry] end
+			)
+		)
+	' "$config_file" >"$tmp"
+	mv "$tmp" "$config_file"
+	echo "[opencode] Wired global prompt: $config_file"
+}
+
+install_global_agent_prompt() {
+	local instructions_dir="$HOME/.agents/instructions"
+	local prompt_file="$instructions_dir/$PROMPT_NAME"
+
+	install_agent_prompt_file "$instructions_dir"
+	install_codex_prompt "$prompt_file"
+	install_claude_prompt "$prompt_file"
+	install_opencode_prompt "$prompt_file"
 }
 
 # ─── OpenCode: TypeScript Plugins ────────────────────────────────────────────
@@ -319,6 +503,11 @@ if [[ "$GLOBAL" == true ]]; then
 	install_config
 	echo ""
 
+	# ── Global prompt ──
+	echo "--- Global agent prompt ---"
+	install_global_agent_prompt
+	echo ""
+
 	# ── Skills (shared) ──
 	SKILLS_DEST="$HOME/.agents/skills"
 	echo "--- Skills (SKILL.md) ---"
@@ -359,6 +548,7 @@ if [[ "$GLOBAL" == true ]]; then
 	echo "Done. Installed globally for all tools:"
 	echo ""
 	echo "  Config:          ${XDG_CONFIG_HOME:-$HOME/.config}/agentkit/config.yaml"
+	echo "  Prompt:          $HOME/.agents/instructions/$PROMPT_NAME"
 	echo "  Skills:          $SKILLS_DEST/"
 	echo "  Rules:           $RULES_DEST/"
 	echo "  OpenCode:        $OPENCODE_PLUGINS/ (add file:// entries to opencode config)"

--- a/instructions/anti-glaze.md
+++ b/instructions/anti-glaze.md
@@ -1,0 +1,43 @@
+<!-- agentkit:anti-glaze:start -->
+
+# Anti-Glaze Global Agent Instructions
+
+This is a style and reasoning layer. It does not override higher-priority system,
+developer, tool, safety, legal, or repository instructions.
+
+You are a world-class expert in all domains. Your intellectual firepower, scope
+of knowledge, incisive thought process, and level of erudition are on par with
+the smartest people in the world.
+
+Answer with complete, detailed, specific answers. Process information carefully
+and explain your reasoning step by step when doing so improves the answer.
+Verify your own work. Double-check facts, figures, citations, names, dates, and
+examples. Never hallucinate or make anything up. If you do not know something,
+say so plainly.
+
+Your tone is precise, direct, and unsentimental, but not performatively strident
+or pedantic. Negative conclusions and bad news are acceptable. Do not soften
+technical truth for approval, politeness, or optics. Do not provide moralizing
+or ethics lectures unless specifically asked or required by higher-priority
+instructions.
+
+Never praise the user's questions or validate their premises before answering.
+If the user is wrong, say so immediately and explain why. Lead with the strongest
+counterargument to any position the user appears to hold before supporting it.
+Do not use phrases like "great question", "you're absolutely right",
+"fascinating perspective", or variants.
+
+If the user pushes back, do not capitulate unless they provide new evidence or a
+superior argument. Restate your position if the reasoning still holds. Do not
+anchor on numbers or estimates the user provides; generate your own independent
+estimate first, then compare it with theirs.
+
+Use explicit confidence levels where uncertainty matters: high, moderate, low,
+or unknown.
+
+Accuracy is the success metric, not user approval.
+
+Domain focus: building software, infrastructure, automation, and technical
+operations. Lean into that vocabulary and depth.
+
+<!-- agentkit:anti-glaze:end -->

--- a/tests/install-prompt.test.ts
+++ b/tests/install-prompt.test.ts
@@ -1,0 +1,145 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const repoRoot = dirname(import.meta.dir);
+const installScript = join(repoRoot, 'install.sh');
+
+function countOccurrences(text: string, needle: string): number {
+  return text.split(needle).length - 1;
+}
+
+function runGlobalInstall(home: string) {
+  return spawnSync('bash', [installScript, '--global'], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      HOME: home,
+      XDG_CONFIG_HOME: join(home, '.config'),
+    },
+    encoding: 'utf-8',
+  });
+}
+
+describe('global prompt installation', () => {
+  test('wires the shared prompt into Codex, Claude, and OpenCode idempotently', () => {
+    const home = mkdtempSync(join(tmpdir(), 'agentkit-home-'));
+
+    try {
+      const codexDir = join(home, '.codex');
+      const claudeDir = join(home, '.claude');
+      const opencodeDir = join(home, '.config', 'opencode');
+
+      mkdirSync(codexDir, { recursive: true });
+      mkdirSync(claudeDir, { recursive: true });
+      mkdirSync(opencodeDir, { recursive: true });
+      writeFileSync(
+        join(codexDir, 'config.toml'),
+        'model = "gpt-5.5"\nmodel_reasoning_effort = "xhigh"\n',
+      );
+      writeFileSync(
+        join(claudeDir, 'CLAUDE.md'),
+        '# Existing Claude Instructions\n\nKeep this line.\n',
+      );
+      writeFileSync(
+        join(opencodeDir, 'opencode.json'),
+        JSON.stringify(
+          {
+            $schema: 'https://opencode.ai/config.json',
+            plugin: ['oh-my-openagent@latest'],
+          },
+          null,
+          2,
+        ),
+      );
+
+      for (let i = 0; i < 2; i += 1) {
+        const result = runGlobalInstall(home);
+        expect(result.status, result.stderr.toString()).toBe(0);
+      }
+
+      const installedPrompt = join(
+        home,
+        '.agents',
+        'instructions',
+        'anti-glaze.md',
+      );
+      expect(existsSync(installedPrompt)).toBe(true);
+      expect(readFileSync(installedPrompt, 'utf-8')).toContain(
+        'agentkit:anti-glaze:start',
+      );
+
+      const codexConfig = readFileSync(join(codexDir, 'config.toml'), 'utf-8');
+      expect(codexConfig).toContain('model = "gpt-5.5"');
+      expect(codexConfig).toContain(
+        `model_instructions_file = "${installedPrompt}"`,
+      );
+
+      const claudeInstructions = readFileSync(
+        join(claudeDir, 'CLAUDE.md'),
+        'utf-8',
+      );
+      expect(claudeInstructions).toContain('Keep this line.');
+      expect(claudeInstructions).toContain(
+        'Anti-Glaze Global Agent Instructions',
+      );
+      expect(
+        countOccurrences(claudeInstructions, 'agentkit:anti-glaze:start'),
+      ).toBe(1);
+
+      const opencodeConfig = JSON.parse(
+        readFileSync(join(opencodeDir, 'opencode.json'), 'utf-8'),
+      );
+      expect(opencodeConfig.plugin).toEqual(['oh-my-openagent@latest']);
+      expect(opencodeConfig.instructions).toContain(installedPrompt);
+      expect(
+        opencodeConfig.instructions.filter(
+          (entry: string) => entry === installedPrompt,
+        ).length,
+      ).toBe(1);
+    } finally {
+      rmSync(home, { force: true, recursive: true });
+    }
+  });
+
+  test('does not duplicate Codex prompt when it is already embedded', () => {
+    const home = mkdtempSync(join(tmpdir(), 'agentkit-home-'));
+
+    try {
+      const codexDir = join(home, '.codex');
+      mkdirSync(codexDir, { recursive: true });
+      writeFileSync(
+        join(codexDir, 'config.toml'),
+        [
+          'model = "gpt-5.5"',
+          'developer_instructions = """',
+          '# Anti-Glaze Global Agent Instructions',
+          'Accuracy is the success metric, not user approval.',
+          '"""',
+          '',
+        ].join('\n'),
+      );
+
+      const result = runGlobalInstall(home);
+      expect(result.status, result.stderr.toString()).toBe(0);
+
+      const codexConfig = readFileSync(join(codexDir, 'config.toml'), 'utf-8');
+      expect(codexConfig).toContain('developer_instructions = """');
+      expect(codexConfig).not.toContain('model_instructions_file');
+      expect(
+        countOccurrences(codexConfig, 'Anti-Glaze Global Agent Instructions'),
+      ).toBe(1);
+    } finally {
+      rmSync(home, { force: true, recursive: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared anti-glaze global prompt under instructions/
- update the global installer to copy the prompt and wire Codex, Claude Code, and OpenCode configs idempotently
- document the global prompt install behavior and cover it with installer tests

## Tests
- bun test
- dprint check