### PR TITLE
feat: infra-tools Claude Code plugin — read-only helm/tofu/git MCP server

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -16,6 +16,12 @@
       },
       "description": "Gated Lua infra toolkit — Kubernetes, ArgoCD, Vault, Prometheus, GitLab, AWS and more through one read-only/approval-gated tool. Requires the `assay` binary on PATH.",
       "version": "0.17.0"
+    },
+    {
+      "name": "infra-tools",
+      "source": "./plugins-cc/infra-tools",
+      "description": "Read-only helm / tofu / git tools for infrastructure investigation, exposed as a typed MCP server. Renders charts, previews plans, and reads git history — never applies or mutates. Requires `bun` on PATH.",
+      "version": "0.1.0"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -76,11 +76,13 @@ marketplace once, then install:
 ```bash
 claude plugin marketplace add developerinlondon/agentkit
 claude plugin install assay
+claude plugin install infra-tools
 ```
 
-| Plugin    | Provides                                                                                                                                                                                        | Source                                                                                        |
-| --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| **assay** | Gated Lua infra toolkit (`assay_run` + `assay_context`) — Kubernetes, ArgoCD, Vault, Prometheus, GitLab, AWS, … through one read-only/approval-gated tool. Requires the `assay` binary on PATH. | vendored from [developerinlondon/assay](https://github.com/developerinlondon/assay) `plugin/` |
+| Plugin          | Provides                                                                                                                                                                                                                                                                                                 | Source                                                                                        |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| **assay**       | Gated Lua infra toolkit (`assay_run` + `assay_context`) — Kubernetes, ArgoCD, Vault, Prometheus, GitLab, AWS, … through one read-only/approval-gated tool. Requires the `assay` binary on PATH.                                                                                                          | vendored from [developerinlondon/assay](https://github.com/developerinlondon/assay) `plugin/` |
+| **infra-tools** | Read-only helm / tofu / git tools (`helm_template`/`helm_list`/`helm_get_values`, `tofu_plan`/`tofu_show`/`tofu_state_list`, `git_log`/`git_diff`/`git_status`/`git_clone_ro`) as a typed MCP server — render charts, preview plans, read git history. Never applies or mutates. Requires `bun` on PATH. | local `plugins-cc/infra-tools/`                                                               |
 
 ## Installation
 

--- a/plugins-cc/infra-tools/.claude-plugin/plugin.json
+++ b/plugins-cc/infra-tools/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin.json",
+  "name": "infra-tools",
+  "version": "0.1.0",
+  "description": "Read-only helm / tofu / git tools for infrastructure investigation, exposed as a typed MCP server. Renders charts, previews plans, and reads git history — never applies or mutates.",
+  "author": {
+    "name": "developerinlondon",
+    "url": "https://github.com/developerinlondon"
+  },
+  "mcpServers": "./.mcp.json",
+  "skills": "./skills/"
+}

--- a/plugins-cc/infra-tools/.mcp.json
+++ b/plugins-cc/infra-tools/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "infra-tools": {
+      "command": "bun",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/server/index.ts"]
+    }
+  }
+}

