### PR TITLE
fix(install): wire pkg-police and coding-police into settings.json

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -455,7 +455,9 @@ merge_claude_settings() {
 	hooks_json=$(jq -n \
 		--arg git_police "$hooks_dir/git-police.sh" \
 		--arg kubectl_police "$hooks_dir/kubectl-police.sh" \
+		--arg pkg_police "$hooks_dir/pkg-police.sh" \
 		--arg format_police "$hooks_dir/format-police.sh" \
+		--arg coding_police "$hooks_dir/coding-police.sh" \
 		'{
       hooks: {
         PreToolUse: [
@@ -473,6 +475,12 @@ merge_claude_settings() {
                 command: $kubectl_police,
                 timeout: 10,
                 statusMessage: "kubectl-police: checking Kargo safety..."
+              },
+              {
+                type: "command",
+                command: $pkg_police,
+                timeout: 10,
+                statusMessage: "pkg-police: enforcing bun..."
               }
             ]
           }
@@ -484,6 +492,11 @@ merge_claude_settings() {
               {
                 type: "command",
                 command: $format_police,
+                timeout: 15
+              },
+              {
+                type: "command",
+                command: $coding_police,
                 timeout: 15
               }
             ]

--- a/tests/install-hooks.test.ts
+++ b/tests/install-hooks.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const repoRoot = dirname(import.meta.dir);
+const installScript = join(repoRoot, 'install.sh');
+
+function runGlobalInstall(home: string) {
+  return spawnSync('bash', [installScript, '--global'], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      HOME: home,
+      XDG_CONFIG_HOME: join(home, '.config'),
+    },
+    encoding: 'utf-8',
+  });
+}
+
+function commandNames(entries: { command: string }[]): string[] {
+  return entries.map((entry) => entry.command.split('/').pop() ?? '');
+}
+
+describe('Claude Code hook wiring', () => {
+  test('wires every shipped police hook into settings.json', () => {
+    const home = mkdtempSync(join(tmpdir(), 'agentkit-hooks-'));
+
+    try {
+      const claudeDir = join(home, '.claude');
+      mkdirSync(claudeDir, { recursive: true });
+
+      const result = runGlobalInstall(home);
+      expect(result.status, result.stderr.toString()).toBe(0);
+
+      const settings = JSON.parse(
+        readFileSync(join(claudeDir, 'settings.json'), 'utf-8'),
+      );
+
+      const preToolUse = settings.hooks.PreToolUse;
+      expect(preToolUse).toHaveLength(1);
+      expect(preToolUse[0].matcher).toBe('Bash');
+      expect(commandNames(preToolUse[0].hooks).sort()).toEqual(
+        ['git-police.sh', 'kubectl-police.sh', 'pkg-police.sh'].sort(),
+      );
+
+      const postToolUse = settings.hooks.PostToolUse;
+      expect(postToolUse).toHaveLength(1);
+      expect(postToolUse[0].matcher).toBe('Edit|Write');
+      expect(commandNames(postToolUse[0].hooks).sort()).toEqual(
+        ['coding-police.sh', 'format-police.sh'].sort(),
+      );
+    } finally {
+      rmSync(home, { force: true, recursive: true });
+    }
+  });
+
+  test('preserves existing top-level settings keys when merging hooks', () => {
+    const home = mkdtempSync(join(tmpdir(), 'agentkit-hooks-'));
+
+    try {
+      const claudeDir = join(home, '.claude');
+      mkdirSync(claudeDir, { recursive: true });
+      writeFileSync(
+        join(claudeDir, 'settings.json'),
+        JSON.stringify(
+          {
+            model: 'opus',
+            permissions: { allow: ['Bash(ls:*)'] },
+          },
+          null,
+          2,
+        ),
+      );
+
+      const result = runGlobalInstall(home);
+      expect(result.status, result.stderr.toString()).toBe(0);
+
+      const settings = JSON.parse(
+        readFileSync(join(claudeDir, 'settings.json'), 'utf-8'),
+      );
+      expect(settings.model).toBe('opus');
+      expect(settings.permissions.allow).toEqual(['Bash(ls:*)']);
+      expect(settings.hooks.PreToolUse).toBeDefined();
+      expect(settings.hooks.PostToolUse).toBeDefined();
+    } finally {
+      rmSync(home, { force: true, recursive: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`merge_claude_settings` hard-coded only 3 of the 5 shipped hook scripts.
`pkg-police.sh` and `coding-police.sh` were copied to `~/.claude/hooks/` but
never activated in `settings.json`.

- Add `pkg-police` as a `PreToolUse` `Bash` hook (matches existing kubectl/git pattern).
- Add `coding-police` as a `PostToolUse` `Edit|Write` hook (matches `format-police` pattern).
- New `tests/install-hooks.test.ts`: asserts all 5 shipped hooks are wired, and
  existing top-level `settings.json` keys (`model`, `permissions`) survive the merge.

## Tests

- bun test (92 pass / 0 fail, +2 new)
- dprint check (clean)