### PR TITLE
feat: comprehensive agentkit Claude Code plugin (hooks + skills + assay/infra-tools MCP)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,6 +8,12 @@
   "description": "Reusable agent tooling distributed as Claude Code plugins. The generic units (MCP tools, skills) are the source of truth; the plugins wrap them for one-step install. See ADR #45.",
   "plugins": [
     {
+      "name": "agentkit",
+      "source": "./plugins-cc/agentkit",
+      "description": "One-shot install of everything agentkit ships for Claude Code: the enforcement police hooks (git / mr / format / coding / kubectl / pkg), the skills, and both MCP toolchains (assay + infra-tools). The assay toolchain requires the `assay` binary on PATH; the infra-tools MCP server needs `bun`. Prefer this over the granular plugins unless you want à-la-carte install.",
+      "version": "0.1.0"
+    },
+    {
       "name": "assay",
       "source": {
         "source": "git-subdir",

--- a/README.md
+++ b/README.md
@@ -69,20 +69,38 @@ Reusable AI agent skills, rules, plugins, hooks, and tools for OpenCode, Claude 
 
 ### Claude Code plugins (marketplace)
 
-Tools ship as MCP servers wrapped in Claude Code plugins (ADR #45 — generic
-units are the source of truth; plugins are convenience wrappers). Add the
-marketplace once, then install:
+Hooks, skills, and tools ship as Claude Code plugins (ADR #45 — the generic units — MCP tools,
+skills, hook scripts — are the source of truth; plugins are convenience wrappers). Add the
+marketplace once, then install. The **agentkit** plugin is the recommended one-shot: a single
+`claude plugin install agentkit` gives you the enforcement hooks, the skills, and **both** MCP
+toolchains (assay + infra-tools) in one step — no separate `install.sh` needed for those. The
+granular **assay** and **infra-tools** plugins remain for à-la-carte installs.
 
 ```bash
 claude plugin marketplace add developerinlondon/agentkit
+
+# Recommended: everything in one step — hooks + skills + assay + infra-tools MCP
+claude plugin install agentkit
+
+# Or à-la-carte — just one toolchain
 claude plugin install assay
 claude plugin install infra-tools
 ```
 
 | Plugin          | Provides                                                                                                                                                                                                                                                                                                 | Source                                                                                        |
 | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| **agentkit**    | One-shot install of everything agentkit ships for Claude Code: the enforcement police hooks (git / mr / format / coding / kubectl / pkg), the skills, and both MCP toolchains (bundles the assay declaration + a copy of the infra-tools server). Needs the `assay` binary and `bun` on PATH.            | local `plugins-cc/agentkit/`                                                                  |
 | **assay**       | Gated Lua infra toolkit (`assay_run` + `assay_context`) — Kubernetes, ArgoCD, Vault, Prometheus, GitLab, AWS, … through one read-only/approval-gated tool. Requires the `assay` binary on PATH.                                                                                                          | vendored from [developerinlondon/assay](https://github.com/developerinlondon/assay) `plugin/` |
 | **infra-tools** | Read-only helm / tofu / git tools (`helm_template`/`helm_list`/`helm_get_values`, `tofu_plan`/`tofu_show`/`tofu_state_list`, `git_log`/`git_diff`/`git_status`/`git_clone_ro`) as a typed MCP server — render charts, preview plans, read git history. Never applies or mutates. Requires `bun` on PATH. | local `plugins-cc/infra-tools/`                                                               |
+
+**Not in the plugin: the always-on rules and instructions.** Claude Code plugins cannot inject
+always-on global context, so the glob-loaded `rules/` and the `instructions/*.md` global prompts
+(anti-glaze, coding-discipline, collaboration-visibility) are **out of scope for the plugin** and
+are still wired into `~/.claude/CLAUDE.md`, Codex, and OpenCode by `install.sh`. Their
+**enforcement**, however, _is_ bundled: the police hooks (`git-police`, `mr-police`,
+`format-police`, `coding-police`, `kubectl-police`, `pkg-police`) run as PreToolUse / PostToolUse
+hooks inside the `agentkit` plugin, so the mechanical guarantees hold even without the global
+instruction text.
 
 ## Installation
 

--- a/plugins-cc/agentkit/.claude-plugin/plugin.json
+++ b/plugins-cc/agentkit/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin.json",
+  "name": "agentkit",
+  "version": "0.1.0",
+  "description": "Everything agentkit ships for Claude Code in one install: enforcement hooks, skills, and the assay + infra-tools MCP toolchains. The assay toolchain requires the `assay` binary on PATH; the infra-tools MCP server needs `bun` on PATH.",
+  "author": {
+    "name": "developerinlondon",
+    "url": "https://github.com/developerinlondon"
+  },
+  "hooks": "./hooks/hooks.json",
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json"
+}

--- a/plugins-cc/agentkit/.mcp.json
+++ b/plugins-cc/agentkit/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "assay": {
+      "command": "assay",
+      "args": ["mcp-serve"]
+    },
+    "infra-tools": {
+      "command": "bun",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/server/index.ts"]
+    }
+  }
+}

--- a/plugins-cc/agentkit/hooks/coding-police.sh
+++ b/plugins-cc/agentkit/hooks/coding-police.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+# coding-police.sh — Claude Code PostToolUse hook (matcher: Edit|Write)
+# Enforces: DRY code, modular files (<1000 lines), short functions, single responsibility
+# Equivalent to: plugins/coding-police.ts (OpenCode)
+set -euo pipefail
+
+# ── Configuration ───────────────────────────────────────────────────────────
+AGENTKIT_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/agentkit/config.yaml"
+
+MAX_FILE_LINES=1000
+MAX_FUNCTION_LINES=100
+MIN_DUPLICATE_LINES=6
+MAX_EXPORTS_PER_FILE=15
+
+load_config() {
+  [[ -f "$AGENTKIT_CONFIG" ]] || return 0
+  local section
+  section=$(sed -n '/^coding-police:/,/^[^ ]/p' "$AGENTKIT_CONFIG" | head -n -1)
+  [[ -z "$section" ]] && return 0
+
+  local val
+  val=$(echo "$section" | grep -oP 'max-file-lines:\s*\K\d+' || true)
+  [[ -n "$val" ]] && MAX_FILE_LINES="$val"
+
+  val=$(echo "$section" | grep -oP 'max-function-lines:\s*\K\d+' || true)
+  [[ -n "$val" ]] && MAX_FUNCTION_LINES="$val"
+
+  val=$(echo "$section" | grep -oP 'min-duplicate-lines:\s*\K\d+' || true)
+  [[ -n "$val" ]] && MIN_DUPLICATE_LINES="$val"
+
+  val=$(echo "$section" | grep -oP 'max-exports-per-file:\s*\K\d+' || true)
+  [[ -n "$val" ]] && MAX_EXPORTS_PER_FILE="$val"
+}
+load_config
+
+# ── Input parsing ───────────────────────────────────────────────────────────
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
+
+# Only trigger on Edit or Write tools
+case "$TOOL_NAME" in
+  Edit|Write|edit|write) ;;
+  *) exit 0 ;;
+esac
+
+# Extract the file path from tool input
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.filePath // empty')
+[[ -z "$FILE_PATH" ]] && exit 0
+
+IS_CODE_FILE=false
+SHOULD_CHECK_PATHS=false
+
+case "$FILE_PATH" in
+  *.ts|*.tsx|*.js|*.jsx|*.py|*.rb|*.go|*.rs|*.java|*.kt|*.cs|*.cpp|*.c|*.h|*.hpp|*.swift|*.scala|*.vue|*.svelte)
+    IS_CODE_FILE=true
+    SHOULD_CHECK_PATHS=true
+    ;;
+  *.yml|*.yaml|*.toml|*.json|*.jsonc|*.ini|*.env|*.service|*.conf|*.cfg)
+    SHOULD_CHECK_PATHS=true
+    ;;
+  *) exit 0 ;;
+esac
+
+# Skip generated/lock files
+case "$FILE_PATH" in
+  *.lock|*.min.*|*.generated.*|*.snap|*.d.ts|package-lock.json|yarn.lock|pnpm-lock.yaml)
+    exit 0 ;;
+esac
+
+[[ -f "$FILE_PATH" ]] || exit 0
+
+VIOLATIONS=()
+
+# ── Check 0: Cross-repo sibling relative paths ─────────────────────────────
+check_cross_repo_relative_paths() {
+  [[ "$SHOULD_CHECK_PATHS" == true ]] || return 0
+
+  local matches
+  matches=$(grep -nE '\{\{[[:space:]]*(inventory_dir|playbook_dir|role_path|ansible_parent_role_paths\[[^]]+\])[[:space:]]*\}\}[[:space:]]*/(\.\./){2,}|(^|["'"'"'=[:space:]])(\.\./){2,}(core|eda|fullcircle|dashboard|gitops|infra|ansible-roles)(/|["'"'"'[:space:]]|$)' "$FILE_PATH" 2>/dev/null || true)
+
+  while IFS= read -r line; do
+    if [[ -n "$line" ]]; then
+      VIOLATIONS+=("CROSS-REPO RELATIVE PATH: ${line}. Do not depend on checkout layout across repos; use a published artifact, a vendored/submodule path inside this repo, or runtime configuration.")
+    fi
+  done <<< "$matches"
+}
+
+# ── Check 1: File length ───────────────────────────────────────────────────
+check_file_length() {
+  local line_count
+  line_count=$(wc -l < "$FILE_PATH")
+  if (( line_count > MAX_FILE_LINES )); then
+    local excess=$(( line_count - MAX_FILE_LINES ))
+    VIOLATIONS+=("FILE TOO LONG: ${line_count} lines (limit: ${MAX_FILE_LINES}, over by ${excess}). Split this file into smaller modules grouped by functionality. Identify logical boundaries (types, helpers, handlers, constants) and extract them.")
+  fi
+}
+
+# ── Check 2: Function lengths ──────────────────────────────────────────────
+check_function_lengths() {
+  # Use awk to find function definitions and track brace depth
+  local long_funcs
+  long_funcs=$(awk -v max="$MAX_FUNCTION_LINES" '
+    # Match function starts for TS/JS/Go/Rust/Java/C
+    /^[[:space:]]*(export[[:space:]]+)?(async[[:space:]]+)?function[[:space:]]+[a-zA-Z_]/ ||
+    /^[[:space:]]*(export[[:space:]]+)?(const|let|var)[[:space:]]+[a-zA-Z_][a-zA-Z0-9_]*[[:space:]]*=[[:space:]]*(async[[:space:]]*)?\(/ ||
+    /^[[:space:]]*(pub[[:space:]]+)?(async[[:space:]]+)?fn[[:space:]]+[a-zA-Z_]/ ||
+    /^[[:space:]]*func[[:space:]]+(\([^)]*\)[[:space:]]+)?[a-zA-Z_]/ {
+      if (in_func && depth == 0) {
+        len = NR - func_start
+        if (len > max) {
+          printf "LONG FUNCTION: `%s` is %d lines (limit: %d, starts at line %d). Break it into smaller helper functions.\n", func_name, len, max, func_start
+        }
+      }
+      # Extract function name
+      name = $0
+      gsub(/^[[:space:]]*(export[[:space:]]+)?(async[[:space:]]+)?(pub[[:space:]]+)?/, "", name)
+      gsub(/^(function|fn|func|const|let|var)[[:space:]]+/, "", name)
+      gsub(/(\([^)]*\)[[:space:]]+)?/, "", name)  # Go receiver
+      gsub(/[[:space:]]*[=({:.].*/, "", name)
+      func_name = name
+      func_start = NR
+      depth = 0
+      in_func = 1
+    }
+
+    # Also match Python def
+    /^[[:space:]]*(async[[:space:]]+)?def[[:space:]]+[a-zA-Z_]/ {
+      if (in_func && depth == 0 && NR > func_start) {
+        len = NR - func_start
+        if (len > max) {
+          printf "LONG FUNCTION: `%s` is %d lines (limit: %d, starts at line %d). Break it into smaller helper functions.\n", func_name, len, max, func_start
+        }
+      }
+      name = $0
+      gsub(/^[[:space:]]*(async[[:space:]]+)?def[[:space:]]+/, "", name)
+      gsub(/[[:space:]]*\(.*/, "", name)
+      func_name = name
+      func_start = NR
+      depth = 0
+      in_func = 1
+    }
+
+    in_func {
+      n = split($0, chars, "")
+      for (i = 1; i <= n; i++) {
+        if (chars[i] == "{") depth++
+        if (chars[i] == "}") depth--
+      }
+      if (depth <= 0 && NR > func_start && index($0, "}") > 0) {
+        len = NR - func_start + 1
+        if (len > max) {
+          printf "LONG FUNCTION: `%s` is %d lines (limit: %d, starts at line %d). Break it into smaller helper functions.\n", func_name, len, max, func_start
+        }
+        in_func = 0
+      }
+    }
+
+    END {
+      if (in_func && depth == 0) {
+        len = NR - func_start
+        if (len > max) {
+          printf "LONG FUNCTION: `%s` is %d lines (limit: %d, starts at line %d). Break it into smaller helper functions.\n", func_name, len, max, func_start
+        }
+      }
+    }
+  ' "$FILE_PATH" 2>/dev/null || true)
+
+  while IFS= read -r line; do
+    if [[ -n "$line" ]]; then VIOLATIONS+=("$line"); fi
+  done <<< "$long_funcs"
+}
+
+# ── Check 3: Duplicate code blocks ─────────────────────────────────────────
+check_duplicate_blocks() {
+  # Normalise: strip comments, blank lines, imports, then find repeated blocks
+  local dupes
+  dupes=$(awk -v min="$MIN_DUPLICATE_LINES" '
+    BEGIN { idx = 0 }
+    {
+      line = $0
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
+
+      # Skip blank, comments, imports, single-char structural lines
+      if (line == "") next
+      if (line ~ /^\/\//) next
+      if (line ~ /^#/) next
+      if (line ~ /^\*/) next
+      if (line ~ /^\/\*/) next
+      if (line ~ /^\*\//) next
+      if (line ~ /^(import|from|require|use |using )/) next
+      if (line ~ /^[{}()\[\];,]$/) next
+
+      idx++
+      norm[idx] = line
+      orig[idx] = NR
+    }
+    END {
+      for (i = 1; i <= idx - min + 1; i++) {
+        block = ""
+        for (k = 0; k < min; k++) {
+          block = block norm[i + k] "\n"
+        }
+
+        if (block in seen) {
+          first = seen[block]
+          key = first ":" orig[i]
+          if (!(key in reported)) {
+            reported[key] = 1
+            printf "DUPLICATE CODE: %d+ line block duplicated at lines %d and %d. Extract into a shared function to keep code DRY.\n", min, first, orig[i]
+          }
+        } else {
+          seen[block] = orig[i]
+        }
+      }
+    }
+  ' "$FILE_PATH" 2>/dev/null || true)
+
+  while IFS= read -r line; do
+    if [[ -n "$line" ]]; then VIOLATIONS+=("$line"); fi
+  done <<< "$dupes"
+}
+
+# ── Check 4: Export count (TS/JS only) ──────────────────────────────────────
+check_export_count() {
+  case "$FILE_PATH" in
+    *.ts|*.tsx|*.js|*.jsx) ;;
+    *) return 0 ;;
+  esac
+
+  local count
+  count=$(grep -cE '^\s*export\s+(default\s+)?(function|class|const|let|var|type|interface|enum|async)' "$FILE_PATH" 2>/dev/null || true)
+  count=${count:-0}
+  if (( count > MAX_EXPORTS_PER_FILE )); then
+    VIOLATIONS+=("TOO MANY EXPORTS: ${count} exports in this file (limit: ${MAX_EXPORTS_PER_FILE}). This suggests the file has multiple responsibilities. Group related exports into separate modules (e.g., types.ts, helpers.ts, constants.ts).")
+  fi
+}
+
+# ── Run all checks ──────────────────────────────────────────────────────────
+check_cross_repo_relative_paths
+
+if [[ "$IS_CODE_FILE" != true ]]; then
+  if (( ${#VIOLATIONS[@]} > 0 )); then
+    {
+      echo ""
+      echo "CODING STANDARDS VIOLATION (coding-police)"
+      echo "=================================================="
+      for i in "${!VIOLATIONS[@]}"; do
+        echo "$(( i + 1 )). ${VIOLATIONS[$i]}"
+        echo ""
+      done
+      echo "REQUIRED ACTIONS:"
+      echo "- Remove cross-repo sibling relative paths from durable config."
+      echo "- Use published artifacts, vendored/submodule paths inside the same repo, or runtime configuration."
+      echo ""
+      echo "Fix these violations before proceeding."
+    } >&2
+  fi
+  exit 0
+fi
+
+check_file_length
+check_function_lengths
+check_duplicate_blocks
+check_export_count
+
+# ── Output violations ──────────────────────────────────────────────────────
+if (( ${#VIOLATIONS[@]} > 0 )); then
+  {
+    echo ""
+    echo "CODING STANDARDS VIOLATION (coding-police)"
+    echo "=================================================="
+    for i in "${!VIOLATIONS[@]}"; do
+      echo "$(( i + 1 )). ${VIOLATIONS[$i]}"
+      echo ""
+    done
+    echo "REQUIRED ACTIONS:"
+    echo "- Keep code DRY: extract duplicated logic into shared functions."
+    echo "- Keep files modular: split files exceeding ${MAX_FILE_LINES} lines by functionality."
+    echo "- Keep functions focused: break functions over ${MAX_FUNCTION_LINES} lines into composable helpers."
+    echo "- Apply Single Responsibility: each file should have one clear purpose."
+    echo "- Remove cross-repo sibling relative paths from durable config."
+    echo ""
+    echo "Fix these violations before proceeding."
+  } >&2
+fi
+
+exit 0

--- a/plugins-cc/agentkit/hooks/format-police.sh
+++ b/plugins-cc/agentkit/hooks/format-police.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# format-police.sh — Claude Code PostToolUse hook (matcher: Edit|Write)
+# Auto-formats files after edit/write using dprint
+# Equivalent to: plugins/format-police.ts (OpenCode)
+set -euo pipefail
+
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
+
+# Only trigger on Edit or Write tools
+case "$TOOL_NAME" in
+  Edit|Write|edit|write) ;;
+  *) exit 0 ;;
+esac
+
+# Extract the file path from tool input
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.filePath // empty')
+[[ -z "$FILE_PATH" ]] && exit 0
+
+# Only format known file types
+case "$FILE_PATH" in
+  *.ts|*.tsx|*.js|*.jsx|*.json|*.jsonc|*.md|*.yaml|*.yml|*.toml|*.css|*.html) ;;
+  *) exit 0 ;;
+esac
+
+# Find dprint binary
+DPRINT=""
+if command -v dprint &>/dev/null; then
+  DPRINT="dprint"
+else
+  # Check mise-managed installs
+  MISE_DIR="$HOME/.local/share/mise/installs/dprint"
+  if [[ -d "$MISE_DIR" ]]; then
+    LATEST=$(ls -1 "$MISE_DIR" 2>/dev/null | sort -V | tail -1)
+    if [[ -n "$LATEST" && -x "$MISE_DIR/$LATEST/dprint" ]]; then
+      DPRINT="$MISE_DIR/$LATEST/dprint"
+    fi
+  fi
+fi
+
+if [[ -z "$DPRINT" ]]; then
+  echo "⚠ dprint not found — skipping format" >&2
+  exit 0
+fi
+
+# Find the nearest dprint.json by walking up from the file's directory
+find_config() {
+  local dir="$1"
+  while [[ "$dir" != "/" && "$dir" != "$HOME" ]]; do
+    [[ -f "$dir/dprint.json" ]] && echo "$dir/dprint.json" && return
+    dir=$(dirname "$dir")
+  done
+}
+
+CONFIG_FLAG=""
+LOCAL_CONFIG=$(find_config "$(dirname "$FILE_PATH")")
+if [[ -n "$LOCAL_CONFIG" ]]; then
+  CONFIG_FLAG="--config $LOCAL_CONFIG"
+elif [[ -n "${DPRINT_DEFAULT_CONFIG:-}" && -f "$DPRINT_DEFAULT_CONFIG" ]]; then
+  CONFIG_FLAG="--config $DPRINT_DEFAULT_CONFIG"
+else
+  echo "⚠ no dprint.json found — set DPRINT_DEFAULT_CONFIG for a global fallback" >&2
+  exit 0
+fi
+
+# Format the file — warn on failure instead of silently swallowing
+if ! "$DPRINT" fmt $CONFIG_FLAG "$FILE_PATH" 2>/tmp/dprint-err.log; then
+  echo "⚠ dprint fmt failed for $FILE_PATH: $(cat /tmp/dprint-err.log)" >&2
+fi
+
+exit 0

--- a/plugins-cc/agentkit/hooks/git-police.sh
+++ b/plugins-cc/agentkit/hooks/git-police.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# git-police.sh — Claude Code PreToolUse hook (matcher: Bash)
+# Blocks: force push, --no-verify, Co-authored-by trailers, commits to protected branches, stale branch creation
+# Equivalent to: plugins/git-police.ts (OpenCode)
+set -euo pipefail
+
+PROTECTED_BRANCHES=("main" "master")
+AGENTKIT_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/agentkit/config.yaml"
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+[[ -z "$COMMAND" ]] && exit 0
+
+load_allowed_repos() {
+	[[ -f "$AGENTKIT_CONFIG" ]] || return
+	local in_section=false
+	while IFS= read -r line; do
+		if [[ "$line" =~ ^[[:space:]]*branch-protection: ]]; then
+			in_section=true
+			continue
+		fi
+		if [[ "$in_section" == true && "$line" =~ ^[[:space:]]*allowed-repos: ]]; then
+			continue
+		fi
+		if [[ "$in_section" == true && "$line" =~ ^[[:space:]]*-[[:space:]]+(.*) ]]; then
+			ALLOWED_REPOS+=("${BASH_REMATCH[1]}")
+		elif [[ "$in_section" == true && ! "$line" =~ ^[[:space:]] ]]; then
+			break
+		fi
+	done < <(sed -n '/^git-police:/,/^[^ ]/p' "$AGENTKIT_CONFIG")
+}
+
+ALLOWED_REPOS=()
+load_allowed_repos
+
+STRIPPED=$(echo "$COMMAND" |
+	sed -E "s/<<-?[[:space:]]*['\"]?([A-Za-z_]+)['\"]?/\n\1_HEREDOC_START\n/g" |
+	sed -E "s/\"([^\"\\\\]|\\\\.)*\"/\"\"/g" |
+	sed -E "s/'[^']*'/''/g")
+
+# The repo a git command operates on: honor `git -C <path>` and a `cd <path>`
+# at the start or after a separator (; && |), falling back to the hook's cwd.
+# The session cwd may be a different repo entirely (or none at all) — every
+# repo-state check below must resolve against the targeted repo, not the cwd.
+# Quoted paths were emptied out of STRIPPED, so those fall back to the cwd.
+git_target_dir() {
+	local dir
+	dir=$(echo "$1" | sed -nE 's/.*git[[:space:]]+-C[[:space:]]+([^[:space:]]+).*/\1/p' | head -1)
+	if [[ -z "$dir" ]]; then
+		dir=$(echo "$1" | sed -nE 's/(^|.*[;&|])[[:space:]]*cd[[:space:]]+([^[:space:];&|]+).*/\2/p' | head -1)
+	fi
+	echo "${dir/#\~/$HOME}"
+}
+TARGET_DIR=$(git_target_dir "$STRIPPED")
+
+# git scoped to the targeted repo (cwd when the command names none).
+tgit() {
+	git ${TARGET_DIR:+-C "$TARGET_DIR"} "$@"
+}
+
+if [[ ${#ALLOWED_REPOS[@]} -gt 0 ]]; then
+	REPO_NAME=$(tgit remote get-url origin 2>/dev/null | sed -E 's|.*[:/]([^/]+/[^/]+?)(\.git)?$|\1|' || echo "")
+	for allowed in "${ALLOWED_REPOS[@]}"; do
+		if [[ "$REPO_NAME" == *"$allowed"* ]]; then
+			exit 0
+		fi
+	done
+fi
+
+deny() {
+	local reason="$1"
+	jq -n --arg r "$reason" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: $r
+    }
+  }'
+	exit 0
+}
+
+# 1. Block --no-verify (skips pre-commit/commit-msg hooks)
+if echo "$STRIPPED" | grep -qiE '\bgit\b.*--no-verify\b'; then
+	deny "BLOCKED: --no-verify is forbidden. Skipping pre-commit hooks bypasses quality gates (linting, tests, formatting). Fix the issue that's causing the hook to fail instead."
+fi
+
+# Detect `git push` as a subcommand (allowing global flags like -C <path>), so
+# `git stash push`, or "push" appearing in a branch name or message, never
+# matches the push rules. Same shape as GIT_COMMIT_RE below.
+GIT_PUSH_RE='\bgit([[:space:]]+(-[A-Za-z][^[:space:]]*|--[A-Za-z][A-Za-z0-9-]*(=[^[:space:]]+)?)([[:space:]]+[^-[:space:]][^[:space:]]*)?)*[[:space:]]+push\b'
+
+# 2. Block force push (--force, -f, --force-with-lease). Every variant rewrites
+#    remote history; sanctioned rewrites are pushed by the user directly.
+if echo "$STRIPPED" | grep -qiE "${GIT_PUSH_RE}"'.*(-f\b|--force\b|--force-with-lease\b)'; then
+	deny "BLOCKED: Force push is forbidden. Force pushing rewrites history and can destroy work. If a history rewrite is truly required, prepare the branch and ask the user to run the force push themselves."
+fi
+
+# The remote a push targets: the first non-flag token after `push` (empty for
+# the implicit upstream). Branch protection guards the canonical repo (origin);
+# pushes that explicitly name a different remote are mirror syncs of refs that
+# already went through review there, so rules 3 and 4 let them pass.
+push_remote() {
+	echo "$1" | awk '{
+		for (i = 1; i <= NF; i++)
+			if ($i == "push") {
+				for (j = i + 1; j <= NF; j++)
+					if ($j !~ /^-/) { print $j; exit }
+				exit
+			}
+	}'
+}
+PUSH_REMOTE=$(push_remote "$STRIPPED")
+
+# 3. Block pushing directly to protected branches (on origin / implicit upstream)
+if [[ -z "$PUSH_REMOTE" || "$PUSH_REMOTE" == "origin" ]]; then
+	for branch in "${PROTECTED_BRANCHES[@]}"; do
+		if echo "$STRIPPED" | grep -qiE "${GIT_PUSH_RE}.*\b${branch}\b"; then
+			deny "BLOCKED: Pushing directly to '${branch}' is forbidden. Create a feature branch and raise a PR instead."
+		fi
+	done
+fi
+
+# 4. Block push when the targeted repo is on a protected branch (even without
+#    branch name in command) — same origin scoping as rule 3.
+if [[ -z "$PUSH_REMOTE" || "$PUSH_REMOTE" == "origin" ]] \
+	&& echo "$STRIPPED" | grep -qiE "$GIT_PUSH_RE"; then
+	CURRENT_BRANCH=$(tgit symbolic-ref --short HEAD 2>/dev/null || echo "")
+	for branch in "${PROTECTED_BRANCHES[@]}"; do
+		if [[ "$CURRENT_BRANCH" == "$branch" ]]; then
+			deny "BLOCKED: You are on '${branch}'. Pushing from a protected branch is forbidden. Create a feature branch first: git checkout -b feat/your-feature-name"
+		fi
+	done
+fi
+
+# Detect `git commit` as a subcommand (not the literal substring "commit"
+# inside a config key like `git config commit.gpgsign`).
+GIT_COMMIT_RE='\bgit([[:space:]]+(-[A-Za-z][^[:space:]]*|--[A-Za-z][A-Za-z0-9-]*(=[^[:space:]]+)?)([[:space:]]+[^-[:space:]][^[:space:]]*)?)*[[:space:]]+commit\b'
+
+# 5. Block AI attribution trailers / signatures in commit commands.
+#    $INPUT is the full PreToolUse JSON payload from stdin; the previous
+#    version referenced an undefined $TOOL_INPUT and silently never matched.
+if echo "$STRIPPED" | grep -qiE "$GIT_COMMIT_RE" \
+	&& echo "$INPUT" | grep -qiE 'co-authored-by|generated with \[claude code\]|🤖 generated|claude\.ai/code|noreply@anthropic\.com'; then
+	deny "BLOCKED: AI attribution in commit messages is forbidden. Do not add Co-authored-by, Signed-off-by, '🤖 Generated with [Claude Code]', claude.ai/code links, noreply@anthropic.com co-authors, or any other AI agent attribution. The commit author is whoever owns the git config. Remove the attribution and retry."
+fi
+
+# 6. Block direct commits to protected branches
+if echo "$STRIPPED" | grep -qiE "$GIT_COMMIT_RE"; then
+	CURRENT_BRANCH=$(tgit symbolic-ref --short HEAD 2>/dev/null || echo "")
+	for branch in "${PROTECTED_BRANCHES[@]}"; do
+		if [[ "$CURRENT_BRANCH" == "$branch" ]]; then
+			deny "BLOCKED: Committing directly to '${branch}' is forbidden. You are on the ${branch} branch. Create a feature branch first: git checkout -b feat/your-feature-name"
+		fi
+	done
+fi
+
+# 7. Branch hygiene at branch creation — the only reliable local chokepoint
+#    (merges happen server-side, so there is no "after merge" hook event).
+#    a) new branches are cut from the default branch, not stacked on another
+#       feature branch (squash merges make stacks conflict); override with
+#       AGENTKIT_ALLOW_BRANCH_STACKING=1 for intentional stacking.
+#    b) local branches whose upstream is gone (squash-merged + remote-deleted)
+#       must be cleaned up before starting new work.
+# The override works from the hook's environment or inline in the command
+# itself (`AGENTKIT_ALLOW_BRANCH_STACKING=1 git checkout -b …`) — inline
+# assignments never reach the hook process, so honor them from the text.
+STACKING_OK="${AGENTKIT_ALLOW_BRANCH_STACKING:-0}"
+if echo "$COMMAND" | grep -qE '(^|[[:space:];&|])AGENTKIT_ALLOW_BRANCH_STACKING=1([[:space:];&|]|$)'; then
+	STACKING_OK=1
+fi
+
+if echo "$STRIPPED" | grep -qiE '\bgit\b.*(checkout\s+-b|switch\s+-c)\b'; then
+	DEFAULT_BRANCH=$(tgit symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||' || true)
+	CURRENT_BRANCH=$(tgit symbolic-ref --short HEAD 2>/dev/null || echo "")
+	if [[ -n "$CURRENT_BRANCH" && "$STACKING_OK" != "1" ]]; then
+		ON_BASE=false
+		for base in "$DEFAULT_BRANCH" "${PROTECTED_BRANCHES[@]}" dev; do
+			[[ -n "$base" && "$CURRENT_BRANCH" == "$base" ]] && ON_BASE=true
+		done
+		if [[ "$ON_BASE" == false ]]; then
+			deny "BLOCKED: The targeted repo is on feature branch '${CURRENT_BRANCH}'. Cut new branches from the freshly pulled default branch (squash merges make stacked branches conflict once the first MR merges). Run: git checkout ${DEFAULT_BRANCH:-main} && git pull, then create the branch. Intentional stacking: prefix the command with AGENTKIT_ALLOW_BRANCH_STACKING=1."
+		fi
+	fi
+	tgit fetch -p --quiet 2>/dev/null || true
+	GONE=$(tgit branch -vv 2>/dev/null | grep ': gone]' | awk '{print $1}' | tr '\n' ' ' || true)
+	if [[ -n "${GONE// /}" ]]; then
+		deny "BLOCKED: Stale local branches with deleted upstreams: ${GONE}. Clean up before starting new work: git branch -vv | awk '/: gone]/ {print \$1}' | xargs -r git branch -D"
+	fi
+fi
+
+# 8. Stale branch protection — warn when creating a branch from a stale base
+if echo "$STRIPPED" | grep -qiE '\bgit\b.*(checkout\s+-b|switch\s+-c)\b'; then
+	CURRENT_BRANCH=$(tgit symbolic-ref --short HEAD 2>/dev/null || echo "")
+	for branch in "${PROTECTED_BRANCHES[@]}"; do
+		if [[ "$CURRENT_BRANCH" == "$branch" ]]; then
+			tgit fetch origin "$branch" --quiet 2>/dev/null || true
+			LOCAL_SHA=$(tgit rev-parse "$branch" 2>/dev/null || echo "")
+			REMOTE_SHA=$(tgit rev-parse "origin/$branch" 2>/dev/null || echo "")
+			if [[ -n "$LOCAL_SHA" && -n "$REMOTE_SHA" && "$LOCAL_SHA" != "$REMOTE_SHA" ]]; then
+				BEHIND=$(tgit rev-list --count "$branch..origin/$branch" 2>/dev/null || echo "0")
+				if [[ "$BEHIND" -gt 0 ]]; then
+					deny "BLOCKED: Your local '${branch}' is ${BEHIND} commit(s) behind origin/${branch}. Run 'git pull origin ${branch}' first to avoid creating a branch from stale code. This prevents merge conflicts and wasted rebases."
+				fi
+			fi
+		fi
+	done
+fi
+
+exit 0

--- a/plugins-cc/agentkit/hooks/hooks.json
+++ b/plugins-cc/agentkit/hooks/hooks.json
@@ -1,0 +1,53 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/git-police.sh",
+            "timeout": 10,
+            "statusMessage": "git-police: checking safety rules..."
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/kubectl-police.sh",
+            "timeout": 10,
+            "statusMessage": "kubectl-police: checking Kargo safety..."
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/pkg-police.sh",
+            "timeout": 10,
+            "statusMessage": "pkg-police: enforcing bun as package manager..."
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/mr-police.sh",
+            "timeout": 15,
+            "statusMessage": "mr-police: checking for unmerged MRs..."
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/format-police.sh",
+            "timeout": 15
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/coding-police.sh",
+            "timeout": 15,
+            "statusMessage": "coding-police: checking coding standards..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins-cc/agentkit/hooks/kubectl-police.sh
+++ b/plugins-cc/agentkit/hooks/kubectl-police.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# kubectl-police.sh — Claude Code PreToolUse hook (matcher: Bash)
+# Blocks: kubectl create/apply on Kargo CRDs
+# Equivalent to: plugins/kubectl-police.ts (OpenCode)
+set -euo pipefail
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+[[ -z "$COMMAND" ]] && exit 0
+
+deny() {
+  local reason="$1"
+  jq -n --arg r "$reason" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: $r
+    }
+  }'
+  exit 0
+}
+
+# Check for kubectl create/apply on Kargo CRDs
+if echo "$COMMAND" | grep -qiE '\bkubectl\b.*\b(create|apply)\b'; then
+  KARGO_CRDS="promotion|promotions|stage|stages|freight|freights|warehouse|warehouses"
+  if echo "$COMMAND" | grep -qiE "\b(${KARGO_CRDS})\b"; then
+    # Extract which CRD was matched
+    CRD=$(echo "$COMMAND" | grep -oiE "\b(${KARGO_CRDS})\b" | head -1 | tr '[:upper:]' '[:lower:]')
+    deny "BLOCKED: Creating/applying Kargo ${CRD} via kubectl is forbidden. kubectl-created Kargo resources poison the stage state machine: Promotions get custom names that break lexicographic sorting, currentPromotion not set. Stages become orphaned state that ArgoCD can't reconcile. Use instead: Kargo UI or auto-promotion for promotions, GitOps (git push) for stage/warehouse/freight changes, kubectl DELETE (not create) to recover from corrupted state."
+  fi
+fi
+
+exit 0

--- a/plugins-cc/agentkit/hooks/mr-police.sh
+++ b/plugins-cc/agentkit/hooks/mr-police.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# mr-police.sh — Claude Code PreToolUse hook (matcher: Bash)
+# Blocks opening a NEW merge request while you already have open MR(s) you
+# authored on the same repo. Stops unmerged MRs from accumulating into a tangle
+# of interdependent branches — merge or close the existing one(s) first.
+#
+# The repo is resolved from the command itself, not the hook's cwd (which may
+# be a different repo entirely): an explicit --repo/-R flag wins, then a
+# `cd <path>` prefix, then the cwd.
+#
+# Threshold is configurable: AGENTKIT_MR_POLICE_MAX (default 1) = how many open
+# MRs you may already have before opening another is blocked. Honored from the
+# hook's environment or inline in the command (`AGENTKIT_MR_POLICE_MAX=2 glab
+# mr create …`) — inline assignments never reach the hook process.
+set -euo pipefail
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+[[ -z "$COMMAND" ]] && exit 0
+
+# Only act on MR-creation commands; everything else passes through instantly.
+if ! echo "$COMMAND" | grep -qiE 'glab[[:space:]]+mr[[:space:]]+create|merge_request\.create'; then
+	exit 0
+fi
+
+deny() {
+	jq -n --arg r "$1" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: $r
+    }
+  }'
+	exit 0
+}
+
+# Every MR carries an assignee from the moment it exists — ownership is never
+# ambiguous. Applies to any agent using these hooks (Claude Code, Proxima, …).
+if echo "$COMMAND" | grep -qiE 'glab[[:space:]]+mr[[:space:]]+create' \
+	&& ! echo "$COMMAND" | grep -qE -- '--assignee|[[:space:]]-a[[:space:]]'; then
+	deny "BLOCKED: glab mr create must include an assignee. Add --assignee <username> (or --assignee @me) and retry — unassigned MRs are not allowed."
+fi
+
+# Need glab to check; if it's unavailable, don't block (fail open).
+command -v glab >/dev/null 2>&1 || exit 0
+
+# The repo the command targets, in priority order:
+# 1. explicit --repo/-R on the glab command (OWNER/REPO, HOST/OWNER/REPO, or URL)
+REPO_ARG=$(echo "$COMMAND" | sed -nE 's/.*(--repo[= ]|-R[[:space:]]+)([^[:space:]"'"'"']+).*/\2/p' | head -1)
+
+# 2. a `cd <path>` at the start or after a separator (; && |) — glab resolves
+#    the repo from that directory, so the check must too.
+TARGET_DIR=$(echo "$COMMAND" | sed -nE 's/(^|.*[;&|])[[:space:]]*cd[[:space:]]+([^[:space:];&|]+).*/\2/p' | head -1)
+TARGET_DIR="${TARGET_DIR/#\~/$HOME}"
+
+# 3. the hook's cwd (previous behavior) via plain git below.
+ORIGIN_URL=$(git ${TARGET_DIR:+-C "$TARGET_DIR"} remote get-url origin 2>/dev/null || echo "")
+[[ -z "$REPO_ARG" && -n "$ORIGIN_URL" ]] && REPO_ARG="$ORIGIN_URL"
+
+# Target the GitLab instance this repo lives on (glab otherwise defaults to
+# gitlab.com, or to a stale GITLAB_HOST in the environment).
+HOST=$(echo "$ORIGIN_URL" | sed -E 's#^(git@|https?://)([^:/]+).*#\2#')
+[[ -n "$HOST" ]] && export GITLAB_HOST="$HOST"
+
+# Threshold: inline assignment in the command wins over the hook's environment.
+MAX_OPEN="${AGENTKIT_MR_POLICE_MAX:-1}"
+INLINE_MAX=$(echo "$COMMAND" | grep -oE '(^|[[:space:];&|])AGENTKIT_MR_POLICE_MAX=[0-9]+' | head -1 | sed -E 's/.*=([0-9]+)/\1/' || true)
+[[ -n "$INLINE_MAX" ]] && MAX_OPEN="$INLINE_MAX"
+
+# Who am I, and what open MRs have I authored on the targeted repo?
+ME=$(glab api /user 2>/dev/null | jq -r '.username // empty')
+[[ -z "$ME" ]] && exit 0
+
+# `|| true`: zero matches must mean "no open MRs", not a pipefail crash that
+# silently fails the hook open.
+MINE=$(glab mr list --author "$ME" ${REPO_ARG:+--repo "$REPO_ARG"} 2>/dev/null | grep -oE '!\b[0-9]+' | sort -u || true)
+COUNT=$(printf '%s\n' "$MINE" | grep -c . || true)
+
+if [[ "$COUNT" -ge "$MAX_OPEN" ]]; then
+	LIST=$(printf '%s ' $MINE)
+	deny "BLOCKED: you already have ${COUNT} open MR(s) you authored on this repo (${LIST}). Do not stack another unmerged MR on top — merge or close the existing one(s) first, then open the next. If these are genuinely independent and must coexist, raise the limit by prefixing the command with AGENTKIT_MR_POLICE_MAX=<n>."
+fi
+
+exit 0

--- a/plugins-cc/agentkit/hooks/pkg-police.sh
+++ b/plugins-cc/agentkit/hooks/pkg-police.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# pkg-police.sh — Claude Code PreToolUse hook (matcher: Bash)
+# Blocks: npm, npx, yarn, pnpm commands — enforces bun as package manager
+# Equivalent to: plugins/pkg-police.ts (OpenCode)
+set -euo pipefail
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+[[ -z "$COMMAND" ]] && exit 0
+
+deny() {
+  local reason="$1"
+  jq -n --arg r "$reason" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: $r
+    }
+  }'
+  exit 0
+}
+
+# Check for npm commands (install, run, test, exec, create, init, publish, ci)
+if echo "$COMMAND" | grep -qiE '\bnpm\s+(install|i|ci|run|test|init|publish|exec|create)\b'; then
+  SUBCMD=$(echo "$COMMAND" | grep -oiE '\bnpm\s+\w+' | head -1)
+  deny "BLOCKED: '${SUBCMD}' is not allowed. Use bun instead. Mapping: npm install → bun install, npm run → bun run, npm test → bun test, npm init → bun init, npx → bunx. Override: user explicitly requests npm."
+fi
+
+# Check for npx
+if echo "$COMMAND" | grep -qiE '\bnpx\s+'; then
+  deny "BLOCKED: 'npx' is not allowed. Use 'bunx' instead. Example: npx tsc → bunx tsc. Override: user explicitly requests npx."
+fi
+
+# Check for yarn
+if echo "$COMMAND" | grep -qiE '\byarn(\s+|$)'; then
+  deny "BLOCKED: 'yarn' is not allowed. Use bun instead. Mapping: yarn → bun install, yarn add → bun add, yarn run → bun run. Override: user explicitly requests yarn."
+fi
+
+# Check for pnpm
+if echo "$COMMAND" | grep -qiE '\bpnpm(\s+|$)'; then
+  deny "BLOCKED: 'pnpm' is not allowed. Use bun instead. Mapping: pnpm install → bun install, pnpm add → bun add, pnpm run → bun run. Override: user explicitly requests pnpm."
+fi
+
+exit 0

--- a/plugins-cc/agentkit/server/index.ts
+++ b/plugins-cc/agentkit/server/index.ts
@@ -1,0 +1,61 @@
+#!/usr/bin/env bun
+// infra-tools MCP server — a stdio JSON-RPC 2.0 server exposing read-only
+// helm / tofu / git tools. Newline-delimited JSON framing (the MCP stdio
+// transport): one JSON object per line on stdin, one JSON object per line on
+// stdout. Diagnostics go to stderr so they never corrupt the protocol channel.
+
+import { type JsonRpcRequest, handleRequest } from './protocol';
+
+const ERR_PARSE = -32700;
+
+function write(obj: unknown): void {
+  process.stdout.write(JSON.stringify(obj) + '\n');
+}
+
+async function dispatchLine(line: string): Promise<void> {
+  const trimmed = line.trim();
+  if (trimmed.length === 0) return;
+
+  let req: JsonRpcRequest;
+  try {
+    req = JSON.parse(trimmed) as JsonRpcRequest;
+  } catch {
+    write({ jsonrpc: '2.0', id: null, error: { code: ERR_PARSE, message: 'parse error' } });
+    return;
+  }
+
+  try {
+    const response = await handleRequest(req);
+    if (response) write(response);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`infra-tools: handler error: ${message}\n`);
+    if (req.id !== undefined) {
+      write({ jsonrpc: '2.0', id: req.id ?? null, error: { code: -32603, message } });
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  for await (const chunk of Bun.stdin.stream()) {
+    buffer += decoder.decode(chunk, { stream: true });
+    let newline = buffer.indexOf('\n');
+    while (newline !== -1) {
+      const line = buffer.slice(0, newline);
+      buffer = buffer.slice(newline + 1);
+      await dispatchLine(line);
+      newline = buffer.indexOf('\n');
+    }
+  }
+
+  // Flush any trailing line that arrived without a terminating newline.
+  await dispatchLine(buffer);
+}
+
+main().catch((err) => {
+  process.stderr.write(`infra-tools: fatal: ${err instanceof Error ? err.stack : err}\n`);
+  process.exit(1);
+});

--- a/plugins-cc/agentkit/server/protocol.ts
+++ b/plugins-cc/agentkit/server/protocol.ts
@@ -1,0 +1,90 @@
+import { TOOL_MAP, TOOLS } from './tools/registry';
+
+// Minimal MCP (Model Context Protocol) method handlers over JSON-RPC 2.0.
+// Only the three methods a read-only tool server needs are implemented:
+// `initialize`, `tools/list`, and `tools/call`.
+
+const DEFAULT_PROTOCOL_VERSION = '2024-11-05';
+const SUPPORTED_PROTOCOL_VERSIONS = new Set(['2024-11-05', '2025-03-26', '2025-06-18']);
+
+export const SERVER_INFO = { name: 'infra-tools', version: '0.1.0' } as const;
+
+// JSON-RPC error codes.
+export const ERR_METHOD_NOT_FOUND = -32601;
+export const ERR_INVALID_PARAMS = -32602;
+
+export interface JsonRpcRequest {
+  jsonrpc: '2.0';
+  id?: string | number | null;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+export interface JsonRpcResponse {
+  jsonrpc: '2.0';
+  id: string | number | null;
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+// Returns a response object, or null for notifications (no id) which get no reply.
+export async function handleRequest(req: JsonRpcRequest): Promise<JsonRpcResponse | null> {
+  const isNotification = req.id === undefined;
+
+  switch (req.method) {
+    case 'initialize':
+      return reply(req, initializeResult(req.params));
+    case 'notifications/initialized':
+    case 'notifications/cancelled':
+      return null; // notifications — never answered
+    case 'ping':
+      return reply(req, {});
+    case 'tools/list':
+      return reply(req, { tools: TOOLS.map(toolInfo) });
+    case 'tools/call':
+      return reply(req, await callTool(req.params));
+    default:
+      if (isNotification) return null;
+      return errorReply(req, ERR_METHOD_NOT_FOUND, `method not found: ${req.method}`);
+  }
+}
+
+function initializeResult(params?: Record<string, unknown>) {
+  const requested = typeof params?.protocolVersion === 'string' ? params.protocolVersion : undefined;
+  const protocolVersion = requested && SUPPORTED_PROTOCOL_VERSIONS.has(requested)
+    ? requested
+    : DEFAULT_PROTOCOL_VERSION;
+  return {
+    protocolVersion,
+    capabilities: { tools: {} },
+    serverInfo: SERVER_INFO,
+  };
+}
+
+function toolInfo(tool: (typeof TOOLS)[number]) {
+  return { name: tool.name, description: tool.description, inputSchema: tool.inputSchema };
+}
+
+async function callTool(params?: Record<string, unknown>) {
+  const name = typeof params?.name === 'string' ? params.name : undefined;
+  const tool = name ? TOOL_MAP.get(name) : undefined;
+  if (!tool) {
+    return textResult(`unknown tool: ${name ?? '(none)'}`, true);
+  }
+  const args = (params?.arguments as Record<string, unknown> | undefined) ?? {};
+  const result = await tool.handler(args);
+  return textResult(JSON.stringify(result, null, 2), !result.ok);
+}
+
+function textResult(text: string, isError: boolean) {
+  return { content: [{ type: 'text', text }], isError };
+}
+
+function reply(req: JsonRpcRequest, result: unknown): JsonRpcResponse | null {
+  if (req.id === undefined) return null;
+  return { jsonrpc: '2.0', id: req.id ?? null, result };
+}
+
+export function errorReply(req: JsonRpcRequest, code: number, message: string): JsonRpcResponse {
+  return { jsonrpc: '2.0', id: req.id ?? null, error: { code, message } };
+}

--- a/plugins-cc/agentkit/server/run.ts
+++ b/plugins-cc/agentkit/server/run.ts
@@ -1,0 +1,44 @@
+// Safe CLI runner. Spawns a binary with an argv array — never a shell string —
+// so no argument can be interpreted as a shell operator (injection-proof by
+// construction). Callers pass a fixed, read-only subcommand plus already-split
+// arguments; there is no shell, no glob expansion, and no word splitting.
+
+export interface CliResult {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+  exit_code: number;
+}
+
+const COMMAND_NOT_FOUND = 127;
+
+export async function runCli(argv: string[], cwd?: string): Promise<CliResult> {
+  if (argv.length === 0) {
+    return { ok: false, stdout: '', stderr: 'runCli: empty argv', exit_code: COMMAND_NOT_FOUND };
+  }
+
+  try {
+    const proc = Bun.spawn(argv, {
+      cwd,
+      stdout: 'pipe',
+      stderr: 'pipe',
+      stdin: 'ignore',
+    });
+
+    const [stdout, stderr, exit_code] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    return { ok: exit_code === 0, stdout, stderr, exit_code };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      stdout: '',
+      stderr: `failed to spawn ${argv[0]}: ${message}`,
+      exit_code: COMMAND_NOT_FOUND,
+    };
+  }
+}

--- a/plugins-cc/agentkit/server/tools/git.ts
+++ b/plugins-cc/agentkit/server/tools/git.ts
@@ -1,0 +1,95 @@
+import { runCli } from '../run';
+import { asString, asStringArray, missingArg, type ToolDef } from './types';
+
+// Git tools — local read subcommands plus one read-only clone. `log`, `diff`,
+// and `status` inspect an existing repo (working directory via spawn cwd, so no
+// user string is parsed as a global git option). `git_clone_ro` is the only
+// write-to-disk op: it shallow-clones a remote INTO `dest` for inspection. It
+// never pushes, commits, or mutates the source, and it does not accept
+// free-form flags (which could smuggle `-c core.sshCommand=...` style RCE).
+
+const SHALLOW_DEPTH = '1';
+
+export const gitTools: ToolDef[] = [
+  {
+    name: 'git_log',
+    description: 'Show commit history of a local repo with `git log` (read-only).',
+    inputSchema: repoSchema({
+      opts: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Extra args appended to `git log` (e.g. --oneline, -n 20, --stat, a ref).',
+      },
+    }),
+    handler: (args) => runInRepo(args, ['log', ...asStringArray(args.opts)]),
+  },
+  {
+    name: 'git_diff',
+    description: 'Show changes in a local repo with `git diff` (read-only).',
+    inputSchema: repoSchema({
+      opts: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Extra args appended to `git diff` (e.g. --stat, HEAD~1, a path, --cached).',
+      },
+    }),
+    handler: (args) => runInRepo(args, ['diff', ...asStringArray(args.opts)]),
+  },
+  {
+    name: 'git_status',
+    description: 'Show the working-tree status of a local repo with `git status` (read-only).',
+    inputSchema: repoSchema(),
+    handler: (args) => runInRepo(args, ['status']),
+  },
+  {
+    name: 'git_clone_ro',
+    description:
+      'Shallow, read-only clone of a remote repo into `dest` for inspection. '
+      + 'Depth 1, no tags; never pushes or mutates the source. This is the only '
+      + 'tool that writes to disk (the local clone), and it writes nothing back.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        url: { type: 'string', description: 'Remote repository URL to clone (read-only).' },
+        dest: { type: 'string', description: 'Local destination directory for the clone.' },
+        ref: {
+          type: 'string',
+          description: 'Optional branch or tag to check out (single-branch shallow clone).',
+        },
+      },
+      required: ['url', 'dest'],
+      additionalProperties: false,
+    },
+    handler: (args) => {
+      const url = asString(args.url);
+      const dest = asString(args.dest);
+      if (!url) return Promise.resolve(missingArg('url'));
+      if (!dest) return Promise.resolve(missingArg('dest'));
+      const argv = ['git', 'clone', '--depth', SHALLOW_DEPTH, '--no-tags'];
+      const ref = asString(args.ref);
+      if (ref) argv.push('--single-branch', '--branch', ref);
+      // `--` terminates option parsing so a url/dest starting with `-` cannot be
+      // treated as a flag.
+      argv.push('--', url, dest);
+      return runCli(argv);
+    },
+  },
+];
+
+function repoSchema(extra: Record<string, unknown> = {}) {
+  return {
+    type: 'object' as const,
+    properties: {
+      dir: { type: 'string', description: 'Path to the local git repository.' },
+      ...extra,
+    },
+    required: ['dir'],
+    additionalProperties: false,
+  };
+}
+
+function runInRepo(args: Record<string, unknown>, argv: string[]) {
+  const dir = asString(args.dir);
+  if (!dir) return Promise.resolve(missingArg('dir'));
+  return runCli(['git', ...argv], dir);
+}

