### PR TITLE
feat(hooks): add mr-police — block stacking unmerged MRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,14 @@ Reusable AI agent skills, rules, plugins, hooks, and tools for OpenCode, Claude 
 
 ### Hooks (Claude Code -- PreToolUse / PostToolUse)
 
-| Hook                  | Type        | Description                                                                            |
-| --------------------- | ----------- | -------------------------------------------------------------------------------------- |
-| **git-police.sh**     | PreToolUse  | Blocks force push, --no-verify, Co-authored-by trailers, commits to protected branches |
-| **kubectl-police.sh** | PreToolUse  | Blocks kubectl create/apply on Kargo CRDs                                              |
-| **format-police.sh**  | PostToolUse | Auto-formats files after edit/write using dprint                                       |
-| **coding-police.sh**  | PostToolUse | Enforces DRY code, modular files (<1000 lines), short functions, single responsibility |
-| **pkg-police.sh**     | PreToolUse  | Enforces bun as package manager — blocks npm, npx, yarn, pnpm commands                 |
+| Hook                  | Type        | Description                                                                                                              |
+| --------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------ |
+| **git-police.sh**     | PreToolUse  | Blocks force push, --no-verify, Co-authored-by trailers, commits to protected branches                                   |
+| **kubectl-police.sh** | PreToolUse  | Blocks kubectl create/apply on Kargo CRDs                                                                                |
+| **format-police.sh**  | PostToolUse | Auto-formats files after edit/write using dprint                                                                         |
+| **coding-police.sh**  | PostToolUse | Enforces DRY code, modular files (<1000 lines), short functions, single responsibility                                   |
+| **pkg-police.sh**     | PreToolUse  | Enforces bun as package manager — blocks npm, npx, yarn, pnpm commands                                                   |
+| **mr-police.sh**      | PreToolUse  | Blocks opening a new MR while you already have an open MR you authored on the repo — stops unmerged MRs from stacking up |
 
 ### Policies (Codex CLI -- exec policy)
 

--- a/hooks/claude/mr-police.sh
+++ b/hooks/claude/mr-police.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# mr-police.sh — Claude Code PreToolUse hook (matcher: Bash)
+# Blocks opening a NEW merge request while you already have open MR(s) you
+# authored on the same repo. Stops unmerged MRs from accumulating into a tangle
+# of interdependent branches — merge or close the existing one(s) first.
+#
+# Threshold is configurable: AGENTKIT_MR_POLICE_MAX (default 1) = how many open
+# MRs you may already have before opening another is blocked.
+set -euo pipefail
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+[[ -z "$COMMAND" ]] && exit 0
+
+# Only act on MR-creation commands; everything else passes through instantly.
+if ! echo "$COMMAND" | grep -qiE 'glab[[:space:]]+mr[[:space:]]+create|merge_request\.create'; then
+	exit 0
+fi
+
+# Need glab to check; if it's unavailable, don't block (fail open).
+command -v glab >/dev/null 2>&1 || exit 0
+
+# Target the GitLab instance this repo lives on (glab otherwise defaults to
+# gitlab.com, or to a stale GITLAB_HOST in the environment).
+HOST=$(git remote get-url origin 2>/dev/null | sed -E 's#^(git@|https?://)([^:/]+).*#\2#')
+[[ -n "$HOST" ]] && export GITLAB_HOST="$HOST"
+
+MAX_OPEN="${AGENTKIT_MR_POLICE_MAX:-1}"
+
+# Who am I, and what open MRs have I authored on this repo?
+ME=$(glab api /user 2>/dev/null | jq -r '.username // empty')
+[[ -z "$ME" ]] && exit 0
+
+MINE=$(glab mr list --author "$ME" 2>/dev/null | grep -oE '!\b[0-9]+' | sort -u)
+COUNT=$(printf '%s\n' "$MINE" | grep -c . || true)
+
+deny() {
+	jq -n --arg r "$1" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: $r
+    }
+  }'
+	exit 0
+}
+
+if [[ "$COUNT" -ge "$MAX_OPEN" ]]; then
+	LIST=$(printf '%s ' $MINE)
+	deny "BLOCKED: you already have ${COUNT} open MR(s) you authored on this repo (${LIST}). Do not stack another unmerged MR on top — merge or close the existing one(s) first, then open the next. If these are genuinely independent and must coexist, raise the limit for this command with AGENTKIT_MR_POLICE_MAX=<n>."
+fi
+
+exit 0

--- a/hooks/claude/settings.json
+++ b/hooks/claude/settings.json
@@ -21,6 +21,12 @@
             "command": "$HOME/.claude/hooks/pkg-police.sh",
             "timeout": 10,
             "statusMessage": "pkg-police: enforcing bun as package manager..."
+          },
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/mr-police.sh",
+            "timeout": 15,
+            "statusMessage": "mr-police: checking for unmerged MRs..."
           }
         ]
       }

--- a/install.sh
+++ b/install.sh
@@ -456,6 +456,7 @@ merge_claude_settings() {
 		--arg git_police "$hooks_dir/git-police.sh" \
 		--arg kubectl_police "$hooks_dir/kubectl-police.sh" \
 		--arg pkg_police "$hooks_dir/pkg-police.sh" \
+		--arg mr_police "$hooks_dir/mr-police.sh" \
 		--arg format_police "$hooks_dir/format-police.sh" \
 		--arg coding_police "$hooks_dir/coding-police.sh" \
 		'{
@@ -481,6 +482,12 @@ merge_claude_settings() {
                 command: $pkg_police,
                 timeout: 10,
                 statusMessage: "pkg-police: enforcing bun..."
+              },
+              {
+                type: "command",
+                command: $mr_police,
+                timeout: 15,
+                statusMessage: "mr-police: checking for unmerged MRs..."
               }
             ]
           }


### PR DESCRIPTION
Adds `mr-police.sh`, a PreToolUse Bash hook that denies opening a new merge request while you already have an open MR you authored on the same repo — so unmerged MRs stop accumulating into a tangle of interdependent branches.

- Triggers on `glab mr create` / `git push -o merge_request.create`.
- Counts open MRs you authored on the repo; denies if `>= AGENTKIT_MR_POLICE_MAX` (default 1).
- Derives `GITLAB_HOST` from the repo remote; fails open if glab is unavailable.
- Wired into `hooks/claude/settings.json` + `install.sh`; documented in README.

Kept separate from git-police on purpose: git-police is local/offline/forge-agnostic, mr-police needs glab + the GitLab API.