### PR TITLE
fix(git-police): scope branch protection to the origin remote

### DIFF
--- a/hooks/claude/git-police.sh
+++ b/hooks/claude/git-police.sh
@@ -70,15 +70,35 @@ if echo "$STRIPPED" | grep -qiE '\bgit\b.*\bpush\b.*(-f\b|--force\b|--force-with
 	deny "BLOCKED: Force push is forbidden. Force pushing rewrites history and can destroy work. If you truly need this, ask the user for explicit approval first."
 fi
 
-# 3. Block pushing directly to protected branches
-for branch in "${PROTECTED_BRANCHES[@]}"; do
-	if echo "$STRIPPED" | grep -qiE "\bgit\b.*\bpush\b.*\b${branch}\b"; then
-		deny "BLOCKED: Pushing directly to '${branch}' is forbidden. Create a feature branch and raise a PR instead."
-	fi
-done
+# The remote a push targets: the first non-flag token after `push` (empty for
+# the implicit upstream). Branch protection guards the canonical repo (origin);
+# pushes that explicitly name a different remote are mirror syncs of refs that
+# already went through review there, so rules 3 and 4 let them pass.
+push_remote() {
+	echo "$1" | awk '{
+		for (i = 1; i <= NF; i++)
+			if ($i == "push") {
+				for (j = i + 1; j <= NF; j++)
+					if ($j !~ /^-/) { print $j; exit }
+				exit
+			}
+	}'
+}
+PUSH_REMOTE=$(push_remote "$STRIPPED")
 
-# 4. Block push when currently on a protected branch (even without branch name in command)
-if echo "$STRIPPED" | grep -qiE '\bgit\b.*\bpush\b'; then
+# 3. Block pushing directly to protected branches (on origin / implicit upstream)
+if [[ -z "$PUSH_REMOTE" || "$PUSH_REMOTE" == "origin" ]]; then
+	for branch in "${PROTECTED_BRANCHES[@]}"; do
+		if echo "$STRIPPED" | grep -qiE "\bgit\b.*\bpush\b.*\b${branch}\b"; then
+			deny "BLOCKED: Pushing directly to '${branch}' is forbidden. Create a feature branch and raise a PR instead."
+		fi
+	done
+fi
+
+# 4. Block push when currently on a protected branch (even without branch name
+#    in command) — same origin scoping as rule 3.
+if [[ -z "$PUSH_REMOTE" || "$PUSH_REMOTE" == "origin" ]] \
+	&& echo "$STRIPPED" | grep -qiE '\bgit\b.*\bpush\b'; then
 	CURRENT_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
 	for branch in "${PROTECTED_BRANCHES[@]}"; do
 		if [[ "$CURRENT_BRANCH" == "$branch" ]]; then

--- a/plugins/git-police.ts
+++ b/plugins/git-police.ts
@@ -84,8 +84,19 @@ function isGitCommitCommand(command: string): boolean {
   );
 }
 
+// The remote a push targets: the first non-flag token after `push` ('' for
+// the implicit upstream). Branch protection guards the canonical repo
+// (origin); pushes naming a different remote are mirror syncs of refs that
+// already went through review there.
+function pushRemote(command: string): string {
+  const m = command.match(/\bpush\b(?:\s+-\S+)*\s+([^-\s]\S*)/i);
+  return m?.[1] ?? '';
+}
+
 function isGitPushToProtected(command: string): boolean {
   if (!/\bgit\b.*\bpush\b/i.test(command)) return false;
+  const remote = pushRemote(command);
+  if (remote && remote !== 'origin') return false;
 
   for (const branch of PROTECTED_BRANCHES) {
     if (new RegExp(`\\bpush\\b.*\\b${branch}\\b`, 'i').test(command)) return true;

--- a/tests/git-police.test.ts
+++ b/tests/git-police.test.ts
@@ -80,6 +80,25 @@ describe('git-police', () => {
     }
   });
 
+  describe('allows mirror-remote pushes of protected branches', () => {
+    // Branch protection guards origin; a push that names a different remote
+    // is a mirror sync of refs that already went through review there.
+    const commands = [
+      'git push up main',
+      'git push up master',
+      'git push -u mirror main',
+      'git push up origin/main:refs/heads/main',
+    ];
+
+    for (const cmd of commands) {
+      test(`allows: ${cmd}`, async () => {
+        const hooks = await gitPolice(mockCtx);
+        const { input, output } = makeInput(cmd);
+        expect(hooks['tool.execute.before']!(input, output)).resolves.toBeUndefined();
+      });
+    }
+  });
+
   describe('blocks AI attribution trailers in commits', () => {
     const commands = [
       'git commit -m "fix stuff\n\nCo-authored-by: Claude <claude@anthropic.com>"',


### PR DESCRIPTION
Rules 3 and 4 blocked **any** push whose command text mentioned a protected branch — including mirror syncs to a secondary remote (e.g. `up`) of refs that already went through review on origin.

Branch protection guards the canonical repo: pushes that explicitly name a non-origin remote now pass; implicit pushes and origin pushes are blocked exactly as before. Applied to both the Claude bash hook and the OpenCode plugin, with test coverage (4 new mirror-push cases; pushing a protected branch to origin remains blocked — verified against the bash hook directly).

Fun fact discovered while shipping this: the hook blocked its own fix's commit because the message *described* the blocked command and the quote-stripping is line-based, so multi-line commit messages leak into the pattern match. Worth a follow-up if it bites again.