--- a/plugins-cc/agentkit/server/tools/helm.ts
+++ b/plugins-cc/agentkit/server/tools/helm.ts
@@ -1,0 +1,83 @@
+import { runCli } from '../run';
+import { asString, asStringArray, missingArg, type ToolDef } from './types';
+
+// Helm tools — strictly read/render subcommands. `template` renders a chart
+// locally (no cluster write, no install); `list` and `get values` only read.
+// The subcommand is hardcoded here; callers can never turn these into
+// install/upgrade/uninstall because they cannot choose the subcommand.
+
+export const helmTools: ToolDef[] = [
+  {
+    name: 'helm_template',
+    description:
+      'Render a Helm chart locally with `helm template` (no install, no cluster mutation). '
+      + 'Use to inspect the manifests a chart would produce.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        chart: {
+          type: 'string',
+          description: 'Chart reference: a local path, a packaged .tgz, or repo/chart.',
+        },
+        opts: {
+          type: 'array',
+          items: { type: 'string' },
+          description:
+            'Extra args appended to `helm template` (e.g. --set, --values, --namespace, '
+            + '--generate-name, a release name). Rendering only — never installs.',
+        },
+      },
+      required: ['chart'],
+      additionalProperties: false,
+    },
+    handler: (args) => {
+      const chart = asString(args.chart);
+      if (!chart) return Promise.resolve(missingArg('chart'));
+      return runCli(['helm', 'template', chart, ...asStringArray(args.opts)]);
+    },
+  },
+  {
+    name: 'helm_list',
+    description: 'List installed Helm releases with `helm list` (read-only).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        namespace: {
+          type: 'string',
+          description: 'Namespace to list releases in. Omit to use the current context namespace.',
+        },
+      },
+      additionalProperties: false,
+    },
+    handler: (args) => {
+      const namespace = asString(args.namespace);
+      const argv = ['helm', 'list'];
+      if (namespace) argv.push('--namespace', namespace);
+      return runCli(argv);
+    },
+  },
+  {
+    name: 'helm_get_values',
+    description: 'Show the user-supplied values of a release with `helm get values` (read-only).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        release: { type: 'string', description: 'Release name to read values from.' },
+        namespace: {
+          type: 'string',
+          description: 'Namespace the release lives in. Omit to use the current context namespace.',
+        },
+      },
+      required: ['release'],
+      additionalProperties: false,
+    },
+    handler: (args) => {
+      const release = asString(args.release);
+      if (!release) return Promise.resolve(missingArg('release'));
+      const namespace = asString(args.namespace);
+      const argv = ['helm', 'get', 'values', release];
+      if (namespace) argv.push('--namespace', namespace);
+      return runCli(argv);
+    },
+  },
+];

