### PR TITLE
feat: version-police blocks stale major dependency pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Reusable AI agent skills, rules, plugins, hooks, and tools for OpenCode, Claude 
 
 | Plugin                | Description                                                                                                              |
 | --------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| **version-police.ts** | Auto-checks Helm/npm/Cargo dependency versions on file write                                                             |
+| **version-police.ts** | Blocks writing dependency pins that are a major version behind the live registry (stale training-data pins)              |
 | **format-police.ts**  | Auto-formats files on write using dprint                                                                                 |
 | **kubectl-police.ts** | Blocks kubectl create/apply for Kargo CRDs (unconditionally)                                                             |
 | **git-police.ts**     | Blocks commits to main/master, force push, --no-verify, AI attribution, push to protected branches                       |
@@ -171,8 +171,48 @@ values.
 Plugins are OpenCode-specific (they use the `@opencode-ai/plugin` TypeScript API). They hook into
 OpenCode's tool execution lifecycle to enforce safety and quality gates.
 
-**version-police.ts**: Checks if Helm chart dependencies, npm packages, or Cargo crates are outdated
-whenever you modify a `Chart.yaml`, `package.json`, or `Cargo.toml`.
+**version-police**: Stops agents from pinning stale dependency versions recalled from training data.
+On every write/edit to a dependency manifest it detects the pins that are newly added or changed,
+looks each one up against the live upstream registry, and **blocks** the write when a pin is one or
+more **major** versions behind the latest release. Minor/patch lag is warned about (logged,
+non-blocking).
+
+Supported manifests and registries:
+
+| Manifest                                    | Registry        |
+| ------------------------------------------- | --------------- |
+| `package.json`                              | npm registry    |
+| `Cargo.toml`                                | crates.io       |
+| `pyproject.toml`, `requirements*.txt`       | PyPI            |
+| `Dockerfile` (`FROM`), `docker-compose.yml` | Docker Hub      |
+| `go.mod`                                    | Go module proxy |
+
+Built for hook speed: only diff-changed pins are checked, each lookup has a ~2.5s timeout and
+**fails open** on any network error (registry downtime never blocks a write), and results are cached
+on disk (`$XDG_CACHE_HOME/agentkit/version-police.json`) for 24h.
+
+**Overrides** (when a pin is deliberate):
+
+- Inline annotation on the pin line (or the line directly above), for any comment-bearing manifest:
+  ```toml
+  serde = "0.9" # version-police: allow serde -- locked for MSRV
+  ```
+  `package.json` is JSON and has no comments, so use the config exceptions list instead.
+- Config exceptions list in your agentkit config (applies to every manifest, including
+  `package.json`) — package names, `*` globs supported:
+  ```yaml
+  version-police:
+    exceptions:
+      - serde
+      - "@types/*"
+  ```
+
+Disable entirely with `version-police.enabled: false` in your config, or by adding `version-police`
+to the `AGENTKIT_SKIP_HOOKS` comma-separated env list.
+
+| Platform | File                        | Hook type           |
+| -------- | --------------------------- | ------------------- |
+| OpenCode | `plugins/version-police.ts` | tool.execute.before |
 
 **format-police.ts**: Auto-formats files after every write/edit using dprint. Auto-discovers the
 dprint binary from PATH or mise.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -39,6 +39,20 @@ pkg-police:
   # Example:
   #   enabled: false
 
+version-police:
+  # Set to false to disable stale-major dependency-pin blocking.
+  # Can also be disabled via AGENTKIT_SKIP_HOOKS=version-police.
+  enabled: true
+
+  # Packages exempted from the major-behind check (deliberate pins).
+  # Applies to every manifest, including package.json (which has no comments).
+  # Exact names or "*" globs are supported.
+  exceptions: []
+  # Example:
+  #   exceptions:
+  #     - serde
+  #     - "@types/*"
+
 comment-police:
   # Maximum lines in a single body comment block before warning.
   max-block-lines: 6

--- a/plugins/version-police.ts
+++ b/plugins/version-police.ts
@@ -1,206 +1,477 @@
 import type { PluginInput } from '@opencode-ai/plugin';
