### PR TITLE
feat(mr-police): require an assignee on MR creation

### DIFF
--- a/hooks/claude/mr-police.sh
+++ b/hooks/claude/mr-police.sh
@@ -17,6 +17,24 @@ if ! echo "$COMMAND" | grep -qiE 'glab[[:space:]]+mr[[:space:]]+create|merge_req
 	exit 0
 fi
 
+deny_early() {
+	jq -n --arg r "$1" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: $r
+    }
+  }'
+	exit 0
+}
+
+# Every MR carries an assignee from the moment it exists — ownership is never
+# ambiguous. Applies to any agent using these hooks (Claude Code, Proxima, …).
+if echo "$COMMAND" | grep -qiE 'glab[[:space:]]+mr[[:space:]]+create' \
+	&& ! echo "$COMMAND" | grep -qE -- '--assignee|[[:space:]]-a[[:space:]]'; then
+	deny_early "BLOCKED: glab mr create must include an assignee. Add --assignee <username> (or --assignee @me) and retry — unassigned MRs are not allowed."
+fi
+
 # Need glab to check; if it's unavailable, don't block (fail open).
 command -v glab >/dev/null 2>&1 || exit 0
 

--- a/tests/install-hooks.test.ts
+++ b/tests/install-hooks.test.ts
@@ -42,7 +42,7 @@ describe('Claude Code hook wiring', () => {
       expect(preToolUse).toHaveLength(1);
       expect(preToolUse[0].matcher).toBe('Bash');
       expect(commandNames(preToolUse[0].hooks).sort()).toEqual(
-        ['git-police.sh', 'kubectl-police.sh', 'pkg-police.sh'].sort(),
+        ['git-police.sh', 'kubectl-police.sh', 'mr-police.sh', 'pkg-police.sh'].sort(),
       );
 
       const postToolUse = settings.hooks.PostToolUse;


### PR DESCRIPTION
Every MR must carry an assignee from the moment it exists — ownership is never ambiguous, whether the author is a human-driven agent or an autonomous one (Proxima).

- **mr-police**: `glab mr create` without `--assignee`/`-a` is denied with a fix-it message. Runs before the open-MR count check (no API round-trip needed).
- **install-hooks test**: fixed stale expectations — the installer has wired `mr-police.sh` into PreToolUse since #28 but the test still listed only three hooks (pre-existing failure on main).

Verified: hook exercised directly both ways (denied without assignee, passes with), full suite 101/101 green (was 100/101 on main).
