### PR TITLE
Block cross-repo relative paths in coding-police

### DIFF
--- a/hooks/claude/coding-police.sh
+++ b/hooks/claude/coding-police.sh
@@ -47,9 +47,17 @@ esac
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.filePath // empty')
 [[ -z "$FILE_PATH" ]] && exit 0
 
-# Only check code files
+IS_CODE_FILE=false
+SHOULD_CHECK_PATHS=false
+
 case "$FILE_PATH" in
-  *.ts|*.tsx|*.js|*.jsx|*.py|*.rb|*.go|*.rs|*.java|*.kt|*.cs|*.cpp|*.c|*.h|*.hpp|*.swift|*.scala|*.vue|*.svelte) ;;
+  *.ts|*.tsx|*.js|*.jsx|*.py|*.rb|*.go|*.rs|*.java|*.kt|*.cs|*.cpp|*.c|*.h|*.hpp|*.swift|*.scala|*.vue|*.svelte)
+    IS_CODE_FILE=true
+    SHOULD_CHECK_PATHS=true
+    ;;
+  *.yml|*.yaml|*.toml|*.json|*.jsonc|*.ini|*.env|*.service|*.conf|*.cfg)
+    SHOULD_CHECK_PATHS=true
+    ;;
   *) exit 0 ;;
 esac
 
@@ -62,6 +70,20 @@ esac
 [[ -f "$FILE_PATH" ]] || exit 0
 
 VIOLATIONS=()
