### PR TITLE
feat(skills): gitlab + github issue-lifecycle skills

### DIFF
--- a/plugins-cc/agentkit/skills/github-issue-lifecycle/SKILL.md
+++ b/plugins-cc/agentkit/skills/github-issue-lifecycle/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: github-issue-lifecycle
+description: >-
+  Issue-first workflow and lifecycle hygiene for GitHub: every piece of work runs
+  against an issue, Projects v2 status stays current on every touch, PRs reference
+  issues without triggering auto-close, and issues close with a verification note.
+  GitHub counterpart of gitlab-issue-lifecycle. Triggers: starting tracked work,
+  updating issue/project status, closing issues, referencing issues from PRs.
+---
+
+# GitHub Issue Lifecycle
+
+This skill encodes generic practice only. Org specifics — default assignee, project
+board, labels, office hours — come from per-repo git config, never from this file.
+
+## Org config (read before creating or updating anything)
+
+```bash
+git config --get agentkit.issues.assignee        # default assignee login (or "@me")
+git config --get agentkit.issues.project         # Projects v2 number or URL, e.g. "7"
+git config --get agentkit.issues.offhours-label  # label to add when working outside office hours
+git config --get agentkit.issues.office-hours    # "Area/City HH:MM-HH:MM", e.g. "Europe/London 09:00-17:00"
+```
+
+If a key is unset the first time it's needed, ask the user once and offer to persist
+the answer with `git config agentkit.issues.<key> <value>`.
+
+## The rules
+
+1. **Issue-first.** Every piece of work runs against an issue. Find an existing one
+   (`gh issue list --search`) or create it BEFORE branching. Trivial fixes inside an
+   existing issue's scope ride that issue.
+2. **PRs reference, never auto-close.** Write `Refs #N` in the PR body — never
+   `Closes/Fixes/Resolves #N`. GitHub's closing keywords auto-close the issue the
+   moment the PR merges to the default branch; the issue must stay open until the fix
+   is verified in the target environment.
+3. **Status current on every touch.** Whenever you act on an issue (start work, open a
+   PR, merge, park it), update its Projects v2 Status field in the same breath. No
+   project board configured → use labels or assignment as the signal, but stay
+   consistent.
+4. **Close with a closure note.** When verified, close with a comment stating root
+   cause, the fix, and the PR reference: `gh issue close N --comment "..."`. Use
+   `--reason completed` for fixed, `--reason "not planned"` for rejected/superseded.
+5. **Project link on creation.** If `agentkit.issues.project` is set, add every new
+   issue to that project (recipe below).
+6. **Off-hours label.** If `agentkit.issues.office-hours` is set and the wall clock in
+   that zone is outside the window, add `agentkit.issues.offhours-label` at creation.
+
+## Status map (Projects v2 Status field)
+
+Field options vary per project — discover them (query below), match by intent:
+
+| When                                            | Typical option |
+| ----------------------------------------------- | -------------- |
+| Filed, awaiting triage decision                 | Triage / Backlog |
+| Triaged, accepted, parked                       | Todo           |
+| Anyone (human or bot) actively working it       | In Progress    |
+| PR up or merged, awaiting verification          | In Review      |
+| Verified and closed                             | Done           |
+
+## Recipes
+
+```bash
+# Create with the org conventions applied:
+gh issue create --title "..." --body "..." \
+  --assignee "$(git config --get agentkit.issues.assignee)" \
+  --label "<labels>"
+
+# Add an issue to the configured Projects v2 board (needs the org/user owner):
+gh project item-add <project-number> --owner <owner> --url <issue-url>
+
+# Discover the Status field id and its options:
+gh project field-list <project-number> --owner <owner> --format json
+
+# Find the item id for the issue, then set Status:
+gh project item-list <project-number> --owner <owner> --format json  # → item id
+gh project item-edit --project-id <project-id> --id <item-id> \
+  --field-id <status-field-id> --single-select-option-id <option-id>
+```
+
+```bash
+# Close with a closure note after verification:
+gh issue close <n> --reason completed --comment "Root cause: ... Fixed by #<pr>: ...
+Verified: <how>."
+```
+
+## Gotchas
+
+- **Closing keywords hide in PR bodies and commit messages.** `Fixes #N` anywhere in a
+  PR body (or a commit that lands on the default branch) auto-closes — audit generated
+  text for them when the review-driven lifecycle is in force.
+- **Projects v2 is a separate API surface.** Issue state (`open`/`closed`,
+  `state_reason`) lives on the issue; Status lives on the project item. Closing an
+  issue does NOT move its project Status unless the project has an auto-archive /
+  workflow rule — check, and set Status explicitly when in doubt.
+- `gh project` commands need the `project` scope: if they 401/403,
+  run `gh auth refresh -s project`.

