### PR TITLE
feat(git-police): enforce branch hygiene at branch creation

### DIFF
--- a/hooks/claude/git-police.sh
+++ b/hooks/claude/git-police.sh
@@ -129,7 +129,33 @@ if echo "$STRIPPED" | grep -qiE "$GIT_COMMIT_RE"; then
 	done
 fi
 
-# 7. Stale branch protection — warn when creating a branch from a stale base
+# 7. Branch hygiene at branch creation — the only reliable local chokepoint
+#    (merges happen server-side, so there is no "after merge" hook event).
+#    a) new branches are cut from the default branch, not stacked on another
+#       feature branch (squash merges make stacks conflict); override with
+#       AGENTKIT_ALLOW_BRANCH_STACKING=1 for intentional stacking.
+#    b) local branches whose upstream is gone (squash-merged + remote-deleted)
+#       must be cleaned up before starting new work.
+if echo "$STRIPPED" | grep -qiE '\bgit\b.*(checkout\s+-b|switch\s+-c)\b'; then
+	DEFAULT_BRANCH=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||' || true)
+	CURRENT_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
+	if [[ -n "$CURRENT_BRANCH" && "${AGENTKIT_ALLOW_BRANCH_STACKING:-0}" != "1" ]]; then
+		ON_BASE=false
+		for base in "$DEFAULT_BRANCH" "${PROTECTED_BRANCHES[@]}" dev; do
+			[[ -n "$base" && "$CURRENT_BRANCH" == "$base" ]] && ON_BASE=true
+		done
+		if [[ "$ON_BASE" == false ]]; then
+			deny "BLOCKED: You are on feature branch '${CURRENT_BRANCH}'. Cut new branches from the freshly pulled default branch (squash merges make stacked branches conflict once the first MR merges). Run: git checkout ${DEFAULT_BRANCH:-main} && git pull, then create the branch. Intentional stacking: AGENTKIT_ALLOW_BRANCH_STACKING=1."
+		fi
+	fi
+	git fetch -p --quiet 2>/dev/null || true
+	GONE=$(git branch -vv 2>/dev/null | grep ': gone]' | awk '{print $1}' | tr '\n' ' ' || true)
+	if [[ -n "${GONE// /}" ]]; then
+		deny "BLOCKED: Stale local branches with deleted upstreams: ${GONE}. Clean up before starting new work: git branch -vv | awk '/: gone]/ {print \$1}' | xargs -r git branch -D"
+	fi
+fi
+
+# 8. Stale branch protection — warn when creating a branch from a stale base
 if echo "$STRIPPED" | grep -qiE '\bgit\b.*(checkout\s+-b|switch\s+-c)\b'; then
 	CURRENT_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
 	for branch in "${PROTECTED_BRANCHES[@]}"; do

--- a/tests/git-police-hygiene.test.ts
+++ b/tests/git-police-hygiene.test.ts
@@ -1,0 +1,86 @@
+import { beforeAll, afterAll, describe, expect, test } from 'bun:test';
+import { execSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Rule 7 (branch hygiene at branch creation) needs real git state — a clone
+// with a deletable origin — so these tests build a fixture repo pair instead
+// of mocking.
+
+const HOOK = join(import.meta.dir, '..', 'hooks', 'claude', 'git-police.sh');
+
+function runHook(cwd: string, command: string): string {
+  const input = JSON.stringify({ tool_input: { command } });
+  const res = spawnSync('bash', [HOOK], { cwd, input, encoding: 'utf-8' });
+  return res.stdout ?? '';
+}
+
+let root: string;
+let origin: string;
+let clone: string;
+
+function git(cwd: string, cmd: string): void {
+  execSync(`git ${cmd}`, { cwd, stdio: 'pipe' });
+}
+
+beforeAll(() => {
+  root = mkdtempSync(join(tmpdir(), 'agentkit-hygiene-'));
+  origin = join(root, 'origin.git');
+  clone = join(root, 'clone');
+  execSync(`git init --bare -b main ${origin}`, { stdio: 'pipe' });
+  execSync(`git clone ${origin} ${clone}`, { stdio: 'pipe' });
+  git(clone, 'config user.email test@example.com');
+  git(clone, 'config user.name test');
+  git(clone, 'commit --allow-empty -m init');
+  git(clone, 'push -q origin main');
+  git(clone, 'remote set-head origin main');
+});
+
+afterAll(() => {
+  rmSync(root, { force: true, recursive: true });
+});
+
+describe('git-police branch hygiene (rule 7)', () => {
+  test('allows branching from a clean default branch', () => {
+    expect(runHook(clone, 'git checkout -b feat/one')).not.toContain('"deny"');
+  });
+
+  test('denies stacking a branch on a feature branch', () => {
+    git(clone, 'checkout -q -b feat/base');
+    const out = runHook(clone, 'git checkout -b feat/stacked');
+    expect(out).toContain('"deny"');
+    expect(out).toContain('feature branch');
+    git(clone, 'checkout -q main');
+  });
+
+  test('AGENTKIT_ALLOW_BRANCH_STACKING=1 overrides the stacking rule', () => {
+    git(clone, 'checkout -q -b feat/base2');
+    const input = JSON.stringify({ tool_input: { command: 'git checkout -b feat/stacked2' } });
+    const res = spawnSync('bash', [HOOK], {
+      cwd: clone,
+      input,
+      encoding: 'utf-8',
+      env: { ...process.env, AGENTKIT_ALLOW_BRANCH_STACKING: '1' },
+    });
+    expect(res.stdout ?? '').not.toContain('feature branch');
+    git(clone, 'checkout -q main');
+  });
+
+  test('denies new branches while gone-upstream branches linger, then allows after cleanup', () => {
+    // Simulate a squash-merged branch: push it, delete the remote, fetch -p.
+    git(clone, 'checkout -q -b feat/merged-away');
+    git(clone, 'commit --allow-empty -m work');
+    git(clone, 'push -q -u origin feat/merged-away');
+    git(clone, 'checkout -q main');
+    git(clone, 'push -q origin --delete feat/merged-away');
+    git(clone, 'fetch -pq');
+
+    const denied = runHook(clone, 'git checkout -b feat/next');
+    expect(denied).toContain('"deny"');
+    expect(denied).toContain('feat/merged-away');
+
+    git(clone, 'branch -D feat/merged-away');
+    expect(runHook(clone, 'git checkout -b feat/next')).not.toContain('feat/merged-away');
+  });
+});


### PR DESCRIPTION
Companion to #33 (the instruction) — this makes it enforced, per review feedback that agents should be *forced* into branch hygiene.

**Why branch creation and not "after merge":** merges happen server-side (auto-merge, human reviewers), so no local hook event exists for them. The next `git checkout -b` / `switch -c` is the reliable chokepoint, and it's exactly when hygiene matters.

Rule 7 denies branch creation when:
- the current branch is a **feature branch** — squash-merge stacks conflict once the first MR merges (override: `AGENTKIT_ALLOW_BRANCH_STACKING=1`)
- **gone-upstream locals linger** (squash-merged + remote-deleted) — the deny message contains the exact cleanup command

Both new command substitutions are `|| true`-guarded (under `set -euo pipefail`, an empty grep would otherwise kill the hook in the common case). Tested against a real fixture repo pair (bare origin + clone): clean-pass, stacking-deny, override, gone-deny → cleanup → pass. Full suite green.