### PR TITLE
feat(install): CC skills, Codex prompts, plugin-mode install, plugin sync

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -14,34 +14,50 @@ supported AI coding tools: OpenCode, Claude Code, and Codex CLI.
 
 Options:
   --global             Install globally (all tools, all projects)
+  --claude-plugin      Global only: install Claude Code bits as the agentkit
+                       plugin (marketplace add + plugin install) INSTEAD of
+                       copying hooks/skills and merging settings.json. The two
+                       modes are mutually exclusive — plugin hooks.json on top
+                       of settings.json hooks would fire every hook twice.
   target-project-dir   Project directory to install into (default: current dir)
 
 Global install locations:
   OpenCode:    ~/.agents/skills/, ~/.agents/plugins/, ~/.agents/rules/
-  Claude Code: ~/.claude/hooks/, ~/.claude/tools/, ~/.claude/settings.json (hooks section merged)
-  Codex CLI:   ~/.codex/rules/
+  Claude Code: ~/.claude/skills/, ~/.claude/hooks/, ~/.claude/tools/,
+               ~/.claude/settings.json (hooks section merged)
+               (--claude-plugin: agentkit plugin via marketplace instead)
+  Codex CLI:   ~/.codex/rules/, ~/.codex/prompts/ (skills as /prompts)
   Prompts:     ~/.agents/instructions/*.md (wired into Codex/Claude/OpenCode)
 
 Project install locations:
   OpenCode:    .opencode/skills/, .opencode/plugins/, .opencode/rules/
-  Claude Code: .claude/hooks/, .claude/tools/, .claude/settings.json (hooks section merged)
+  Claude Code: .claude/skills/, .claude/hooks/, .claude/tools/,
+               .claude/settings.json (hooks section merged)
   Codex CLI:   .codex/rules/
 
 Examples:
   ./install.sh --global               # Install for all tools globally
+  ./install.sh --global --claude-plugin  # Claude Code via plugin, rest as usual
   ./install.sh                        # Install into current project
   ./install.sh ~/code/my-project      # Install into specific project
 USAGE
 	exit 1
 }
 
+CLAUDE_PLUGIN=false
 for arg in "$@"; do
 	case "$arg" in
 	-h | --help) usage ;;
 	--global) GLOBAL=true ;;
+	--claude-plugin) CLAUDE_PLUGIN=true ;;
 	*) TARGET_DIR="$arg" ;;
 	esac
 done
+
+if [[ "$CLAUDE_PLUGIN" == true && "$GLOBAL" != true ]]; then
+	echo "ERROR: --claude-plugin requires --global (plugins are user-level)." >&2
+	exit 1
+fi
 
 # ─── Shared: Skills ──────────────────────────────────────────────────────────
 
@@ -578,6 +594,64 @@ install_codex_policies() {
 	done
 }
 
+# ─── Codex CLI: Skills as Custom Prompts ─────────────────────────────────────
+
+install_codex_skills() {
+	local prompts_dir="$1"
+	mkdir -p "$prompts_dir"
+
+	for skill_dir in "$REPO_DIR"/skills/*/; do
+		local name target
+		name="$(basename "$skill_dir")"
+		[[ -f "$skill_dir/SKILL.md" ]] || continue
+		target="$prompts_dir/$name.md"
+
+		if [[ -f "$target" ]]; then
+			echo "[codex] Updating prompt: $name.md"
+		else
+			echo "[codex] Installing prompt: $name.md"
+		fi
+
+		# Codex prompts are plain markdown invoked as /<name> — strip the
+		# SKILL.md YAML frontmatter, keep the body verbatim.
+		awk 'NR==1 && /^---[[:space:]]*$/ {infm=1; next} infm && /^---[[:space:]]*$/ {infm=0; next} !infm {print}' \
+			"$skill_dir/SKILL.md" >"$target"
+	done
+}
+
+# ─── Claude Code: Plugin-Mode Install ────────────────────────────────────────
+
+install_claude_plugin() {
+	if ! command -v claude &>/dev/null; then
+		echo "[claude] WARNING: claude CLI not found — cannot install the plugin."
+		return 1
+	fi
+
+	echo "[claude] Registering marketplace: $REPO_DIR"
+	claude plugin marketplace add "$REPO_DIR" 2>/dev/null \
+		|| claude plugin marketplace update agentkit
+
+	echo "[claude] Installing plugin: agentkit@agentkit"
+	claude plugin install agentkit@agentkit
+
+	# A leftover manual install would run every hook twice (settings.json +
+	# the plugin's hooks.json) — warn loudly, never edit user settings.
+	local settings_file="$HOME/.claude/settings.json"
+	if [[ -f "$settings_file" ]] && grep -Fq "git-police.sh" "$settings_file"; then
+		echo "[claude] WARNING: manually-installed agentkit hooks found in $settings_file."
+		echo "[claude] Remove that hooks section to avoid double execution alongside the plugin."
+	fi
+	local d
+	for d in "$REPO_DIR"/skills/*/; do
+		if [[ -d "$HOME/.claude/skills/$(basename "$d")" ]]; then
+			echo "[claude] NOTE: manually-installed agentkit skills present in ~/.claude/skills/ — remove them in plugin mode to avoid duplicate listings."
+			break
+		fi
+	done
+
+	echo "[claude] Plugin installed — restart Claude Code to load it."
+}
+
 # ─── User Config (~/.config/agentkit/) ───────────────────────────────────────
 
 install_config() {
@@ -632,18 +706,33 @@ if [[ "$GLOBAL" == true ]]; then
 	# ── Claude Code ──
 	CLAUDE_HOOKS="$HOME/.claude/hooks"
 	CLAUDE_TOOLS="$HOME/.claude/tools"
+	CLAUDE_SKILLS="$HOME/.claude/skills"
 	CLAUDE_SETTINGS="$HOME/.claude/settings.json"
-	echo "--- Claude Code (bash hooks) ---"
-	install_claude_hooks "$CLAUDE_HOOKS" "$CLAUDE_SETTINGS"
-	echo ""
+	if [[ "$CLAUDE_PLUGIN" == true ]] && install_claude_plugin; then
+		CLAUDE_MODE="plugin (agentkit@agentkit)"
+		echo ""
+	else
+		[[ "$CLAUDE_PLUGIN" == true ]] && echo "[claude] Falling back to manual install."
+		CLAUDE_MODE="manual ($CLAUDE_HOOKS, hooks in $CLAUDE_SETTINGS)"
+		echo "--- Claude Code (bash hooks) ---"
+		install_claude_hooks "$CLAUDE_HOOKS" "$CLAUDE_SETTINGS"
+		echo ""
+		echo "--- Claude Code (skills) ---"
+		install_skills "$CLAUDE_SKILLS"
+		echo ""
+	fi
 	echo "--- Standalone tools ---"
 	install_tools "$CLAUDE_TOOLS"
 	echo ""
 
 	# ── Codex CLI ──
 	CODEX_RULES="$HOME/.codex/rules"
+	CODEX_PROMPTS="$HOME/.codex/prompts"
 	echo "--- Codex CLI (Starlark policies) ---"
 	install_codex_policies "$CODEX_RULES"
+	echo ""
+	echo "--- Codex CLI (skills as prompts) ---"
+	install_codex_skills "$CODEX_PROMPTS"
 	echo ""
 
 	# ── Summary ──
@@ -651,12 +740,12 @@ if [[ "$GLOBAL" == true ]]; then
 	echo ""
 	echo "  Config:          ${XDG_CONFIG_HOME:-$HOME/.config}/agentkit/config.yaml"
 	echo "  Prompts:         $HOME/.agents/instructions/*.md"
-	echo "  Skills:          $SKILLS_DEST/"
+	echo "  Skills:          $SKILLS_DEST/ (OpenCode), $CLAUDE_SKILLS/ (Claude Code)"
 	echo "  Rules:           $RULES_DEST/"
 	echo "  OpenCode:        $OPENCODE_PLUGINS/ (add file:// entries to opencode config)"
-	echo "  Claude Code:     $CLAUDE_HOOKS/ (hooks in $CLAUDE_SETTINGS)"
+	echo "  Claude Code:     $CLAUDE_MODE"
 	echo "  Tools:           $CLAUDE_TOOLS/"
-	echo "  Codex CLI:       $CODEX_RULES/ (auto-loaded at startup)"
+	echo "  Codex CLI:       $CODEX_RULES/ (auto-loaded), $CODEX_PROMPTS/ (/name prompts)"
 
 # ─── Main: Project Install ───────────────────────────────────────────────────
 
@@ -688,9 +777,13 @@ else
 	# ── Claude Code ──
 	CLAUDE_HOOKS="$TARGET_DIR/.claude/hooks"
 	CLAUDE_TOOLS="$TARGET_DIR/.claude/tools"
+	CLAUDE_SKILLS="$TARGET_DIR/.claude/skills"
 	CLAUDE_SETTINGS="$TARGET_DIR/.claude/settings.json"
 	echo "--- Claude Code (bash hooks) ---"
 	install_claude_hooks "$CLAUDE_HOOKS" "$CLAUDE_SETTINGS"
+	echo ""
+	echo "--- Claude Code (skills) ---"
+	install_skills "$CLAUDE_SKILLS"
 	echo ""
 	echo "--- Standalone tools ---"
 	install_tools "$CLAUDE_TOOLS"
@@ -705,7 +798,7 @@ else
 	# ── Summary ──
 	echo "Done. Installed into $TARGET_DIR for all tools:"
 	echo ""
-	echo "  Skills:      $SKILLS_DEST/"
+	echo "  Skills:      $SKILLS_DEST/ (OpenCode), $CLAUDE_SKILLS/ (Claude Code)"
 	echo "  Rules:       $RULES_DEST/"
 	echo "  OpenCode:    $OPENCODE_PLUGINS/"
 	echo "  Claude Code: $CLAUDE_HOOKS/ (hooks in $CLAUDE_SETTINGS)"
@@ -714,6 +807,7 @@ else
 	echo ""
 	echo "Verify with:"
 	echo "  ls $SKILLS_DEST/"
+	echo "  ls $CLAUDE_SKILLS/"
 	echo "  ls $OPENCODE_PLUGINS/"
 	echo "  ls $CLAUDE_HOOKS/"
 	echo "  ls $CLAUDE_TOOLS/"

--- a/plugins-cc/agentkit/hooks/git-police.sh
+++ b/plugins-cc/agentkit/hooks/git-police.sh
@@ -133,6 +133,45 @@ if [[ -z "$PUSH_REMOTE" || "$PUSH_REMOTE" == "origin" ]] \
 	done
 fi
 
+# 4b. Freshness: a feature-branch push must carry the latest integration
+#     branch — a stale branch merges into a codebase it never saw (squash-merge
+#     repos surface this as surprise conflicts or silently regressed files).
+#     The fetch is a single ref and quick. The integration branch defaults to
+#     origin/HEAD; repos whose MRs target another branch (env-branch layouts)
+#     set it once with: git config agentkit.integration-branch <branch>.
+#     The override works from the hook's environment or inline in the command
+#     itself (`AGENTKIT_ALLOW_STALE_PUSH=1 git push …`) — inline assignments
+#     never reach the hook process, so honor them from the text (same
+#     treatment as AGENTKIT_ALLOW_BRANCH_STACKING in rule 7).
+STALE_PUSH_OK="${AGENTKIT_ALLOW_STALE_PUSH:-0}"
+if echo "$COMMAND" | grep -qE '(^|[[:space:];&|])AGENTKIT_ALLOW_STALE_PUSH=1([[:space:];&|]|$)'; then
+	STALE_PUSH_OK=1
+fi
+if [[ -z "$PUSH_REMOTE" || "$PUSH_REMOTE" == "origin" ]] \
+	&& [[ "$STALE_PUSH_OK" != "1" ]] \
+	&& echo "$STRIPPED" | grep -qiE "$GIT_PUSH_RE"; then
+	INTEGRATION_BRANCH=$(tgit config --get agentkit.integration-branch 2>/dev/null || true)
+	DEFAULT_BRANCH="$INTEGRATION_BRANCH"
+	if [[ -z "$DEFAULT_BRANCH" ]]; then
+		DEFAULT_BRANCH=$(tgit symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||')
+	fi
+	if [[ -z "$DEFAULT_BRANCH" ]]; then
+		for cand in main master; do
+			if tgit show-ref --verify --quiet "refs/remotes/origin/${cand}"; then
+				DEFAULT_BRANCH="$cand"
+				break
+			fi
+		done
+	fi
+	if [[ -n "$DEFAULT_BRANCH" ]]; then
+		tgit fetch --quiet origin "$DEFAULT_BRANCH" 2>/dev/null || true
+		BEHIND=$(tgit rev-list --count "HEAD..origin/${DEFAULT_BRANCH}" 2>/dev/null || echo 0)
+		if [[ "${BEHIND:-0}" -gt 0 ]]; then
+			deny "BLOCKED: Your branch is ${BEHIND} commit(s) behind origin/${DEFAULT_BRANCH}. Merge the latest ${DEFAULT_BRANCH} before pushing: git fetch origin && git merge origin/${DEFAULT_BRANCH} — resolve any conflicts, re-run the repo's gates, then push. Intentional stale push: prefix the command with AGENTKIT_ALLOW_STALE_PUSH=1. MRs targeting a different branch: git config agentkit.integration-branch <branch>."
+		fi
+	fi
+fi
+
 # Detect `git commit` as a subcommand (not the literal substring "commit"
 # inside a config key like `git config commit.gpgsign`).
 GIT_COMMIT_RE='\bgit([[:space:]]+(-[A-Za-z][^[:space:]]*|--[A-Za-z][A-Za-z0-9-]*(=[^[:space:]]+)?)([[:space:]]+[^-[:space:]][^[:space:]]*)?)*[[:space:]]+commit\b'

--- a/scripts/sync-cc-plugin.sh
+++ b/scripts/sync-cc-plugin.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# One-way sync: top-level sources → the Claude Code plugin (plugins-cc/agentkit).
+# The generic units (hooks/claude, skills) are the source of truth (ADR #45);
+# the plugin wraps them for one-step install. Run after changing either source
+# tree and commit the result — the plugin must never be edited directly.
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PLUGIN_DIR="$REPO_DIR/plugins-cc/agentkit"
+
+# Hooks: copy scripts only — hooks.json (the plugin's wiring) is plugin-owned.
+for hook in "$REPO_DIR"/hooks/claude/*.sh; do
+	cp "$hook" "$PLUGIN_DIR/hooks/$(basename "$hook")"
+done
+echo "[sync] hooks/claude/*.sh -> plugins-cc/agentkit/hooks/"
+
+# Skills: full mirror — remove skills that no longer exist at top level.
+for plugin_skill in "$PLUGIN_DIR"/skills/*/; do
+	name="$(basename "$plugin_skill")"
+	if [[ ! -d "$REPO_DIR/skills/$name" ]]; then
+		echo "[sync] removing dropped skill: $name"
+		rm -rf "$plugin_skill"
+	fi
+done
+for skill in "$REPO_DIR"/skills/*/; do
+	name="$(basename "$skill")"
+	rm -rf "$PLUGIN_DIR/skills/$name"
+	cp -r "$skill" "$PLUGIN_DIR/skills/$name"
+done
+echo "[sync] skills/* -> plugins-cc/agentkit/skills/"
+
+# Fail loudly if the result is an invalid plugin (best-effort: needs claude CLI).
+if command -v claude &>/dev/null; then
+	claude plugin validate "$PLUGIN_DIR" && echo "[sync] plugin manifest valid"
+fi
+
+if ! git -C "$REPO_DIR" diff --quiet -- plugins-cc/agentkit; then
+	echo "[sync] plugin updated — review and commit the changes"
+else
+	echo "[sync] plugin already in sync"
+fi


### PR DESCRIPTION
Refs #57

- **Claude Code skills**: install_skills now also targets ~/.claude/skills (global) and .claude/skills (project) — previously skills only reached OpenCode.
- **Codex skills-as-prompts**: new install_codex_skills writes each SKILL.md (frontmatter stripped) to ~/.codex/prompts/<name>.md, invocable as /<name>.
- **Plugin mode**: opt-in `--global --claude-plugin` registers the repo as a marketplace and installs agentkit@agentkit INSTEAD of the manual CC copy — mutually exclusive by design (plugin hooks.json + settings.json hooks would fire every hook twice); warns about leftover manual hooks/skills, never edits user settings. Falls back to manual install when the claude CLI is missing.
- **scripts/sync-cc-plugin.sh**: one-way sync (hooks/claude, skills → plugins-cc/agentkit) with claude plugin validate; run here to heal existing drift — the plugin's git-police.sh was missing rule 4b entirely (+39 lines).

Verified by running `./install.sh --global`: all 9 skills in ~/.claude/skills (loaded live in a session), ~/.codex/prompts populated with clean markdown, settings.json still valid with 4 PreToolUse hooks, plugin manifest validation passing.