### PR TITLE
feat(instructions): surface-aware diagrams + final-answer structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Reusable AI agent skills, rules, plugins, hooks, and tools for OpenCode, Claude 
 | **gitops-master**       | GitOps operations for ArgoCD + Kargo: diagnose, verify, promote, setup                   |
 | **autonomous-workflow** | Proposal-first development, commit hygiene, decision authority                           |
 | **code-quality**        | Warnings-as-errors, no underscore prefixes, test coverage                                |
-| **documentation**       | ASCII diagrams, structured plan format, formatting rules                                 |
+| **documentation**       | Surface-aware diagrams (Mermaid / ASCII), structured plan format, formatting rules       |
 | **issue-raiser**        | GitLab issue creation with root cause analysis and git-history-based assignees           |
 | **project-planning**    | Structured project planning: break down ideas into architecture, file structure, roadmap |
 

--- a/instructions/collaboration-visibility.md
+++ b/instructions/collaboration-visibility.md
@@ -17,8 +17,15 @@ work is in progress, not only after it is complete.
 
 ## Explain With Diagrams
 
-Use compact ASCII diagrams when they make the work easier to follow, especially for debugging,
-GitOps flows, deployment paths, service relationships, data flow, and multi-repository changes.
+Use a diagram when it makes the work easier to follow, especially for debugging, GitOps flows,
+deployment paths, service relationships, data flow, and multi-repository changes. Pick the format
+by where the output is read.
+
+On markdown-rendered surfaces (chat UIs with Mermaid support, GitLab/GitHub issues, MRs, and
+READMEs), use a `mermaid` code fence (`flowchart LR`/`TD` or `sequenceDiagram`) so it renders as a
+real diagram. Do not draw ASCII-art boxes there; they render poorly.
+
+On plain-text surfaces (terminals, commit messages, git diffs, logs), use compact ASCII:
 
 ```text
 current state ----> action ----> expected result
@@ -28,9 +35,15 @@ current state ----> action ----> expected result
 
 Keep diagrams practical:
 
-- Use plain ASCII so they render in terminals, diffs, logs, and chat.
-- Keep diagrams small enough to scan quickly.
+- Keep diagrams small enough to scan quickly, and label the edges.
 - Prefer diagrams that show state, flow, dependencies, or decision points.
 - Do not add decorative diagrams that do not clarify the work.
+
+## Structure Final Answers
+
+- Lead with the outcome in one or two sentences, then the evidence and detail.
+- Concise but comprehensive: compact bullet lists over paragraphs; every bullet earns its place —
+  no filler, no restating the question.
+- Use tables for enumerable facts and `code` for commands, names, and paths.
 
 <!-- agentkit:collaboration-visibility:end -->

--- a/skills/documentation/SKILL.md
+++ b/skills/documentation/SKILL.md
@@ -1,20 +1,23 @@
 ---
 name: documentation
 description: >-
-  Documentation standards: ASCII box-drawing diagrams (not Mermaid), structured plan format,
-  compact tables for comparisons. Use when writing docs, plans, READMEs, or architecture
-  documents in any project.
+  Documentation standards: surface-aware diagrams (Mermaid where markdown renders, ASCII for
+  terminals and diffs), structured plan format, compact tables for comparisons. Use when writing
+  docs, plans, READMEs, or architecture documents in any project.
 ---
 
 # Documentation Standards
 
 ## Diagrams
 
-- Use ASCII box-drawing diagrams (NOT Mermaid) -- they render everywhere: terminals, git diffs, code
-  review, plain text, any monospace font
-- Use box-drawing characters: + - | / \ > < = and standard ASCII art
-- Wrap diagrams in triple-backtick code blocks (no language tag)
-- Keep diagrams compact -- max ~40 lines, ~80 chars wide
+Pick the diagram format by where the document is primarily read:
+
+- Rendered markdown (READMEs, docs sites, GitLab/GitHub issues and MRs, chat UIs with Mermaid
+  support): use `mermaid` code fences (`flowchart LR`/`TD`, `sequenceDiagram`) -- they render as
+  real diagrams. Keep them compact (<= ~10 nodes) and label the edges.
+- Plain text (plans and notes read in editors, terminals, git diffs, any monospace surface): use
+  ASCII box-drawing diagrams with + - | / \ > < =, wrapped in triple-backtick code blocks (no
+  language tag). Max ~40 lines, ~80 chars wide.
 - For data flow: use arrows ---> and ---- with labels
 - For hierarchy: use tree notation +-- |
 


### PR DESCRIPTION
## What

Agentkit mandated ASCII diagrams everywhere — including surfaces that render markdown, so chat-UI agents (Proxima) and GitLab/GitHub MRs got ASCII boxes where a real diagram would render. This makes the guidance surface-aware:

- **collaboration-visibility instruction**: `mermaid` fences on markdown-rendered surfaces (chat UIs with Mermaid support, GitLab/GitHub issues/MRs/READMEs); compact ASCII on plain-text surfaces (terminals, commit messages, diffs, logs). Adds a **Structure Final Answers** section: lead with the outcome, concise bullet-first, tables for enumerable facts.
- **documentation skill**: same surface-aware rule; drops the blanket "NOT Mermaid".
- README skill table updated to match.

## Verified

- `bun test tests/install-prompt.test.ts` passes (marker assertions unaffected)
- `dprint fmt` clean