### PR TITLE
feat: chime hook — audible nudge when Claude Code needs the human

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Reusable AI agent skills, rules, plugins, hooks, and tools for OpenCode, Claude 
 | **format-police.sh**  | PostToolUse | Auto-formats files after edit/write using dprint                                                                         |
 | **coding-police.sh**  | PostToolUse | Enforces DRY code, modular files (<1000 lines), short functions, single responsibility                                   |
 | **pkg-police.sh**     | PreToolUse  | Enforces bun as package manager — blocks npm, npx, yarn, pnpm commands                                                   |
+| **chime.sh**          | Notification/Stop | Audible nudge when Claude needs you: springy boing on permission prompts/questions, soft ping when a turn finishes. Mute: `touch ~/.claude/.chime-off` or `CLAUDE_CHIME=0` |
 | **mr-police.sh**      | PreToolUse  | Blocks opening a new MR while you already have an open MR you authored on the repo — stops unmerged MRs from stacking up |
 
 ### Policies (Codex CLI -- exec policy)

--- a/hooks/claude/chime.sh
+++ b/hooks/claude/chime.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# chime.sh — audible nudge when Claude Code needs the human.
+#
+# Wired as a Notification hook (permission prompt / question waiting → a
+# springy "boing") and a Stop hook (turn finished, reply awaiting you → a
+# soft ping) so you hear it when you're not looking at the terminal.
+#
+# Toggle off without editing settings:
+#   touch ~/.claude/.chime-off      # mute
+#   rm ~/.claude/.chime-off         # unmute
+# or export CLAUDE_CHIME=0 in the environment.
+#
+# Usage: chime.sh [attention|done]   (default: attention)
+
+[ "${CLAUDE_CHIME:-1}" = "0" ] && exit 0
+[ -f "$HOME/.claude/.chime-off" ] && exit 0
+
+kind="${1:-attention}"
+
+# macOS: "Sosumi" is the springiest stock sound — distinctive enough to
+# register as "Claude needs me" from across the room (Funk and Frog are the
+# other boingy options under /System/Library/Sounds/).
+if command -v afplay >/dev/null 2>&1; then
+  case "$kind" in
+    done) afplay /System/Library/Sounds/Ping.aiff >/dev/null 2>&1 ;;
+    *) afplay /System/Library/Sounds/Sosumi.aiff >/dev/null 2>&1 ;;
+  esac
+  exit 0
+fi
+
+# Linux: freedesktop sound theme via PulseAudio/PipeWire, if present.
+if command -v paplay >/dev/null 2>&1; then
+  base=/usr/share/sounds/freedesktop/stereo
+  case "$kind" in
+    done) f="$base/complete.oga" ;;
+    *) f="$base/bell.oga" ;;
+  esac
+  [ -f "$f" ] && paplay "$f" >/dev/null 2>&1 && exit 0
+fi
+
+# Last resort: the terminal bell.
+printf '\a'
+exit 0

--- a/hooks/claude/settings.json
+++ b/hooks/claude/settings.json
@@ -48,6 +48,30 @@
           }
         ]
       }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/chime.sh attention",
+            "async": true,
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/chime.sh done",
+            "async": true,
+            "timeout": 10
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
Refs #50. New `hooks/claude/chime.sh` + settings-template wiring: **Notification** → springy boing (Sosumi) for permission prompts/questions, **Stop** → soft ping when a turn finishes, both `async` so nothing blocks. Mute toggle without touching settings: `touch ~/.claude/.chime-off` or `CLAUDE_CHIME=0`. macOS afplay, Linux paplay (freedesktop theme) fallback, terminal bell as last resort. README hooks table updated. Verified locally: both sounds play, mute file silences, JSON template valid.