### PR TITLE
fix(git-police): match `git commit` as subcommand, not literal substring

### DIFF
--- a/hooks/claude/git-police.sh
+++ b/hooks/claude/git-police.sh
@@ -87,16 +87,20 @@ if echo "$STRIPPED" | grep -qiE '\bgit\b.*\bpush\b'; then
 	done
 fi
 
+# Detect `git commit` as a subcommand (not the literal substring "commit"
+# inside a config key like `git config commit.gpgsign`).
+GIT_COMMIT_RE='\bgit([[:space:]]+(-[A-Za-z][^[:space:]]*|--[A-Za-z][A-Za-z0-9-]*(=[^[:space:]]+)?)([[:space:]]+[^-[:space:]][^[:space:]]*)?)*[[:space:]]+commit\b'
+
 # 5. Block AI attribution trailers / signatures in commit commands.
 #    $INPUT is the full PreToolUse JSON payload from stdin; the previous
 #    version referenced an undefined $TOOL_INPUT and silently never matched.
-if echo "$STRIPPED" | grep -qiE '\bgit\b.*\bcommit\b' \
+if echo "$STRIPPED" | grep -qiE "$GIT_COMMIT_RE" \
 	&& echo "$INPUT" | grep -qiE 'co-authored-by|generated with \[claude code\]|🤖 generated|claude\.ai/code|noreply@anthropic\.com'; then
 	deny "BLOCKED: AI attribution in commit messages is forbidden. Do not add Co-authored-by, Signed-off-by, '🤖 Generated with [Claude Code]', claude.ai/code links, noreply@anthropic.com co-authors, or any other AI agent attribution. The commit author is whoever owns the git config. Remove the attribution and retry."
 fi
 
 # 6. Block direct commits to protected branches
-if echo "$STRIPPED" | grep -qiE '\bgit\b.*\bcommit\b'; then
+if echo "$STRIPPED" | grep -qiE "$GIT_COMMIT_RE"; then
 	CURRENT_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
 	for branch in "${PROTECTED_BRANCHES[@]}"; do
 		if [[ "$CURRENT_BRANCH" == "$branch" ]]; then

--- a/plugins/git-police.ts
+++ b/plugins/git-police.ts
@@ -77,7 +77,11 @@ function getCurrentBranch(cwd: string): string | null {
 }
 
 function isGitCommitCommand(command: string): boolean {
-  return /\bgit\b.*\bcommit\b/i.test(command);
+  // Match `git commit` as a subcommand, not the literal substring "commit"
+  // inside config keys like `git config commit.gpgsign`.
+  return /\bgit(\s+(-[A-Za-z]\S*|--[A-Za-z][A-Za-z0-9-]*(=\S+)?)(\s+[^-\s]\S*)?)*\s+commit\b/i.test(
+    command,
+  );
 }
 
 function isGitPushToProtected(command: string): boolean {


### PR DESCRIPTION
## Summary

The git-police hook (and OpenCode plugin) used `\bgit\b.*\bcommit\b` to detect `git commit` commands. That regex matches the literal substring `commit` anywhere after `git`, so it false-positives on:

- `git config --global commit.gpgsign`
- `git config commit.gpgsign true`
- `git -c commit.template=… <anything>`

…blocking legitimate read-only config queries on protected branches with `"Committing directly to main is forbidden."`

## Fix

Tighten the regex to require `commit` to follow `git` with only flag-shaped tokens between them (e.g. `-C path`, `-c key=val`, `--no-pager`, `--git-dir=…`). Applied to:

- `hooks/claude/git-police.sh` — both call sites (AI-attribution check + protected-branch check)
- `plugins/git-police.ts` — `isGitCommitCommand`

## Test plan

- [x] Regex unit cases pass (13/13): plain commit, --amend, `-C path commit`, `-c key=val commit`, `--no-pager commit`, compound shells, vs. `config commit.gpgsign`, `log --grep commit-fix`, `log feat/commit-helper`, `rev-parse some-commit-name`.
- [x] On a real protected branch: `git config --global --get commit.gpgsign` no longer blocked.
- [x] Hook still blocks `git commit -m foo` on main.
- [x] Commit on this branch was signed and merged via the new path (proves the protected-branch check still works for actual commits).