--- a/plugins-cc/infra-tools/server/index.ts
+++ b/plugins-cc/infra-tools/server/index.ts
@@ -1,0 +1,61 @@
+#!/usr/bin/env bun
+// infra-tools MCP server — a stdio JSON-RPC 2.0 server exposing read-only
+// helm / tofu / git tools. Newline-delimited JSON framing (the MCP stdio
+// transport): one JSON object per line on stdin, one JSON object per line on
+// stdout. Diagnostics go to stderr so they never corrupt the protocol channel.
+
+import { type JsonRpcRequest, handleRequest } from './protocol';
+
+const ERR_PARSE = -32700;
+
+function write(obj: unknown): void {
+  process.stdout.write(JSON.stringify(obj) + '\n');
+}
+
+async function dispatchLine(line: string): Promise<void> {
+  const trimmed = line.trim();
+  if (trimmed.length === 0) return;
+
+  let req: JsonRpcRequest;
+  try {
+    req = JSON.parse(trimmed) as JsonRpcRequest;
+  } catch {
+    write({ jsonrpc: '2.0', id: null, error: { code: ERR_PARSE, message: 'parse error' } });
+    return;
+  }
+
+  try {
+    const response = await handleRequest(req);
+    if (response) write(response);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`infra-tools: handler error: ${message}\n`);
+    if (req.id !== undefined) {
+      write({ jsonrpc: '2.0', id: req.id ?? null, error: { code: -32603, message } });
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  for await (const chunk of Bun.stdin.stream()) {
+    buffer += decoder.decode(chunk, { stream: true });
+    let newline = buffer.indexOf('\n');
+    while (newline !== -1) {
+      const line = buffer.slice(0, newline);
+      buffer = buffer.slice(newline + 1);
+      await dispatchLine(line);
+      newline = buffer.indexOf('\n');
+    }
+  }
+
+  // Flush any trailing line that arrived without a terminating newline.
+  await dispatchLine(buffer);
+}
+
+main().catch((err) => {
+  process.stderr.write(`infra-tools: fatal: ${err instanceof Error ? err.stack : err}\n`);
+  process.exit(1);
+});

--- a/plugins-cc/infra-tools/server/protocol.ts
+++ b/plugins-cc/infra-tools/server/protocol.ts
@@ -1,0 +1,90 @@
+import { TOOL_MAP, TOOLS } from './tools/registry';
+
+// Minimal MCP (Model Context Protocol) method handlers over JSON-RPC 2.0.
+// Only the three methods a read-only tool server needs are implemented:
+// `initialize`, `tools/list`, and `tools/call`.
+
+const DEFAULT_PROTOCOL_VERSION = '2024-11-05';
+const SUPPORTED_PROTOCOL_VERSIONS = new Set(['2024-11-05', '2025-03-26', '2025-06-18']);
+
+export const SERVER_INFO = { name: 'infra-tools', version: '0.1.0' } as const;
+
+// JSON-RPC error codes.
+export const ERR_METHOD_NOT_FOUND = -32601;
+export const ERR_INVALID_PARAMS = -32602;
+
+export interface JsonRpcRequest {
+  jsonrpc: '2.0';
+  id?: string | number | null;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+export interface JsonRpcResponse {
+  jsonrpc: '2.0';
+  id: string | number | null;
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+// Returns a response object, or null for notifications (no id) which get no reply.
+export async function handleRequest(req: JsonRpcRequest): Promise<JsonRpcResponse | null> {
+  const isNotification = req.id === undefined;
+
+  switch (req.method) {
+    case 'initialize':
+      return reply(req, initializeResult(req.params));
+    case 'notifications/initialized':
+    case 'notifications/cancelled':
+      return null; // notifications — never answered
+    case 'ping':
+      return reply(req, {});
+    case 'tools/list':
+      return reply(req, { tools: TOOLS.map(toolInfo) });
+    case 'tools/call':
+      return reply(req, await callTool(req.params));
+    default:
+      if (isNotification) return null;
+      return errorReply(req, ERR_METHOD_NOT_FOUND, `method not found: ${req.method}`);
+  }
+}
+
+function initializeResult(params?: Record<string, unknown>) {
+  const requested = typeof params?.protocolVersion === 'string' ? params.protocolVersion : undefined;
+  const protocolVersion = requested && SUPPORTED_PROTOCOL_VERSIONS.has(requested)
+    ? requested
+    : DEFAULT_PROTOCOL_VERSION;
+  return {
+    protocolVersion,
+    capabilities: { tools: {} },
+    serverInfo: SERVER_INFO,
+  };
+}
+
+function toolInfo(tool: (typeof TOOLS)[number]) {
+  return { name: tool.name, description: tool.description, inputSchema: tool.inputSchema };
+}
+
+async function callTool(params?: Record<string, unknown>) {
+  const name = typeof params?.name === 'string' ? params.name : undefined;
+  const tool = name ? TOOL_MAP.get(name) : undefined;
+  if (!tool) {
+    return textResult(`unknown tool: ${name ?? '(none)'}`, true);
+  }
+  const args = (params?.arguments as Record<string, unknown> | undefined) ?? {};
+  const result = await tool.handler(args);
+  return textResult(JSON.stringify(result, null, 2), !result.ok);
+}
+
+function textResult(text: string, isError: boolean) {
+  return { content: [{ type: 'text', text }], isError };
+}
+
+function reply(req: JsonRpcRequest, result: unknown): JsonRpcResponse | null {
+  if (req.id === undefined) return null;
+  return { jsonrpc: '2.0', id: req.id ?? null, result };
+}
+
+export function errorReply(req: JsonRpcRequest, code: number, message: string): JsonRpcResponse {
+  return { jsonrpc: '2.0', id: req.id ?? null, error: { code, message } };
+}

--- a/plugins-cc/infra-tools/server/run.ts
+++ b/plugins-cc/infra-tools/server/run.ts
@@ -1,0 +1,44 @@
+// Safe CLI runner. Spawns a binary with an argv array — never a shell string —
+// so no argument can be interpreted as a shell operator (injection-proof by
+// construction). Callers pass a fixed, read-only subcommand plus already-split
+// arguments; there is no shell, no glob expansion, and no word splitting.
+
+export interface CliResult {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+  exit_code: number;
+}
+
+const COMMAND_NOT_FOUND = 127;
+
+export async function runCli(argv: string[], cwd?: string): Promise<CliResult> {
+  if (argv.length === 0) {
+    return { ok: false, stdout: '', stderr: 'runCli: empty argv', exit_code: COMMAND_NOT_FOUND };
+  }
+
+  try {
+    const proc = Bun.spawn(argv, {
+      cwd,
+      stdout: 'pipe',
+      stderr: 'pipe',
+      stdin: 'ignore',
+    });
+
+    const [stdout, stderr, exit_code] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    return { ok: exit_code === 0, stdout, stderr, exit_code };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      stdout: '',
+      stderr: `failed to spawn ${argv[0]}: ${message}`,
+      exit_code: COMMAND_NOT_FOUND,
+    };
+  }
+}

--- a/plugins-cc/infra-tools/server/tools/git.ts
+++ b/plugins-cc/infra-tools/server/tools/git.ts
@@ -1,0 +1,95 @@
+import { runCli } from '../run';
+import { asString, asStringArray, missingArg, type ToolDef } from './types';
+
+// Git tools — local read subcommands plus one read-only clone. `log`, `diff`,
+// and `status` inspect an existing repo (working directory via spawn cwd, so no
+// user string is parsed as a global git option). `git_clone_ro` is the only
+// write-to-disk op: it shallow-clones a remote INTO `dest` for inspection. It
+// never pushes, commits, or mutates the source, and it does not accept
+// free-form flags (which could smuggle `-c core.sshCommand=...` style RCE).
+
+const SHALLOW_DEPTH = '1';
+
+export const gitTools: ToolDef[] = [
+  {
+    name: 'git_log',
+    description: 'Show commit history of a local repo with `git log` (read-only).',
+    inputSchema: repoSchema({
+      opts: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Extra args appended to `git log` (e.g. --oneline, -n 20, --stat, a ref).',
+      },
+    }),
+    handler: (args) => runInRepo(args, ['log', ...asStringArray(args.opts)]),
+  },
+  {
+    name: 'git_diff',
+    description: 'Show changes in a local repo with `git diff` (read-only).',
+    inputSchema: repoSchema({
+      opts: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Extra args appended to `git diff` (e.g. --stat, HEAD~1, a path, --cached).',
+      },
+    }),
+    handler: (args) => runInRepo(args, ['diff', ...asStringArray(args.opts)]),
+  },
+  {
+    name: 'git_status',
+    description: 'Show the working-tree status of a local repo with `git status` (read-only).',
+    inputSchema: repoSchema(),
+    handler: (args) => runInRepo(args, ['status']),
+  },
+  {
+    name: 'git_clone_ro',
+    description:
+      'Shallow, read-only clone of a remote repo into `dest` for inspection. '
+      + 'Depth 1, no tags; never pushes or mutates the source. This is the only '
+      + 'tool that writes to disk (the local clone), and it writes nothing back.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        url: { type: 'string', description: 'Remote repository URL to clone (read-only).' },
+        dest: { type: 'string', description: 'Local destination directory for the clone.' },
+        ref: {
+          type: 'string',
+          description: 'Optional branch or tag to check out (single-branch shallow clone).',
+        },
+      },
+      required: ['url', 'dest'],
+      additionalProperties: false,
+    },
+    handler: (args) => {
+      const url = asString(args.url);
+      const dest = asString(args.dest);
+      if (!url) return Promise.resolve(missingArg('url'));
+      if (!dest) return Promise.resolve(missingArg('dest'));
+      const argv = ['git', 'clone', '--depth', SHALLOW_DEPTH, '--no-tags'];
+      const ref = asString(args.ref);
+      if (ref) argv.push('--single-branch', '--branch', ref);
+      // `--` terminates option parsing so a url/dest starting with `-` cannot be
+      // treated as a flag.
+      argv.push('--', url, dest);
+      return runCli(argv);
+    },
+  },
+];
+
+function repoSchema(extra: Record<string, unknown> = {}) {
+  return {
+    type: 'object' as const,
+    properties: {
+      dir: { type: 'string', description: 'Path to the local git repository.' },
+      ...extra,
+    },
+    required: ['dir'],
+    additionalProperties: false,
+  };
+}
+
+function runInRepo(args: Record<string, unknown>, argv: string[]) {
+  const dir = asString(args.dir);
+  if (!dir) return Promise.resolve(missingArg('dir'));
+  return runCli(['git', ...argv], dir);
+}