-import { spawnSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
-import path from 'node:path';
+import { readFileSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join, isAbsolute, resolve, basename } from 'node:path';
+import { homedir } from 'node:os';
 
-const HELM_CHART_FILE = /Chart\.yaml$/;
-const PACKAGE_JSON_FILE = /package\.json$/;
-const CARGO_TOML_FILE = /Cargo\.toml$/;
+// ---------------------------------------------------------------------------
+// A pin is a single dependency version declaration found in a manifest.
+// `raw` is the source line (used for inline-override detection); `inlineAllow`
+// is precomputed by the parser because it needs surrounding-line context.
+// ---------------------------------------------------------------------------
 
-const checkedThisSession = new Set<string>();
+export type Ecosystem = 'npm' | 'cargo' | 'pypi' | 'docker' | 'go';
 
-function checkHelmVersions(filePath: string): string[] {
-  const warnings: string[] = [];
-  let content: string;
-  try {
-    content = readFileSync(filePath, 'utf-8');
-  } catch {
-    return warnings;
-  }
-
-  const depRegex =
-    /^\s+-\s+name:\s*["']?([^"'\n]+)["']?\s*\n\s+version:\s*["']?([^"'\n]+)["']?\s*\n\s+repository:\s*["']?([^"'\n]+)["']?/gm;
-  let match;
-  while ((match = depRegex.exec(content)) !== null) {
-    const [, name, version, repo] = match;
-    const cacheKey = `helm:${repo}/${name}`;
-    if (checkedThisSession.has(cacheKey)) continue;
-    checkedThisSession.add(cacheKey);
-
-    try {
-      const repoAlias = Buffer.from(repo).toString('base64').slice(0, 12).replace(
-        /[^a-z0-9]/gi,
-        '',
-      );
-      spawnSync('helm', ['repo', 'add', repoAlias, repo], {
-        timeout: 15000,
-        stdio: 'ignore',
-      });
-      spawnSync('helm', ['repo', 'update', repoAlias], {
-        timeout: 15000,
-        stdio: 'ignore',
-      });
-
-      const result = spawnSync(
-        'helm',
-        ['search', 'repo', `${repoAlias}/${name}`, '--versions', '-o', 'json'],
-        { timeout: 15000, encoding: 'utf-8' },
-      );
-
-      if (result.status === 0 && result.stdout) {
-        const versions = JSON.parse(result.stdout);
-        if (versions.length > 0) {
-          const latest = versions[0].version;
-          if (latest !== version) {
-            warnings.push(
-              `OUTDATED: ${name} ${version} -> latest is ${latest} (${repo})`,
-            );
-          } else {
-            warnings.push(`OK: ${name} ${version} is latest`);
-          }
-        }
-      }
-    } catch {
-      warnings.push(`SKIP: Could not check ${name} ${version} (network/timeout)`);
-    }
-  }
-
-  return warnings;
+export interface Pin {
+  ecosystem: Ecosystem;
+  name: string;
+  version: string;
+  raw: string;
+  inlineAllow: boolean;
 }
 
-function checkNpmVersions(filePath: string): string[] {
-  const warnings: string[] = [];
-  let content: string;
-  try {
-    content = readFileSync(filePath, 'utf-8');
-  } catch {
-    return warnings;
-  }
+interface VersionPoliceConfig {
+  enabled: boolean;
+  exceptions: string[];
+}
 
-  let pkg: { dependencies?: Record<string, string>; devDependencies?: Record<string, string>; };
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const LOOKUP_TIMEOUT_MS = 2500;
+const SKIP_SPEC = /^(latest|\*|workspace:|file:|link:|git\+|https?:)/i;
+
+// ---------------------------------------------------------------------------
+// Config + kill switch
+// ---------------------------------------------------------------------------
+
+function getAgentkitConfigPath(): string {
+  const xdg = process.env.XDG_CONFIG_HOME || join(homedir(), '.config');
+  return join(xdg, 'agentkit', 'config.yaml');
+}
+
+export function loadConfig(): VersionPoliceConfig {
+  const defaults: VersionPoliceConfig = { enabled: true, exceptions: [] };
+  try {
+    const content = readFileSync(getAgentkitConfigPath(), 'utf-8');
+    const lines = content.split('\n');
+    let inSection = false;
+    const sectionLines: string[] = [];
+    for (const line of lines) {
+      if (/^version-police:/.test(line)) {
+        inSection = true;
+        continue;
+      }
+      if (inSection) {
+        if (/^\S/.test(line)) break;
+        sectionLines.push(line);
+      }
+    }
+    if (sectionLines.length === 0) return defaults;
+    const section = sectionLines.join('\n');
+    const enabled = !/enabled:\s*false/i.test(section);
+    const exMatch = section.match(/exceptions:\s*\n((?:\s*-\s*.+\n?)*)/);
+    const exceptions = exMatch
+      ? [...exMatch[1].matchAll(/^\s*-\s+(.+)$/gm)].map((m) =>
+        m[1].replace(/\s+#.*$/, '').replace(/^["']|["']$/g, '').trim()
+      )
+      : [];
+    return { enabled, exceptions };
+  } catch {
+    return defaults;
+  }
+}
+
+export function isDisabled(config: VersionPoliceConfig): boolean {
+  if (!config.enabled) return true;
+  const skip = process.env.AGENTKIT_SKIP_HOOKS || '';
+  return skip.split(',').map((s) => s.trim()).includes('version-police');
+}
+
+// ---------------------------------------------------------------------------
+// Overrides
+// ---------------------------------------------------------------------------
+
+export function inlineAllow(line: string, prevLine: string, pkg: string): boolean {
+  for (const candidate of [line, prevLine]) {
+    const m = candidate.match(/version-police:\s*allow\b(?:\s+(\S+))?/i);
+    if (!m) continue;
+    const named = m[1];
+    if (!named || named === '*' || named === pkg) return true;
+  }
+  return false;
+}
+
+export function matchesException(name: string, patterns: string[]): boolean {
+  for (const pattern of patterns) {
+    if (pattern === name) return true;
+    if (pattern.includes('*')) {
+      const rx = new RegExp(
+        '^' + pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*') + '$',
+      );
+      if (rx.test(name)) return true;
+    }
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Version comparison
+// ---------------------------------------------------------------------------
+
+export function parseVersion(v: string): [number, number, number] {
+  const cleaned = v.replace(/^[\^~>=<v\s]+/, '').split(/[-+]/)[0];
+  const parts = cleaned.split('.').map((p) => parseInt(p, 10));
+  return [parts[0] || 0, parts[1] || 0, parts[2] || 0];
+}
+
+export function majorLag(pinned: string, latest: string): number {
+  return parseVersion(latest)[0] - parseVersion(pinned)[0];
+}
+
+function isBehind(pinned: string, latest: string): boolean {
+  const p = parseVersion(pinned);
+  const l = parseVersion(latest);
+  for (let i = 0; i < 3; i++) {
+    if (l[i] > p[i]) return true;
+    if (l[i] < p[i]) return false;
+  }
+  return false;
+}
+
+export function analyzePin(
+  pin: Pin,
+  latest: string | null,
+  config: VersionPoliceConfig,
+): 'block' | 'warn' | 'ok' {
+  if (pin.inlineAllow) return 'ok';
+  if (matchesException(pin.name, config.exceptions)) return 'ok';
+  if (!latest) return 'ok'; // fail open: could not determine latest
+  if (majorLag(pin.version, latest) >= 1) return 'block';
+  if (isBehind(pin.version, latest)) return 'warn';
+  return 'ok';
+}
+
+// ---------------------------------------------------------------------------
+// Manifest parsing
+// ---------------------------------------------------------------------------
+
+function cleanSpec(spec: string): string | null {
+  const trimmed = spec.trim();
+  if (SKIP_SPEC.test(trimmed)) return null;
+  const version = trimmed.replace(/^[\^~>=<\s]+/, '');
+  if (!/^\d+\.\d+/.test(version)) return null;
+  return version;
+}
+
+function parseNpm(content: string): Pin[] {
+  const pins: Pin[] = [];
+  let pkg: Record<string, Record<string, string>>;
   try {
     pkg = JSON.parse(content);
   } catch {
-    return warnings;
+    return pins;
   }
-
-  const allDeps = { ...pkg.dependencies, ...pkg.devDependencies };
-  for (const [name, versionSpec] of Object.entries(allDeps)) {
-    if (name.startsWith('@opencode-ai/')) continue;
-
-    const version = versionSpec.replace(/^[\^~>=<]*/g, '');
-    if (!version || version === 'latest' || version === '*') continue;
-
-    const cacheKey = `npm:${name}`;
-    if (checkedThisSession.has(cacheKey)) continue;
-    checkedThisSession.add(cacheKey);
-
-    try {
-      const result = spawnSync('npm', ['view', name, 'version'], {
-        timeout: 10000,
-        encoding: 'utf-8',
-      });
-      if (result.status === 0 && result.stdout) {
-        const latest = result.stdout.trim();
-        if (latest !== version) {
-          warnings.push(`OUTDATED: ${name} ${version} -> latest is ${latest}`);
-        } else {
-          warnings.push(`OK: ${name} ${version} is latest`);
-        }
-      }
-    } catch {
-      warnings.push(`SKIP: Could not check ${name} ${version} (network/timeout)`);
+  const groups = ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies'];
+  for (const group of groups) {
+    const deps = pkg[group];
+    if (!deps || typeof deps !== 'object') continue;
+    for (const [name, spec] of Object.entries(deps)) {
+      if (typeof spec !== 'string') continue;
+      const version = cleanSpec(spec);
+      if (!version) continue;
+      // JSON has no comments — inline override is never available here.
+      pins.push({ ecosystem: 'npm', name, version, raw: `"${name}": "${spec}"`, inlineAllow: false });
     }
   }
-
-  return warnings;
+  return pins;
 }
 
-function checkCargoVersions(filePath: string): string[] {
-  const warnings: string[] = [];
-  let content: string;
+function parseLineManifest(
+  content: string,
+  ecosystem: Ecosystem,
+  matcher: (line: string, inDeps: boolean) => { name: string; version: string } | null,
+  sectionGate?: (line: string) => boolean | null,
+): Pin[] {
+  const pins: Pin[] = [];
+  const lines = content.split('\n');
+  let inDeps = sectionGate ? false : true;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (sectionGate) {
+      const gate = sectionGate(line);
+      if (gate !== null) {
+        inDeps = gate;
+        continue;
+      }
+    }
+    const hit = matcher(line, inDeps);
+    if (!hit) continue;
+    const prev = i > 0 ? lines[i - 1] : '';
+    pins.push({
+      ecosystem,
+      name: hit.name,
+      version: hit.version,
+      raw: line,
+      inlineAllow: inlineAllow(line, prev, hit.name),
+    });
+  }
+  return pins;
+}
+
+function parseCargo(content: string): Pin[] {
+  return parseLineManifest(
+    content,
+    'cargo',
+    (line, inDeps) => {
+      if (!inDeps) return null;
+      const m = line.match(/^\s*([\w-]+)\s*=\s*(?:"([^"]+)"|\{[^}]*\bversion\s*=\s*"([^"]+)")/);
+      if (!m) return null;
+      const version = cleanSpec(m[2] || m[3] || '');
+      return version ? { name: m[1], version } : null;
+    },
+    (line) => {
+      if (/^\s*\[.*dependencies.*\]/.test(line)) return true;
+      if (/^\s*\[/.test(line)) return false;
+      return null;
+    },
+  );
+}
+
+function parsePypi(content: string): Pin[] {
+  return parseLineManifest(content, 'pypi', (line) => {
+    // requirements.txt / PEP 508: pkg==1.2.3 ; poetry: pkg = "^1.2.3"
+    const pep = line.match(/^\s*["']?([A-Za-z0-9._-]+)["']?\s*==\s*["']?([0-9][^"'\s;,\]]*)/);
+    if (pep) return { name: pep[1], version: pep[2] };
+    const poetry = line.match(/^\s*([A-Za-z0-9._-]+)\s*=\s*"([\^~>=<]*[0-9][^"]*)"/);
+    if (poetry) {
+      const version = cleanSpec(poetry[2]);
+      if (version && poetry[1] !== 'python') return { name: poetry[1], version };
+    }
+    return null;
+  });
+}
+
+function parseDocker(content: string): Pin[] {
+  return parseLineManifest(content, 'docker', (line) => {
+    const from = line.match(/^\s*FROM\s+([^\s:@]+):([^\s@]+)/i);
+    const compose = line.match(/^\s*image:\s*["']?([^\s:"'@]+):([^\s"'@]+)/i);
+    const m = from || compose;
+    if (!m) return null;
+    const tag = m[2].split('-')[0];
+    if (!/^\d+(\.\d+)*$/.test(tag)) return null;
+    return { name: m[1], version: tag };
+  });
+}
+
+function parseGo(content: string): Pin[] {
+  return parseLineManifest(content, 'go', (line) => {
+    const m = line.match(/^\s*(?:require\s+)?([\w.\-/]+\.[\w.\-/]+)\s+v(\d+\.\d+\.\d+)/);
+    if (!m) return null;
+    return { name: m[1], version: m[2] };
+  });
+}
+
+export function parsePins(filePath: string, content: string): Pin[] {
+  const name = basename(filePath).toLowerCase();
+  if (name === 'package.json') return parseNpm(content);
+  if (name === 'cargo.toml') return parseCargo(content);
+  if (name === 'pyproject.toml' || /^requirements.*\.txt$/.test(name)) return parsePypi(content);
+  if (name === 'dockerfile' || name.endsWith('.dockerfile')) return parseDocker(content);
+  if (/^(docker-)?compose.*\.ya?ml$/.test(name)) return parseDocker(content);
+  if (name === 'go.mod') return parseGo(content);
+  return [];
+}
+
+export function isManifest(filePath: string): boolean {
+  return /^(package\.json|cargo\.toml|pyproject\.toml|go\.mod|dockerfile)$|^requirements.*\.txt$|\.dockerfile$|^(docker-)?compose.*\.ya?ml$/i
+    .test(basename(filePath));
+}
+
+export function changedPins(filePath: string, newContent: string, oldContent: string): Pin[] {
+  const oldPins = parsePins(filePath, oldContent);
+  const newPins = parsePins(filePath, newContent);
+  return newPins.filter(
+    (np) => !oldPins.some((op) => op.name === np.name && op.version === np.version),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Registry lookup + on-disk cache
+// ---------------------------------------------------------------------------
+
+type Cache = Record<string, { v: string; t: number }>;
+
+function cachePath(): string {
+  const base = process.env.XDG_CACHE_HOME || join(homedir(), '.cache');
+  return join(base, 'agentkit', 'version-police.json');
+}
+
+export function cachedVersion(cache: Cache, key: string, now: number): string | null {
+  const entry = cache[key];
+  if (!entry) return null;
+  if (now - entry.t > CACHE_TTL_MS) return null;
+  return entry.v;
+}
+
+function readCache(path: string): Cache {
   try {
-    content = readFileSync(filePath, 'utf-8');
+    return JSON.parse(readFileSync(path, 'utf-8')) as Cache;
   } catch {
-    return warnings;
+    return {};
   }
-
-  const depRegex = /^(\w[\w-]*)\s*=\s*(?:"([^"]+)"|{[^}]*version\s*=\s*"([^"]+)")/gm;
-  let inDeps = false;
-  for (const line of content.split('\n')) {
-    if (/^\[.*dependencies.*\]/.test(line)) {
-      inDeps = true;
-      continue;
-    }
-    if (/^\[/.test(line)) {
-      inDeps = false;
-      continue;
-    }
-    if (!inDeps) continue;
-
-    const m = line.match(/^(\w[\w-]*)\s*=\s*(?:"([^"]+)"|{[^}]*version\s*=\s*"([^"]+)")/);
-    if (!m) continue;
-
-    const name = m[1];
-    const version = (m[2] || m[3]).replace(/^[\^~>=<]*/g, '');
-    const cacheKey = `cargo:${name}`;
-    if (checkedThisSession.has(cacheKey)) continue;
-    checkedThisSession.add(cacheKey);
-
-    try {
-      const result = spawnSync('cargo', ['search', name, '--limit', '1'], {
-        timeout: 10000,
-        encoding: 'utf-8',
-      });
-      if (result.status === 0 && result.stdout) {
-        const m2 = result.stdout.match(new RegExp(`^${name}\\s*=\\s*"([^"]+)"`));
-        if (m2) {
-          const latest = m2[1];
-          if (latest !== version) {
-            warnings.push(`OUTDATED: ${name} ${version} -> latest is ${latest}`);
-          } else {
-            warnings.push(`OK: ${name} ${version} is latest`);
-          }
-        }
-      }
-    } catch {
-      warnings.push(`SKIP: Could not check ${name} ${version} (network/timeout)`);
-    }
-  }
-
-  return warnings;
 }
+
+function writeCache(path: string, cache: Cache): void {
+  try {
+    mkdirSync(join(path, '..'), { recursive: true });
+    writeFileSync(path, JSON.stringify(cache));
+  } catch {
+    // cache is best-effort; ignore write failures
+  }
+}
+
+async function fetchJson(url: string): Promise<any | null> {
+  try {
+    const res = await fetch(url, {
+      signal: AbortSignal.timeout(LOOKUP_TIMEOUT_MS),
+      headers: { 'User-Agent': 'agentkit-version-police' },
+    });
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null; // fail open on any network error / timeout
+  }
+}
+
+async function fetchLatest(pin: Pin): Promise<string | null> {
+  if (pin.ecosystem === 'npm') {
+    const data = await fetchJson(`https://registry.npmjs.org/${pin.name.replace('/', '%2F')}/latest`);
+    return data?.version ?? null;
+  }
+  if (pin.ecosystem === 'pypi') {
+    const data = await fetchJson(`https://pypi.org/pypi/${pin.name}/json`);
+    return data?.info?.version ?? null;
+  }
+  if (pin.ecosystem === 'cargo') {
+    const data = await fetchJson(`https://crates.io/api/v1/crates/${pin.name}`);
+    return data?.crate?.max_stable_version ?? data?.crate?.newest_version ?? null;
+  }
+  if (pin.ecosystem === 'go') {
+    const escaped = pin.name.replace(/([A-Z])/g, (c) => '!' + c.toLowerCase());
+    const data = await fetchJson(`https://proxy.golang.org/${escaped}/@latest`);
+    return data?.Version ?? null;
+  }
+  if (pin.ecosystem === 'docker') {
+    const repo = pin.name.includes('/') ? pin.name : `library/${pin.name}`;
+    const data = await fetchJson(
+      `https://hub.docker.com/v2/repositories/${repo}/tags?page_size=100&ordering=last_updated`,
+    );
+    const tags: string[] = (data?.results ?? [])
+      .map((r: { name: string }) => r.name)
+      .filter((t: string) => /^\d+(\.\d+)*$/.test(t));
+    if (tags.length === 0) return null;
+    return tags.sort((a, b) => majorLag(a, b) || parseVersion(b)[1] - parseVersion(a)[1])[0];
+  }
+  return null;
+}
+
+type GetLatest = (pin: Pin) => Promise<string | null>;
+
+function diskGetLatest(path: string): GetLatest {
+  const cache = readCache(path);
+  return async (pin: Pin) => {
+    const key = `${pin.ecosystem}:${pin.name}`;
+    const hit = cachedVersion(cache, key, Date.now());
+    if (hit) return hit;
+    const latest = await fetchLatest(pin);
+    if (latest) {
+      cache[key] = { v: latest, t: Date.now() };
+      writeCache(path, cache);
+    }
+    return latest;
+  };
+}
+
+export async function evaluatePins(
+  pins: Pin[],
+  getLatest: GetLatest,
+  config: VersionPoliceConfig,
+): Promise<{ blocks: string[]; warns: string[] }> {
+  const blocks: string[] = [];
+  const warns: string[] = [];
+  for (const pin of pins) {
+    if (pin.inlineAllow || matchesException(pin.name, config.exceptions)) continue;
+    const latest = await getLatest(pin);
+    const verdict = analyzePin(pin, latest, config);
+    if (verdict === 'block') {
+      blocks.push(
+        `${pin.name} pinned at ${pin.version} is ${majorLag(pin.version, latest!)} major version(s) ` +
+          `behind latest ${latest} (${pin.ecosystem})`,
+      );
+    } else if (verdict === 'warn') {
+      warns.push(`${pin.name} ${pin.version} -> latest ${latest} (${pin.ecosystem})`);
+    }
+  }
+  return { blocks, warns };
+}
+
+function blockMessage(blocks: string[]): string {
+  return (
+    `BLOCKED: stale major dependency version(s) detected by version-police.\n` +
+    `${'='.repeat(50)}\n` +
+    blocks.map((b, i) => `${i + 1}. ${b}`).join('\n') +
+    `\n\n` +
+    `These pins are at least one MAJOR version behind the live registry — likely\n` +
+    `recalled from training data. Use the current major version instead.\n\n` +
+    `If a pin is deliberate, override it:\n` +
+    `  - Inline (non-JSON manifests): add on the pin line or the line above:\n` +
+    `      # version-police: allow <package> -- <reason>\n` +
+    `  - Config (any manifest, incl. package.json): add to ~/.config/agentkit/config.yaml:\n` +
+    `      version-police:\n` +
+    `        exceptions:\n` +
+    `          - <package>\n\n` +
+    `Disable entirely: version-police.enabled: false, or\n` +
+    `AGENTKIT_SKIP_HOOKS=version-police.`
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Plugin entry point
+// ---------------------------------------------------------------------------
 
 export default async function versionPolice(ctx: PluginInput) {
+  const config = loadConfig();
+
   return {
-    'tool.execute.after': async (
-      input: { tool: string; sessionID: string; callID: string; },
-      output: { title: string; output: string; metadata: unknown; },
-    ) => {
+    'tool.execute.before': async (
+      input: { tool: string; sessionID: string; callID: string },
+      output: { args: Record<string, unknown> },
+    ): Promise<void> => {
       const toolName = input.tool?.toLowerCase();
       if (toolName !== 'edit' && toolName !== 'write') return;
+      if (isDisabled(config)) return;
 
-      const relativePath = output.title;
-      if (!relativePath) return;
+      const args = output.args;
+      const filePath = (args.filePath || args.file_path || args.path) as string | undefined;
+      if (!filePath || !isManifest(filePath)) return;
 
-      const absPath = path.isAbsolute(relativePath)
-        ? relativePath
-        : path.resolve(ctx.worktree, relativePath);
-
-      let warnings: string[] = [];
-
-      if (HELM_CHART_FILE.test(relativePath)) {
-        warnings = checkHelmVersions(absPath);
-      } else if (PACKAGE_JSON_FILE.test(relativePath)) {
-        warnings = checkNpmVersions(absPath);
-      } else if (CARGO_TOML_FILE.test(relativePath)) {
-        warnings = checkCargoVersions(absPath);
+      const absPath = isAbsolute(filePath) ? filePath : resolve(ctx.directory, filePath);
+      let oldContent = '';
+      try {
+        oldContent = readFileSync(absPath, 'utf-8');
+      } catch {
+        // new file — every pin is "changed"
       }
 
-      if (warnings.length > 0) {
-        output.output += `\n\nDEPENDENCY VERSION CHECK\n${
-          warnings.map((w) => `  ${w}`).join('\n')
-        }\n\nIf any dependency is OUTDATED, you MUST update it to the latest version before proceeding. Do NOT use outdated versions from your training data.`;
+      let newContent: string;
+      if (toolName === 'write') {
+        newContent = (args.content as string) || '';
+      } else {
+        const oldString = (args.oldString as string) || '';
+        const newString = (args.newString as string) || '';
+        newContent = args.replaceAll
+          ? oldContent.split(oldString).join(newString)
+          : oldContent.replace(oldString, newString);
+      }
+      if (!newContent) return;
+
+      const pins = changedPins(filePath, newContent, oldContent);
+      if (pins.length === 0) return;
+
+      const { blocks, warns } = await evaluatePins(pins, diskGetLatest(cachePath()), config);
+      for (const w of warns) {
+        console.warn(`[version-police] OUTDATED (minor/patch, non-blocking): ${w}`);
+      }
+      if (blocks.length > 0) {
+        throw new Error(blockMessage(blocks));
       }
     },
   };

--- a/tests/version-police.test.ts
+++ b/tests/version-police.test.ts
@@ -1,0 +1,240 @@
+import { describe, test, expect } from 'bun:test';
+import type { Pin } from '../plugins/version-police';
+import versionPolice, {
+  analyzePin,
+  cachedVersion,
+  changedPins,
+  evaluatePins,
+  inlineAllow,
+  isManifest,
+  loadConfig,
+  majorLag,
+  matchesException,
+  parsePins,
+  parseVersion,
+} from '../plugins/version-police';
+
+const config = { enabled: true, exceptions: [] };
+const mockCtx = { directory: '/tmp', worktree: '/tmp' } as any;
+
+function pin(over: Partial<Pin> = {}): Pin {
+  return { ecosystem: 'npm', name: 'react', version: '17.0.0', raw: '', inlineAllow: false, ...over };
+}
+
+describe('parsePins', () => {
+  test('extracts npm deps and skips ranges/latest', () => {
+    const content = JSON.stringify({
+      dependencies: { react: '^17.0.0', 'is-latest': 'latest', linked: 'workspace:*' },
+      devDependencies: { typescript: '5.3.3' },
+    });
+    const pins = parsePins('package.json', content);
+    expect(pins.map((p) => p.name).sort()).toEqual(['react', 'typescript']);
+    expect(pins.find((p) => p.name === 'react')!.version).toBe('17.0.0');
+  });
+
+  test('extracts Cargo deps only inside dependency sections', () => {
+    const content = [
+      '[package]',
+      'name = "x"',
+      'version = "1.2.3"',
+      '',
+      '[dependencies]',
+      'serde = "0.9.0"',
+      'tokio = { version = "0.2.0", features = ["full"] }',
+    ].join('\n');
+    const pins = parsePins('Cargo.toml', content);
+    expect(pins.map((p) => `${p.name}@${p.version}`).sort()).toEqual(['serde@0.9.0', 'tokio@0.2.0']);
+  });
+
+  test('extracts pypi pins from requirements and pyproject', () => {
+    expect(parsePins('requirements.txt', 'django==3.2.0\nflask>=2.0').map((p) => p.name)).toEqual([
+      'django',
+    ]);
+    const poetry = '[tool.poetry.dependencies]\npython = "^3.11"\nrequests = "^2.20.0"';
+    expect(parsePins('pyproject.toml', poetry).map((p) => p.name)).toEqual(['requests']);
+  });
+
+  test('extracts docker image tags, skipping non-semver tags', () => {
+    const content = 'FROM node:18.19.0-alpine AS build\nFROM nginx:latest';
+    const pins = parsePins('Dockerfile', content);
+    expect(pins.map((p) => `${p.name}@${p.version}`)).toEqual(['node@18.19.0']);
+  });
+
+  test('extracts go module versions', () => {
+    const content = 'require (\n\tgithub.com/gin-gonic/gin v1.7.0\n)';
+    const pins = parsePins('go.mod', content);
+    expect(pins[0]).toMatchObject({ name: 'github.com/gin-gonic/gin', version: '1.7.0' });
+  });
+});
+
+describe('isManifest', () => {
+  test('recognises supported manifests and rejects others', () => {
+    for (const f of ['package.json', 'Cargo.toml', 'pyproject.toml', 'requirements-dev.txt', 'Dockerfile', 'docker-compose.yml', 'go.mod']) {
+      expect(isManifest(f)).toBe(true);
+    }
+    expect(isManifest('src/index.ts')).toBe(false);
+    expect(isManifest('README.md')).toBe(false);
+  });
+});
+
+describe('changedPins', () => {
+  test('returns only new or version-changed pins', () => {
+    const oldC = JSON.stringify({ dependencies: { react: '17.0.0', lodash: '4.17.21' } });
+    const newC = JSON.stringify({ dependencies: { react: '18.0.0', lodash: '4.17.21', axios: '1.0.0' } });
+    const changed = changedPins('package.json', newC, oldC).map((p) => p.name).sort();
+    expect(changed).toEqual(['axios', 'react']); // lodash unchanged is skipped
+  });
+});
+
+describe('inlineAllow', () => {
+  test('matches on same line, unnamed, and named package', () => {
+    expect(inlineAllow('serde = "0.9" # version-police: allow', '', 'serde')).toBe(true);
+    expect(inlineAllow('serde = "0.9" # version-police: allow serde -- legacy', '', 'serde')).toBe(true);
+    expect(inlineAllow('serde = "0.9"', '# version-police: allow serde', 'serde')).toBe(true);
+  });
+  test('does not match a different named package', () => {
+    expect(inlineAllow('serde = "0.9" # version-police: allow tokio', '', 'serde')).toBe(false);
+    expect(inlineAllow('serde = "0.9"', '', 'serde')).toBe(false);
+  });
+});
+
+describe('matchesException', () => {
+  test('exact and glob patterns', () => {
+    expect(matchesException('react', ['react'])).toBe(true);
+    expect(matchesException('@types/node', ['@types/*'])).toBe(true);
+    expect(matchesException('react-dom', ['react'])).toBe(false);
+  });
+});
+
+describe('version math', () => {
+  test('parseVersion strips prefixes and prerelease', () => {
+    expect(parseVersion('^1.2.3')).toEqual([1, 2, 3]);
+    expect(parseVersion('v2.0.0-rc1')).toEqual([2, 0, 0]);
+  });
+  test('majorLag', () => {
+    expect(majorLag('17.0.0', '19.0.0')).toBe(2);
+    expect(majorLag('4.17.20', '4.17.21')).toBe(0);
+  });
+});
+
+describe('analyzePin', () => {
+  test('blocks a pin one or more majors behind', () => {
+    expect(analyzePin(pin({ version: '17.0.0' }), '19.0.0', config)).toBe('block');
+  });
+  test('warns on minor/patch lag', () => {
+    expect(analyzePin(pin({ version: '4.17.20' }), '4.17.21', config)).toBe('warn');
+  });
+  test('ok when up to date', () => {
+    expect(analyzePin(pin({ version: '19.0.0' }), '19.0.0', config)).toBe('ok');
+  });
+  test('fails open when latest is null (network failure)', () => {
+    expect(analyzePin(pin({ version: '1.0.0' }), null, config)).toBe('ok');
+  });
+  test('inline allow overrides a stale major', () => {
+    expect(analyzePin(pin({ version: '1.0.0', inlineAllow: true }), '9.0.0', config)).toBe('ok');
+  });
+  test('config exception overrides a stale major', () => {
+    expect(analyzePin(pin({ version: '1.0.0' }), '9.0.0', { enabled: true, exceptions: ['react'] })).toBe('ok');
+  });
+});
+
+describe('cachedVersion', () => {
+  const now = 1_000_000_000_000;
+  test('returns a fresh entry', () => {
+    expect(cachedVersion({ 'npm:react': { v: '19.0.0', t: now } }, 'npm:react', now + 1000)).toBe('19.0.0');
+  });
+  test('returns null for a stale entry (>24h)', () => {
+    expect(cachedVersion({ 'npm:react': { v: '19.0.0', t: now } }, 'npm:react', now + 25 * 3600_000)).toBeNull();
+  });
+  test('returns null when key absent', () => {
+    expect(cachedVersion({}, 'npm:react', now)).toBeNull();
+  });
+});
+
+describe('evaluatePins', () => {
+  test('stale major is blocked', async () => {
+    const { blocks, warns } = await evaluatePins([pin({ version: '17.0.0' })], async () => '19.0.0', config);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toContain('react');
+    expect(blocks[0]).toContain('19.0.0');
+    expect(warns).toHaveLength(0);
+  });
+
+  test('minor lag warns only', async () => {
+    const { blocks, warns } = await evaluatePins([pin({ version: '4.17.20', name: 'lodash' })], async () => '4.17.21', config);
+    expect(blocks).toHaveLength(0);
+    expect(warns).toHaveLength(1);
+  });
+
+  test('network failure fails open (no blocks/warns)', async () => {
+    const { blocks, warns } = await evaluatePins([pin({ version: '1.0.0' })], async () => null, config);
+    expect(blocks).toHaveLength(0);
+    expect(warns).toHaveLength(0);
+  });
+
+  test('inline-allow pin is skipped without a lookup', async () => {
+    let looked = false;
+    const { blocks } = await evaluatePins([pin({ version: '1.0.0', inlineAllow: true })], async () => {
+      looked = true;
+      return '9.0.0';
+    }, config);
+    expect(blocks).toHaveLength(0);
+    expect(looked).toBe(false);
+  });
+
+  test('config exception pin is skipped without a lookup', async () => {
+    let looked = false;
+    const { blocks } = await evaluatePins([pin({ version: '1.0.0' })], async () => {
+      looked = true;
+      return '9.0.0';
+    }, { enabled: true, exceptions: ['react'] });
+    expect(blocks).toHaveLength(0);
+    expect(looked).toBe(false);
+  });
+
+  test('cache-hit path: getLatest served from an in-memory cache blocks a stale major', async () => {
+    const cache = { 'npm:react': { v: '19.0.0', t: Date.now() } };
+    const getLatest = async (p: Pin) => cachedVersion(cache, `${p.ecosystem}:${p.name}`, Date.now());
+    const { blocks } = await evaluatePins([pin({ version: '16.0.0' })], getLatest, config);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toContain('behind latest 19.0.0');
+  });
+});
+
+describe('plugin hook', () => {
+  test('ignores non edit/write tools', async () => {
+    const hooks = await versionPolice(mockCtx);
+    const input = { tool: 'bash', sessionID: 't', callID: 't' };
+    const output = { args: { command: 'ls' } };
+    expect(hooks['tool.execute.before']!(input, output)).resolves.toBeUndefined();
+  });
+
+  test('ignores writes to non-manifest files', async () => {
+    const hooks = await versionPolice(mockCtx);
+    const input = { tool: 'write', sessionID: 't', callID: 't' };
+    const output = { args: { filePath: '/tmp/index.ts', content: 'const x = 1' } };
+    expect(hooks['tool.execute.before']!(input, output)).resolves.toBeUndefined();
+  });
+
+  test('disabled via AGENTKIT_SKIP_HOOKS is a no-op', async () => {
+    const prev = process.env.AGENTKIT_SKIP_HOOKS;
+    process.env.AGENTKIT_SKIP_HOOKS = 'version-police';
+    try {
+      const hooks = await versionPolice(mockCtx);
+      const input = { tool: 'write', sessionID: 't', callID: 't' };
+      const output = { args: { filePath: '/tmp/package.json', content: '{"dependencies":{"react":"1.0.0"}}' } };
+      await expect(hooks['tool.execute.before']!(input, output)).resolves.toBeUndefined();
+    } finally {
+      if (prev === undefined) delete process.env.AGENTKIT_SKIP_HOOKS;
+      else process.env.AGENTKIT_SKIP_HOOKS = prev;
+    }
+  });
+});
+
+describe('loadConfig', () => {
+  test('returns defaults when no config present', () => {
+    const cfg = loadConfig();
+    expect(cfg).toHaveProperty('enabled');
+    expect(cfg).toHaveProperty('exceptions');
+  });
+});


### PR DESCRIPTION
## What

Rewrites the `version-police` OpenCode plugin from a passive "outdated" warner into a gate that **blocks** writes pinning a dependency **one or more major versions behind** the live registry — the classic "agent recalls a stale version from training data" failure.

## Behaviour

- Triggers on `write`/`edit` to dependency manifests; checks **only the pins that were newly added or changed**.
- Registries: **npm**, **crates.io**, **PyPI**, **Docker Hub**, **Go proxy**.
- **Block** on `>= 1` major behind (throws in `tool.execute.before`). **Warn** (logged, non-blocking) on minor/patch lag.
- Hook-speed: ~2.5s per-lookup timeout, **fails open** on any network error (registry downtime never blocks), 24h on-disk cache at `$XDG_CACHE_HOME/agentkit/version-police.json`.

## Overrides

- Inline (comment-bearing manifests): `# version-police: allow <pkg> -- <reason>` on the pin line or the line above.
- Config exceptions (any manifest, incl. `package.json` which has no comments): `version-police.exceptions` list, exact names or `*` globs.
- Kill switch: `version-police.enabled: false`, or add `version-police` to `AGENTKIT_SKIP_HOOKS`.

## Tests

`bun test` — 142 pass / 0 fail (31 new): stale-major blocked, minor warns, inline-allow + config-exception pass, network-failure fails open, cache-hit path, parsers for all five ecosystems.

Docs: README plugin table + detailed section; `config.example.yaml` entry.

Supersedes #38 (that branch was cut from a stale local main and conflicted).