--- a/plugins-cc/agentkit/server/tools/registry.ts
+++ b/plugins-cc/agentkit/server/tools/registry.ts
@@ -1,0 +1,12 @@
+import { gitTools } from './git';
+import { helmTools } from './helm';
+import { tofuTools } from './tofu';
+import type { ToolDef } from './types';
+
+// The complete, fixed set of exposed tools. There is deliberately no generic
+// "run any subcommand" escape hatch — every tool binds a hardcoded, read-only
+// subcommand. Mutating operations (helm install/upgrade/uninstall, tofu
+// apply/destroy, git push/commit/reset) are simply not represented here.
+export const TOOLS: ToolDef[] = [...helmTools, ...tofuTools, ...gitTools];
+
+export const TOOL_MAP: Map<string, ToolDef> = new Map(TOOLS.map((t) => [t.name, t]));

--- a/plugins-cc/agentkit/server/tools/tofu.ts
+++ b/plugins-cc/agentkit/server/tools/tofu.ts
@@ -1,0 +1,75 @@
+import { runCli } from '../run';
+import { asString, asStringArray, type ToolDef } from './types';
+
+// OpenTofu / Terraform tools — plan/read subcommands only. `plan` previews a
+// change set and never applies it; `show` and `state list` are read-only. There
+// is no path to `apply` or `destroy` because the subcommand is hardcoded.
+//
+// The working directory is passed via the spawn cwd (not an argv positional),
+// so no user string is ever parsed as a flag or a global option.
+
+// Prefer `tofu`; fall back to `terraform` when tofu is not on PATH.
+function tofuBin(): string {
+  if (Bun.which('tofu')) return 'tofu';
+  if (Bun.which('terraform')) return 'terraform';
+  return 'tofu';
+}
+
+const dirProp = {
+  dir: {
+    type: 'string',
+    description: 'Working directory containing the OpenTofu/Terraform configuration.',
+  },
+};
+
+export const tofuTools: ToolDef[] = [
+  {
+    name: 'tofu_plan',
+    description:
+      'Preview infrastructure changes with `tofu plan` (falls back to `terraform plan`). '
+      + 'Plan only — this never applies or destroys anything.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        ...dirProp,
+        opts: {
+          type: 'array',
+          items: { type: 'string' },
+          description:
+            'Extra args appended to `plan` (e.g. -var, -var-file, -target, -no-color). '
+            + 'Preview only — never applies.',
+        },
+      },
+      required: ['dir'],
+      additionalProperties: false,
+    },
+    handler: (args) => {
+      const dir = asString(args.dir) ?? '.';
+      return runCli([tofuBin(), 'plan', ...asStringArray(args.opts)], dir);
+    },
+  },
+  {
+    name: 'tofu_show',
+    description:
+      'Show the current state or a saved plan with `tofu show` (read-only; '
+      + 'falls back to `terraform show`).',
+    inputSchema: {
+      type: 'object',
+      properties: { ...dirProp },
+      additionalProperties: false,
+    },
+    handler: (args) => runCli([tofuBin(), 'show'], asString(args.dir) ?? '.'),
+  },
+  {
+    name: 'tofu_state_list',
+    description:
+      'List resources tracked in state with `tofu state list` (read-only; '
+      + 'falls back to `terraform state list`).',
+    inputSchema: {
+      type: 'object',
+      properties: { ...dirProp },
+      additionalProperties: false,
+    },
+    handler: (args) => runCli([tofuBin(), 'state', 'list'], asString(args.dir) ?? '.'),
+  },
+];

