### PR TITLE
fix(hooks): resolve targeted repo, not hook cwd, in git/mr-police

### DIFF
--- a/hooks/claude/git-police.sh
+++ b/hooks/claude/git-police.sh
@@ -34,19 +34,39 @@ load_allowed_repos() {
 ALLOWED_REPOS=()
 load_allowed_repos
 
+STRIPPED=$(echo "$COMMAND" |
+	sed -E "s/<<-?[[:space:]]*['\"]?([A-Za-z_]+)['\"]?/\n\1_HEREDOC_START\n/g" |
+	sed -E "s/\"([^\"\\\\]|\\\\.)*\"/\"\"/g" |
+	sed -E "s/'[^']*'/''/g")
+
+# The repo a git command operates on: honor `git -C <path>` and a `cd <path>`
+# at the start or after a separator (; && |), falling back to the hook's cwd.
+# The session cwd may be a different repo entirely (or none at all) — every
+# repo-state check below must resolve against the targeted repo, not the cwd.
+# Quoted paths were emptied out of STRIPPED, so those fall back to the cwd.
+git_target_dir() {
+	local dir
+	dir=$(echo "$1" | sed -nE 's/.*git[[:space:]]+-C[[:space:]]+([^[:space:]]+).*/\1/p' | head -1)
+	if [[ -z "$dir" ]]; then
+		dir=$(echo "$1" | sed -nE 's/(^|.*[;&|])[[:space:]]*cd[[:space:]]+([^[:space:];&|]+).*/\2/p' | head -1)
+	fi
+	echo "${dir/#\~/$HOME}"
+}
+TARGET_DIR=$(git_target_dir "$STRIPPED")
+
+# git scoped to the targeted repo (cwd when the command names none).
+tgit() {
+	git ${TARGET_DIR:+-C "$TARGET_DIR"} "$@"
+}
+
 if [[ ${#ALLOWED_REPOS[@]} -gt 0 ]]; then
-	REPO_NAME=$(git remote get-url origin 2>/dev/null | sed -E 's|.*[:/]([^/]+/[^/]+?)(\.git)?$|\1|' || echo "")
+	REPO_NAME=$(tgit remote get-url origin 2>/dev/null | sed -E 's|.*[:/]([^/]+/[^/]+?)(\.git)?$|\1|' || echo "")
 	for allowed in "${ALLOWED_REPOS[@]}"; do
 		if [[ "$REPO_NAME" == *"$allowed"* ]]; then
 			exit 0
 		fi
 	done
 fi
-
-STRIPPED=$(echo "$COMMAND" |
-	sed -E "s/<<-?[[:space:]]*['\"]?([A-Za-z_]+)['\"]?/\n\1_HEREDOC_START\n/g" |
-	sed -E "s/\"([^\"\\\\]|\\\\.)*\"/\"\"/g" |
-	sed -E "s/'[^']*'/''/g")
 
 deny() {
 	local reason="$1"
@@ -101,26 +121,11 @@ if [[ -z "$PUSH_REMOTE" || "$PUSH_REMOTE" == "origin" ]]; then
 	done
 fi
 
-# The repo a git command operates on: honor `git -C <path>` and a leading
-# `cd <path> &&`, falling back to the hook's cwd. Quoted paths were emptied
-# out of STRIPPED, so those fall back to the cwd as before.
-git_target_dir() {
-	local dir
-	dir=$(echo "$1" | sed -nE 's/.*git[[:space:]]+-C[[:space:]]+([^[:space:]]+).*/\1/p' | head -1)
-	if [[ -z "$dir" ]]; then
-		dir=$(echo "$1" | sed -nE 's/^[[:space:]]*cd[[:space:]]+([^[:space:];&|]+).*/\1/p' | head -1)
-	fi
-	echo "${dir/#\~/$HOME}"
-}
-
 # 4. Block push when the targeted repo is on a protected branch (even without
-#    branch name in command) — same origin scoping as rule 3. The branch is
-#    resolved from the repo the command targets, not the hook's cwd, which may
-#    be a different repo entirely (or none at all).
+#    branch name in command) — same origin scoping as rule 3.
 if [[ -z "$PUSH_REMOTE" || "$PUSH_REMOTE" == "origin" ]] \
 	&& echo "$STRIPPED" | grep -qiE "$GIT_PUSH_RE"; then
-	TARGET_DIR=$(git_target_dir "$STRIPPED")
-	CURRENT_BRANCH=$(git ${TARGET_DIR:+-C "$TARGET_DIR"} symbolic-ref --short HEAD 2>/dev/null || echo "")
+	CURRENT_BRANCH=$(tgit symbolic-ref --short HEAD 2>/dev/null || echo "")
 	for branch in "${PROTECTED_BRANCHES[@]}"; do
 		if [[ "$CURRENT_BRANCH" == "$branch" ]]; then
 			deny "BLOCKED: You are on '${branch}'. Pushing from a protected branch is forbidden. Create a feature branch first: git checkout -b feat/your-feature-name"
@@ -142,7 +147,7 @@ fi
 
 # 6. Block direct commits to protected branches
 if echo "$STRIPPED" | grep -qiE "$GIT_COMMIT_RE"; then
-	CURRENT_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
+	CURRENT_BRANCH=$(tgit symbolic-ref --short HEAD 2>/dev/null || echo "")
 	for branch in "${PROTECTED_BRANCHES[@]}"; do
 		if [[ "$CURRENT_BRANCH" == "$branch" ]]; then
 			deny "BLOCKED: Committing directly to '${branch}' is forbidden. You are on the ${branch} branch. Create a feature branch first: git checkout -b feat/your-feature-name"
@@ -157,20 +162,28 @@ fi
 #       AGENTKIT_ALLOW_BRANCH_STACKING=1 for intentional stacking.
 #    b) local branches whose upstream is gone (squash-merged + remote-deleted)
 #       must be cleaned up before starting new work.
+# The override works from the hook's environment or inline in the command
+# itself (`AGENTKIT_ALLOW_BRANCH_STACKING=1 git checkout -b …`) — inline
+# assignments never reach the hook process, so honor them from the text.
+STACKING_OK="${AGENTKIT_ALLOW_BRANCH_STACKING:-0}"
+if echo "$COMMAND" | grep -qE '(^|[[:space:];&|])AGENTKIT_ALLOW_BRANCH_STACKING=1([[:space:];&|]|$)'; then
+	STACKING_OK=1
+fi
+
 if echo "$STRIPPED" | grep -qiE '\bgit\b.*(checkout\s+-b|switch\s+-c)\b'; then
-	DEFAULT_BRANCH=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||' || true)
-	CURRENT_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
-	if [[ -n "$CURRENT_BRANCH" && "${AGENTKIT_ALLOW_BRANCH_STACKING:-0}" != "1" ]]; then
+	DEFAULT_BRANCH=$(tgit symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||' || true)
+	CURRENT_BRANCH=$(tgit symbolic-ref --short HEAD 2>/dev/null || echo "")
+	if [[ -n "$CURRENT_BRANCH" && "$STACKING_OK" != "1" ]]; then
 		ON_BASE=false
 		for base in "$DEFAULT_BRANCH" "${PROTECTED_BRANCHES[@]}" dev; do
 			[[ -n "$base" && "$CURRENT_BRANCH" == "$base" ]] && ON_BASE=true
 		done
 		if [[ "$ON_BASE" == false ]]; then
-			deny "BLOCKED: You are on feature branch '${CURRENT_BRANCH}'. Cut new branches from the freshly pulled default branch (squash merges make stacked branches conflict once the first MR merges). Run: git checkout ${DEFAULT_BRANCH:-main} && git pull, then create the branch. Intentional stacking: AGENTKIT_ALLOW_BRANCH_STACKING=1."
+			deny "BLOCKED: The targeted repo is on feature branch '${CURRENT_BRANCH}'. Cut new branches from the freshly pulled default branch (squash merges make stacked branches conflict once the first MR merges). Run: git checkout ${DEFAULT_BRANCH:-main} && git pull, then create the branch. Intentional stacking: prefix the command with AGENTKIT_ALLOW_BRANCH_STACKING=1."
 		fi
 	fi
-	git fetch -p --quiet 2>/dev/null || true
-	GONE=$(git branch -vv 2>/dev/null | grep ': gone]' | awk '{print $1}' | tr '\n' ' ' || true)
+	tgit fetch -p --quiet 2>/dev/null || true
+	GONE=$(tgit branch -vv 2>/dev/null | grep ': gone]' | awk '{print $1}' | tr '\n' ' ' || true)
 	if [[ -n "${GONE// /}" ]]; then
 		deny "BLOCKED: Stale local branches with deleted upstreams: ${GONE}. Clean up before starting new work: git branch -vv | awk '/: gone]/ {print \$1}' | xargs -r git branch -D"
 	fi
@@ -178,14 +191,14 @@ fi
 
 # 8. Stale branch protection — warn when creating a branch from a stale base
 if echo "$STRIPPED" | grep -qiE '\bgit\b.*(checkout\s+-b|switch\s+-c)\b'; then
-	CURRENT_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
+	CURRENT_BRANCH=$(tgit symbolic-ref --short HEAD 2>/dev/null || echo "")
 	for branch in "${PROTECTED_BRANCHES[@]}"; do
 		if [[ "$CURRENT_BRANCH" == "$branch" ]]; then
-			git fetch origin "$branch" --quiet 2>/dev/null || true
-			LOCAL_SHA=$(git rev-parse "$branch" 2>/dev/null || echo "")
-			REMOTE_SHA=$(git rev-parse "origin/$branch" 2>/dev/null || echo "")
+			tgit fetch origin "$branch" --quiet 2>/dev/null || true
+			LOCAL_SHA=$(tgit rev-parse "$branch" 2>/dev/null || echo "")
+			REMOTE_SHA=$(tgit rev-parse "origin/$branch" 2>/dev/null || echo "")
 			if [[ -n "$LOCAL_SHA" && -n "$REMOTE_SHA" && "$LOCAL_SHA" != "$REMOTE_SHA" ]]; then
-				BEHIND=$(git rev-list --count "$branch..origin/$branch" 2>/dev/null || echo "0")
+				BEHIND=$(tgit rev-list --count "$branch..origin/$branch" 2>/dev/null || echo "0")
 				if [[ "$BEHIND" -gt 0 ]]; then
 					deny "BLOCKED: Your local '${branch}' is ${BEHIND} commit(s) behind origin/${branch}. Run 'git pull origin ${branch}' first to avoid creating a branch from stale code. This prevents merge conflicts and wasted rebases."
 				fi

--- a/hooks/claude/mr-police.sh
+++ b/hooks/claude/mr-police.sh
@@ -4,8 +4,14 @@
 # authored on the same repo. Stops unmerged MRs from accumulating into a tangle
 # of interdependent branches — merge or close the existing one(s) first.
 #
+# The repo is resolved from the command itself, not the hook's cwd (which may
+# be a different repo entirely): an explicit --repo/-R flag wins, then a
+# `cd <path>` prefix, then the cwd.
+#
 # Threshold is configurable: AGENTKIT_MR_POLICE_MAX (default 1) = how many open
-# MRs you may already have before opening another is blocked.
+# MRs you may already have before opening another is blocked. Honored from the
+# hook's environment or inline in the command (`AGENTKIT_MR_POLICE_MAX=2 glab
+# mr create …`) — inline assignments never reach the hook process.
 set -euo pipefail
 
 INPUT=$(cat)
@@ -17,7 +23,7 @@ if ! echo "$COMMAND" | grep -qiE 'glab[[:space:]]+mr[[:space:]]+create|merge_req
 	exit 0
 fi
 
-deny_early() {
+deny() {
 	jq -n --arg r "$1" '{
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
@@ -32,40 +38,47 @@ deny_early() {
 # ambiguous. Applies to any agent using these hooks (Claude Code, Proxima, …).
 if echo "$COMMAND" | grep -qiE 'glab[[:space:]]+mr[[:space:]]+create' \
 	&& ! echo "$COMMAND" | grep -qE -- '--assignee|[[:space:]]-a[[:space:]]'; then
-	deny_early "BLOCKED: glab mr create must include an assignee. Add --assignee <username> (or --assignee @me) and retry — unassigned MRs are not allowed."
+	deny "BLOCKED: glab mr create must include an assignee. Add --assignee <username> (or --assignee @me) and retry — unassigned MRs are not allowed."
 fi
 
 # Need glab to check; if it's unavailable, don't block (fail open).
 command -v glab >/dev/null 2>&1 || exit 0
 
+# The repo the command targets, in priority order:
+# 1. explicit --repo/-R on the glab command (OWNER/REPO, HOST/OWNER/REPO, or URL)
+REPO_ARG=$(echo "$COMMAND" | sed -nE 's/.*(--repo[= ]|-R[[:space:]]+)([^[:space:]"'"'"']+).*/\2/p' | head -1)
+
+# 2. a `cd <path>` at the start or after a separator (; && |) — glab resolves
+#    the repo from that directory, so the check must too.
+TARGET_DIR=$(echo "$COMMAND" | sed -nE 's/(^|.*[;&|])[[:space:]]*cd[[:space:]]+([^[:space:];&|]+).*/\2/p' | head -1)
+TARGET_DIR="${TARGET_DIR/#\~/$HOME}"
+
+# 3. the hook's cwd (previous behavior) via plain git below.
+ORIGIN_URL=$(git ${TARGET_DIR:+-C "$TARGET_DIR"} remote get-url origin 2>/dev/null || echo "")
+[[ -z "$REPO_ARG" && -n "$ORIGIN_URL" ]] && REPO_ARG="$ORIGIN_URL"
+
 # Target the GitLab instance this repo lives on (glab otherwise defaults to
 # gitlab.com, or to a stale GITLAB_HOST in the environment).
-HOST=$(git remote get-url origin 2>/dev/null | sed -E 's#^(git@|https?://)([^:/]+).*#\2#')
+HOST=$(echo "$ORIGIN_URL" | sed -E 's#^(git@|https?://)([^:/]+).*#\2#')
 [[ -n "$HOST" ]] && export GITLAB_HOST="$HOST"
 
+# Threshold: inline assignment in the command wins over the hook's environment.
 MAX_OPEN="${AGENTKIT_MR_POLICE_MAX:-1}"
+INLINE_MAX=$(echo "$COMMAND" | grep -oE '(^|[[:space:];&|])AGENTKIT_MR_POLICE_MAX=[0-9]+' | head -1 | sed -E 's/.*=([0-9]+)/\1/' || true)
+[[ -n "$INLINE_MAX" ]] && MAX_OPEN="$INLINE_MAX"
 
-# Who am I, and what open MRs have I authored on this repo?
+# Who am I, and what open MRs have I authored on the targeted repo?
 ME=$(glab api /user 2>/dev/null | jq -r '.username // empty')
 [[ -z "$ME" ]] && exit 0
 
-MINE=$(glab mr list --author "$ME" 2>/dev/null | grep -oE '!\b[0-9]+' | sort -u)
+# `|| true`: zero matches must mean "no open MRs", not a pipefail crash that
+# silently fails the hook open.
+MINE=$(glab mr list --author "$ME" ${REPO_ARG:+--repo "$REPO_ARG"} 2>/dev/null | grep -oE '!\b[0-9]+' | sort -u || true)
 COUNT=$(printf '%s\n' "$MINE" | grep -c . || true)
-
-deny() {
-	jq -n --arg r "$1" '{
-    hookSpecificOutput: {
-      hookEventName: "PreToolUse",
-      permissionDecision: "deny",
-      permissionDecisionReason: $r
-    }
-  }'
-	exit 0
-}
 
 if [[ "$COUNT" -ge "$MAX_OPEN" ]]; then
 	LIST=$(printf '%s ' $MINE)
-	deny "BLOCKED: you already have ${COUNT} open MR(s) you authored on this repo (${LIST}). Do not stack another unmerged MR on top — merge or close the existing one(s) first, then open the next. If these are genuinely independent and must coexist, raise the limit for this command with AGENTKIT_MR_POLICE_MAX=<n>."
+	deny "BLOCKED: you already have ${COUNT} open MR(s) you authored on this repo (${LIST}). Do not stack another unmerged MR on top — merge or close the existing one(s) first, then open the next. If these are genuinely independent and must coexist, raise the limit by prefixing the command with AGENTKIT_MR_POLICE_MAX=<n>."
 fi
 
 exit 0

--- a/tests/git-police-hygiene.test.ts
+++ b/tests/git-police-hygiene.test.ts
@@ -85,6 +85,55 @@ describe('git-police branch hygiene (rule 7)', () => {
   });
 });
 
+describe('git-police branch creation resolves the targeted repo (rules 6-7)', () => {
+  test('allows git -C targeting a main-branch repo while the cwd repo is on a feature branch', () => {
+    const target = join(root, 'clone-main-target');
+    execSync(`git clone ${origin} ${target}`, { stdio: 'pipe' });
+    git(target, 'remote set-head origin main');
+    git(clone, 'checkout -q -b feat/cwd-decoy');
+    expect(runHook(clone, `git -C ${target} checkout -b feat/from-target`)).not.toContain(
+      '"deny"',
+    );
+    git(clone, 'checkout -q main');
+    git(clone, 'branch -D feat/cwd-decoy');
+  });
+
+  test('denies cd-prefixed branch creation when the targeted repo is on a feature branch', () => {
+    const target = join(root, 'clone-feature-target');
+    execSync(`git clone ${origin} ${target}`, { stdio: 'pipe' });
+    git(target, 'remote set-head origin main');
+    git(target, 'checkout -q -b feat/base');
+    const out = runHook(root, `cd ${target} && git checkout -b feat/stacked`);
+    expect(out).toContain('"deny"');
+    expect(out).toContain('feature branch');
+  });
+
+  test('inline AGENTKIT_ALLOW_BRANCH_STACKING=1 in the command overrides stacking', () => {
+    git(clone, 'checkout -q -b feat/base-inline');
+    const out = runHook(clone, 'AGENTKIT_ALLOW_BRANCH_STACKING=1 git checkout -b feat/stacked-inline');
+    expect(out).not.toContain('feature branch');
+    git(clone, 'checkout -q main');
+    git(clone, 'branch -D feat/base-inline');
+  });
+
+  test('allows commit in a cd-targeted feature-branch repo while the cwd repo is on main', () => {
+    const target = join(root, 'clone-commit-target');
+    execSync(`git clone ${origin} ${target}`, { stdio: 'pipe' });
+    git(target, 'remote set-head origin main');
+    git(target, 'checkout -q -b feat/commit-here');
+    git(clone, 'checkout -q main');
+    expect(runHook(clone, `cd ${target} && git commit --allow-empty -m work`)).not.toContain(
+      '"deny"',
+    );
+  });
+
+  test('denies commit when the git -C target is on main, even from a non-repo cwd', () => {
+    const out = runHook(root, `git -C ${clone} commit --allow-empty -m nope`);
+    expect(out).toContain('"deny"');
+    expect(out).toContain('Committing directly');
+  });
+});
+
 describe('git-police push branch resolution (rule 4)', () => {
   test("denies plain push when the cwd repo is on 'main'", () => {
     git(clone, 'checkout -q main');

--- a/tests/mr-police.test.ts
+++ b/tests/mr-police.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeAll, afterAll, describe, expect, test } from 'bun:test';
+import { execSync, spawnSync } from 'node:child_process';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// mr-police must resolve the repo from the COMMAND (an explicit --repo flag or
+// a `cd <path>` prefix), not the hook's cwd, and honor an inline
+// AGENTKIT_MR_POLICE_MAX. Tests run against a glab shim so nothing talks to a
+// real GitLab: the shim answers `api /user` and `mr list`, reporting one open
+// MR whenever its arguments mention "busy", and logs every invocation.
+
+const HOOK = join(import.meta.dir, '..', 'hooks', 'claude', 'mr-police.sh');
+
+let root: string;
+let shimLog: string;
+let repoBusy: string;
+let repoFree: string;
+
+function makeRepo(dir: string, originUrl: string): void {
+  mkdirSync(dir);
+  execSync('git init -q -b main', { cwd: dir, stdio: 'pipe' });
+  execSync(`git remote add origin ${originUrl}`, { cwd: dir, stdio: 'pipe' });
+}
+
+function runHook(cwd: string, command: string): string {
+  const input = JSON.stringify({ tool_input: { command } });
+  const env = { ...process.env, PATH: `${join(root, 'bin')}:${process.env.PATH}`, SHIM_LOG: shimLog };
+  delete env.AGENTKIT_MR_POLICE_MAX;
+  delete env.GITLAB_HOST;
+  const res = spawnSync('bash', [HOOK], { cwd, input, encoding: 'utf-8', env });
+  return res.stdout ?? '';
+}
+
+function shimCalls(): string {
+  try {
+    return readFileSync(shimLog, 'utf-8');
+  } catch {
+    return '';
+  }
+}
+
+beforeAll(() => {
+  root = mkdtempSync(join(tmpdir(), 'agentkit-mrpolice-'));
+  shimLog = join(root, 'shim.log');
+  mkdirSync(join(root, 'bin'));
+  const shim = `#!/usr/bin/env bash
+echo "\${GITLAB_HOST:-nohost}|$*" >> "$SHIM_LOG"
+case "$1 $2" in
+  "api /user") echo '{"username":"tester"}' ;;
+  "mr list") [[ "$*" == *busy* ]] && echo '!42 open change' ;;
+esac
+exit 0
+`;
+  writeFileSync(join(root, 'bin', 'glab'), shim);
+  chmodSync(join(root, 'bin', 'glab'), 0o755);
+  repoBusy = join(root, 'repo-busy');
+  repoFree = join(root, 'repo-free');
+  makeRepo(repoBusy, 'git@gitlab.example.com:group/busy.git');
+  makeRepo(repoFree, 'git@gitlab.example.com:group/free.git');
+});
+
+afterEach(() => {
+  rmSync(shimLog, { force: true });
+});
+
+afterAll(() => {
+  rmSync(root, { force: true, recursive: true });
+});
+
+describe('mr-police repo resolution', () => {
+  test('denies via the cd-targeted repo, passing its origin to glab', () => {
+    const out = runHook(root, `cd ${repoBusy} && glab mr create --assignee me --title x`);
+    expect(out).toContain('"deny"');
+    expect(out).toContain('!42');
+    expect(shimCalls()).toContain('--repo git@gitlab.example.com:group/busy.git');
+    expect(shimCalls()).toContain('gitlab.example.com|');
+  });
+
+  test('allows when the cd-targeted repo has no open MRs, whatever the cwd repo has', () => {
+    const out = runHook(repoBusy, `cd ${repoFree} && glab mr create --assignee me --title x`);
+    expect(out).not.toContain('"deny"');
+    expect(shimCalls()).toContain('--repo git@gitlab.example.com:group/free.git');
+  });
+
+  test('an explicit --repo flag wins over the cwd repo', () => {
+    const out = runHook(repoBusy, 'glab mr create --repo group/free --assignee me --title x');
+    expect(out).not.toContain('"deny"');
+    expect(shimCalls()).toContain('mr list --author tester --repo group/free');
+  });
+
+  test('falls back to the cwd repo when the command names none', () => {
+    const out = runHook(repoBusy, 'glab mr create --assignee me --title x');
+    expect(out).toContain('"deny"');
+    expect(shimCalls()).toContain('--repo git@gitlab.example.com:group/busy.git');
+  });
+});
+
+describe('mr-police threshold override', () => {
+  test('inline AGENTKIT_MR_POLICE_MAX raises the limit for that command', () => {
+    const out = runHook(
+      root,
+      `cd ${repoBusy} && AGENTKIT_MR_POLICE_MAX=2 glab mr create --assignee me --title x`,
+    );
+    expect(out).not.toContain('"deny"');
+  });
+
+  test('environment AGENTKIT_MR_POLICE_MAX still works', () => {
+    const input = JSON.stringify({
+      tool_input: { command: `cd ${repoBusy} && glab mr create --assignee me --title x` },
+    });
+    const res = spawnSync('bash', [HOOK], {
+      cwd: root,
+      input,
+      encoding: 'utf-8',
+      env: {
+        ...process.env,
+        PATH: `${join(root, 'bin')}:${process.env.PATH}`,
+        SHIM_LOG: shimLog,
+        AGENTKIT_MR_POLICE_MAX: '2',
+      },
+    });
+    expect(res.stdout ?? '').not.toContain('"deny"');
+  });
+});
+
+describe('mr-police assignee rule', () => {
+  test('denies an unassigned MR before ever calling glab', () => {
+    const out = runHook(root, `cd ${repoFree} && glab mr create --title x`);
+    expect(out).toContain('"deny"');
+    expect(out).toContain('assignee');
+    expect(shimCalls()).toBe('');
+  });
+});


### PR DESCRIPTION
The session cwd is often a different repo than the one a command targets (`git -C <path>`, `cd <path> && …`, `glab --repo/-R`). git-police rules 6–8 and mr-police's open-MR count all evaluated the **cwd** repo, producing false blocks when working across repos from one session (hit in practice: cwd on a platform feature branch blocked branch creation and MR creation in an unrelated repo that was cleanly on `main` with zero open MRs).

## Changes

- **git-police**: compute the target dir once (`git -C`, or `cd` at the start/after a separator `; && |`) and run every repo-state check through it (`tgit` wrapper). Rule 4 (push) already did this; rules 6 (protected-branch commit), 7 (branch hygiene), and 8 (stale base) now share the same resolution. The allowed-repos escape also resolves the targeted repo.
- **mr-police**: repo resolution priority `--repo/-R` flag > `cd`-prefixed dir > cwd; the resolved repo is passed to `glab mr list --repo` explicitly and `GITLAB_HOST` derives from the targeted repo's origin.
- **Inline overrides now actually work**: `AGENTKIT_ALLOW_BRANCH_STACKING=1` / `AGENTKIT_MR_POLICE_MAX=<n>` are parsed from the command text. Inline env assignments never reach the hook process, so the escape hatches the deny messages advertised were impossible to use as documented.
- **Latent crash fixed**: with zero open MRs, `grep` exits 1 and `set -euo pipefail` killed mr-police mid-script — it was silently failing open on the happy path.

## Testing

- `bun test`: 154 pass / 0 fail (5 new target-resolution cases in the hygiene suite, new hermetic `mr-police.test.ts` against a `glab` shim that logs its invocations).
- Live validation: with the fixed hooks installed, branch creation and MR creation targeting another repo on `main` pass from a cwd on a feature branch, while plain commands against the cwd repo still deny correctly.

## Known residual (separate issue)

Heredoc/quoted **prose** spanning multiple lines survives into `STRIPPED` (the sed runs per line), so command text that merely *mentions* git operations — e.g. a PR body describing branch commands — can still trigger rules against the resolved target repo. Worth a follow-up that drops heredoc bodies entirely before matching.