--- a/plugins-cc/infra-tools/server/tools/helm.ts
+++ b/plugins-cc/infra-tools/server/tools/helm.ts
@@ -1,0 +1,83 @@
+import { runCli } from '../run';
+import { asString, asStringArray, missingArg, type ToolDef } from './types';
+
+// Helm tools — strictly read/render subcommands. `template` renders a chart
+// locally (no cluster write, no install); `list` and `get values` only read.
+// The subcommand is hardcoded here; callers can never turn these into
+// install/upgrade/uninstall because they cannot choose the subcommand.
+
+export const helmTools: ToolDef[] = [
+  {
+    name: 'helm_template',
+    description:
+      'Render a Helm chart locally with `helm template` (no install, no cluster mutation). '
+      + 'Use to inspect the manifests a chart would produce.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        chart: {
+          type: 'string',
+          description: 'Chart reference: a local path, a packaged .tgz, or repo/chart.',
+        },
+        opts: {
+          type: 'array',
+          items: { type: 'string' },
+          description:
+            'Extra args appended to `helm template` (e.g. --set, --values, --namespace, '
+            + '--generate-name, a release name). Rendering only — never installs.',
+        },
+      },
+      required: ['chart'],
+      additionalProperties: false,
+    },
+    handler: (args) => {
+      const chart = asString(args.chart);
+      if (!chart) return Promise.resolve(missingArg('chart'));
+      return runCli(['helm', 'template', chart, ...asStringArray(args.opts)]);
+    },
+  },
+  {
+    name: 'helm_list',
+    description: 'List installed Helm releases with `helm list` (read-only).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        namespace: {
+          type: 'string',
+          description: 'Namespace to list releases in. Omit to use the current context namespace.',
+        },
+      },
+      additionalProperties: false,
+    },
+    handler: (args) => {
+      const namespace = asString(args.namespace);
+      const argv = ['helm', 'list'];
+      if (namespace) argv.push('--namespace', namespace);
+      return runCli(argv);
+    },
+  },
+  {
+    name: 'helm_get_values',
+    description: 'Show the user-supplied values of a release with `helm get values` (read-only).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        release: { type: 'string', description: 'Release name to read values from.' },
+        namespace: {
+          type: 'string',
+          description: 'Namespace the release lives in. Omit to use the current context namespace.',
+        },
+      },
+      required: ['release'],
+      additionalProperties: false,
+    },
+    handler: (args) => {
+      const release = asString(args.release);
+      if (!release) return Promise.resolve(missingArg('release'));
+      const namespace = asString(args.namespace);
+      const argv = ['helm', 'get', 'values', release];
+      if (namespace) argv.push('--namespace', namespace);
+      return runCli(argv);
+    },
+  },
+];