--- a/plugins-cc/agentkit/server/tools/types.ts
+++ b/plugins-cc/agentkit/server/tools/types.ts
@@ -1,0 +1,38 @@
+import type { CliResult } from '../run';
+
+// A minimal JSON Schema shape — enough to describe our tool inputs for the
+// MCP `tools/list` response. Kept loose on purpose; hosts do the validation.
+export interface JsonSchema {
+  type: 'object';
+  properties: Record<string, unknown>;
+  required?: string[];
+  additionalProperties?: boolean;
+}
+
+export type ToolArgs = Record<string, unknown>;
+
+export interface ToolDef {
+  name: string;
+  description: string;
+  inputSchema: JsonSchema;
+  handler: (args: ToolArgs) => Promise<CliResult>;
+}
+
+// Coerce an untyped arg into a string, or return undefined when absent.
+export function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+// Coerce an untyped arg into a string[] of extra CLI flags. Anything that is
+// not a string is dropped, so a malformed `opts` can never smuggle a non-arg.
+export function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === 'string');
+}
+
+const INVALID_ARGS = 2;
+
+// Shared CliResult for a missing/blank required argument.
+export function missingArg(name: string): CliResult {
+  return { ok: false, stdout: '', stderr: `missing required argument: ${name}`, exit_code: INVALID_ARGS };
+}

--- a/plugins-cc/agentkit/skills/autonomous-workflow/SKILL.md
+++ b/plugins-cc/agentkit/skills/autonomous-workflow/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: autonomous-workflow
+description: >-
+  Proposal-first development workflow with commit hygiene and decision authority rules.
+  Enforces: propose before modifying, atomic commits, no force flags, warnings-as-errors.
+  Use for any project where AI agents are primary developers and need guardrails.
+---
+
+# Autonomous Workflow
+
+## Proposal-First (CRITICAL)
+
+NEVER create or modify files without explicit approval. Always:
+
+1. PROPOSE the change (what, why, which files)
+2. WAIT for approval
+3. IMPLEMENT only after approval
+
+Exceptions: bug fixes in already-approved work, read-only research, formatting.
+
+## Decision Authority (for approved work)
+
+- Fix bugs, warnings, missing error handling, broken imports: proceed without asking
+- Add missing tests, fix linting issues, update outdated deps: proceed without asking
+- Change architecture, add new infrastructure, switch libraries: ASK first
+- Delete or significantly restructure existing code: ASK first
+
+## After Every Change
+
+- Run the relevant test suite
+- Run the linter/type checker
+- Fix ALL warnings, not just errors
+- Run the project's formatter on changed files
+
+## Unused Variables
+
+- NEVER prefix unused variables with underscore (_var) to silence linters
+- Either USE the variable or REMOVE it entirely
+- If a function parameter is required by an interface but unused, restructure to avoid it
+- This applies to all languages: TypeScript, Rust, Python
+
+## Commit Hygiene
+
+- Never use --force, --no-verify, HUSKY=0 without explicit permission
+- Never commit .env files, credentials, or secrets
+- Atomic commits: one logical change per commit
+- Never add `Co-authored-by`, `Ultraworked with`, or any AI agent attribution to commits, PRs/MRs,
+  comments, or changelogs. Keep commit messages clean and focused on the change itself.
+
+## Fresh Context for Large Work
+
+Before starting large implementations (multi-phase plans, migrations, new stack deployments):
+
+- Commit and push all preparatory work (plans, config updates)
+- Start a fresh session / compact context to maximize available context window
+- Reference the plan file for implementation details rather than relying on conversation history
+
+## Continuous Config Improvement
+
+Agent instructions are living documents. When you discover something that should be codified -- a new
+pattern, a gotcha, a convention, a lesson learned -- PROPOSE updating the relevant config file:
+
+1. **What to codify**: Recurring mistakes, new conventions, environment-specific gotchas, workflow
+   patterns that should be standardized
+2. **Always propose first**: Never silently update config files. Describe what you learned and why
+   it should be codified. Wait for approval.

--- a/plugins-cc/agentkit/skills/code-quality/SKILL.md
+++ b/plugins-cc/agentkit/skills/code-quality/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: code-quality
+description: >-
+  Code quality standards: warnings-as-errors, no underscore prefixes for unused vars,
+  mandatory test coverage. Apply to any TypeScript, JavaScript, Rust, or Python project.
+  Triggers: code review, linting, writing new functions, refactoring.
+---
+
+# Code Quality Standards
+
+## Unused Variables
+
+- NEVER prefix unused variables with underscore (_) to silence linters
+- Either USE the variable or REMOVE it entirely
+- If a function parameter is required by an interface but unused, restructure to avoid it
+- Exception: destructuring where you need to skip positional elements (rare)
+
+## Warnings Are Errors
+
+- Treat ALL compiler/linter warnings as errors that must be fixed
+- Do not leave warnings for "later" -- fix them now
+- Common warnings to watch: unused imports, unreachable code, implicit any
+
+## Test Coverage
+
+- Every new function or module MUST have corresponding tests
+- Test the happy path AND at least one error/edge case
+- Run existing tests after changes to verify nothing breaks
+
+## Type Safety
+
+- Never use `as any`, `@ts-ignore`, or `@ts-expect-error` to suppress type errors
+- Never use empty catch blocks `catch(e) {}`
+- Never delete failing tests to make the suite "pass"
+
+## Formatting
+
+- Always run the project's formatter after editing any file
+- Verify formatting before committing

--- a/plugins-cc/agentkit/skills/documentation/SKILL.md
+++ b/plugins-cc/agentkit/skills/documentation/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: documentation
+description: >-
+  Documentation standards: surface-aware diagrams (Mermaid where markdown renders, ASCII for
+  terminals and diffs), structured plan format, compact tables for comparisons. Use when writing
+  docs, plans, READMEs, or architecture documents in any project.
+---
+
+# Documentation Standards
+
+## Diagrams
+
+Pick the diagram format by where the document is primarily read:
+
+- Rendered markdown (READMEs, docs sites, GitLab/GitHub issues and MRs, chat UIs with Mermaid
+  support): use `mermaid` code fences (`flowchart LR`/`TD`, `sequenceDiagram`) -- they render as
+  real diagrams. Keep them compact (<= ~10 nodes) and label the edges.
+- Plain text (plans and notes read in editors, terminals, git diffs, any monospace surface): use
+  ASCII box-drawing diagrams with + - | / \ > < =, wrapped in triple-backtick code blocks (no
+  language tag). Max ~40 lines, ~80 chars wide.
+- For data flow: use arrows ---> and ---- with labels
+- For hierarchy: use tree notation +-- |
+
+## Plan Files
+
+- Plans should include: Status, Created date, Dependencies, Architecture diagram, Task list
+- Task items use checkbox format: `- [ ] description`
+
+## Format
+
+- Always run the project's formatter on markdown files after editing
+- Use tables for structured comparisons
+- Use code blocks with language tags for all code/config snippets
+- Keep lines under 100 characters where possible

