### PR TITLE
chore(license): adopt Apache-2.0 with NOTICE and CLA

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,102 @@
+# agentkit Contributor License Agreement
+
+Thank you for your interest in contributing to agentkit (the "Project"), maintained by Nayeem Syed (the
+"Project Owner").
+
+This Contributor License Agreement ("Agreement") clarifies the intellectual property license granted
+with Contributions from any person or entity to the Project. It protects You, the Project Owner, and
+users of the Project; it does not change Your rights to use Your own Contributions for any other
+purpose.
+
+By submitting a Contribution to the Project (for example, by opening a pull request and
+acknowledging this Agreement via the CLA Assistant comment), You accept and agree to the following
+terms for Your present and future Contributions submitted to the Project.
+
+## 1. Definitions
+
+**"You"** (or **"Your"**) means the copyright owner or legal entity authorized by the copyright
+owner that is making this Agreement with the Project Owner.
+
+**"Contribution"** means any original work of authorship, including any modifications or additions
+to an existing work, that is intentionally submitted by You to the Project for inclusion in, or
+documentation of, the Project. For the purposes of this definition, "submitted" means any form of
+electronic, verbal, or written communication sent to the Project or its maintainers, including but
+not limited to communication on issue trackers, source code control systems, and mailing lists, but
+excluding communication that is conspicuously marked or otherwise designated in writing by You as
+"Not a Contribution."
+
+## 2. Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to the Project Owner and to
+recipients of software distributed by the Project Owner a **perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable** copyright license to **reproduce, prepare derivative works
+of, publicly display, publicly perform, sublicense, and distribute** Your Contributions and such
+derivative works **under any license terms, including but not limited to** the Apache License,
+Version 2.0, **and including under proprietary or commercial license terms**.
+
+This means: You retain the copyright to Your Contribution, but You grant the Project Owner the right
+to relicense the Project (including Your Contribution) under different terms in the future, and to
+include Your Contribution in proprietary or commercial editions of the Project or related products.
+
+## 3. Grant of Patent License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to the Project Owner and to
+recipients of software distributed by the Project Owner a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have
+made, use, offer to sell, sell, import, and otherwise transfer the Project, where such license
+applies only to those patent claims licensable by You that are necessarily infringed by Your
+Contribution(s) alone or by combination of Your Contribution(s) with the Project to which such
+Contribution(s) was submitted. If any entity institutes patent litigation against You or any other
+entity (including a cross-claim or counterclaim in a lawsuit) alleging that Your Contribution, or
+the Project to which You have contributed, constitutes direct or contributory patent infringement,
+then any patent licenses granted to that entity under this Agreement for that Contribution or
+Project shall terminate as of the date such litigation is filed.
+
+## 4. You Have the Right to Grant This License
+
+You represent that:
+
+1. You are legally entitled to grant the above license. If Your employer(s) have rights to
+   intellectual property that You create that includes Your Contributions, You represent that You
+   have received permission to make Contributions on behalf of that employer, that Your employer has
+   waived such rights for Your Contributions to the Project, or that Your employer has executed a
+   separate agreement with the Project Owner.
+2. Each of Your Contributions is Your original creation (see Section 5 for submissions on behalf of
+   others).
+3. Your Contribution submissions include complete details of any third-party license or other
+   restriction (including, but not limited to, related patents and trademarks) of which You are
+   personally aware and which are associated with any part of Your Contributions.
+
+## 5. Submissions of Work That Is Not Your Original Creation
+
+Should You wish to submit work that is not Your original creation, You may submit it to the Project
+separately from any Contribution, identifying the complete details of its source and of any license
+or other restriction (including, but not limited to, related patents, trademarks, and license
+agreements) of which You are personally aware, and conspicuously marking the work as "Submitted on
+behalf of a third-party: [named here]".
+
+## 6. No Obligation
+
+You are not expected to provide support for Your Contributions, except to the extent You desire to
+provide support. You may provide support for free, for a fee, or not at all. Unless required by
+applicable law or agreed to in writing, You provide Your Contributions on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any
+warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR
+PURPOSE.
+
+## 7. Notice of Changes
+
+You agree to notify the Project Owner of any facts or circumstances of which You become aware that
+would make the representations in this Agreement inaccurate in any respect.
+
+---
+
+## How to sign
+
+When You open a pull request, the **CLA Assistant** bot will post a comment asking You to sign this
+Agreement. You sign by clicking the link in the bot's comment and agreeing to these terms with Your
+GitHub account. You only need to sign once — the signature applies to all Your future Contributions
+to the Project.
+
+If You are contributing on behalf of an employer, please ensure You have Your employer's permission
+before signing.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may accept and charge a
+      fee for, or grant additional warranty, support, indemnity, or
+      other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Nayeem Syed
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,7 @@
+agentkit
+Copyright 2026 Nayeem Syed
+
+This product includes software developed by agentkit contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License").
+See the LICENSE file for the full license text.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Reusable AI agent skills, rules, plugins, hooks, and tools for OpenCode, Claude Code, and other AI coding agents.
 
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+
 ## What's Included
 
 ### Skills (SKILL.md -- works everywhere via skills.sh)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "agentkit",
   "private": true,
+  "license": "Apache-2.0",
   "scripts": {
     "test": "bun test"
   },


### PR DESCRIPTION
Brings agentkit's licensing in line with assay:

- `LICENSE` — Apache-2.0 (verbatim from assay)
- `NOTICE` — copyright attribution to Nayeem Syed
- `CLA.md` — contributor license agreement preserving relicensing rights
- `package.json` — `license: Apache-2.0` field
- `README.md` — license badge

Closes the gap where agentkit was public but unlicensed (all-rights-reserved by default), which made downstream use in dependent projects legally ungranted.