### PR TITLE
feat: add coding-discipline global instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ Reusable AI agent skills, rules, plugins, hooks, and tools for OpenCode, Claude 
 | **coding-police.rules**  | Coding standards guidance + prompts on heredoc/tee writes that may produce oversized files |
 | **pkg-police.rules**     | Enforces bun as package manager — blocks npm, npx, yarn, pnpm commands                     |
 
+### Instructions (global agent prompts wired into Claude / Codex / OpenCode)
+
+| Instruction              | Description                                                                                         |
+| ------------------------ | --------------------------------------------------------------------------------------------------- |
+| **anti-glaze.md**        | Tone and reasoning layer: precise, direct, no sycophancy, explicit confidence levels                |
+| **coding-discipline.md** | 11-rule behavioral contract for code work (think first, simplicity, surgical changes, fail loud, …) |
+
 ## Installation
 
 ### Option 1: skills.sh CLI (skills only, all agents)
@@ -73,12 +80,13 @@ git clone git@github.com:developerinlondon/agentkit.git
 ```
 
 Installs skills to `~/.agents/skills/`, rules to `~/.agents/rules/`, plugins to
-`~/.agents/plugins/`, tools to `~/.claude/tools/`, and the shared anti-glaze prompt to
-`~/.agents/instructions/anti-glaze.md`. The global installer also wires that prompt into Codex
-(`~/.codex/config.toml`), Claude Code (`~/.claude/CLAUDE.md`), and OpenCode
-(`~/.config/opencode/opencode.json`) idempotently. Skills are auto-discovered by OpenCode. For
-global plugins, add `file://` entries to your opencode config (the installer prints the exact entries
-to add).
+`~/.agents/plugins/`, tools to `~/.claude/tools/`, and every `instructions/*.md` prompt to
+`~/.agents/instructions/`. The global installer wires every instruction file into Codex
+(`~/.codex/config.toml` — concatenated into `developer_instructions`), Claude Code
+(`~/.claude/CLAUDE.md` — one markered block per file), and OpenCode
+(`~/.config/opencode/opencode.json` — one entry per file in `instructions[]`) idempotently. Skills
+are auto-discovered by OpenCode. For global plugins, add `file://` entries to your opencode config
+(the installer prints the exact entries to add).
 
 ### Option 3: Install into a specific project
 

--- a/install.sh
+++ b/install.sh
@@ -20,7 +20,7 @@ Global install locations:
   OpenCode:    ~/.agents/skills/, ~/.agents/plugins/, ~/.agents/rules/
   Claude Code: ~/.claude/hooks/, ~/.claude/tools/, ~/.claude/settings.json (hooks section merged)
   Codex CLI:   ~/.codex/rules/