+
+# ── Check 0: Cross-repo sibling relative paths ─────────────────────────────
+check_cross_repo_relative_paths() {
+  [[ "$SHOULD_CHECK_PATHS" == true ]] || return 0
+
+  local matches
+  matches=$(grep -nE '\{\{[[:space:]]*(inventory_dir|playbook_dir|role_path|ansible_parent_role_paths\[[^]]+\])[[:space:]]*\}\}[[:space:]]*/(\.\./){2,}|(^|["'"'"'=[:space:]])(\.\./){2,}(core|eda|fullcircle|dashboard|gitops|infra|ansible-roles)(/|["'"'"'[:space:]]|$)' "$FILE_PATH" 2>/dev/null || true)
+
+  while IFS= read -r line; do
+    if [[ -n "$line" ]]; then
+      VIOLATIONS+=("CROSS-REPO RELATIVE PATH: ${line}. Do not depend on checkout layout across repos; use a published artifact, a vendored/submodule path inside this repo, or runtime configuration.")
+    fi
+  done <<< "$matches"
+}
 
 # ── Check 1: File length ───────────────────────────────────────────────────
 check_file_length() {
@@ -214,6 +236,28 @@ check_export_count() {
 }
 
 # ── Run all checks ──────────────────────────────────────────────────────────
+check_cross_repo_relative_paths
+
+if [[ "$IS_CODE_FILE" != true ]]; then
+  if (( ${#VIOLATIONS[@]} > 0 )); then
+    {
+      echo ""
+      echo "CODING STANDARDS VIOLATION (coding-police)"
+      echo "=================================================="
+      for i in "${!VIOLATIONS[@]}"; do
+        echo "$(( i + 1 )). ${VIOLATIONS[$i]}"
+        echo ""
+      done
+      echo "REQUIRED ACTIONS:"
+      echo "- Remove cross-repo sibling relative paths from durable config."
+      echo "- Use published artifacts, vendored/submodule paths inside the same repo, or runtime configuration."
+      echo ""
+      echo "Fix these violations before proceeding."
+    } >&2
+  fi
+  exit 0
+fi
+
 check_file_length
 check_function_lengths
 check_duplicate_blocks
@@ -234,6 +278,7 @@ if (( ${#VIOLATIONS[@]} > 0 )); then
     echo "- Keep files modular: split files exceeding ${MAX_FILE_LINES} lines by functionality."
     echo "- Keep functions focused: break functions over ${MAX_FUNCTION_LINES} lines into composable helpers."
     echo "- Apply Single Responsibility: each file should have one clear purpose."
+    echo "- Remove cross-repo sibling relative paths from durable config."
     echo ""
     echo "Fix these violations before proceeding."
   } >&2

--- a/plugins/coding-police.ts
+++ b/plugins/coding-police.ts
@@ -27,6 +27,9 @@ const DEFAULTS: CodingPoliceConfig = {
 const CODE_FILE =
   /\.(ts|tsx|js|jsx|py|rb|go|rs|java|kt|cs|cpp|c|h|hpp|swift|scala|vue|svelte)$/;
 
+const PATH_REFERENCE_FILE =
+  /\.(ya?ml|toml|json|jsonc|ini|env|service|conf|cfg)$/;
+
 // Files that are legitimately long (auto-generated, lockfiles, etc.)
 const SKIP_FILES =
   /\.(lock|min\.\w+|generated\.\w+|snap|d\.ts)$|package-lock\.json|yarn\.lock|pnpm-lock\.yaml/;
@@ -282,6 +285,42 @@ export function checkExportCount(
   return null;
 }
 
+/**
+ * Check 5: Cross-repo sibling relative paths in durable config.
+ *
+ * Infrastructure and deploy config must not reach into sibling repositories
+ * with paths such as `{{ inventory_dir }}/../../../dashboard` or
+ * `../../../../core/dashboard`. Use published artifacts, submodules/vendor
+ * paths inside the same repo, or explicit runtime config instead.
+ */
+export function checkCrossRepoRelativePaths(
+  lines: string[],
+  filePath: string,
+): string[] {
+  if (!PATH_REFERENCE_FILE.test(filePath) && !CODE_FILE.test(filePath)) {
+    return [];
+  }
+
+  const warnings: string[] = [];
+  const repoClimbWithJinja =
+    /\{\{\s*(?:inventory_dir|playbook_dir|role_path|ansible_parent_role_paths\[[^\]]+\])\s*\}\}\s*\/(?:\.\.\/){2,}/;
+  const siblingRepoPath =
+    /(?:^|["'=:\s])(?:\.\.\/){2,}(?:core|eda|fullcircle|dashboard|gitops|infra|ansible-roles)(?:\/|["'\s]|$)/;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (repoClimbWithJinja.test(line) || siblingRepoPath.test(line)) {
+      warnings.push(
+        `CROSS-REPO RELATIVE PATH: line ${i + 1} uses a sibling-repo path. ` +
+          `Do not depend on checkout layout across repos; use a published artifact, ` +
+          `a vendored/submodule path inside this repo, or runtime configuration.`,
+      );
+    }
+  }
+
+  return warnings;
+}
+
 // ---------------------------------------------------------------------------
 // Plugin entry point
 // ---------------------------------------------------------------------------
@@ -300,8 +339,6 @@ export default async function codingPolice(ctx: PluginInput) {
       const relativePath = output.title;
       if (!relativePath) return;
 
-      // Only check code files
-      if (!CODE_FILE.test(relativePath)) return;
       // Skip generated/lock files
       if (SKIP_FILES.test(relativePath)) return;
       // Check exclusion patterns from config
@@ -324,6 +361,29 @@ export default async function codingPolice(ctx: PluginInput) {
 
       const lines = content.split('\n');
       const violations: string[] = [];
+
+      // Check 0: Cross-repo sibling relative paths. This applies to config
+      // and docs as well as code, because the common failure mode is Ansible
+      // inventory/YAML.
+      violations.push(...checkCrossRepoRelativePaths(lines, relativePath));
+
+      // Remaining checks only apply to code files.
+      if (!CODE_FILE.test(relativePath)) {
+        if (violations.length === 0) return;
+
+        output.output +=
+          `\n\n` +
+          `CODING STANDARDS VIOLATION (coding-police)\n` +
+          `${'='.repeat(50)}\n` +
+          violations.map((v, i) => `${i + 1}. ${v}`).join('\n\n') +
+          `\n\n` +
+          `REQUIRED ACTIONS:\n` +
+          `- Remove cross-repo sibling relative paths from durable config.\n` +
+          `- Use published artifacts, vendored/submodule paths inside the same repo, or runtime configuration.\n` +
+          `\n` +
+          `Fix these violations before proceeding.`;
+        return;
+      }
 
       // Check 1: File length
       const lengthWarning = checkFileLength(lines, config.maxFileLines);
@@ -356,6 +416,7 @@ export default async function codingPolice(ctx: PluginInput) {
         `- Keep files modular: split files exceeding ${config.maxFileLines} lines by functionality.\n` +
         `- Keep functions focused: break functions over ${config.maxFunctionLines} lines into composable helpers.\n` +
         `- Apply Single Responsibility: each file should have one clear purpose.\n` +
+        `- Remove cross-repo sibling relative paths from durable config.\n` +
         `\n` +
         `Fix these violations before proceeding.`;
     },

--- a/policies/codex/coding-police.rules
+++ b/policies/codex/coding-police.rules
@@ -26,6 +26,11 @@
 #
 # 5. MODULARIZATION: Group related code into cohesive modules.
 #    Prefer many small files over few large files.
+#
+# 6. CROSS-REPO PATHS: Do not write durable config that reaches into sibling
+#    repositories using paths like `{{ inventory_dir }}/../../../dashboard` or
+#    `../../../../core/dashboard`. Use published artifacts, vendored/submodule
+#    paths inside the same repo, or runtime configuration.
 
 # ── LARGE HEREDOC WRITES ───────────────────────────────────────────────────
 # Prompt when writing code via heredoc to a code file — these often produce
@@ -55,6 +60,6 @@ prefix_rule(
 prefix_rule(
     pattern = ["bash", "-c"],
     decision = "prompt",
-    justification = "Running bash -c with code generation may produce large files. Coding standards require: max 1000 lines per file, max 100 lines per function, no duplicated code blocks, no more than 15 exports per file. Verify the result stays modular.",
+    justification = "Running bash -c with code generation may produce large files or durable cross-repo sibling paths. Coding standards require: max 1000 lines per file, max 100 lines per function, no duplicated code blocks, no more than 15 exports per file, and no paths like '{{ inventory_dir }}/../../../dashboard' or '../../../../core/...'. Verify the result stays modular and repo-boundary clean.",
     match = ["bash -c 'cat << EOF >> app.ts'"],
 )

--- a/tests/coding-police.test.ts
+++ b/tests/coding-police.test.ts
@@ -4,6 +4,7 @@ import codingPolice, {
   checkFunctionLengths,
   checkDuplicateBlocks,
   checkExportCount,
+  checkCrossRepoRelativePaths,
 } from '../plugins/coding-police';
 
 // ---------------------------------------------------------------------------
@@ -288,6 +289,35 @@ describe('checkExportCount', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Check 5: Cross-repo relative paths
+// ---------------------------------------------------------------------------
+
+describe('checkCrossRepoRelativePaths', () => {
+  test('flags Ansible inventory paths that climb into sibling repos', () => {
+    const code = [
+      'sysops_install_source_dir: "{{ inventory_dir }}/../../../dashboard"',
+      'auth_ui_source_dir: "{{ inventory_dir }}/../../../../core/auth-ui"',
+    ];
+    const warnings = checkCrossRepoRelativePaths(
+      code,
+      'inventories/production/hosts.yml',
+    );
+    expect(warnings).toHaveLength(2);
+    expect(warnings[0]).toContain('CROSS-REPO RELATIVE PATH');
+  });
+
+  test('allows local paths that do not cross repo boundaries', () => {
+    const code = [
+      'dashboard_root: "/opt/eda-dashboard"',
+      'template: "../templates/service.j2"',
+    ];
+    expect(
+      checkCrossRepoRelativePaths(code, 'inventories/production/hosts.yml'),
+    ).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Plugin integration (hook wiring)
 // ---------------------------------------------------------------------------
 
@@ -322,5 +352,21 @@ describe('coding-police plugin', () => {
     const output = { title: 'package-lock.json', output: 'done', metadata: {} };
     await hooks['tool.execute.after']!(input, output);
     expect(output.output).toBe('done');
+  });
+
+  test('reports cross-repo relative paths in config files', async () => {
+    const dir = await Bun.$`mktemp -d`.text();
+    const file = `${dir.trim()}/hosts.yml`;
+    await Bun.write(
+      file,
+      'sysops_install_source_dir: "{{ inventory_dir }}/../../../dashboard"\n',
+    );
+
+    const hooks = await codingPolice({ ...mockCtx, worktree: dir.trim() });
+    const input = { tool: 'write', sessionID: 'test', callID: 'test' };
+    const output = { title: 'hosts.yml', output: 'done', metadata: {} };
+    await hooks['tool.execute.after']!(input, output);
+
+    expect(output.output).toContain('CROSS-REPO RELATIVE PATH');
   });
 });


### PR DESCRIPTION
## Summary
- detect sibling repo relative paths in durable config files
- mirror the guard in OpenCode coding-police and Claude hook
- document the Codex policy expectation

## Tests
- bun test
- bash -n hooks/claude/coding-police.sh
- dprint check
- git diff --check
- direct Claude hook fixture with {{ inventory_dir }}/../../../dashboard