--- a/plugins-cc/agentkit/skills/gitlab-issue-lifecycle/SKILL.md
+++ b/plugins-cc/agentkit/skills/gitlab-issue-lifecycle/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: gitlab-issue-lifecycle
+description: >-
+  Issue-first workflow and lifecycle hygiene for GitLab: every piece of work runs
+  against an issue, work-item statuses stay current on every touch, MRs reference
+  issues without auto-closing, and issues close with a verification note.
+  Complements issue-raiser (which covers researching and writing a new issue).
+  Triggers: starting tracked work, updating issue status, linking issues to
+  epics, closing issues, referencing issues from MRs.
+---
+
+# GitLab Issue Lifecycle
+
+This skill encodes generic practice only. Org specifics — default assignee, epic,
+labels, office hours — come from per-repo git config, never from this file.
+
+## Org config (read before creating or updating anything)
+
+```bash
+git config --get agentkit.issues.assignee        # default assignee username
+git config --get agentkit.issues.epic            # "<group-path>#<epic-iid>", e.g. "my-group/platform#7"
+git config --get agentkit.issues.offhours-label  # label to add when working outside office hours
+git config --get agentkit.issues.office-hours    # "Area/City HH:MM-HH:MM", e.g. "Europe/London 09:00-17:00"
+```
+
+If a key is unset the first time it's needed, ask the user once and offer to persist
+the answer with `git config agentkit.issues.<key> <value>`. Detect the GitLab host and
+project path from `git remote -v` (see issue-raiser Phase 0) — never hardcode a host.
+
+## The rules
+
+1. **Issue-first.** Every piece of work runs against an issue. Find an existing one or
+   create it BEFORE branching. Trivial fixes inside an existing issue's scope ride that
+   issue; retroactive filing is a fallback, not the default.
+2. **MRs reference, never auto-close.** Write `Refs #N` in the MR description — never
+   `Closes #N` / `Fixes #N`. The issue stays open through merge and deployment; whoever
+   verifies the fix in the target environment closes it.
+3. **Status current on every touch.** Whenever you act on an issue (start work, open an
+   MR, merge, park it), update its work-item status in the same breath — a board that
+   lies is worse than no board. See the status map below.
+4. **Close with a closure note.** When verified, post a note stating root cause, the
+   fix, and the MR reference — then close. Closing without the note loses the trail.
+5. **Epic link on creation.** If `agentkit.issues.epic` is set, attach every new issue
+   to that epic (recipe below).
+6. **Off-hours label.** If `agentkit.issues.office-hours` is set and the wall clock in
+   that zone is outside the window, add `agentkit.issues.offhours-label` at creation.
+
+## Status map (work-item statuses)
+
+Statuses are grouped by category; discover the actual names per namespace (query
+below) — never hardcode status IDs across instances.
+
+| When                                                  | Category      |
+| ----------------------------------------------------- | ------------- |
+| Filed, awaiting human triage decision                 | `triage`      |
+| Triaged, accepted, parked (e.g. pending design)       | `to_do`       |
+| Anyone (human or bot) actively working it             | `in_progress` |
+| MR up or merged, awaiting verification                | `in_progress` (an "In review"-named status if the lifecycle has one) |
+| Verified and closed                                   | `done` (auto-set when the issue is closed) |
+| Rejected / superseded                                 | `canceled`    |
+
+## Recipes
+
+Work-item status is **GraphQL-only** — it is a widget, separate from the REST
+open/closed state.
+
+```bash
+# Discover the lifecycle statuses for the namespace (IDs differ per instance):
+glab api graphql -f query='query { namespace(fullPath: "<group>") {
+  lifecycles { nodes { name statuses { id name category } } } } }'
+
+# Read current status + global work-item id for issues by iid:
+glab api graphql -f query='query { project(fullPath: "<group/project>") {
+  workItems(iids: ["12"]) { nodes { iid state id
+    widgets { ... on WorkItemWidgetStatus { status { id name } } } } } } }'
+
+# Set a status:
+glab api graphql -f query='mutation { workItemUpdate(input: {
+  id: "gid://gitlab/WorkItem/<global-id>",
+  statusWidget: {status: "gid://gitlab/WorkItems::Statuses::Custom::Status/<n>"}
+}) { errors } }'
+```
+
+```bash
+# Link an issue to an epic — needs the issue's GLOBAL id (the `id` field),
+# NOT the project-scoped iid:
+glab api -X POST "groups/<url-encoded-group>/epics/<epic-iid>/issues/<issue-global-id>"
+```
+
+```bash
+# Close with a closure note (note first, then close):
+glab api -X POST "projects/<url-encoded-path>/issues/<iid>/notes" \
+  -H "Content-Type: application/json" --input note.json
+glab api -X PUT "projects/<url-encoded-path>/issues/<iid>" -f state_event=close
+```
+
+## glab gotchas (cost real debugging time — respect them)
+
+- **Form-encoded arrays silently drop.** `-F "user_ids[]=5"` and `-F "assignee_ids[]=5"`
+  do not reach the server as arrays. Always send arrays/objects as a JSON body:
+  `-H "Content-Type: application/json" --input payload.json`.
+- **zsh does not word-split unquoted variables.** A `for pair in "a b" ...; set -- $pair`
+  loop that works in bash builds broken URLs in zsh. Prefer explicit commands or
+  python for anything beyond a trivial loop.
+- The project's approvals/notes/issues REST endpoints accept a JSON body with the same
+  field names the docs list as form params — when a form call 400s/404s mysteriously,
+  retry as JSON before assuming the endpoint is wrong.