--- a/plugins-cc/infra-tools/server/tools/registry.ts
+++ b/plugins-cc/infra-tools/server/tools/registry.ts
@@ -1,0 +1,12 @@
+import { gitTools } from './git';
+import { helmTools } from './helm';
+import { tofuTools } from './tofu';
+import type { ToolDef } from './types';
+
+// The complete, fixed set of exposed tools. There is deliberately no generic
+// "run any subcommand" escape hatch — every tool binds a hardcoded, read-only
+// subcommand. Mutating operations (helm install/upgrade/uninstall, tofu
+// apply/destroy, git push/commit/reset) are simply not represented here.
+export const TOOLS: ToolDef[] = [...helmTools, ...tofuTools, ...gitTools];
+
+export const TOOL_MAP: Map<string, ToolDef> = new Map(TOOLS.map((t) => [t.name, t]));

--- a/plugins-cc/infra-tools/server/tools/tofu.ts
+++ b/plugins-cc/infra-tools/server/tools/tofu.ts
@@ -1,0 +1,75 @@
+import { runCli } from '../run';
+import { asString, asStringArray, type ToolDef } from './types';
+
+// OpenTofu / Terraform tools — plan/read subcommands only. `plan` previews a
+// change set and never applies it; `show` and `state list` are read-only. There
+// is no path to `apply` or `destroy` because the subcommand is hardcoded.
+//
+// The working directory is passed via the spawn cwd (not an argv positional),
+// so no user string is ever parsed as a flag or a global option.
+
+// Prefer `tofu`; fall back to `terraform` when tofu is not on PATH.
+function tofuBin(): string {
+  if (Bun.which('tofu')) return 'tofu';
+  if (Bun.which('terraform')) return 'terraform';
+  return 'tofu';
+}
+
+const dirProp = {
+  dir: {
+    type: 'string',
+    description: 'Working directory containing the OpenTofu/Terraform configuration.',
+  },
+};
+
+export const tofuTools: ToolDef[] = [
+  {
+    name: 'tofu_plan',
+    description:
+      'Preview infrastructure changes with `tofu plan` (falls back to `terraform plan`). '
+      + 'Plan only — this never applies or destroys anything.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        ...dirProp,
+        opts: {
+          type: 'array',
+          items: { type: 'string' },
+          description:
+            'Extra args appended to `plan` (e.g. -var, -var-file, -target, -no-color). '
+            + 'Preview only — never applies.',
+        },
+      },
+      required: ['dir'],
+      additionalProperties: false,
+    },
+    handler: (args) => {
+      const dir = asString(args.dir) ?? '.';
+      return runCli([tofuBin(), 'plan', ...asStringArray(args.opts)], dir);
+    },
+  },
+  {
+    name: 'tofu_show',
+    description:
+      'Show the current state or a saved plan with `tofu show` (read-only; '
+      + 'falls back to `terraform show`).',
+    inputSchema: {
+      type: 'object',
+      properties: { ...dirProp },
+      additionalProperties: false,
+    },
+    handler: (args) => runCli([tofuBin(), 'show'], asString(args.dir) ?? '.'),
+  },
+  {
+    name: 'tofu_state_list',
+    description:
+      'List resources tracked in state with `tofu state list` (read-only; '
+      + 'falls back to `terraform state list`).',
+    inputSchema: {
+      type: 'object',
+      properties: { ...dirProp },
+      additionalProperties: false,
+    },
+    handler: (args) => runCli([tofuBin(), 'state', 'list'], asString(args.dir) ?? '.'),
+  },
+];

