### PR TITLE
fix(git-police): resolve push branch from the targeted repo, not hook cwd

### DIFF
--- a/hooks/claude/git-police.sh
+++ b/hooks/claude/git-police.sh
@@ -65,9 +65,10 @@ if echo "$STRIPPED" | grep -qiE '\bgit\b.*--no-verify\b'; then
 	deny "BLOCKED: --no-verify is forbidden. Skipping pre-commit hooks bypasses quality gates (linting, tests, formatting). Fix the issue that's causing the hook to fail instead."
 fi
 
-# 2. Block force push (--force, -f, but allow --force-with-lease)
+# 2. Block force push (--force, -f, --force-with-lease). Every variant rewrites
+#    remote history; sanctioned rewrites are pushed by the user directly.
 if echo "$STRIPPED" | grep -qiE '\bgit\b.*\bpush\b.*(-f\b|--force\b|--force-with-lease\b)'; then
-	deny "BLOCKED: Force push is forbidden. Force pushing rewrites history and can destroy work. If you truly need this, ask the user for explicit approval first."
+	deny "BLOCKED: Force push is forbidden. Force pushing rewrites history and can destroy work. If a history rewrite is truly required, prepare the branch and ask the user to run the force push themselves."
 fi
 
 # The remote a push targets: the first non-flag token after `push` (empty for
@@ -95,11 +96,26 @@ if [[ -z "$PUSH_REMOTE" || "$PUSH_REMOTE" == "origin" ]]; then
 	done
 fi
 
-# 4. Block push when currently on a protected branch (even without branch name
-#    in command) — same origin scoping as rule 3.
+# The repo a git command operates on: honor `git -C <path>` and a leading
+# `cd <path> &&`, falling back to the hook's cwd. Quoted paths were emptied
+# out of STRIPPED, so those fall back to the cwd as before.
+git_target_dir() {
+	local dir
+	dir=$(echo "$1" | sed -nE 's/.*git[[:space:]]+-C[[:space:]]+([^[:space:]]+).*/\1/p' | head -1)
+	if [[ -z "$dir" ]]; then
+		dir=$(echo "$1" | sed -nE 's/^[[:space:]]*cd[[:space:]]+([^[:space:];&|]+).*/\1/p' | head -1)
+	fi
+	echo "${dir/#\~/$HOME}"
+}
+
+# 4. Block push when the targeted repo is on a protected branch (even without
+#    branch name in command) — same origin scoping as rule 3. The branch is
+#    resolved from the repo the command targets, not the hook's cwd, which may
+#    be a different repo entirely (or none at all).
 if [[ -z "$PUSH_REMOTE" || "$PUSH_REMOTE" == "origin" ]] \
 	&& echo "$STRIPPED" | grep -qiE '\bgit\b.*\bpush\b'; then
-	CURRENT_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
+	TARGET_DIR=$(git_target_dir "$STRIPPED")
+	CURRENT_BRANCH=$(git ${TARGET_DIR:+-C "$TARGET_DIR"} symbolic-ref --short HEAD 2>/dev/null || echo "")
 	for branch in "${PROTECTED_BRANCHES[@]}"; do
 		if [[ "$CURRENT_BRANCH" == "$branch" ]]; then
 			deny "BLOCKED: You are on '${branch}'. Pushing from a protected branch is forbidden. Create a feature branch first: git checkout -b feat/your-feature-name"

--- a/tests/git-police-hygiene.test.ts
+++ b/tests/git-police-hygiene.test.ts
@@ -84,3 +84,26 @@ describe('git-police branch hygiene (rule 7)', () => {
     expect(runHook(clone, 'git checkout -b feat/next')).not.toContain('feat/merged-away');
   });
 });
+
+describe('git-police push branch resolution (rule 4)', () => {
+  test("denies plain push when the cwd repo is on 'main'", () => {
+    git(clone, 'checkout -q main');
+    const out = runHook(clone, 'git push origin HEAD');
+    expect(out).toContain('"deny"');
+    expect(out).toContain("You are on 'main'");
+  });
+
+  test('allows git -C push targeting a feature-branch repo while cwd is on main', () => {
+    const target = join(root, 'clone-feature');
+    execSync(`git clone ${origin} ${target}`, { stdio: 'pipe' });
+    git(target, 'checkout -q -b feat/rule4');
+    git(clone, 'checkout -q main');
+    expect(runHook(clone, `git -C ${target} push -u origin feat/rule4`)).not.toContain('"deny"');
+  });
+
+  test('denies git -C push targeting a repo on main even from a non-repo cwd', () => {
+    const out = runHook(root, `git -C ${clone} push origin HEAD`);
+    expect(out).toContain('"deny"');
+    expect(out).toContain("You are on 'main'");
+  });
+});


### PR DESCRIPTION
Rule 4 determined the current branch via `git symbolic-ref` in the hook's cwd, which is the session working directory — not necessarily the repo the command targets. This false-positived on `git -C <worktree> push` for feature branches while the session cwd sat on a repo checked out to `main`, and missed true positives when the cwd wasn't a repo at all.

- Resolve the target repo from `git -C <path>` or a leading `cd <path> &&`, falling back to the hook cwd (quoted paths are emptied by STRIPPED and keep the old fallback behavior).
- Rule 2: the comment claimed `--force-with-lease` is allowed, but the regex, the TS plugin, and the test suite all block it — align the comment and deny message with the tested behavior (all force-push variants blocked; sanctioned rewrites are pushed by the user).
- Tests: three new rule-4 cases in the hygiene harness (plain push on main still denied; `git -C` to a feature-branch repo allowed from a main cwd; `git -C` to a main repo denied from a non-repo cwd).

Known gap left for a follow-up: the `allowed-repos` check (line 38) still resolves `origin` from the hook cwd — same bug class, pre-existing.

Full suite: 108 pass / 0 fail.