### PR TITLE
docs(instructions): add collaboration visibility prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,11 @@ Reusable AI agent skills, rules, plugins, hooks, and tools for OpenCode, Claude 
 
 ### Instructions (global agent prompts wired into Claude / Codex / OpenCode)
 
-| Instruction              | Description                                                                                         |
-| ------------------------ | --------------------------------------------------------------------------------------------------- |
-| **anti-glaze.md**        | Tone and reasoning layer: precise, direct, no sycophancy, explicit confidence levels                |
-| **coding-discipline.md** | 11-rule behavioral contract for code work (think first, simplicity, surgical changes, fail loud, …) |
+| Instruction                     | Description                                                                                         |
+| ------------------------------- | --------------------------------------------------------------------------------------------------- |
+| **anti-glaze.md**               | Tone and reasoning layer: precise, direct, no sycophancy, explicit confidence levels                |
+| **coding-discipline.md**        | 11-rule behavioral contract for code work (think first, simplicity, surgical changes, fail loud, …) |
+| **collaboration-visibility.md** | Progress updates, checkpoint summaries, and compact ASCII diagrams for multi-step work              |
 
 ## Installation
 

--- a/instructions/collaboration-visibility.md
+++ b/instructions/collaboration-visibility.md
@@ -1,0 +1,36 @@
+<!-- agentkit:collaboration-visibility:start -->
+
+# Collaboration Visibility
+
+Default behavior for agent work. The user should be able to understand what is happening while the
+work is in progress, not only after it is complete.
+
+## Keep The User In The Loop
+
+- Send short progress updates during multi-step work, long-running commands, debugging, deployments,
+  and repository operations.
+- Before edits, commits, pushes, merges, migrations, service restarts, or live infrastructure
+  changes, state what you are about to change and why.
+- After each significant step, summarize what changed, what was verified, and what remains.
+- If a command fails, a check is skipped, or a result is uncertain, say so directly and name the next
+  diagnostic step.
+
+## Explain With Diagrams
+
+Use compact ASCII diagrams when they make the work easier to follow, especially for debugging,
+GitOps flows, deployment paths, service relationships, data flow, and multi-repository changes.
+
+```text
+current state ----> action ----> expected result
+      |                              |
+      +---- risk / blocker ---------+
+```
+
+Keep diagrams practical:
+
+- Use plain ASCII so they render in terminals, diffs, logs, and chat.
+- Keep diagrams small enough to scan quickly.
+- Prefer diagrams that show state, flow, dependencies, or decision points.
+- Do not add decorative diagrams that do not clarify the work.
+
+<!-- agentkit:collaboration-visibility:end -->

--- a/tests/install-prompt.test.ts
+++ b/tests/install-prompt.test.ts
@@ -74,13 +74,23 @@ describe('global prompt installation', () => {
         'instructions',
         'coding-discipline.md',
       );
+      const collaborationVisibility = join(
+        home,
+        '.agents',
+        'instructions',
+        'collaboration-visibility.md',
+      );
       expect(existsSync(antiGlaze)).toBe(true);
       expect(existsSync(codingDiscipline)).toBe(true);
+      expect(existsSync(collaborationVisibility)).toBe(true);
       expect(readFileSync(antiGlaze, 'utf-8')).toContain(
         'agentkit:anti-glaze:start',
       );
       expect(readFileSync(codingDiscipline, 'utf-8')).toContain(
         'agentkit:coding-discipline:start',
+      );
+      expect(readFileSync(collaborationVisibility, 'utf-8')).toContain(
+        'agentkit:collaboration-visibility:start',
       );
 
       const codexConfig = readFileSync(join(codexDir, 'config.toml'), 'utf-8');
@@ -93,6 +103,12 @@ describe('global prompt installation', () => {
       expect(
         countOccurrences(codexConfig, 'agentkit:coding-discipline:start'),
       ).toBe(1);
+      expect(
+        countOccurrences(
+          codexConfig,
+          'agentkit:collaboration-visibility:start',
+        ),
+      ).toBe(1);
 
       const claudeInstructions = readFileSync(
         join(claudeDir, 'CLAUDE.md'),
@@ -103,11 +119,18 @@ describe('global prompt installation', () => {
         'Anti-Glaze Global Agent Instructions',
       );
       expect(claudeInstructions).toContain('Coding Discipline');
+      expect(claudeInstructions).toContain('Collaboration Visibility');
       expect(
         countOccurrences(claudeInstructions, 'agentkit:anti-glaze:start'),
       ).toBe(1);
       expect(
         countOccurrences(claudeInstructions, 'agentkit:coding-discipline:start'),
+      ).toBe(1);
+      expect(
+        countOccurrences(
+          claudeInstructions,
+          'agentkit:collaboration-visibility:start',
+        ),
       ).toBe(1);
 
       const opencodeConfig = JSON.parse(
@@ -116,6 +139,7 @@ describe('global prompt installation', () => {
       expect(opencodeConfig.plugin).toEqual(['oh-my-openagent@latest']);
       expect(opencodeConfig.instructions).toContain(antiGlaze);
       expect(opencodeConfig.instructions).toContain(codingDiscipline);
+      expect(opencodeConfig.instructions).toContain(collaborationVisibility);
       expect(
         opencodeConfig.instructions.filter(
           (entry: string) => entry === antiGlaze,
@@ -124,6 +148,11 @@ describe('global prompt installation', () => {
       expect(
         opencodeConfig.instructions.filter(
           (entry: string) => entry === codingDiscipline,
+        ).length,
+      ).toBe(1);
+      expect(
+        opencodeConfig.instructions.filter(
+          (entry: string) => entry === collaborationVisibility,
         ).length,
       ).toBe(1);
     } finally {


### PR DESCRIPTION
## Summary\n- add a global collaboration visibility instruction for progress updates and ASCII diagrams\n- document the new instruction in README\n- extend prompt installation tests to cover the new instruction\n\n## Verification\n- bun test\n- bunx dprint check README.md tests/install-prompt.test.ts instructions/collaboration-visibility.md