--- a/plugins-cc/infra-tools/server/tools/types.ts
+++ b/plugins-cc/infra-tools/server/tools/types.ts
@@ -1,0 +1,38 @@
+import type { CliResult } from '../run';
+
+// A minimal JSON Schema shape — enough to describe our tool inputs for the
+// MCP `tools/list` response. Kept loose on purpose; hosts do the validation.
+export interface JsonSchema {
+  type: 'object';
+  properties: Record<string, unknown>;
+  required?: string[];
+  additionalProperties?: boolean;
+}
+
+export type ToolArgs = Record<string, unknown>;
+
+export interface ToolDef {
+  name: string;
+  description: string;
+  inputSchema: JsonSchema;
+  handler: (args: ToolArgs) => Promise<CliResult>;
+}
+
+// Coerce an untyped arg into a string, or return undefined when absent.
+export function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+// Coerce an untyped arg into a string[] of extra CLI flags. Anything that is
+// not a string is dropped, so a malformed `opts` can never smuggle a non-arg.
+export function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === 'string');
+}
+
+const INVALID_ARGS = 2;
+
+// Shared CliResult for a missing/blank required argument.
+export function missingArg(name: string): CliResult {
+  return { ok: false, stdout: '', stderr: `missing required argument: ${name}`, exit_code: INVALID_ARGS };
+}