--- a/skills/github-issue-lifecycle/SKILL.md
+++ b/skills/github-issue-lifecycle/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: github-issue-lifecycle
+description: >-
+  Issue-first workflow and lifecycle hygiene for GitHub: every piece of work runs
+  against an issue, Projects v2 status stays current on every touch, PRs reference
+  issues without triggering auto-close, and issues close with a verification note.
+  GitHub counterpart of gitlab-issue-lifecycle. Triggers: starting tracked work,
+  updating issue/project status, closing issues, referencing issues from PRs.
+---
+
+# GitHub Issue Lifecycle
+
+This skill encodes generic practice only. Org specifics — default assignee, project
+board, labels, office hours — come from per-repo git config, never from this file.
+
+## Org config (read before creating or updating anything)
+
+```bash
+git config --get agentkit.issues.assignee        # default assignee login (or "@me")
+git config --get agentkit.issues.project         # Projects v2 number or URL, e.g. "7"
+git config --get agentkit.issues.offhours-label  # label to add when working outside office hours
+git config --get agentkit.issues.office-hours    # "Area/City HH:MM-HH:MM", e.g. "Europe/London 09:00-17:00"
+```
+
+If a key is unset the first time it's needed, ask the user once and offer to persist
+the answer with `git config agentkit.issues.<key> <value>`.
+
+## The rules
+
+1. **Issue-first.** Every piece of work runs against an issue. Find an existing one
+   (`gh issue list --search`) or create it BEFORE branching. Trivial fixes inside an
+   existing issue's scope ride that issue.
+2. **PRs reference, never auto-close.** Write `Refs #N` in the PR body — never
+   `Closes/Fixes/Resolves #N`. GitHub's closing keywords auto-close the issue the
+   moment the PR merges to the default branch; the issue must stay open until the fix
+   is verified in the target environment.
+3. **Status current on every touch.** Whenever you act on an issue (start work, open a
+   PR, merge, park it), update its Projects v2 Status field in the same breath. No
+   project board configured → use labels or assignment as the signal, but stay
+   consistent.
+4. **Close with a closure note.** When verified, close with a comment stating root
+   cause, the fix, and the PR reference: `gh issue close N --comment "..."`. Use
+   `--reason completed` for fixed, `--reason "not planned"` for rejected/superseded.
+5. **Project link on creation.** If `agentkit.issues.project` is set, add every new
+   issue to that project (recipe below).
+6. **Off-hours label.** If `agentkit.issues.office-hours` is set and the wall clock in
+   that zone is outside the window, add `agentkit.issues.offhours-label` at creation.
+
+## Status map (Projects v2 Status field)
+
+Field options vary per project — discover them (query below), match by intent:
+
+| When                                            | Typical option |
+| ----------------------------------------------- | -------------- |
+| Filed, awaiting triage decision                 | Triage / Backlog |
+| Triaged, accepted, parked                       | Todo           |
+| Anyone (human or bot) actively working it       | In Progress    |
+| PR up or merged, awaiting verification          | In Review      |
+| Verified and closed                             | Done           |
+
+## Recipes
+
+```bash
+# Create with the org conventions applied:
+gh issue create --title "..." --body "..." \
+  --assignee "$(git config --get agentkit.issues.assignee)" \
+  --label "<labels>"
+
+# Add an issue to the configured Projects v2 board (needs the org/user owner):
+gh project item-add <project-number> --owner <owner> --url <issue-url>
+
+# Discover the Status field id and its options:
+gh project field-list <project-number> --owner <owner> --format json
+
+# Find the item id for the issue, then set Status:
+gh project item-list <project-number> --owner <owner> --format json  # → item id
+gh project item-edit --project-id <project-id> --id <item-id> \
+  --field-id <status-field-id> --single-select-option-id <option-id>
+```
+
+```bash
+# Close with a closure note after verification:
+gh issue close <n> --reason completed --comment "Root cause: ... Fixed by #<pr>: ...
+Verified: <how>."
+```
+
+## Gotchas
+
+- **Closing keywords hide in PR bodies and commit messages.** `Fixes #N` anywhere in a
+  PR body (or a commit that lands on the default branch) auto-closes — audit generated
+  text for them when the review-driven lifecycle is in force.
+- **Projects v2 is a separate API surface.** Issue state (`open`/`closed`,
+  `state_reason`) lives on the issue; Status lives on the project item. Closing an
+  issue does NOT move its project Status unless the project has an auto-archive /
+  workflow rule — check, and set Status explicitly when in doubt.
+- `gh project` commands need the `project` scope: if they 401/403,
+  run `gh auth refresh -s project`.