-  Prompt:      ~/.agents/instructions/anti-glaze.md (wired into Codex/Claude/OpenCode)
+  Prompts:     ~/.agents/instructions/*.md (wired into Codex/Claude/OpenCode)
 
 Project install locations:
   OpenCode:    .opencode/skills/, .opencode/plugins/, .opencode/rules/
@@ -84,13 +84,23 @@ install_rules() {
 	done
 }
 
-# ─── Shared: Global Agent Prompt ─────────────────────────────────────────────
+# ─── Shared: Global Agent Prompts ────────────────────────────────────────────
 
-PROMPT_NAME="anti-glaze.md"
-PROMPT_SOURCE="$REPO_DIR/instructions/$PROMPT_NAME"
-PROMPT_MARKER_START="<!-- agentkit:anti-glaze:start -->"
-PROMPT_MARKER_END="<!-- agentkit:anti-glaze:end -->"
-PROMPT_TITLE="Anti-Glaze Global Agent Instructions"
+prompt_basename() {
+	basename "$1" .md
+}
+
+prompt_marker_start() {
+	echo "<!-- agentkit:$(prompt_basename "$1"):start -->"
+}
+
+prompt_marker_end() {
+	echo "<!-- agentkit:$(prompt_basename "$1"):end -->"
+}
+
+prompt_title() {
+	grep -m1 '^# ' "$1" | sed 's/^# //'
+}
 
 set_codex_developer_instructions() {
 	local file="$1"
@@ -163,30 +173,64 @@ set_codex_developer_instructions() {
 
 install_agent_prompt_file() {
 	local instructions_dir="$1"
+	local source_file="$2"
+	local name
+	name="$(basename "$source_file")"
 	mkdir -p "$instructions_dir"
 
-	if [[ -f "$instructions_dir/$PROMPT_NAME" ]]; then
-		echo "[prompt] Updating: $instructions_dir/$PROMPT_NAME"
+	if [[ -f "$instructions_dir/$name" ]]; then
+		echo "[prompt] Updating: $instructions_dir/$name"
 	else
-		echo "[prompt] Installing: $instructions_dir/$PROMPT_NAME"
+		echo "[prompt] Installing: $instructions_dir/$name"
 	fi
 
-	cp "$PROMPT_SOURCE" "$instructions_dir/$PROMPT_NAME"
+	cp "$source_file" "$instructions_dir/$name"
 }
 
-install_codex_prompt() {
-	local prompt_file="$1"
+codex_has_managed_prompt() {
+	local config_file="$1"
+	local instructions_dir="$2"
+	local prompt_file title
+	if grep -Fq "agentkit:" "$config_file"; then
+		return 0
+	fi
+	for prompt_file in "$instructions_dir"/*.md; do
+		[[ -f "$prompt_file" ]] || continue
+		title="$(prompt_title "$prompt_file")"
+		if [[ -n "$title" ]] && grep -Fq "$title" "$config_file"; then
+			return 0
+		fi
+	done
+	return 1
+}
+
+install_codex_prompts() {
+	local instructions_dir="$1"
 	local config_file="$HOME/.codex/config.toml"
 
 	if [[ -f "$config_file" ]] \
 		&& grep -Eq '^[[:space:]]*developer_instructions[[:space:]]*=' "$config_file" \
-		&& ! grep -Fq "$PROMPT_TITLE" "$config_file" \
-		&& ! grep -Fq "$PROMPT_MARKER_START" "$config_file"; then
+		&& ! codex_has_managed_prompt "$config_file" "$instructions_dir"; then
 		echo "[codex] WARNING: developer_instructions already exists without agentkit prompt; leaving unchanged: $config_file"
 		return
 	fi
 
-	set_codex_developer_instructions "$config_file" "$prompt_file"
+	local combined_file
+	combined_file="$(mktemp)"
+	local first=true
+	local prompt_file
+	for prompt_file in "$instructions_dir"/*.md; do
+		[[ -f "$prompt_file" ]] || continue
+		if $first; then
+			first=false
+		else
+			echo "" >>"$combined_file"
+		fi
+		cat "$prompt_file" >>"$combined_file"
+	done
+
+	set_codex_developer_instructions "$config_file" "$combined_file"
+	rm -f "$combined_file"
 	echo "[codex] Wired developer_instructions: $config_file"
 }
 
@@ -194,17 +238,25 @@ install_claude_prompt() {
 	local prompt_file="$1"
 	local claude_file="$HOME/.claude/CLAUDE.md"
 	local tmp="${claude_file}.tmp"
+	local name
+	local marker_start
+	local marker_end
+	local title
+	name="$(basename "$prompt_file")"
+	marker_start="$(prompt_marker_start "$prompt_file")"
+	marker_end="$(prompt_marker_end "$prompt_file")"
+	title="$(prompt_title "$prompt_file")"
 
 	mkdir -p "$(dirname "$claude_file")"
 
 	if [[ ! -f "$claude_file" ]]; then
 		cp "$prompt_file" "$claude_file"
-		echo "[claude] Created global instructions: $claude_file"
+		echo "[claude] Created global instructions with $name: $claude_file"
 		return
 	fi
 
-	if grep -Fq "$PROMPT_MARKER_START" "$claude_file"; then
-		awk -v source="$prompt_file" -v start="$PROMPT_MARKER_START" -v end="$PROMPT_MARKER_END" '
+	if grep -Fq "$marker_start" "$claude_file"; then
+		awk -v source="$prompt_file" -v start="$marker_start" -v end="$marker_end" '
 			function print_source() {
 				while ((getline line < source) > 0) {
 					print line
@@ -225,15 +277,15 @@ install_claude_prompt() {
 			}
 		' "$claude_file" >"$tmp"
 		mv "$tmp" "$claude_file"
-		echo "[claude] Updated global prompt block: $claude_file"
-	elif grep -Fq "$PROMPT_TITLE" "$claude_file"; then
-		echo "[claude] Global prompt already present without agentkit markers: $claude_file"
+		echo "[claude] Updated prompt block ($name): $claude_file"
+	elif [[ -n "$title" ]] && grep -Fq "$title" "$claude_file"; then
+		echo "[claude] Prompt already present without agentkit markers ($name): $claude_file"
 	else
 		{
 			printf '\n'
 			cat "$prompt_file"
 		} >>"$claude_file"
-		echo "[claude] Added global prompt block: $claude_file"
+		echo "[claude] Added prompt block ($name): $claude_file"
 	fi
 }
 
@@ -273,12 +325,28 @@ install_opencode_prompt() {
 
 install_global_agent_prompt() {
 	local instructions_dir="$HOME/.agents/instructions"
-	local prompt_file="$instructions_dir/$PROMPT_NAME"
+	mkdir -p "$instructions_dir"
 
-	install_agent_prompt_file "$instructions_dir"
-	install_codex_prompt "$prompt_file"
-	install_claude_prompt "$prompt_file"
-	install_opencode_prompt "$prompt_file"
+	local source_file
+	local found=false
+	for source_file in "$REPO_DIR"/instructions/*.md; do
+		[[ -f "$source_file" ]] || continue
+		install_agent_prompt_file "$instructions_dir" "$source_file"
+		found=true
+	done
+
+	if ! $found; then
+		return
+	fi
+
+	install_codex_prompts "$instructions_dir"
+
+	local prompt_file
+	for prompt_file in "$instructions_dir"/*.md; do
+		[[ -f "$prompt_file" ]] || continue
+		install_claude_prompt "$prompt_file"
+		install_opencode_prompt "$prompt_file"
+	done
 }
 
 # ─── OpenCode: TypeScript Plugins ────────────────────────────────────────────
@@ -562,7 +630,7 @@ if [[ "$GLOBAL" == true ]]; then
 	echo "Done. Installed globally for all tools:"
 	echo ""
 	echo "  Config:          ${XDG_CONFIG_HOME:-$HOME/.config}/agentkit/config.yaml"
-	echo "  Prompt:          $HOME/.agents/instructions/$PROMPT_NAME"
+	echo "  Prompts:         $HOME/.agents/instructions/*.md"
 	echo "  Skills:          $SKILLS_DEST/"
 	echo "  Rules:           $RULES_DEST/"
 	echo "  OpenCode:        $OPENCODE_PLUGINS/ (add file:// entries to opencode config)"

--- a/instructions/coding-discipline.md
+++ b/instructions/coding-discipline.md
@@ -1,0 +1,89 @@
+<!-- agentkit:coding-discipline:start -->
+
+# Coding Discipline
+
+Default behavior for code work in this project. Bias toward caution over speed on non-trivial
+changes. Use judgment on trivial tasks.
+
+## 1. Think before coding
+
+State assumptions explicitly. If uncertain, ask rather than guess. Present multiple
+interpretations when something is ambiguous. Push back when a simpler approach exists. Stop
+when confused and name what is unclear.
+
+## 2. Simplicity first
+
+Minimum code that solves the stated problem. Nothing speculative. No features beyond what was
+asked. No abstractions for single-use code. If a senior engineer would call it overcomplicated,
+simplify.
+
+## 3. Surgical changes
+
+Touch only what the task requires. Clean up only your own mess. Do not improve adjacent code,
+comments, or formatting. Do not refactor what is not broken. Match the existing style.
+
+## 4. Goal-driven execution
+
+Define success criteria up front, then loop until verified. Strong success criteria let you
+iterate independently — do not follow steps blindly.
+
+## 5. Use the model for judgment, not deterministic work
+
+Use the agent for classification, drafting, summarization, extraction. Do not route, retry, or
+run deterministic transforms through the model. If code can answer, code answers.
+
+## 6. Surface conflicts; do not average them
+
+When two patterns in the codebase contradict, pick one — typically the more recent or more
+tested. Explain why. Flag the other for cleanup. Do not blend them.
+
+## 7. Read before you write
+
+Before adding code, read the file's exports, immediate callers, and the shared utilities it
+depends on. "Looks orthogonal" is dangerous. If you do not understand why nearby code is
+structured the way it is, ask.
+
+## 8. Tests verify intent, not just behavior
+
+Tests must encode why the behavior matters, not only what the code does. A test that cannot
+fail when the underlying business rule changes is the wrong test.
+
+## 9. Checkpoint after every significant step
+
+Summarize what was done, what is verified, and what is left. Do not continue from a state you
+cannot describe back. If you lose track, stop and restate.
+
+## 10. Match the codebase's conventions
+
+Conformance beats personal taste inside the codebase. If a convention is genuinely harmful,
+raise it explicitly rather than silently forking.
+
+## 11. Fail loud
+
+"Completed" is wrong if anything was skipped silently. "Tests pass" is wrong if any were
+skipped. Default to surfacing uncertainty, not hiding it.
+
+## Where these are mechanically enforced
+
+These rules are behavioral; the agentkit hook portfolio enforces the adjacent concrete slices:
+
+- Rule 2 (simplicity) — `coding-police` enforces the file (≤1000 lines), function
+  (≤100 lines), duplication (≥6 lines), and per-file export caps.
+- Rule 7 (read before write) — Claude Code natively errors when you Edit a file without a
+  prior Read of that same file. The broader "read exports and callers first" is on the agent.
+- Rule 10 (conventions) — `format-police` runs dprint on every write/edit; `comment-police`
+  enforces comment discipline.
+- Rule 11 (fail loud) — `git-police` blocks `--no-verify`, AI-attribution trailers, force
+  push, and direct commits to protected branches.
+
+Everything else is on the agent to honor.
+
+## Source
+
+Adapted from Mnimiy's "12-rule CLAUDE.md template"
+(https://x.com/Mnilax/status/2053116311132155938), itself building on the original four rules
+attributed to Andrej Karpathy. Rule 6 from the source (per-task and per-session token budgets)
+is intentionally omitted — agentkit ships static instructions and cannot enforce runtime token
+caps.
+
+<!-- agentkit:coding-discipline:end -->

--- a/tests/install-prompt.test.ts
+++ b/tests/install-prompt.test.ts
@@ -31,7 +31,7 @@ function runGlobalInstall(home: string) {
 }
 
 describe('global prompt installation', () => {
-  test('wires the shared prompt into Codex, Claude, and OpenCode idempotently', () => {
+  test('wires every instructions file into Codex, Claude, and OpenCode idempotently', () => {
     const home = mkdtempSync(join(tmpdir(), 'agentkit-home-'));
 
     try {
@@ -67,25 +67,32 @@ describe('global prompt installation', () => {
         expect(result.status, result.stderr.toString()).toBe(0);
       }
 
-      const installedPrompt = join(
+      const antiGlaze = join(home, '.agents', 'instructions', 'anti-glaze.md');
+      const codingDiscipline = join(
         home,
         '.agents',
         'instructions',
-        'anti-glaze.md',
+        'coding-discipline.md',
       );
-      expect(existsSync(installedPrompt)).toBe(true);
-      expect(readFileSync(installedPrompt, 'utf-8')).toContain(
+      expect(existsSync(antiGlaze)).toBe(true);
+      expect(existsSync(codingDiscipline)).toBe(true);
+      expect(readFileSync(antiGlaze, 'utf-8')).toContain(
         'agentkit:anti-glaze:start',
+      );
+      expect(readFileSync(codingDiscipline, 'utf-8')).toContain(
+        'agentkit:coding-discipline:start',
       );
 
       const codexConfig = readFileSync(join(codexDir, 'config.toml'), 'utf-8');
       expect(codexConfig).toContain('model = "gpt-5.5"');
       expect(codexConfig).toContain('developer_instructions = """');
-      expect(codexConfig).toContain('agentkit:anti-glaze:start');
       expect(codexConfig).not.toContain('model_instructions_file');
       expect(countOccurrences(codexConfig, 'agentkit:anti-glaze:start')).toBe(
         1,
       );
+      expect(
+        countOccurrences(codexConfig, 'agentkit:coding-discipline:start'),
+      ).toBe(1);
 
       const claudeInstructions = readFileSync(
         join(claudeDir, 'CLAUDE.md'),
@@ -95,18 +102,28 @@ describe('global prompt installation', () => {
       expect(claudeInstructions).toContain(
         'Anti-Glaze Global Agent Instructions',
       );
+      expect(claudeInstructions).toContain('Coding Discipline');
       expect(
         countOccurrences(claudeInstructions, 'agentkit:anti-glaze:start'),
+      ).toBe(1);
+      expect(
+        countOccurrences(claudeInstructions, 'agentkit:coding-discipline:start'),
       ).toBe(1);
 
       const opencodeConfig = JSON.parse(
         readFileSync(join(opencodeDir, 'opencode.json'), 'utf-8'),
       );
       expect(opencodeConfig.plugin).toEqual(['oh-my-openagent@latest']);
-      expect(opencodeConfig.instructions).toContain(installedPrompt);
+      expect(opencodeConfig.instructions).toContain(antiGlaze);
+      expect(opencodeConfig.instructions).toContain(codingDiscipline);
       expect(
         opencodeConfig.instructions.filter(
-          (entry: string) => entry === installedPrompt,
+          (entry: string) => entry === antiGlaze,
+        ).length,
+      ).toBe(1);
+      expect(
+        opencodeConfig.instructions.filter(
+          (entry: string) => entry === codingDiscipline,
         ).length,
       ).toBe(1);
     } finally {


### PR DESCRIPTION
## Summary

- Add `instructions/coding-discipline.md`: 11-rule behavioral contract for code work,
  adapted from Mnimiy's 12-rule CLAUDE.md template
  (https://x.com/Mnilax/status/2053116311132155938). Rule 6 (per-task / per-session
  token budgets) omitted — agentkit ships static instructions and cannot enforce
  runtime caps.
- Generalize `install.sh` to wire every `instructions/*.md` file into Codex
  (concatenated `developer_instructions`), Claude Code (one markered block per file),
  and OpenCode (one `instructions[]` entry per file). Per-file marker derived from
  basename: `<!-- agentkit:<basename>:start -->`.
- Extend `install-prompt` test to cover the multi-file case.
- README: add Instructions section listing both files.

## Tests

- bun test (90 pass / 0 fail)
- dprint check (clean)