### PR TITLE
chore: dprint config covers yaml; ignore .omc/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 bun.lock
+.omc/

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -58,7 +58,7 @@ comment-police:
     - 'closes\s*#\d+'
     - 'fixes\s*#\d+'
     - 'TODO[: ]+(for|after|once)\b'
-    - 'as part of (this|the) (PR|MR|fix)'
+    - "as part of (this|the) (PR|MR|fix)"
 
   # File path patterns to exclude from checks.
   exclude-patterns: []

--- a/dprint.json
+++ b/dprint.json
@@ -5,11 +5,15 @@
   },
   "json": {},
   "toml": {},
-  "includes": ["**/*.md", "**/*.json", "**/*.toml"],
-  "excludes": [".git"],
+  "yaml": {
+    "printWidth": 100
+  },
+  "includes": ["**/*.md", "**/*.json", "**/*.toml", "**/*.yaml", "**/*.yml"],
+  "excludes": [".git", ".omc", "node_modules"],
   "plugins": [
     "https://plugins.dprint.dev/markdown-0.17.8.wasm",
     "https://plugins.dprint.dev/json-0.19.4.wasm",
-    "https://plugins.dprint.dev/toml-0.6.3.wasm"
+    "https://plugins.dprint.dev/toml-0.6.3.wasm",
+    "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.6.0.wasm"
   ]
 }

--- a/skills/gitops-master/SKILL.md
+++ b/skills/gitops-master/SKILL.md
@@ -44,16 +44,16 @@ Before running ANY kubectl command, you MUST discover the environment. Follow th
 
 ```yaml
 # Expected format:
-ssh_command: "MISE_ENV=test mise run server:ssh"   # How to reach the cluster (omit if local kubectl works)
-kargo_namespace: "kargo-my-project-test"            # Kargo project namespace
-kargo_controller_namespace: "kargo"                  # Where Kargo controller runs (may differ from default)
-argocd_namespace: "infra"                           # ArgoCD apps namespace
-argocd_controller_namespace: "argocd"                # Where ArgoCD controller runs (may differ from default)
-monitoring_namespace: "monitoring"                   # Monitoring namespace
-app_namespace: "my-app-test"                         # Application namespace
-domain: "example.com"                                # Cluster domain
-kargo_project: "my-project"                          # Kargo project name
-warehouse_name: "platform-apps"                      # Kargo warehouse name
+ssh_command: "MISE_ENV=test mise run server:ssh" # How to reach the cluster (omit if local kubectl works)
+kargo_namespace: "kargo-my-project-test" # Kargo project namespace
+kargo_controller_namespace: "kargo" # Where Kargo controller runs (may differ from default)
+argocd_namespace: "infra" # ArgoCD apps namespace
+argocd_controller_namespace: "argocd" # Where ArgoCD controller runs (may differ from default)
+monitoring_namespace: "monitoring" # Monitoring namespace
+app_namespace: "my-app-test" # Application namespace
+domain: "example.com" # Cluster domain
+kargo_project: "my-project" # Kargo project name
+warehouse_name: "platform-apps" # Kargo warehouse name
 ```
 
 ### Step 2: If no config file, auto-discover from cluster
@@ -638,14 +638,14 @@ spec:
                     command: ["/bin/bash", "-c"]
                     args:
                       - |
-                          # Level 1: Check pods
-                          kubectl get pods -n <namespace> --no-headers | grep -v Running && exit 1
+                        # Level 1: Check pods
+                        kubectl get pods -n <namespace> --no-headers | grep -v Running && exit 1
 
-                          # Level 2: Check health
-                          kubectl exec -n <namespace> deploy/<name> -- wget -qO- http://localhost:<port>/health || exit 1
+                        # Level 2: Check health
+                        kubectl exec -n <namespace> deploy/<name> -- wget -qO- http://localhost:<port>/health || exit 1
 
-                          echo "All checks passed"
-                          exit 0
+                        echo "All checks passed"
+                        exit 0
 ```
 
 ### RBAC for Verification Jobs


### PR DESCRIPTION
## Summary

- Add YAML plugin (`g-plane/pretty_yaml`) with `printWidth: 100` so `.yml`/`.yaml` files are kept formatted.
- Extend `includes` to cover `.yaml` / `.yml`.
- Extend `excludes` with `.omc` (OMC runtime state) and `node_modules`.
- Add `.omc/` to `.gitignore` so OMC runtime state is never committed.
- Reformat the two files that the new config touches:
  - `config.example.yaml` — pretty_yaml normalises single-quoted strings to double-quoted (its default).
  - `skills/gitops-master/SKILL.md` — embedded YAML fenced block has trailing-comment column-alignment collapsed; one bash-in-yaml fenced block has indentation normalised.

## Test plan

- [x] `dprint fmt` is idempotent on a fresh checkout (no second-pass diff).
- [x] `dprint check` passes locally.
- [x] PR is signed (GPG key `11F993FCF5EEE14C`).