--- a/skills/gitlab-issue-lifecycle/SKILL.md
+++ b/skills/gitlab-issue-lifecycle/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: gitlab-issue-lifecycle
+description: >-
+  Issue-first workflow and lifecycle hygiene for GitLab: every piece of work runs
+  against an issue, work-item statuses stay current on every touch, MRs reference
+  issues without auto-closing, and issues close with a verification note.
+  Complements issue-raiser (which covers researching and writing a new issue).
+  Triggers: starting tracked work, updating issue status, linking issues to
+  epics, closing issues, referencing issues from MRs.
+---
+
+# GitLab Issue Lifecycle
+
+This skill encodes generic practice only. Org specifics — default assignee, epic,
+labels, office hours — come from per-repo git config, never from this file.
+
+## Org config (read before creating or updating anything)
+
+```bash
+git config --get agentkit.issues.assignee        # default assignee username
+git config --get agentkit.issues.epic            # "<group-path>#<epic-iid>", e.g. "my-group/platform#7"
+git config --get agentkit.issues.offhours-label  # label to add when working outside office hours
+git config --get agentkit.issues.office-hours    # "Area/City HH:MM-HH:MM", e.g. "Europe/London 09:00-17:00"
+```
+
+If a key is unset the first time it's needed, ask the user once and offer to persist
+the answer with `git config agentkit.issues.<key> <value>`. Detect the GitLab host and
+project path from `git remote -v` (see issue-raiser Phase 0) — never hardcode a host.
+
+## The rules
+
+1. **Issue-first.** Every piece of work runs against an issue. Find an existing one or
+   create it BEFORE branching. Trivial fixes inside an existing issue's scope ride that
+   issue; retroactive filing is a fallback, not the default.
+2. **MRs reference, never auto-close.** Write `Refs #N` in the MR description — never
+   `Closes #N` / `Fixes #N`. The issue stays open through merge and deployment; whoever
+   verifies the fix in the target environment closes it.
+3. **Status current on every touch.** Whenever you act on an issue (start work, open an
+   MR, merge, park it), update its work-item status in the same breath — a board that
+   lies is worse than no board. See the status map below.
+4. **Close with a closure note.** When verified, post a note stating root cause, the
+   fix, and the MR reference — then close. Closing without the note loses the trail.
+5. **Epic link on creation.** If `agentkit.issues.epic` is set, attach every new issue
+   to that epic (recipe below).
+6. **Off-hours label.** If `agentkit.issues.office-hours` is set and the wall clock in
+   that zone is outside the window, add `agentkit.issues.offhours-label` at creation.
+
+## Status map (work-item statuses)
+
+Statuses are grouped by category; discover the actual names per namespace (query
+below) — never hardcode status IDs across instances.
+
+| When                                                  | Category      |
+| ----------------------------------------------------- | ------------- |
+| Filed, awaiting human triage decision                 | `triage`      |
+| Triaged, accepted, parked (e.g. pending design)       | `to_do`       |
+| Anyone (human or bot) actively working it             | `in_progress` |
+| MR up or merged, awaiting verification                | `in_progress` (an "In review"-named status if the lifecycle has one) |
+| Verified and closed                                   | `done` (auto-set when the issue is closed) |
+| Rejected / superseded                                 | `canceled`    |
+
+## Recipes
+
+Work-item status is **GraphQL-only** — it is a widget, separate from the REST
+open/closed state.
+
+```bash
+# Discover the lifecycle statuses for the namespace (IDs differ per instance):
+glab api graphql -f query='query { namespace(fullPath: "<group>") {
+  lifecycles { nodes { name statuses { id name category } } } } }'
+
+# Read current status + global work-item id for issues by iid:
+glab api graphql -f query='query { project(fullPath: "<group/project>") {
+  workItems(iids: ["12"]) { nodes { iid state id
+    widgets { ... on WorkItemWidgetStatus { status { id name } } } } } } }'
+
+# Set a status:
+glab api graphql -f query='mutation { workItemUpdate(input: {
+  id: "gid://gitlab/WorkItem/<global-id>",
+  statusWidget: {status: "gid://gitlab/WorkItems::Statuses::Custom::Status/<n>"}
+}) { errors } }'
+```
+
+```bash
+# Link an issue to an epic — needs the issue's GLOBAL id (the `id` field),
+# NOT the project-scoped iid:
+glab api -X POST "groups/<url-encoded-group>/epics/<epic-iid>/issues/<issue-global-id>"
+```
+
+```bash
+# Close with a closure note (note first, then close):
+glab api -X POST "projects/<url-encoded-path>/issues/<iid>/notes" \
+  -H "Content-Type: application/json" --input note.json
+glab api -X PUT "projects/<url-encoded-path>/issues/<iid>" -f state_event=close
+```
+
+## glab gotchas (cost real debugging time — respect them)
+
+- **Form-encoded arrays silently drop.** `-F "user_ids[]=5"` and `-F "assignee_ids[]=5"`
+  do not reach the server as arrays. Always send arrays/objects as a JSON body:
+  `-H "Content-Type: application/json" --input payload.json`.
+- **zsh does not word-split unquoted variables.** A `for pair in "a b" ...; set -- $pair`
+  loop that works in bash builds broken URLs in zsh. Prefer explicit commands or
+  python for anything beyond a trivial loop.
+- The project's approvals/notes/issues REST endpoints accept a JSON body with the same
+  field names the docs list as form params — when a form call 400s/404s mysteriously,
+  retry as JSON before assuming the endpoint is wrong.


### PR DESCRIPTION
Refs #55

Two new skills encoding the issue-first lifecycle practice, org-agnostic:

- **gitlab-issue-lifecycle** — issue-first, Refs-not-Closes, work-item status hygiene on every touch (GraphQL statusWidget, statuses discovered by category — never hardcoded IDs), epic linking (global id, not iid), close-with-closure-note, off-hours labeling. Plus the glab gotchas that cost real debugging time (form arrays silently drop → JSON --input; zsh word-splitting).
- **github-issue-lifecycle** — same practice on GitHub: Projects v2 status field mechanics, auto-close keyword avoidance, close --reason + closure comment.

Org specifics (assignee, epic/project, labels, office hours) are read from per-repo `git config agentkit.issues.*` — the skills ship placeholders only; grepped clean of any org identifiers. Mirrored into plugins-cc/agentkit/skills/ per the existing copy convention.