--- a/plugins-cc/infra-tools/skills/infra-tools/SKILL.md
+++ b/plugins-cc/infra-tools/skills/infra-tools/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: infra-tools
+description: >-
+  Inspect Helm releases and charts, preview OpenTofu/Terraform plans, and read
+  git history using the read-only infra-tools MCP server. Trigger when asked to
+  render/template a Helm chart, list releases or get their values, run a tofu/
+  terraform plan or show/state-list, or read git log/diff/status or clone a repo
+  for inspection. All operations are read-only — never applies or mutates.
+---
+
+# infra-tools
+
+Read-oriented wrappers around the infrastructure CLIs that stay raw engines
+(`helm`, `tofu`/`terraform`, `git`). Each is a typed MCP tool, so a host gates by
+**tool name + structured arguments** instead of regex-parsing a shell string.
+
+## Golden rule
+
+These tools **only read**. There is no tool that applies, upgrades, destroys,
+pushes, or commits. If a task needs to change infrastructure, produce the plan or
+diff with these tools and hand it to review — the change itself goes through the
+normal write path (e.g. a GitLab MR / approval-gated flow), never through here.
+
+## Tools
+
+| Tool              | Runs                         | What it does                                           |
+| ----------------- | ---------------------------- | ------------------------------------------------------ |
+| `helm_template`   | `helm template`              | Render a chart locally (no install, no cluster write). |
+| `helm_list`       | `helm list`                  | List installed releases.                               |
+| `helm_get_values` | `helm get values`            | Read a release's user-supplied values.                 |
+| `tofu_plan`       | `tofu plan` (or `terraform`) | Preview a change set — never applies.                  |
+| `tofu_show`       | `tofu show`                  | Show current state or a saved plan.                    |
+| `tofu_state_list` | `tofu state list`            | List resources tracked in state.                       |
+| `git_log`         | `git log`                    | Read commit history of a local repo.                   |
+| `git_diff`        | `git diff`                   | Read changes in a local repo.                          |
+| `git_status`      | `git status`                 | Read working-tree status.                              |
+| `git_clone_ro`    | `git clone --depth 1`        | Shallow read-only clone into `dest` for inspection.    |
+
+`git_clone_ro` is the only tool that writes to disk — it clones a remote **for
+reading**, shallow and tag-free, and never pushes or mutates the source.
+
+## Requirements
+
+- `bun` on PATH (the server runs directly as a `.ts` file — no build step).
+- The relevant CLI on PATH for the tool you call (`helm`, `tofu`/`terraform`,
+  `git`). `tofu_*` tools fall back to `terraform` when `tofu` is absent.
+
+Each tool returns `{ ok, stdout, stderr, exit_code }` as JSON text content.

