### PR TITLE
feat: Claude Code marketplace distributing the assay plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-marketplace.json",
+  "name": "agentkit",
+  "owner": {
+    "name": "developerinlondon",
+    "url": "https://github.com/developerinlondon"
+  },
+  "description": "Reusable agent tooling distributed as Claude Code plugins. The generic units (MCP tools, skills) are the source of truth; the plugins wrap them for one-step install. See ADR #45.",
+  "plugins": [
+    {
+      "name": "assay",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/developerinlondon/assay",
+        "path": "plugin"
+      },
+      "description": "Gated Lua infra toolkit — Kubernetes, ArgoCD, Vault, Prometheus, GitLab, AWS and more through one read-only/approval-gated tool. Requires the `assay` binary on PATH.",
+      "version": "0.17.0"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -67,6 +67,21 @@ Reusable AI agent skills, rules, plugins, hooks, and tools for OpenCode, Claude 
 | **coding-discipline.md**        | 11-rule behavioral contract for code work (think first, simplicity, surgical changes, fail loud, …) |
 | **collaboration-visibility.md** | Progress updates, checkpoint summaries, and compact ASCII diagrams for multi-step work              |
 
+### Claude Code plugins (marketplace)
+
+Tools ship as MCP servers wrapped in Claude Code plugins (ADR #45 — generic
+units are the source of truth; plugins are convenience wrappers). Add the
+marketplace once, then install:
+
+```bash
+claude plugin marketplace add developerinlondon/agentkit
+claude plugin install assay
+```
+
+| Plugin    | Provides                                                                                                                                                                                        | Source                                                                                        |
+| --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| **assay** | Gated Lua infra toolkit (`assay_run` + `assay_context`) — Kubernetes, ArgoCD, Vault, Prometheus, GitLab, AWS, … through one read-only/approval-gated tool. Requires the `assay` binary on PATH. | vendored from [developerinlondon/assay](https://github.com/developerinlondon/assay) `plugin/` |
+
 ## Installation
 
 ### Option 1: skills.sh CLI (skills only, all agents)


### PR DESCRIPTION
First slice of #44, against ADR #45.

Adds `.claude-plugin/marketplace.json` so agentkit is the one-step distribution point for MCP-tool plugins:

```
claude plugin marketplace add developerinlondon/agentkit
claude plugin install assay
```

Vendors the assay plugin from `developerinlondon/assay` `plugin/` via a `git-subdir` source, so installing from agentkit's marketplace pulls the gated `assay_run` + `assay_context` tools + usage skill. README gains a 'Claude Code plugins (marketplace)' section.

The generic infra-CLI tool plugin (helm/tofu/git as an MCP server) is the remaining part of #44 and will be added to this same marketplace as a focused follow-up. marketplace.json validates; 154 tests pass.