--- a/plugins-cc/agentkit/skills/gitops-master/SKILL.md
+++ b/plugins-cc/agentkit/skills/gitops-master/SKILL.md
@@ -1,0 +1,831 @@
+---
+name: gitops-master
+description: >-
+  GitOps operations master for ArgoCD + Kargo. Diagnose stuck stages,
+  verify deployments, manage promotions, configure verification and retry.
+  Triggers: 'stage stuck', 'sync failed', 'promote', 'verify stage',
+  'kargo', 'argocd', 'gitops', 'pipeline', 'freight'
+---
+
+# GitOps Master
+
+You are a GitOps operations specialist combining four specializations:
+
+1. **Diagnostician**: Kargo state machine internals, ArgoCD failure taxonomy, root cause analysis
+2. **Verifier**: 4-level verification taxonomy, RBAC checklists, health validation
+3. **Promoter**: Safe promotion workflows, pre-checks, post-verification
+4. **Architect**: Pipeline setup, verification config, retry tuning, architecture detection
+
+---
+
+## MODE DETECTION (FIRST STEP)
+
+Analyze the user's request to determine operation mode:
+
+| User Request Pattern                             | Mode     | Jump To     |
+| ------------------------------------------------ | -------- | ----------- |
+| "stage stuck", "sync failed", "pods crashing",   | DIAGNOSE | Phase D1-D8 |
+| "error", "debug", "broken", "not working"        |          |             |
+| "check stage", "verify", "health", "is it up"    | VERIFY   | Phase V1-V4 |
+| "promote", "pipeline status", "freight",         | PROMOTE  | Phase P1-P4 |
+| "advance stage", "push through"                  |          |             |
+| "add verification", "configure", "retry config", | SETUP    | Phase S1-S4 |
+| "RBAC", "new stage", "analysis template"         |          |             |
+
+**CRITICAL**: Don't default to DIAGNOSE mode. Parse the actual request.
+
+---
+
+## ENVIRONMENT DISCOVERY (MANDATORY BEFORE ANY COMMAND)
+
+Before running ANY kubectl command, you MUST discover the environment. Follow this cascade:
+
+### Step 1: Check for `.gitops-config.yaml` in the project root
+
+```yaml
+# Expected format:
+ssh_command: "MISE_ENV=test mise run server:ssh" # How to reach the cluster (omit if local kubectl works)
+kargo_namespace: "kargo-my-project-test" # Kargo project namespace
+kargo_controller_namespace: "kargo" # Where Kargo controller runs (may differ from default)
+argocd_namespace: "infra" # ArgoCD apps namespace
+argocd_controller_namespace: "argocd" # Where ArgoCD controller runs (may differ from default)
+monitoring_namespace: "monitoring" # Monitoring namespace
+app_namespace: "my-app-test" # Application namespace
+domain: "example.com" # Cluster domain
+kargo_project: "my-project" # Kargo project name
+warehouse_name: "platform-apps" # Kargo warehouse name
+```
+
+### Step 2: If no config file, auto-discover from cluster
+
+```bash
+# Discover Kargo project namespaces
+kubectl get projects.kargo.akuity.io -A -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.namespace}{"\n"}{end}'
+
+# Discover stages to confirm namespace
+kubectl get stages -A -o jsonpath='{range .items[*]}{.metadata.namespace}{"\t"}{.metadata.name}{"\n"}{end}'
+
+# Discover ArgoCD namespace
+kubectl get applications -A --no-headers | head -1 | awk '{print $1}'
+
+# Discover domain from ingress/configmap
+kubectl get ingress -A -o jsonpath='{range .items[*]}{.spec.rules[*].host}{"\n"}{end}' | head -1 | sed 's/^[^.]*\.//'
+
+# Check if direct kubectl works or SSH is needed
+kubectl get nodes 2>/dev/null && echo "Direct kubectl works" || echo "May need SSH tunnel or proxy"
+```
+
+### Step 3: If auto-discovery fails, ASK the user
+
+Present this template and ask them to fill in the values:
+
+```
+I need your cluster details to proceed:
+- How do I reach kubectl? (direct / SSH command / proxy)
+- Kargo project namespace?
+- ArgoCD apps namespace?
+- Monitoring namespace? (if applicable)
+- Application namespace?
+- Cluster domain?
+```
+
+### Store as Variables
+
+Once discovered, use these throughout ALL commands:
+
+```
+${SSH_CMD}              = SSH/proxy prefix (empty if direct kubectl works)
+${KARGO_NS}            = Kargo project namespace (stages, promotions, freight)
+${KARGO_CONTROLLER_NS} = Kargo controller namespace (defaults to "kargo", may differ)
+${ARGOCD_NS}           = ArgoCD applications namespace
+${ARGOCD_CONTROLLER_NS} = ArgoCD controller namespace (defaults to "argocd", may differ)
+${MONITORING_NS}       = Monitoring namespace
+${APP_NS}              = Application namespace
+${DOMAIN}              = Cluster domain
+${KARGO_PROJECT}       = Kargo project name
+${WAREHOUSE}           = Kargo warehouse name
+```
+
+**NEVER hardcode namespace names or domains in commands.**
+
+---
+
+---
+
+# DIAGNOSE MODE (Phase D1-D8)
+
+## PHASE D1: Parallel Information Gathering (MANDATORY FIRST STEP)
+
+Execute ALL of the following commands IN PARALLEL to minimize latency:
+
+```bash
+# Group 1: Kargo state
+${SSH_CMD} kubectl get stages -n ${KARGO_NS} -o wide
+${SSH_CMD} kubectl get promotions -n ${KARGO_NS} --sort-by=.metadata.creationTimestamp
+
+# Group 2: ArgoCD state
+${SSH_CMD} kubectl get applications -n ${ARGOCD_NS}
+
+# Group 3: Controller health
+${SSH_CMD} kubectl get pods -n ${KARGO_CONTROLLER_NS} -l app.kubernetes.io/name=kargo
+${SSH_CMD} kubectl get pods -n ${ARGOCD_CONTROLLER_NS} -l app.kubernetes.io/name=argocd-repo-server
+
+# Group 4: Recent events
+${SSH_CMD} kubectl get events -n ${KARGO_NS} --sort-by=.lastTimestamp --field-selector=type!=Normal
+```
+
+Capture these data points simultaneously:
+
+1. Which stages are NOT in Verified phase
+2. Which promotions are in non-terminal state (Running, Pending)
+3. Which ArgoCD apps are not Synced+Healthy
+4. Whether Kargo controller and ArgoCD repo-server are running
+5. Recent warning/error events in the Kargo project namespace
+
+---
+
+## PHASE D2: Kargo State Machine Rules (CRITICAL KNOWLEDGE)
+
+See [references/kargo-state-machine.md](references/kargo-state-machine.md) for the 8 rules of Kargo's internal state machine and retry configuration guidelines.
+
+---
+
+## PHASE D3: ArgoCD Sync Failure Taxonomy
+
+See [references/argocd-troubleshooting.md](references/argocd-troubleshooting.md) for the complete error pattern table and debugging commands.
+
+---
+
+## PHASE D4: Decision Tree (FOLLOW THIS EXACTLY)
+
+```
+Stage stuck?
+|
++- 1. Check stage.status.phase
+|  |
+|  +- "Failed" or stuck not-Verified
+|  |  +-- Go to step 2
+|  |
+|  +-- "Verified" / "Healthy"
+|     +-- Stage is fine. Problem is elsewhere.
+|
++- 2. Check stage.status.conditions[0]
+|  |
+|  +- reason: "LastPromotionErrored"
+|  |  +-- Check lastPromotion.name
+|  |     +- Non-timestamp name (manually created via kubectl)
+|  |     |  +-- FIX: Delete Stage CR entirely, let ArgoCD recreate from git
+|  |     |     This clears poisoned lastPromotion state
+|  |     +-- Auto-generated name
+|  |        +-- Check promotion step errors
+|  |           +- "connection refused :8081" -> Add retry config (see references/kargo-state-machine.md)
+|  |           +- "sync tasks failed" -> Check ArgoCD app operationState
+|  |           +-- Other -> Fix root cause, push new commit to trigger new freight
+|  |
+|  +- reason: "NoFreight"
+|  |  +-- Check freightHistory
+|  |     +- Empty -> No successful promotion ever ran
+|  |     |  +-- Check Warehouse: is it creating freight?
+|  |     |     +- No freight -> Warehouse subscription misconfigured
+|  |     |     +-- Freight exists -> Check if stage has auto-promote or needs manual
+|  |     +-- Stale -> lastPromotion stuck, blocking freight tracking
+|  |        +-- Same fix as LastPromotionErrored
+|  |
+|  +- reason: "VerificationFailed"
+|  |  +-- Check AnalysisRun
+|  |     +-- kubectl get analysisruns -n ${KARGO_NS} --sort-by=.metadata.creationTimestamp
+|  |        +- Job failed -> kubectl logs job/<job-name> -n ${KARGO_NS}
+|  |        |  +- RBAC error ("forbidden") -> Fix ClusterRole (see V4)
+|  |        |  +- HTTP check failed -> Check service/ingress/SSO
+|  |        |  +-- Pod check failed -> Check namespace, pod selectors
+|  |        +-- No AnalysisRun exists -> Verification SA or template misconfigured
+|  |
+|  +- reason: "ReconcileError"
+|  |  +-- Usually transient
+|  |     +-- Force refresh:
+|  |        kubectl annotate stage <name> -n ${KARGO_NS} --overwrite \
+|  |          kargo.akuity.io/refresh=$(date +%s)
+|  |
+|  +-- reason: "ActivePromotion"
+|     +-- A promotion is currently running
+|        +- If running for > 15 min -> Likely stuck
+|        |  +-- Check controller logs (step 3)
+|        +-- If < 15 min -> Wait for it
+|
++- 3. Check Kargo controller logs
+|  |
+|  +-- kubectl logs -n ${KARGO_CONTROLLER_NS} deploy/kargo-controller --tail=200 | grep <stage-name>
+|     |
+|     +- "Promotion already exists for Freight"
+|     |  +-- Delete old errored promotions for that freight:
+|     |     kubectl delete promotions -n ${KARGO_NS} -l kargo.akuity.io/freight=<freight-name>
+|     |
+|     +- "current Freight needs to be verified"
+|     |  +-- Verification is blocking new promotions
+|     |     +-- Fix verification first (check AnalysisRun)
+|     |
+|     +- "Stage has not passed health checks"
+|     |  +-- Health gate is blocking verification
+|     |     +-- Check ArgoCD app health for all apps in this stage
+|     |
+|     +-- "error reconciling Stage"
+|        +-- Check full error message for specifics
+|
++-- 4. Nuclear option (LAST RESORT)
+   |
+   +-- Delete Stage CR + all its Promotions, let ArgoCD recreate from git
+      |
+      +- kubectl delete stage <name> -n ${KARGO_NS}
+      +- kubectl delete promotions -n ${KARGO_NS} --all
+      +-- Wait for ArgoCD to recreate Stage from Helm templates
+         Then new freight will auto-promote through clean state
+```
+
+---
+
+## PHASE D5: Known Gotchas (MEMORIZE THESE)
+
+<critical_warning>
+
+### Gotcha 1: Never Create Promotions via kubectl
+
+Promotions created via `kubectl create` or `kubectl apply`:
+
+- Don't properly set `currentPromotion` on the Stage
+- Custom names break lexicographic sorting (anti-loop logic)
+- Can permanently poison the stage state machine
+
+**Use**: Kargo UI, Kargo CLI, or auto-promotion. NEVER kubectl.
+
+### Gotcha 2: Stale ArgoCD operationState
+
+ArgoCD keeps the last `operationState` indefinitely. An error message from 3 hours ago does NOT mean
+the app is currently failing. Always check `finishedAt` timestamp.
+
+```bash
+# Check when the last operation actually finished
+${SSH_CMD} kubectl get app <name> -n ${ARGOCD_NS} \
+  -o jsonpath='{.status.operationState.finishedAt}'
+```
+
+### Gotcha 3: 10-Second Health Delay
+
+After ArgoCD sync completes, Kargo waits 10 seconds before trusting health status. This prevents
+false positives from stale ArgoCD health cache. Don't panic if health check doesn't pass immediately
+after sync.
+
+### Gotcha 4: Verification RBAC is Silent
+
+If the verification Job's ServiceAccount lacks permissions, the Job fails but the error is buried in
+Job logs. The AnalysisRun just shows "Failed" with no useful message.
+
+**Always check**: `kubectl logs job/<analysisrun-job> -n ${KARGO_NS}`
+
+### Gotcha 5: Empty Git Commits Don't Create Freight
+
+Kargo's Warehouse checks the git tree hash, not the commit hash. An empty commit (no file changes)
+produces the same tree hash and Kargo won't create new Freight.
+
+**Workaround**: Touch a file or add a meaningful change.
+
+### Gotcha 6: selfHeal vs Immediate Recreation
+
+ArgoCD's `selfHeal: true` recreates deleted resources, but NOT immediately. The reconciliation loop
+runs every 3 minutes by default. If you delete a resource to "fix" it, it may take up to 3 minutes
+to come back.
+
+### Gotcha 7: Monitoring Stage is Heavy
+
+The monitoring stage (kube-prometheus-stack + loki) typically requires:
+
+- `timeout: 10m` on argocd-update steps (default 5m is too short)
+- `errorThreshold: 3` (repo-server often OOM-restarts during prometheus chart render)
+- Patient waiting: full sync can take 5-8 minutes
+
+### Gotcha 8: Foundation Stage Chicken-and-Egg
+
+If your foundation stage contains ArgoCD and Kargo themselves, it should use auto-sync (ArgoCD
+manages itself) rather than Kargo-controlled promotion. Kargo can't promote itself.
+</critical_warning>
+
+---
+
+## PHASE D6: Fix Patterns (Quick Reference)
+
+| Problem                  | Fix Command / Action                                                                               | When to Use                                      |
+| ------------------------ | -------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| Poisoned stage state     | Delete Stage CR: `kubectl delete stage <name> -n ${KARGO_NS}`                                      | lastPromotion stuck on manual/errored promotion  |
+| Stale errored promotions | Delete Promotions: `kubectl delete promotions -n ${KARGO_NS} -l kargo.akuity.io/stage=<stage>`     | Auto-promotion says "already exists for freight" |
+| Verification RBAC        | Add resources to ClusterRole bound to verification SA                                              | AnalysisRun Job fails with "forbidden"           |
+| Transient sync failure   | Add `retry: {timeout: 10m, errorThreshold: 3}` to argocd-update step                               | ArgoCD repo-server restarts, connection refused  |
+| Force stage refresh      | `kubectl annotate stage <name> -n ${KARGO_NS} --overwrite kargo.akuity.io/refresh=$(date +%s)`     | Stage not reconciling, stale status              |
+| Force warehouse refresh  | `kubectl annotate warehouse <name> -n ${KARGO_NS} --overwrite kargo.akuity.io/refresh=$(date +%s)` | New commits not detected as freight              |
+| ArgoCD app stuck syncing | `kubectl patch app <name> -n ${ARGOCD_NS} --type merge -p '{"operation": null}'`                   | operationState stuck, blocking new syncs         |
+| CRD ordering issue       | Move CRD-dependent app to later stage (operators -> platform)                                      | "no matches for kind" errors during sync         |
+| All else fails           | Delete Stage + all Promotions, let ArgoCD recreate                                                 | Multiple overlapping issues, unclear root cause  |
+
+---
+
+## PHASE D7: Mandatory Diagnostic Output
+
+After running the decision tree, you MUST output:
+
+```
+DIAGNOSIS
+=========
+Stage: <stage-name>
+Phase: <current phase>
+Health: <health status>
+
+Root Cause: <one-line summary>
+Evidence: <what command output showed this>
+
+Recommended Fix:
+  1. <specific action with exact command>
+  2. <verification command to confirm fix>
+
+Risk Level: LOW | MEDIUM | HIGH
+  LOW = Safe to apply, easily reversible
+  MEDIUM = Requires careful execution, may cause brief disruption
+  HIGH = Nuclear option, will cause temporary pipeline disruption
+```
+
+---
+
+---
+
+# VERIFY MODE (Phase V1-V4)
+
+## PHASE V1: Verification Taxonomy
+
+See [references/verification-taxonomy.md](references/verification-taxonomy.md) for the 4-level verification taxonomy and per-stage verification matrices.
+
+---
+
+## PHASE V2: Running Verification
+
+### Quick Verification (Level 1 + 2 only)
+
+```bash
+# Run these in parallel for fast feedback:
+${SSH_CMD} kubectl get pods -A --field-selector=status.phase!=Running,status.phase!=Succeeded
+${SSH_CMD} kubectl get applications -n ${ARGOCD_NS}
+${SSH_CMD} kubectl get stages -n ${KARGO_NS}
+```
+
+### Full Verification (All 4 levels for a specific stage)
+
+1. Run Level 1 checks from the verification matrix
+2. If L1 passes, run Level 2 checks
+3. If L2 passes, run Level 3 checks (may require browser/curl)
+4. If L3 passes, run Level 4 checks (functional tests)
+
+**STOP at first failure level.** Don't check L3 if L2 is broken.
+
+---
+
+## PHASE V3: Verification RBAC
+
+See the RBAC checklist in [references/verification-taxonomy.md](references/verification-taxonomy.md).
+
+---
+
+## PHASE V4: Mandatory Verification Output
+
+After running verification, you MUST output:
+
+```
+VERIFICATION REPORT
+===================
+Stage: <stage-name>
+Timestamp: <when checks ran>
+
+Level 1 (Infrastructure): PASS | FAIL
+  [x] Pods running: <count>/<expected>
+  [x] CRDs installed: <list>
+  [ ] Secrets present: <missing-secret> FAILED
+
+Level 2 (Service Health): PASS | FAIL | SKIPPED
+  [x] Health endpoints responding
+  [ ] Prometheus targets: 0 active FAILED
+
+Level 3 (Ingress & Auth): PASS | FAIL | SKIPPED
+  ...
+
+Level 4 (Functional): PASS | FAIL | SKIPPED
+  ...
+
+Overall: PASS | FAIL at Level <N>
+Action Required: <what to fix, or "None">
+```
+
+---
+
+---
+
+# PROMOTE MODE (Phase P1-P4)
+
+## PHASE P1: Pre-Promotion Checks (MANDATORY)
+
+Before promoting freight through ANY stage, verify:
+
+```bash
+# 1. Check current pipeline state
+${SSH_CMD} kubectl get stages -n ${KARGO_NS} -o wide
+
+# 2. Check available freight
+${SSH_CMD} kubectl get freight -n ${KARGO_NS} \
+  --sort-by=.metadata.creationTimestamp
+
+# 3. Check if target stage has pending/running promotions
+${SSH_CMD} kubectl get promotions -n ${KARGO_NS} \
+  -l kargo.akuity.io/stage=<target-stage> --sort-by=.metadata.creationTimestamp
+
+# 4. Check upstream stage is Verified for this freight
+${SSH_CMD} kubectl get stage <upstream-stage> -n ${KARGO_NS} \
+  -o jsonpath='{.status.lastVerification}'
+```
+
+**DO NOT PROMOTE IF:**
+
+- Target stage has a Running promotion (wait for it)
+- Target stage has an Errored promotion for this freight (fix first, see D4)
+- Upstream stage is NOT Verified for this freight
+- ArgoCD apps in target stage are currently syncing
+
+---
+
+## PHASE P2: Promotion Methods
+
+### Method 1: Auto-Promotion (PREFERRED)
+
+Most stages should have auto-promotion enabled. If freight is verified in the upstream stage, it
+automatically promotes to the next stage. No manual action needed.
+
+### Method 2: Kargo UI (RECOMMENDED for manual)
+
+Use the Kargo dashboard at `kargo.${DOMAIN}` to:
+
+1. Navigate to the pipeline view
+2. Click on the freight to promote
+3. Select the target stage
+4. Click "Promote"
+
+### Method 3: Kargo CLI (if available)
+
+```bash
+kargo promote --project ${KARGO_PROJECT} --stage <target-stage> --freight <freight-name>
+```
+
+<critical_warning>
+
+### Method 4: kubectl (NEVER DO THIS)
+
+**NEVER create Promotions via kubectl.** kubectl-created promotions:
+
+- Don't properly set currentPromotion on the Stage
+- Custom names break lexicographic sorting
+- Can permanently poison the stage state machine
+- May require deleting the entire Stage CR to fix
+  </critical_warning>
+
+---
+
+## PHASE P3: Monitoring During Promotion
+
+After promotion starts, monitor progress:
+
+```bash
+# Watch promotion status (repeat every 30s)
+${SSH_CMD} kubectl get promotions -n ${KARGO_NS} \
+  -l kargo.akuity.io/stage=<stage> --sort-by=.metadata.creationTimestamp -o wide
+
+# Watch ArgoCD sync progress
+${SSH_CMD} kubectl get app <app-name> -n ${ARGOCD_NS} \
+  -o jsonpath='{.status.sync.status} {.status.health.status}'
+
+# Watch stage phase transition
+${SSH_CMD} kubectl get stage <stage> -n ${KARGO_NS} \
+  -o jsonpath='{.status.phase} {.status.health}'
+```
+
+**Expected progression:**
+
+```
+Promotion: Pending -> Running -> Succeeded
+ArgoCD:    OutOfSync -> Syncing -> Synced+Healthy
+Stage:     NotApplicable -> Healthy -> (verification runs) -> Verified
+```
+
+**If promotion takes > 10 minutes:**
+
+1. Check ArgoCD app sync status
+2. Check repo-server logs for OOM or connection errors
+3. Check if retry config is set (see references/kargo-state-machine.md)
+
+---
+
+## PHASE P4: Post-Promotion Verification
+
+After promotion succeeds, run verification for the target stage (jump to VERIFY mode V1-V4).
+
+Confirm:
+
+1. Stage phase is `Verified`
+2. Freight appears in stage's `freightHistory`
+3. Downstream stages (if auto-promote) start their promotion
+4. No warning events in the namespace
+
+---
+
+---
+
+# SETUP MODE (Phase S1-S4)
+
+## PHASE S1: Architecture Detection (MANDATORY FIRST STEP)
+
+Before making ANY configuration changes, scan the existing GitOps architecture:
+
+```bash
+# 1. Discover existing stages and their dependency chain
+${SSH_CMD} kubectl get stages -n ${KARGO_NS} \
+  -o jsonpath='{range .items[*]}{.metadata.name}: {.spec.requestedFreight[*].sources}{"\n"}{end}'
+
+# 2. Discover which ArgoCD apps each stage promotes
+# Check the Kargo stage definitions in your gitops directory
+
+# 3. Discover existing verification templates
+${SSH_CMD} kubectl get analysistemplates -n ${KARGO_NS}
+
+# 4. Discover verification RBAC
+${SSH_CMD} kubectl get clusterroles -l app=kargo-verification
+${SSH_CMD} kubectl get serviceaccounts -n ${KARGO_NS}
+```
+
+---
+
+## PHASE S2: Adding a New Stage
+
+### Checklist
+
+1. [ ] Add stage definition with correct `requestedFreight` dependency
+2. [ ] Configure `promotionTemplate` with `argocd-update` steps for each app
+3. [ ] Add retry config on argocd-update steps
+4. [ ] Create ApplicationSet for the layer (auto-sync DISABLED for Kargo-controlled stages)
+5. [ ] Add `kargo.akuity.io/authorized-stage` annotation to ApplicationSet template
+6. [ ] Create AnalysisTemplate for verification
+7. [ ] Create ServiceAccount + RBAC for verification Jobs
+8. [ ] Test with a single app first, then add remaining apps
+
+### Stage Template
+
+```yaml
+- apiVersion: kargo.akuity.io/v1alpha1
+  kind: Stage
+  metadata:
+    name: <stage-name>
+    namespace: ${KARGO_NS}
+  spec:
+    requestedFreight:
+      - origin:
+          kind: Warehouse
+          name: ${WAREHOUSE}
+        sources:
+          stages:
+            - <upstream-stage-name>
+    promotionTemplate:
+      spec:
+        steps:
+          - uses: argocd-update
+            config:
+              apps:
+                - name: <app-name>
+                  namespace: ${ARGOCD_NS}
+            retry:
+              timeout: 10m
+              errorThreshold: 3
+    verification:
+      analysisTemplates:
+        - name: <stage-name>-health
+```
+
+---
+
+## PHASE S3: Adding Verification
+
+### AnalysisTemplate Pattern
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: <stage-name>-health
+  namespace: ${KARGO_NS}
+spec:
+  metrics:
+    - name: <check-name>
+      provider:
+        job:
+          spec:
+            backoffLimit: 1
+            template:
+              spec:
+                serviceAccountName: kargo-verification
+                restartPolicy: Never
+                containers:
+                  - name: verify
+                    image: alpine/k8s:latest
+                    command: ["/bin/bash", "-c"]
+                    args:
+                      - |
+                        # Level 1: Check pods
+                        kubectl get pods -n <namespace> --no-headers | grep -v Running && exit 1
+
+                        # Level 2: Check health
+                        kubectl exec -n <namespace> deploy/<name> -- wget -qO- http://localhost:<port>/health || exit 1
+
+                        echo "All checks passed"
+                        exit 0
+```
+
+### RBAC for Verification Jobs
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kargo-verification
+  namespace: ${KARGO_NS}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kargo-verification
+  labels:
+    app: kargo-verification
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "services", "configmaps"]
+    verbs: ["get", "list"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "statefulsets"]
+    verbs: ["get", "list"]
+  - apiGroups: ["argoproj.io"]
+    resources: ["applications"]
+    verbs: ["get", "list"]
+  # Add more resources as verification needs grow
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kargo-verification
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kargo-verification
+subjects:
+  - kind: ServiceAccount
+    name: kargo-verification
+    namespace: ${KARGO_NS}
+```
+
+---
+
+## PHASE S4: Retry and Timeout Tuning
+
+### Guidelines by App Complexity
+
+| App Type                         | Timeout | ErrorThreshold | Rationale                        |
+| -------------------------------- | ------- | -------------- | -------------------------------- |
+| Simple (configmap, small deploy) | 3m      | 2              | Fast sync, few resources         |
+| Medium (ESO, Crossplane)         | 5m      | 2              | CRD installation takes time      |
+| Heavy (kube-prometheus-stack)    | 10m     | 3              | Huge chart, repo-server OOM risk |
+| Very Heavy (loki with PVCs)      | 10m     | 3              | PVC binding + large statefulset  |
+
+### Symptoms That Need Retry Tuning
+
+| Symptom                                      | Likely Fix                         |
+| -------------------------------------------- | ---------------------------------- |
+| Promotion fails intermittently               | Increase errorThreshold to 3       |
+| "connection refused :8081" in promotion logs | Add retry + check repo-server RAM  |
+| Promotion times out on first attempt         | Increase timeout to 10m            |
+| Same promotion succeeds on manual retry      | Definitely needs errorThreshold >1 |
+
+---
+
+---
+
+# ANTI-PATTERNS (ALL MODES)
+
+## Diagnose Mode
+
+- Guessing the fix without checking stage.status.conditions -> **WRONG**
+- Deleting random resources hoping it fixes things -> **WRONG**
+- Ignoring controller logs -> **WRONG** (they contain the actual error)
+- Creating a new Promotion via kubectl to "retry" -> **CATASTROPHIC** (see Gotcha 1)
+
+## Verify Mode
+
+- Checking only Level 1 (pods) and declaring "it works" -> **INCOMPLETE**
+- Skipping RBAC check when verification fails -> **WRONG** (silent RBAC failures)
+- Not checking Prometheus targets when monitoring is deployed -> **WRONG**
+
+## Promote Mode
+
+- Promoting when upstream stage is not Verified -> **WILL FAIL**
+- Creating Promotions via kubectl -> **NEVER DO THIS**
+- Not monitoring promotion progress -> **RISKY** (won't catch stuck promotions)
+- Promoting during active ArgoCD sync -> **RACE CONDITION**
+
+## Setup Mode
+
+- Adding a stage without retry config -> **WILL FAIL on transient errors**
+- Forgetting `kargo.akuity.io/authorized-stage` annotation -> **Promotion will be rejected**
+- Not testing with a single app first -> **DEBUGGING NIGHTMARE**
+- Setting auto-sync on non-foundation stages -> **CONFLICTS WITH KARGO**
+
+---
+
+# QUICK REFERENCE
+
+## Essential Commands
+
+All commands assume environment variables from the ENVIRONMENT DISCOVERY step.
+
+```bash
+# Kargo stages overview
+${SSH_CMD} kubectl get stages -n ${KARGO_NS} -o wide
+
+# Recent promotions
+${SSH_CMD} kubectl get promotions -n ${KARGO_NS} \
+  --sort-by=.metadata.creationTimestamp -o wide
+
+# Available freight
+${SSH_CMD} kubectl get freight -n ${KARGO_NS} \
+  --sort-by=.metadata.creationTimestamp
+
+# ArgoCD apps
+${SSH_CMD} kubectl get applications -n ${ARGOCD_NS}
+
+# Kargo controller logs
+${SSH_CMD} kubectl logs -n ${KARGO_CONTROLLER_NS} deploy/kargo-controller --tail=100
+
+# ArgoCD repo-server logs (common failure point)
+${SSH_CMD} kubectl logs -n ${ARGOCD_CONTROLLER_NS} deploy/argocd-repo-server --tail=50
+
+# AnalysisRuns (verification results)
+${SSH_CMD} kubectl get analysisruns -n ${KARGO_NS} \
+  --sort-by=.metadata.creationTimestamp
+
+# Force stage reconcile
+${SSH_CMD} kubectl annotate stage <name> -n ${KARGO_NS} \
+  --overwrite kargo.akuity.io/refresh=$(date +%s)
+
+# Force warehouse reconcile
+${SSH_CMD} kubectl annotate warehouse <name> -n ${KARGO_NS} \
+  --overwrite kargo.akuity.io/refresh=$(date +%s)
+
+# Check all unhealthy pods
+${SSH_CMD} kubectl get pods -A --field-selector=status.phase!=Running,status.phase!=Succeeded
+```
+
+## Discovered Namespaces
+
+These come from ENVIRONMENT DISCOVERY. Common defaults:
+
+| Variable                  | Common Default | Contains                                   |
+| ------------------------- | -------------- | ------------------------------------------ |
+| `${ARGOCD_CONTROLLER_NS}` | `argocd`       | ArgoCD server, ApplicationSets             |
+| `${KARGO_CONTROLLER_NS}`  | `kargo`        | Kargo controller, API                      |
+| `${KARGO_NS}`             | varies         | Kargo Project, Stages, Promotions, Freight |
+| `${ARGOCD_NS}`            | `infra`        | ArgoCD Applications                        |
+| `${MONITORING_NS}`        | `monitoring`   | Prometheus, Grafana, Loki, Alloy           |
+| `${APP_NS}`               | varies         | Application workloads                      |
+
+## Pipeline Dependency Chain (Example)
+
+Your actual chain is discovered from the cluster. A typical pattern:
+
+```
+Warehouse
+    |
+    v
+foundation (auto-sync, ArgoCD self-manages)
+    |  ArgoCD, Kargo, Traefik, cert-manager, etc.
+    |
+    v
+operators (Kargo-controlled)
+    |  ESO, Crossplane, etc.
+    |
+    v
+monitoring (Kargo-controlled)
+    |  kube-prometheus-stack, Loki, Alloy, etc.
+    |
+    v
+platform (Kargo-controlled)
+    |  Databases, Auth, Workflow engines, etc.
+    |
+    v
+services (Kargo-controlled)
+       Application services
+```

--- a/plugins-cc/agentkit/skills/gitops-master/references/argocd-troubleshooting.md
+++ b/plugins-cc/agentkit/skills/gitops-master/references/argocd-troubleshooting.md
@@ -1,0 +1,31 @@
+# ArgoCD Sync Failure Taxonomy
+
+| Error Pattern                   | Root Cause                           | Fix                                              |
+| ------------------------------- | ------------------------------------ | ------------------------------------------------ |
+| "connection refused :8081"      | repo-server down/restarting          | Wait + retry config, check repo-server pod       |
+| "one or more sync tasks failed" | PostSync hooks or resource apply err | Check app `.status.operationState.syncResult`    |
+| "ComparisonError"               | Manifest generation failed           | Check repo-server logs, helm chart validity      |
+| "OutOfSync" after sync          | Ignored differences not configured   | Add `ignoreDifferences` to Application           |
+| "Degraded" health               | Pod CrashLoop / OOM                  | Check pod events, resource limits                |
+| "Unknown" health                | Resource has no health check defined | Add custom health check or ignore                |
+| "Progressing" stuck             | Deployment rollout stuck             | Check pod scheduling, resource quotas, PVC binds |
+| "SyncError" on CRDs             | CRD applied before operator ready    | Ensure operator deploys in earlier stage         |
+| "rpc error: code = Unavailable" | ArgoCD API server overloaded         | Check argocd-server pod resources                |
+
+**IMPORTANT**: ArgoCD shows stale `operationState`. Always check the `finishedAt` timestamp, not
+just the error message. An error from 3 hours ago is not the current problem.
+
+## Debugging Commands
+
+```bash
+# Check when the last operation actually finished
+${SSH_CMD} kubectl get app <name> -n ${ARGOCD_NS} \
+  -o jsonpath='{.status.operationState.finishedAt}'
+
+# Check repo-server logs (common failure point)
+${SSH_CMD} kubectl logs -n argocd deploy/argocd-repo-server --tail=50
+
+# Check ArgoCD app sync status
+${SSH_CMD} kubectl get app <app-name> -n ${ARGOCD_NS} \
+  -o jsonpath='{.status.sync.status} {.status.health.status}'
+```

--- a/plugins-cc/agentkit/skills/gitops-master/references/kargo-state-machine.md
+++ b/plugins-cc/agentkit/skills/gitops-master/references/kargo-state-machine.md
@@ -1,0 +1,75 @@
+# Kargo State Machine Rules
+
+The 8 facts about how Kargo tracks promotion state internally:
+
+```
+KARGO STATE MACHINE (from regular_stages.go):
+==============================================
+
+1. lastPromotion is ONLY set when currentPromotion != nil
+   (line 637 in regular_stages.go)
+
+2. Promotion names are compared LEXICOGRAPHICALLY
+   - Auto-generated names use timestamps: "foundation.01jkx..."
+   - Manually-created names that sort AFTER auto ones break anti-loop logic
+   - This is the #1 cause of "poisoned stage state"
+
+3. Anti-loop protection:
+   - If ANY terminal promotion exists for this freight, Kargo won't re-promote
+   - Prevents infinite promote -> fail -> promote cycles
+   - BUT: a manually-errored promotion counts as terminal, blocking ALL future
+     auto-promotions for that freight
+
+4. Sequential gate pipeline:
+   promotion -> health -> verification -> verified -> auto-promote next
+   Each gate BLOCKS all subsequent gates if stuck in non-terminal state
+
+5. freightHistory tracks what freight the stage has successfully promoted
+   - Empty freightHistory = no successful promotion ever ran
+   - Stale freightHistory = lastPromotion is stuck, blocking freight tracking
+
+6. Stage health is ONLY assessed when lastPromotion.status.phase == Succeeded
+   - If lastPromotion is stuck in Errored, health checks never run
+
+7. Verification ONLY runs after health checks pass
+   - If health gate is blocked, verification never starts
+   - AnalysisRun Jobs are created only after health passes
+
+8. The "less than 10 seconds" rule:
+   - After ArgoCD sync, Kargo doesn't trust health for 10 seconds
+   - This prevents false-positive health from stale ArgoCD status
+```
+
+## Kargo Step Retry Configuration
+
+```yaml
+# DEFAULT VALUES (often too aggressive):
+#   argocd-update timeout: 5 minutes
+#   errorThreshold: 1 (NO retries - single failure aborts)
+
+# RECOMMENDED for heavy apps (kube-prometheus-stack, loki, etc.):
+steps:
+  - uses: argocd-update
+    config:
+      apps: [...]
+    retry:
+      timeout: 10m # Allow 10 minutes for large chart sync
+      errorThreshold: 3 # Retry up to 3 times on transient failures
+
+# RECOMMENDED for lightweight apps (configmaps, simple deployments):
+steps:
+  - uses: argocd-update
+    config:
+      apps: [...]
+    retry:
+      timeout: 5m
+      errorThreshold: 2
+```
+
+**KEY FACTS about retry**:
+
+- Retry config goes on EACH step, not globally on the stage
+- `errorThreshold: 1` (default) = NO retries, first failure is fatal
+- `timeout` controls how long the step can run total, not per-retry
+- Transient "connection refused :8081" errors are the #1 reason to add retries
+- ArgoCD repo-server OOM-restarts are common with large charts (prometheus, loki)

--- a/plugins-cc/agentkit/skills/gitops-master/references/verification-taxonomy.md
+++ b/plugins-cc/agentkit/skills/gitops-master/references/verification-taxonomy.md
@@ -1,0 +1,105 @@
+# Verification Taxonomy (4 Levels)
+
+```
++--------------------------------------------------------------+
+|                  Verification Levels                          |
++--------------------------------------------------------------+
+|                                                               |
+|  Level 1: Infrastructure (pods, CRDs, secrets)                |
+|  +-- Pods running in correct namespace                        |
+|  +-- Required CRDs installed                                  |
+|  +-- Secrets exist with expected keys                         |
+|  +-- PVCs bound, storage available                            |
+|                                                               |
+|  Level 2: Service Health (endpoints, readiness)               |
+|  +-- Health/readiness endpoints responding                    |
+|  +-- Internal service-to-service connectivity                 |
+|  +-- Database/queue connections established                   |
+|  +-- Metrics endpoint scraping (Prometheus targets > 0)       |
+|                                                               |
+|  Level 3: Ingress & Auth (external access, SSO)               |
+|  +-- External URL accessible (via ingress/tunnel)             |
+|  +-- SSO redirect works (302 to auth provider)                |
+|  +-- Service account / API key auth works                     |
+|  +-- OAuth2-proxy header injection working                    |
+|  +-- TLS certificate valid                                    |
+|                                                               |
+|  Level 4: Functional (user-facing features work)              |
+|  +-- Dashboard loads with real data                           |
+|  +-- Query API returns expected results                       |
+|  +-- Data pipeline ingesting (logs flowing to Loki)           |
+|  +-- Alerts configured and firing test alert                  |
+|                                                               |
++--------------------------------------------------------------+
+```
+
+## Per-Stage Verification Matrix (Example)
+
+Adapt these checks to your actual stages and applications.
+
+### Foundation Stage (Example)
+
+| Level | What to Check                       | Command                                                                                       |
+| ----- | ----------------------------------- | --------------------------------------------------------------------------------------------- |
+| L1    | ArgoCD, Kargo, Traefik pods         | `kubectl get pods -n argocd && kubectl get pods -n kargo && kubectl get pods -n ${ARGOCD_NS}` |
+| L1    | Cert-manager CRDs                   | `kubectl get crd certificates.cert-manager.io`                                                |
+| L2    | ArgoCD API responds                 | `kubectl exec -n argocd deploy/argocd-server -- wget -qO- http://localhost:8080/healthz`      |
+| L2    | Kargo API responds                  | `kubectl exec -n kargo deploy/kargo-api -- wget -qO- http://localhost:8443/healthz`           |
+| L3    | ArgoCD dashboard accessible via SSO | Check external URL: `argocd.${DOMAIN}`                                                        |
+| L4    | ArgoCD can discover and sync apps   | `kubectl get applications -n ${ARGOCD_NS}`                                                    |
+
+### Operators Stage (Example)
+
+| Level | What to Check                 | Command                                                                                     |
+| ----- | ----------------------------- | ------------------------------------------------------------------------------------------- |
+| L1    | ESO controller + webhook pods | `kubectl get pods -n ${ARGOCD_NS} -l app.kubernetes.io/name=external-secrets`               |
+| L1    | ESO CRDs installed            | `kubectl get crd externalsecrets.external-secrets.io`                                       |
+| L1    | Crossplane pods + providers   | `kubectl get pods -n crossplane-system`                                                     |
+| L2    | ESO controller ready          | `kubectl get deploy -n ${ARGOCD_NS} external-secrets -o jsonpath='{.status.readyReplicas}'` |
+| L4    | ClusterSecretStore connected  | `kubectl get clustersecretstore -o jsonpath='{.items[*].status.conditions[0].status}'`      |
+
+### Monitoring Stage (Example)
+
+| Level | What to Check                         | Command                                                                                                                       |
+| ----- | ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| L1    | Prometheus, Grafana, Loki, Alloy pods | `kubectl get pods -n ${MONITORING_NS}`                                                                                        |
+| L1    | Prometheus PVC bound                  | `kubectl get pvc -n ${MONITORING_NS}`                                                                                         |
+| L2    | Prometheus targets scraping           | `kubectl exec -n ${MONITORING_NS} deploy/kube-prometheus-stack-prometheus -- wget -qO- http://localhost:9090/api/v1/targets`  |
+| L2    | Loki readiness                        | `kubectl exec -n ${MONITORING_NS} deploy/loki -- wget -qO- http://localhost:3100/ready`                                       |
+| L2    | Grafana health                        | `kubectl exec -n ${MONITORING_NS} deploy/kube-prometheus-stack-grafana -- wget -qO- http://localhost:3000/api/health`         |
+| L3    | Grafana SSO login                     | Check external URL: `logs.${DOMAIN}`                                                                                          |
+| L4    | Logs flowing to Loki                  | Query Loki via Grafana for recent log entries                                                                                 |
+| L4    | Alertmanager receiving alerts         | `kubectl exec -n ${MONITORING_NS} deploy/kube-prometheus-stack-alertmanager -- wget -qO- http://localhost:9093/api/v2/status` |
+
+## Verification RBAC Checklist
+
+When Kargo runs AnalysisRun verification Jobs, the Job's ServiceAccount needs explicit RBAC for
+every resource it accesses. Missing RBAC causes SILENT failures.
+
+| What the Verification Job Does | Required RBAC                             |
+| ------------------------------ | ----------------------------------------- |
+| `kubectl get pods`             | `pods: [get, list]`                       |
+| `kubectl get applications`     | `applications.argoproj.io: [get, list]`   |
+| `kubectl get secrets`          | `secrets: [get, list]`                    |
+| `kubectl get configmaps`       | `configmaps: [get, list]`                 |
+| `kubectl get <CRD>`            | `<crd-resource>.<api-group>: [get, list]` |
+| `curl internal service`        | No RBAC needed (network policy only)      |
+| `curl external URL`            | No RBAC needed (egress network policy)    |
+
+**DEBUGGING RBAC FAILURES:**
+
+```bash
+# 1. Find the AnalysisRun
+${SSH_CMD} kubectl get analysisruns -n ${KARGO_NS} \
+  --sort-by=.metadata.creationTimestamp
+
+# 2. Find the Job it created
+${SSH_CMD} kubectl get jobs -n ${KARGO_NS} \
+  --sort-by=.metadata.creationTimestamp
+
+# 3. Check Job logs for RBAC errors
+${SSH_CMD} kubectl logs job/<job-name> -n ${KARGO_NS}
+
+# 4. If "forbidden" error: check which ServiceAccount the Job uses
+#    and what ClusterRole/Role is bound to it
+```

--- a/plugins-cc/agentkit/skills/issue-raiser/SKILL.md
+++ b/plugins-cc/agentkit/skills/issue-raiser/SKILL.md
@@ -1,0 +1,261 @@
+---
+name: issue-raiser
+description: >-
+  Raises well-structured GitLab issues with root cause analysis, proposed solutions,
+  and correct assignees based on git history. Adapts to any GitLab instance and project
+  conventions automatically. Triggers: raising issues, reporting bugs, creating tickets,
+  filing defects, feature requests, refactoring proposals.
+---
+
+# Issue Raiser Skill
+
+Create professional, well-researched GitLab issues that include root cause analysis,
+concrete proposed solutions, and correctly identified assignees. This skill adapts to
+whatever GitLab setup the current repository uses.
+
+## Phase 0: Discover the Environment
+
+Before doing anything, auto-detect the project's GitLab setup. Do NOT assume any
+specific host, group, or project structure.
+
+### Detect GitLab host and project path
+
+```bash
+# List all remotes — the user may have multiple (mirrors, forks, etc.)
+git remote -v
+
+# Determine the GitLab hostname from the remote URL
+# SSH:   git@gitlab.example.com:group/project.git  → host=gitlab.example.com, path=group/project
+# HTTPS: https://gitlab.example.com/group/project.git → same extraction
+```
+
+If multiple remotes exist, ask the user which one to target unless context makes it obvious.
+
+### Determine if glab is configured for the target host
+
+```bash
+glab auth status
+```
+
+- If the target host appears in the auth status, use it directly.
+- If it's a self-hosted instance not listed, every `glab` command needs `GITLAB_HOST=<detected-host>` prefixed.
+- If auth is missing entirely, inform the user they need to run `glab auth login --hostname <host>`.
+
+### Build your glab command prefix
+
+Based on discovery, construct the prefix you'll use for all commands in this session:
+
+```bash
+# For gitlab.com (default host):
+glab issue list -R <group/project>
+
+# For self-hosted:
+GITLAB_HOST=<detected-host> glab issue list -R <group/project>
+```
+
+Store this mentally and use it consistently. Never hardcode a host.
+
+## Phase 1: Research Before Writing
+
+### Understand the project's issue conventions
+
+Every project has its own style. Discover it:
+
+```bash
+# List recent open issues to learn the format
+<prefix> glab issue list -R <path> --per-page 10
+
+# Read 2-3 issues to understand structure, tone, and depth
+<prefix> glab issue view <recent-issue-number> -R <path>
+```
+
+Look for:
+
+- Do issues use templates (Description / Acceptance Criteria / Technical Notes)?
+- What level of detail is expected?
+- Are code snippets included?
+- What tone — formal, casual, terse?
+
+### Discover available labels and milestones
+
+```bash
+# Labels
+<prefix> glab label list -R <path>
+
+# Milestones — try project-level first, then group-level
+<prefix> glab api "projects/<url-encoded-path>/milestones?state=active"
+<prefix> glab api "groups/<group>/milestones?state=active"
+```
+
+Choose labels and milestones that match the issue type. If unsure, match what similar
+recent issues used.
+
+### Check for duplicates
+
+```bash
+<prefix> glab issue list -R <path> --search "<keywords>"
+```
+
+If a related issue exists, reference it rather than duplicating.
+
+### Verify the bug exists on latest code
+
+Never file a bug based solely on deployed code — it may already be fixed:
+
+```bash
+# Fetch latest
+git fetch <remote> --tags
+
+# Check the relevant file on the latest default branch
+git show <remote>/main:<path/to/file>
+
+# Compare with what's deployed (look at image tags, helm values, etc.)
+```
+
+If the bug is fixed on latest but still deployed, note that in the issue.
+
+## Phase 2: Build the Root Cause Analysis
+
+This is what separates a useful issue from a vague bug report. Always include:
+
+### Trace the code path
+
+- Read the source files involved
+- Identify the **exact** file, function, and line number where the problem originates
+- Understand WHY the code behaves this way — don't just describe the symptom
+
+### Trace the git history
+
+```bash
+# Who last modified the file?
+git log <remote>/main --format='%an <%ae> | %s' -- <file> | head -10
+
+# Who introduced the specific problematic code?
+git log <remote>/main -S "<pattern>" --format='%h %an <%ae> | %s' -- <file>
+
+# What does the blame say for the specific lines?
+git blame <remote>/main -- <file> | grep -A2 -B2 "<pattern>"
+```
+
+### Check related branches
+
+```bash
+# Is someone already working on a fix?
+git branch -r | grep -i "<keyword>"
+git log <remote>/<branch> --format='%an | %s' -5
+```
+
+## Phase 3: Write the Issue
+
+Adapt the structure to match the project's existing conventions (discovered in Phase 1).
+Use this as a baseline — add or remove sections as the project's style dictates:
+
+```markdown
+## Description
+
+<What is happening? Include exact error messages. Be specific about where — which
+page, endpoint, environment.>
+
+## Root Cause
+
+<WHY it happens. Reference exact file paths, line numbers, and include code snippets.
+Explain the logic flaw, not just the symptom.>
+
+## Proposed Solution
+
+<Concrete code changes with before/after snippets. If multiple approaches exist,
+list them with tradeoffs and state which one is recommended.>
+
+## Files to Change
+
+| File           | Change                 |
+| -------------- | ---------------------- |
+| `path/to/file` | What to change and why |
+
+## Acceptance Criteria
+
+- [ ] <Specific, testable statement>
+- <Include edge cases and non-regression>
+```
+
+### Title conventions
+
+Match the project's existing pattern. If none is apparent, use:
+
+- **Bugs**: `Bug: <component> — <symptom>`
+- **UI**: `UI: <description>`
+- **Refactor**: `Refactor: <description>`
+- **Feature**: `Feat: <description>`
+
+## Phase 4: Create the Issue
+
+```bash
+<prefix> glab issue create -R <path> \
+  --title "<title>" \
+  --label "<label1>,<label2>" \
+  --milestone "<milestone>" \
+  --description "$(cat <<'EOF'
+<issue body using heredoc to preserve formatting>
+EOF
+)"
+```
+
+Always use a heredoc (`<<'EOF'`) for the description to preserve markdown formatting,
+code blocks, and special characters.
+
+## Phase 5: Identify and Assign Developers
+
+### Find the right people from git history
+
+```bash
+# Primary contributors to the affected files
+git log <remote>/main --format='%an <%ae>' -- <file> | sort | uniq -c | sort -rn | head -5
+
+# Who introduced the specific code in question
+git log <remote>/main -S "<code-pattern>" --format='%h %an <%ae> | %s' -- <file>
+
+# Who is actively working on related feature branches
+git log <remote>/<related-branch> --format='%an <%ae> | %s' -5
+```
+
+### Resolve git names to GitLab usernames
+
+Git commit names don't always match GitLab usernames. Search for them:
+
+```bash
+# Search project/group members
+<prefix> glab api "projects/<url-encoded-path>/members/all" | python3 -c "
+import json, sys
+for m in json.load(sys.stdin):
+    print(f\"{m['username']:30s} {m['name']}\")"
+
+# If not found in project, check group
+<prefix> glab api "groups/<group>/members/all" | python3 -c "..."
+
+# If still not found, search all users
+<prefix> glab api "users?search=<name>" | python3 -c "..."
+```
+
+### Assignment logic
+
+1. **Primary assignee**: Developer who owns the domain or is actively working on a related branch
+2. **Secondary assignee**: Developer who introduced the bug or who built the surrounding system
+3. Present your reasoning to the user before assigning — let them confirm
+
+```bash
+<prefix> glab issue update <number> -R <path> --assignee "user1,user2"
+```
+
+## Quality Checklist
+
+Before submitting, verify:
+
+- [ ] Environment was auto-detected (host, project path, glab prefix)
+- [ ] Issue format matches the project's existing conventions
+- [ ] Root cause identified with specific file paths and line numbers
+- [ ] Verified the bug exists on the latest code (not just the deployed version)
+- [ ] Proposed solution includes concrete code changes
+- [ ] Labels and milestone match project conventions
+- [ ] No duplicate of an existing issue
+- [ ] Acceptance criteria are specific and testable
+- [ ] Assignees are based on git history analysis, not assumptions

--- a/plugins-cc/agentkit/skills/project-planning/SKILL.md
+++ b/plugins-cc/agentkit/skills/project-planning/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: project-planning
+description: >-
+  Structured project planning: break down a new project idea into plan files covering
+  architecture, file structure, and implementation roadmap. Triggers: 'new project',
+  'plan a feature', 'break down', 'architecture', 'roadmap', 'design a system'.
+---
+
+# Project Planning
+
+## When NOT to Use
+
+- Trivial single-file changes or bug fixes
+- Features that fit entirely in one file
+- Refactors with no architectural decisions
+
+## Process
+
+1. Ask clarifying questions to understand the project idea fully
+2. Create `00-plan.md` first -- get approval before continuing
+3. Create `01-architecture.md` -- get approval for the technical design
+4. Create remaining plan files
+5. Create `AGENTS.md` last (it summarises decisions from the plan files)
+6. Set up `dprint.json` for markdown formatting
+
+## Directory Structure
+
+```
+.claude/plans/
+├── 00-brainstorm/          (optional: early-stage research)
+│   └── 00-plan.md
+└── 01-implementation/
+    ├── 00-plan.md          (overview, problem, solution, estimates)
+    ├── 01-architecture.md  (system design, ASCII diagrams, data flow)
+    ├── 02-file-structure.md (module/package/crate layout)
+    ├── 03-roadmap.md       (sprints with tasks and time estimates)
+    ├── 04-wireframes.md    (optional: UI screens in ASCII art)
+    └── 05-user-workflows.md (optional: end-to-end user scenarios)
+```
+
+## What Goes in Each File
+
+### 00-plan.md
+
+Include a header block with: created date, status, repo name, and links to the other plan files.
+
+Body covers:
+
+- Problem statement (what pain does this solve?)
+- What makes it unique (vs existing tools)
+- Target users and their context
+- Integration points with other systems
+- All time estimates in AI agent time (see Estimation Rules below)
+
+### 01-architecture.md
+
+- High-level system diagram in ASCII (NOT Mermaid)
+- Module/crate dependency graph
+- Data flow diagrams
+- Database schema (if applicable)
+- Key traits, interfaces, or contracts
+
+Wrap every diagram in a triple-backtick code block with no language tag.
+
+### 02-file-structure.md
+
+Full directory tree with inline annotations explaining each module's purpose.
+
+- Rust projects: workspace layout + per-crate breakdown
+- TypeScript projects: package structure + key files
+- Annotate non-obvious directories with a short comment
+
+### 03-roadmap.md
+
+Break implementation into numbered sprints. Sprint 0 is always project scaffolding.
+The final sprint is always polish and release prep.
+
+Each sprint includes:
+
+- Numbered task list with per-task AI time estimates
+- Sprint total estimate
+- Quality gate: what must pass before the next sprint starts
+- Dependencies on other sprints
+
+### 04-wireframes.md (optional)
+
+ASCII art wireframes for each UI screen or view. Include a navigation flow diagram
+showing how screens connect. One diagram per screen.
+
+### 05-user-workflows.md (optional)
+
+Step-by-step scenarios showing how a user accomplishes a goal end-to-end.
+Cover the happy path and at least one error or edge case per workflow.
+
+## Estimation Rules
+
+- NEVER give human developer time estimates
+- All estimates are AI agent time: 16h/day throughput, roughly 4x human speed
+- Include per-task estimates AND sprint totals
+- Sprint 0 (scaffolding) is typically 2-3 hours AI time
+- Label estimates clearly: `[AI: 1.5h]` or `[AI: 30min]`
+
+## AGENTS.md
+
+Create at the repo root after the plan files are approved. Include:
+
+- **Project context**: name, repo, current phase, active branch, plan file locations
+- **Post-edit hooks**: formatter command, ASCII box fixer if used
+- **Key architecture decisions**: bullet points, one decision per line
+- **Anti-patterns**: things to NEVER do in this codebase (specific to this project)
+- **Dependencies**: key libraries and the reason each was chosen
+
+## Diagram Rules
+
+- ASCII only -- no Mermaid, no SVG, no image files
+- Box-drawing characters: `+`, `-`, `|`, `/`, `\`, `>`, `<`
+- Max ~40 lines tall, ~80 chars wide per diagram
+- Data flow: use `---->` arrows with labels
+- Hierarchy: use `+--` and `|` tree notation
+- Always wrap in triple-backtick code blocks

--- a/plugins-cc/agentkit/skills/test-driven-development/SKILL.md
+++ b/plugins-cc/agentkit/skills/test-driven-development/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: test-driven-development
+description: >-
+  Enforces strict Test-Driven Development (TDD) workflow: RED-GREEN-REFACTOR cycle.
+  Tests MUST be written BEFORE implementation. Every change starts with a failing test.
+  Applies to any language (Rust, TypeScript, Python, Go, etc.).
+  Triggers: writing new features, fixing bugs, adding endpoints, refactoring, any code change.
+---
+
+# Test-Driven Development (TDD)
+
+## The Cycle (NON-NEGOTIABLE)
+
+Every code change follows this exact sequence:
+
+1. **RED** — Write a test that describes the desired behavior. Run it. It MUST fail.
+2. **GREEN** — Write the MINIMAL code to make the test pass. Nothing more.
+3. **REFACTOR** — Clean up while keeping tests green. Remove duplication, improve naming.
+
+**No code without a test. No test without seeing it fail first.**
+
+## When to Apply
+
+TDD applies to ALL code changes:
+
+- **New features**: Test the behavior before writing it
+- **Bug fixes**: Write a test that reproduces the bug, THEN fix it
+- **Refactoring**: Ensure tests cover the behavior before changing implementation
+- **API endpoints**: Test request/response contract before implementing the handler
+- **CLI commands**: Test arg parsing and output before wiring the command
+- **Data models**: Test serialization/deserialization before defining structs
+
+## Workflow Steps (Detailed)
+
+### Step 1: Write the Test
+
+- Write a test that describes WHAT the code should do, not HOW
+- Use descriptive test names: `user_login_returns_token`, not `test1`
+- Test one behavior per test function
+- Include edge cases and error paths
+
+### Step 2: Verify RED
+
+- Run the test suite
+- Confirm the new test FAILS
+- Confirm it fails for the RIGHT REASON (missing function, wrong return value — not a syntax error)
+- If the test passes immediately, it's not testing new behavior — rewrite it
+
+### Step 3: Implement (Minimal)
+
+- Write ONLY the code needed to make the failing test pass
+- Do not add extra features, optimizations, or "while I'm here" changes
+- Do not write code that isn't covered by a test
+
+### Step 4: Verify GREEN
+
+- Run the FULL test suite (not just the new test)
+- ALL tests must pass — new AND existing
+- If existing tests break, fix the implementation, not the tests
+
+### Step 5: Refactor
+
+- Clean up duplication, improve names, extract helpers
+- Run tests after EVERY refactor step to ensure nothing breaks
+- This is where you improve code quality — not during GREEN
+
+## Anti-Patterns (BLOCKING violations)
+
+- Writing implementation before tests
+- Writing tests that pass immediately (never saw RED)
+- Skipping the RED verification step ("I know it'll fail")
+- Writing tests after the fact to "backfill coverage"
+- Deleting or modifying tests to make them pass instead of fixing code
+- Writing too much implementation at once (should be incremental)
+- Testing implementation details instead of behavior
+- Skipping the refactor step
+
+## Test Quality Standards
+
+- Each test should be independent — no shared mutable state between tests
+- Tests should be fast — mock external dependencies (network, filesystem, databases)
+- Test names should read like specifications
+- Prefer `assert_eq!` over `assert!` for better failure messages
+- Test error paths, not just happy paths
+- One logical assertion per test (multiple `assert_eq!` on the same result is fine)
+
+## Bug Fix Protocol
+
+When fixing a bug:
+
+1. Write a test that REPRODUCES the bug (fails with current code)
+2. Verify the test fails — this proves you understand the bug
+3. Fix the bug with minimal changes
+4. Verify the test passes — this proves the fix works
+5. The test now permanently guards against regression

--- a/tests/agentkit-plugin.test.ts
+++ b/tests/agentkit-plugin.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync, statSync } from 'node:fs';
+import { basename, join } from 'node:path';
+
+// The comprehensive "agentkit" Claude Code plugin bundles, in one install:
+//   - the enforcement police hooks (wired via hooks/hooks.json),
+//   - the agentkit skills, and
+//   - both MCP toolchains (assay + a copy of the infra-tools server).
+// These tests pin that wiring so a regression (a missing/renamed script, a
+// dropped MCP server, a hook that lost its executable bit) fails loudly instead
+// of shipping a plugin that half-installs.
+
+const repoRoot = join(import.meta.dir, '..');
+const pluginDir = join(repoRoot, 'plugins-cc', 'agentkit');
+
+// The police hooks wired by hooks/claude/settings.json — exactly what the plugin
+// must re-wire under ${CLAUDE_PLUGIN_ROOT}. There is no comment-police.sh: the
+// comment-police police ships only as an OpenCode plugin (plugins/comment-police.ts),
+// so it is intentionally absent from both settings.json and this plugin.
+const PRE_TOOL_USE_HOOKS = ['git-police.sh', 'kubectl-police.sh', 'pkg-police.sh', 'mr-police.sh'];
+const POST_TOOL_USE_HOOKS = ['format-police.sh', 'coding-police.sh'];
+const ALL_POLICE_HOOKS = [...PRE_TOOL_USE_HOOKS, ...POST_TOOL_USE_HOOKS];
+
+function readJson(...parts: string[]): any {
+  return JSON.parse(readFileSync(join(pluginDir, ...parts), 'utf-8'));
+}
+
+function commandBasenames(entries: { command: string }[]): string[] {
+  return entries.map((entry) => basename(entry.command));
+}
+
+describe('agentkit plugin manifest', () => {
+  test('plugin.json declares name agentkit and wires hooks, skills, and mcpServers', () => {
+    const plugin = readJson('.claude-plugin', 'plugin.json');
+    expect(plugin.name).toBe('agentkit');
+    expect(plugin.version).toBe('0.1.0');
+    expect(plugin.hooks).toBe('./hooks/hooks.json');
+    expect(plugin.skills).toBe('./skills/');
+    expect(plugin.mcpServers).toBe('./.mcp.json');
+  });
+});
+
+describe('agentkit plugin hooks', () => {
+  test('hooks.json wires exactly the police hooks under ${CLAUDE_PLUGIN_ROOT}', () => {
+    const hooks = readJson('hooks', 'hooks.json').hooks;
+
+    expect(hooks.PreToolUse).toHaveLength(1);
+    expect(hooks.PreToolUse[0].matcher).toBe('Bash');
+    expect(commandBasenames(hooks.PreToolUse[0].hooks).sort()).toEqual([...PRE_TOOL_USE_HOOKS].sort());
+
+    expect(hooks.PostToolUse).toHaveLength(1);
+    expect(hooks.PostToolUse[0].matcher).toBe('Edit|Write');
+    expect(commandBasenames(hooks.PostToolUse[0].hooks).sort()).toEqual([...POST_TOOL_USE_HOOKS].sort());
+
+    // Every command must resolve inside the plugin, never a ~/.claude path.
+    const allEntries = [...hooks.PreToolUse[0].hooks, ...hooks.PostToolUse[0].hooks];
+    for (const entry of allEntries) {
+      expect(entry.command).toStartWith('${CLAUDE_PLUGIN_ROOT}/hooks/');
+      expect(entry.command).not.toContain('.claude/hooks');
+      expect(entry.type).toBe('command');
+      expect(typeof entry.timeout).toBe('number');
+    }
+  });
+
+  test('every referenced police script exists and is executable', () => {
+    // hooks.json must reference these and they must be present + runnable.
+    const referenced = new Set(
+      readJson('hooks', 'hooks.json').hooks.PreToolUse[0].hooks
+        .concat(readJson('hooks', 'hooks.json').hooks.PostToolUse[0].hooks)
+        .map((entry: { command: string }) => basename(entry.command)),
+    );
+
+    for (const script of ALL_POLICE_HOOKS) {
+      expect(referenced.has(script), `${script} referenced in hooks.json`).toBe(true);
+      const mode = statSync(join(pluginDir, 'hooks', script)).mode;
+      expect((mode & 0o111) !== 0, `${script} is executable`).toBe(true);
+    }
+  });
+});
+
+describe('agentkit plugin MCP servers', () => {
+  test('.mcp.json declares both the assay and infra-tools servers', () => {
+    const servers = readJson('.mcp.json').mcpServers;
+    expect(Object.keys(servers).sort()).toEqual(['assay', 'infra-tools']);
+
+    expect(servers.assay.command).toBe('assay');
+    expect(servers.assay.args).toEqual(['mcp-serve']);
+
+    expect(servers['infra-tools'].command).toBe('bun');
+    // The bundled server must live inside this plugin (plugins are cached as
+    // copied files — a cross-plugin path would not survive install).
+    expect(servers['infra-tools'].args).toEqual(['${CLAUDE_PLUGIN_ROOT}/server/index.ts']);
+  });
+});
+
+describe('agentkit plugin skills', () => {
+  test('ships the agentkit skills, each with a SKILL.md', () => {
+    const expectedSkills = [
+      'autonomous-workflow',
+      'code-quality',
+      'documentation',
+      'gitops-master',
+      'issue-raiser',
+      'project-planning',
+      'test-driven-development',
+    ];
+    for (const skill of expectedSkills) {
+      const skillMd = join(pluginDir, 'skills', skill, 'SKILL.md');
+      expect(statSync(skillMd).isFile(), `${skill}/SKILL.md exists`).toBe(true);
+    }
+  });
+});
+
+describe('marketplace lists the agentkit plugin', () => {
+  test('agentkit is present, first, and the granular plugins remain', () => {
+    const marketplace = JSON.parse(
+      readFileSync(join(repoRoot, '.claude-plugin', 'marketplace.json'), 'utf-8'),
+    );
+    const names = marketplace.plugins.map((p: { name: string }) => p.name);
+    // Recommended one-shot first, then the à-la-carte plugins.
+    expect(names).toEqual(['agentkit', 'assay', 'infra-tools']);
+
+    const agentkit = marketplace.plugins.find((p: { name: string }) => p.name === 'agentkit');
+    expect(agentkit.source).toBe('./plugins-cc/agentkit');
+    expect(agentkit.version).toBe('0.1.0');
+  });
+});
+
+// Reuse of the infra-tools server integration coverage against the COPY bundled
+// inside the agentkit plugin: prove the server still boots and lists its tools
+// from its new location (this is the smoke test the plugin depends on).
+describe('bundled infra-tools server (copied into the agentkit plugin)', () => {
+  const SERVER = join(pluginDir, 'server', 'index.ts');
+
+  interface RpcResponse {
+    jsonrpc: string;
+    id: number | string | null;
+    result?: any;
+    error?: { code: number; message: string };
+  }
+
+  async function rpc(requests: object[]): Promise<RpcResponse[]> {
+    const proc = Bun.spawn(['bun', SERVER], { stdin: 'pipe', stdout: 'pipe', stderr: 'pipe' });
+    proc.stdin.write(requests.map((r) => JSON.stringify(r)).join('\n') + '\n');
+    await proc.stdin.end();
+    const out = await new Response(proc.stdout).text();
+    await proc.exited;
+    return out.trim().split('\n').filter((l) => l.length > 0).map((l) => JSON.parse(l) as RpcResponse);
+  }
+
+  const initialize = {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2025-06-18',
+      capabilities: {},
+      clientInfo: { name: 't', version: '0' },
+    },
+  };
+
+  test('initialize + tools/list works from the bundled copy', async () => {
+    const responses = await rpc([initialize, { jsonrpc: '2.0', id: 2, method: 'tools/list' }]);
+
+    const init = responses.find((r) => r.id === 1)!;
+    expect(init.error).toBeUndefined();
+    expect(init.result.serverInfo).toEqual({ name: 'infra-tools', version: '0.1.0' });
+
+    const list = responses.find((r) => r.id === 2)!;
+    const names: string[] = list.result.tools.map((t: { name: string }) => t.name);
+    expect(names.sort()).toEqual([
+      'git_clone_ro',
+      'git_diff',
+      'git_log',
+      'git_status',
+      'helm_get_values',
+      'helm_list',
+      'helm_template',
+      'tofu_plan',
+      'tofu_show',
+      'tofu_state_list',
+    ]);
+    // No mutating escape hatch leaked into the bundled copy.
+    expect(names.some((n) => /apply|install|upgrade|uninstall|destroy|push|commit|reset/.test(n)))
+      .toBe(false);
+  });
+});


### PR DESCRIPTION
One `claude plugin install agentkit` now gives the enforcement hooks + skills + both MCP toolchains — no separate step for those.

## plugins-cc/agentkit/
- **hooks/** — the 6 wired police hooks (git/kubectl/pkg/mr as PreToolUse, format/coding as PostToolUse), byte-identical copies of `hooks/claude/*.sh`, referenced via `${CLAUDE_PLUGIN_ROOT}`. Mirrors settings.json 1:1 (events/matchers/timeouts/statusMessages); only the command path changed, no script edits. (6, not 7 — comment-police ships only as an OpenCode plugin, not wired in settings.json.)
- **.mcp.json** — declares both `assay` (`assay mcp-serve`, PATH binary) and `infra-tools` (bundled bun server).
- **server/** — copy of the infra-tools MCP server (plugins cache as copied files, so cross-plugin paths can't survive). Smoke-tested from the new location: initialize + 10 read-only tools.
- **skills/** — the 7 agentkit skills.

## marketplace
`[agentkit, assay, infra-tools]` — agentkit first (recommended one-shot); granular entries kept for à-la-carte.

## Not bundled (by design)
`rules/` + `instructions/` — CC plugins can't inject always-on global context, so `install.sh` still handles those. But their **enforcement** is in the bundled police hooks. README documents this.

## Verified
- `bun test`: new plugin test stable 7/7; full suite passes (the occasional 1-fail is the pre-existing flake #48, not this change). dprint clean, oxlint 0 errors, all 4 JSON files valid. Hooks run correctly from the plugin location (pkg/kubectl/git/format police all behave).

Follow-ups: pre-existing `coding-police.sh` `head -n -1` macOS-ism (byte-identical to source); server/hooks duplication with the standalone sources (inherent to CC copied-file model — worth a sync check).