--- a/tests/infra-tools-mcp.test.ts
+++ b/tests/infra-tools-mcp.test.ts
@@ -1,0 +1,193 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Integration test: spawns the infra-tools MCP server as a real subprocess and
+// drives it over the stdio JSON-RPC transport, exactly as a host (Claude Code)
+// would via the `.mcp.json` `command: bun` declaration.
+
+const SERVER = join(import.meta.dir, '..', 'plugins-cc', 'infra-tools', 'server', 'index.ts');
+
+const EXPECTED_TOOLS = [
+  'helm_template',
+  'helm_list',
+  'helm_get_values',
+  'tofu_plan',
+  'tofu_show',
+  'tofu_state_list',
+  'git_log',
+  'git_diff',
+  'git_status',
+  'git_clone_ro',
+];
+
+// Subcommands that would mutate infra — must never be reachable as a tool.
+const FORBIDDEN_TOOL_NAMES = [
+  'helm_install',
+  'helm_upgrade',
+  'helm_uninstall',
+  'tofu_apply',
+  'tofu_destroy',
+  'git_push',
+  'git_commit',
+  'git_reset',
+  'run',
+  'exec',
+  'shell',
+  'sh',
+];
+
+interface RpcResponse {
+  jsonrpc: string;
+  id: number | string | null;
+  result?: any;
+  error?: { code: number; message: string };
+}
+
+// Write every request, close stdin, then read all newline-delimited responses.
+// The server's read loop ends on stdin EOF, so the process exits cleanly.
+async function rpc(requests: object[]): Promise<RpcResponse[]> {
+  const proc = Bun.spawn(['bun', SERVER], { stdin: 'pipe', stdout: 'pipe', stderr: 'pipe' });
+  proc.stdin.write(requests.map((r) => JSON.stringify(r)).join('\n') + '\n');
+  await proc.stdin.end();
+  const out = await new Response(proc.stdout).text();
+  await proc.exited;
+  return out.trim().split('\n').filter((l) => l.length > 0).map((l) => JSON.parse(l) as RpcResponse);
+}
+
+function byId(responses: RpcResponse[], id: number): RpcResponse {
+  const found = responses.find((r) => r.id === id);
+  if (!found) throw new Error(`no response for id ${id} in: ${JSON.stringify(responses)}`);
+  return found;
+}
+
+let repoDir: string;
+
+beforeAll(() => {
+  repoDir = mkdtempSync(join(tmpdir(), 'infra-tools-git-'));
+  const env = {
+    ...process.env,
+    GIT_AUTHOR_NAME: 'Test',
+    GIT_AUTHOR_EMAIL: 'test@example.com',
+    GIT_COMMITTER_NAME: 'Test',
+    GIT_COMMITTER_EMAIL: 'test@example.com',
+  };
+  const git = (args: string[]) => {
+    const r = Bun.spawnSync(['git', ...args], { cwd: repoDir, env });
+    if (r.exitCode !== 0) throw new Error(`git ${args.join(' ')} failed: ${r.stderr.toString()}`);
+  };
+  git(['init', '-q']);
+  writeFileSync(join(repoDir, 'README.md'), '# fixture\n');
+  git(['add', '.']);
+  git(['commit', '-q', '-m', 'infra-tools fixture commit']);
+});
+
+afterAll(() => {
+  if (repoDir) rmSync(repoDir, { recursive: true, force: true });
+});
+
+describe('infra-tools MCP server', () => {
+  const initialize = {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 't', version: '0' } },
+  };
+
+  test('initialize handshake returns serverInfo and tools capability', async () => {
+    const [res] = await rpc([initialize]);
+    expect(res.error).toBeUndefined();
+    expect(res.result.serverInfo).toEqual({ name: 'infra-tools', version: '0.1.0' });
+    expect(res.result.capabilities.tools).toBeDefined();
+    expect(res.result.protocolVersion).toBe('2025-06-18');
+  });
+
+  test('tools/list exposes exactly the read-only helm/tofu/git tools', async () => {
+    const responses = await rpc([initialize, { jsonrpc: '2.0', id: 2, method: 'tools/list' }]);
+    const names: string[] = byId(responses, 2).result.tools.map((t: { name: string }) => t.name);
+    expect(names.sort()).toEqual([...EXPECTED_TOOLS].sort());
+  });
+
+  test('no mutating or generic-escape-hatch tool is exposed', async () => {
+    const responses = await rpc([initialize, { jsonrpc: '2.0', id: 2, method: 'tools/list' }]);
+    const names: string[] = byId(responses, 2).result.tools.map((t: { name: string }) => t.name);
+    for (const forbidden of FORBIDDEN_TOOL_NAMES) {
+      expect(names).not.toContain(forbidden);
+    }
+    // Nothing named for apply/install/push/destroy/uninstall, however spelled.
+    expect(names.some((n) => /apply|install|upgrade|uninstall|destroy|push|commit|reset/.test(n)))
+      .toBe(false);
+  });
+
+  test('every tool declares a typed input schema', async () => {
+    const responses = await rpc([initialize, { jsonrpc: '2.0', id: 2, method: 'tools/list' }]);
+    for (const tool of byId(responses, 2).result.tools) {
+      expect(tool.inputSchema.type).toBe('object');
+      expect(typeof tool.description).toBe('string');
+    }
+  });
+
+  test('tools/call git_log runs against a fixture repo and returns the commit', async () => {
+    const responses = await rpc([
+      initialize,
+      {
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: { name: 'git_log', arguments: { dir: repoDir, opts: ['--oneline'] } },
+      },
+    ]);
+    const result = byId(responses, 3).result;
+    expect(result.isError).toBe(false);
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.ok).toBe(true);
+    expect(payload.exit_code).toBe(0);
+    expect(payload.stdout).toContain('infra-tools fixture commit');
+  });
+
+  test('tools/call git_status returns clean working tree for the fixture', async () => {
+    const responses = await rpc([
+      initialize,
+      {
+        jsonrpc: '2.0',
+        id: 4,
+        method: 'tools/call',
+        params: { name: 'git_status', arguments: { dir: repoDir } },
+      },
+    ]);
+    const payload = JSON.parse(byId(responses, 4).result.content[0].text);
+    expect(payload.ok).toBe(true);
+    expect(payload.stdout).toContain('nothing to commit');
+  });
+
+  test('tools/call on an unknown tool is reported as an error result', async () => {
+    const responses = await rpc([
+      initialize,
+      {
+        jsonrpc: '2.0',
+        id: 5,
+        method: 'tools/call',
+        params: { name: 'helm_install', arguments: {} },
+      },
+    ]);
+    const result = byId(responses, 5).result;
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('unknown tool');
+  });
+
+  test('unknown JSON-RPC method returns method-not-found', async () => {
+    const responses = await rpc([initialize, { jsonrpc: '2.0', id: 6, method: 'no/such/method' }]);
+    expect(byId(responses, 6).error?.code).toBe(-32601);
+  });
+
+  test('malformed JSON line returns a parse error', async () => {
+    const proc = Bun.spawn(['bun', SERVER], { stdin: 'pipe', stdout: 'pipe', stderr: 'pipe' });
+    proc.stdin.write('{ not json }\n');
+    await proc.stdin.end();
+    const out = await new Response(proc.stdout).text();
+    await proc.exited;
+    const res = JSON.parse(out.trim()) as RpcResponse;
+    expect(res.error?.code).toBe(-32700);
+  });
+});


### PR DESCRIPTION
Completes #44 (against ADR #45). Adds a read-only helm/tofu/git MCP server plugin to agentkit's marketplace, so agentkit bundles both the vendored assay plugin and this one. Zero-dep hand-rolled JSON-RPC stdio server; 10 read-only tools (each a fixed non-mutating subcommand, argv-array spawning, no shell). bun test 163 pass; oxlint clean; smoke-tested. Full detail in the branch commit.