### PR TITLE
feat(police): inline user-approved overrides

### DIFF
--- a/hooks/claude/pkg-police.sh
+++ b/hooks/claude/pkg-police.sh
@@ -9,6 +9,16 @@ COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 
 [[ -z "$COMMAND" ]] && exit 0
 
+# User-approved escape hatch for tools that only work with npm/yarn/pnpm.
+# Works from the environment or inline (`AGENTKIT_ALLOW_PKG=1 npm ci`) —
+# inline assignments never reach the hook process, so honor them from the
+# text (same treatment as AGENTKIT_ALLOW_STALE_PUSH in git-police).
+PKG_OK="${AGENTKIT_ALLOW_PKG:-0}"
+if echo "$COMMAND" | grep -qE '(^|[[:space:];&|])AGENTKIT_ALLOW_PKG=1([[:space:];&|]|$)'; then
+  PKG_OK=1
+fi
+[[ "$PKG_OK" == "1" ]] && exit 0
+
 deny() {
   local reason="$1"
   jq -n --arg r "$reason" '{
@@ -24,22 +34,22 @@ deny() {
 # Check for npm commands (install, run, test, exec, create, init, publish, ci)
 if echo "$COMMAND" | grep -qiE '\bnpm\s+(install|i|ci|run|test|init|publish|exec|create)\b'; then
   SUBCMD=$(echo "$COMMAND" | grep -oiE '\bnpm\s+\w+' | head -1)
-  deny "BLOCKED: '${SUBCMD}' is not allowed. Use bun instead. Mapping: npm install → bun install, npm run → bun run, npm test → bun test, npm init → bun init, npx → bunx. Override: user explicitly requests npm."
+  deny "BLOCKED: '${SUBCMD}' is not allowed. Use bun instead. Mapping: npm install → bun install, npm run → bun run, npm test → bun test, npm init → bun init, npx → bunx. Override (only when the user approves npm): prefix with AGENTKIT_ALLOW_PKG=1."
 fi
 
 # Check for npx
 if echo "$COMMAND" | grep -qiE '\bnpx\s+'; then
-  deny "BLOCKED: 'npx' is not allowed. Use 'bunx' instead. Example: npx tsc → bunx tsc. Override: user explicitly requests npx."
+  deny "BLOCKED: 'npx' is not allowed. Use 'bunx' instead. Example: npx tsc → bunx tsc. Override (only when the user approves npx): prefix with AGENTKIT_ALLOW_PKG=1."
 fi
 
 # Check for yarn
 if echo "$COMMAND" | grep -qiE '\byarn(\s+|$)'; then
-  deny "BLOCKED: 'yarn' is not allowed. Use bun instead. Mapping: yarn → bun install, yarn add → bun add, yarn run → bun run. Override: user explicitly requests yarn."
+  deny "BLOCKED: 'yarn' is not allowed. Use bun instead. Mapping: yarn → bun install, yarn add → bun add, yarn run → bun run. Override (only when the user approves yarn): prefix with AGENTKIT_ALLOW_PKG=1."
 fi
 
 # Check for pnpm
 if echo "$COMMAND" | grep -qiE '\bpnpm(\s+|$)'; then
-  deny "BLOCKED: 'pnpm' is not allowed. Use bun instead. Mapping: pnpm install → bun install, pnpm add → bun add, pnpm run → bun run. Override: user explicitly requests pnpm."
+  deny "BLOCKED: 'pnpm' is not allowed. Use bun instead. Mapping: pnpm install → bun install, pnpm add → bun add, pnpm run → bun run. Override (only when the user approves pnpm): prefix with AGENTKIT_ALLOW_PKG=1."
 fi
 
 exit 0

--- a/hooks/claude/resource-police.sh
+++ b/hooks/claude/resource-police.sh
@@ -9,6 +9,17 @@ INPUT=$("$CAT_BIN")
 COMMAND=$(printf '%s' "$INPUT" | "$JQ_BIN" -r '.tool_input.command // empty')
 [[ -z "$COMMAND" ]] && exit 0
 
+# User-approved escape hatch for sanctioned delegated workloads (e.g. an
+# approved ansible apply). Heavy commands stay bounded regardless. Works from
+# the environment or inline (`AGENTKIT_ALLOW_DELEGATED=1 ansible-playbook …`);
+# inline assignments never reach the hook process, so honor them from the text
+# (same treatment as AGENTKIT_ALLOW_STALE_PUSH in git-police).
+DELEGATED_OK="${AGENTKIT_ALLOW_DELEGATED:-0}"
+if printf '%s' "$COMMAND" \
+	| grep -qE '(^|[[:space:];&|])AGENTKIT_ALLOW_DELEGATED=1([[:space:];&|]|$)'; then
+	DELEGATED_OK=1
+fi
+
 deny() {
 	local segment="$1"
 	local kind="${2:-heavy}"
@@ -20,7 +31,7 @@ deny() {
 		runner_hint="$PWD/.claude/tools/agentkit-run"
 	fi
 	if [[ "$kind" == delegated ]]; then
-		reason="BLOCKED: delegated workload cannot be contained by agentkit-run: $segment. Use a separately approved dedicated runner or verified engine-native limits."
+		reason="BLOCKED: delegated workload cannot be contained by agentkit-run: $segment. Use a separately approved dedicated runner or verified engine-native limits. User-approved delegated workloads: prefix with AGENTKIT_ALLOW_DELEGATED=1."
 	else
 		reason="BLOCKED: resource-intensive command is not contained: $segment. Run it through $runner_hint, for example: $runner_hint --profile compile -- bun run typecheck. Use profile browser for Playwright and browser builds."
 	fi
@@ -265,7 +276,9 @@ analyze_command() {
 			if ! is_trusted_runner; then deny "$segment" delegated; fi
 			if parse_wrapped_launch; then
 				unwrap_environment
-				if is_delegating; then deny "$segment" delegated; fi
+				if is_delegating && [[ "$DELEGATED_OK" != 1 ]]; then
+					deny "$segment" delegated
+				fi
 			fi
 			continue
 		fi
@@ -273,7 +286,9 @@ analyze_command() {
 			analyze_command "$PAYLOAD" $((depth + 1))
 			continue
 		fi
-		if is_delegating; then deny "$segment" delegated; fi
+		if is_delegating && [[ "$DELEGATED_OK" != 1 ]]; then
+			deny "$segment" delegated
+		fi
 		if is_heavy; then deny "$segment"; fi
 	done <<<"$segments"
 }

--- a/plugins-cc/agentkit/hooks/pkg-police.sh
+++ b/plugins-cc/agentkit/hooks/pkg-police.sh
@@ -9,6 +9,16 @@ COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 
 [[ -z "$COMMAND" ]] && exit 0
 
+# User-approved escape hatch for tools that only work with npm/yarn/pnpm.
+# Works from the environment or inline (`AGENTKIT_ALLOW_PKG=1 npm ci`) —
+# inline assignments never reach the hook process, so honor them from the
+# text (same treatment as AGENTKIT_ALLOW_STALE_PUSH in git-police).
+PKG_OK="${AGENTKIT_ALLOW_PKG:-0}"
+if echo "$COMMAND" | grep -qE '(^|[[:space:];&|])AGENTKIT_ALLOW_PKG=1([[:space:];&|]|$)'; then
+  PKG_OK=1
+fi
+[[ "$PKG_OK" == "1" ]] && exit 0
+
 deny() {
   local reason="$1"
   jq -n --arg r "$reason" '{
@@ -24,22 +34,22 @@ deny() {
 # Check for npm commands (install, run, test, exec, create, init, publish, ci)
 if echo "$COMMAND" | grep -qiE '\bnpm\s+(install|i|ci|run|test|init|publish|exec|create)\b'; then
   SUBCMD=$(echo "$COMMAND" | grep -oiE '\bnpm\s+\w+' | head -1)
-  deny "BLOCKED: '${SUBCMD}' is not allowed. Use bun instead. Mapping: npm install → bun install, npm run → bun run, npm test → bun test, npm init → bun init, npx → bunx. Override: user explicitly requests npm."
+  deny "BLOCKED: '${SUBCMD}' is not allowed. Use bun instead. Mapping: npm install → bun install, npm run → bun run, npm test → bun test, npm init → bun init, npx → bunx. Override (only when the user approves npm): prefix with AGENTKIT_ALLOW_PKG=1."
 fi
 
 # Check for npx
 if echo "$COMMAND" | grep -qiE '\bnpx\s+'; then
-  deny "BLOCKED: 'npx' is not allowed. Use 'bunx' instead. Example: npx tsc → bunx tsc. Override: user explicitly requests npx."
+  deny "BLOCKED: 'npx' is not allowed. Use 'bunx' instead. Example: npx tsc → bunx tsc. Override (only when the user approves npx): prefix with AGENTKIT_ALLOW_PKG=1."
 fi
 
 # Check for yarn
 if echo "$COMMAND" | grep -qiE '\byarn(\s+|$)'; then
-  deny "BLOCKED: 'yarn' is not allowed. Use bun instead. Mapping: yarn → bun install, yarn add → bun add, yarn run → bun run. Override: user explicitly requests yarn."
+  deny "BLOCKED: 'yarn' is not allowed. Use bun instead. Mapping: yarn → bun install, yarn add → bun add, yarn run → bun run. Override (only when the user approves yarn): prefix with AGENTKIT_ALLOW_PKG=1."
 fi
 
 # Check for pnpm
 if echo "$COMMAND" | grep -qiE '\bpnpm(\s+|$)'; then
-  deny "BLOCKED: 'pnpm' is not allowed. Use bun instead. Mapping: pnpm install → bun install, pnpm add → bun add, pnpm run → bun run. Override: user explicitly requests pnpm."
+  deny "BLOCKED: 'pnpm' is not allowed. Use bun instead. Mapping: pnpm install → bun install, pnpm add → bun add, pnpm run → bun run. Override (only when the user approves pnpm): prefix with AGENTKIT_ALLOW_PKG=1."
 fi
 
 exit 0

--- a/plugins-cc/agentkit/hooks/resource-police.sh
+++ b/plugins-cc/agentkit/hooks/resource-police.sh
@@ -9,6 +9,17 @@ INPUT=$("$CAT_BIN")
 COMMAND=$(printf '%s' "$INPUT" | "$JQ_BIN" -r '.tool_input.command // empty')
 [[ -z "$COMMAND" ]] && exit 0
 
+# User-approved escape hatch for sanctioned delegated workloads (e.g. an
+# approved ansible apply). Heavy commands stay bounded regardless. Works from
+# the environment or inline (`AGENTKIT_ALLOW_DELEGATED=1 ansible-playbook …`);
+# inline assignments never reach the hook process, so honor them from the text
+# (same treatment as AGENTKIT_ALLOW_STALE_PUSH in git-police).
+DELEGATED_OK="${AGENTKIT_ALLOW_DELEGATED:-0}"
+if printf '%s' "$COMMAND" \
+	| grep -qE '(^|[[:space:];&|])AGENTKIT_ALLOW_DELEGATED=1([[:space:];&|]|$)'; then
+	DELEGATED_OK=1
+fi
+
 deny() {
 	local segment="$1"
 	local kind="${2:-heavy}"
@@ -20,7 +31,7 @@ deny() {
 		runner_hint="$PWD/.claude/tools/agentkit-run"
 	fi
 	if [[ "$kind" == delegated ]]; then
-		reason="BLOCKED: delegated workload cannot be contained by agentkit-run: $segment. Use a separately approved dedicated runner or verified engine-native limits."
+		reason="BLOCKED: delegated workload cannot be contained by agentkit-run: $segment. Use a separately approved dedicated runner or verified engine-native limits. User-approved delegated workloads: prefix with AGENTKIT_ALLOW_DELEGATED=1."
 	else
 		reason="BLOCKED: resource-intensive command is not contained: $segment. Run it through $runner_hint, for example: $runner_hint --profile compile -- bun run typecheck. Use profile browser for Playwright and browser builds."
 	fi
@@ -265,7 +276,9 @@ analyze_command() {
 			if ! is_trusted_runner; then deny "$segment" delegated; fi
 			if parse_wrapped_launch; then
 				unwrap_environment
-				if is_delegating; then deny "$segment" delegated; fi
+				if is_delegating && [[ "$DELEGATED_OK" != 1 ]]; then
+					deny "$segment" delegated
+				fi
 			fi
 			continue
 		fi
@@ -273,7 +286,9 @@ analyze_command() {
 			analyze_command "$PAYLOAD" $((depth + 1))
 			continue
 		fi
-		if is_delegating; then deny "$segment" delegated; fi
+		if is_delegating && [[ "$DELEGATED_OK" != 1 ]]; then
+			deny "$segment" delegated
+		fi
 		if is_heavy; then deny "$segment"; fi
 	done <<<"$segments"
 }

--- a/plugins/pkg-police.ts
+++ b/plugins/pkg-police.ts
@@ -57,12 +57,17 @@ function detectBlockedPkgManager(command: string): string | null {
         `  npx <cmd>                          →  bunx <cmd>\n` +
         `  npm test                           →  bun test\n` +
         `\n` +
-        `Override: set pkg-police.enabled: false in agentkit config,\n` +
-        `or user explicitly requests a different package manager.`
+        `Override: prefix with AGENTKIT_ALLOW_PKG=1 (only when the user\n` +
+        `approves it), or set pkg-police.enabled: false in agentkit config.`
       );
     }
   }
   return null;
+}
+
+function isPkgOverride(command: string): boolean {
+  return process.env.AGENTKIT_ALLOW_PKG === '1'
+    || /(^|[\s;&|])AGENTKIT_ALLOW_PKG=1([\s;&|]|$)/.test(command);
 }
 
 export default async function pkgPolice(_ctx: PluginInput) {
@@ -77,6 +82,7 @@ export default async function pkgPolice(_ctx: PluginInput) {
 
       const command = output.args.command as string | undefined;
       if (!command) return;
+      if (isPkgOverride(command)) return;
 
       const error = detectBlockedPkgManager(command);
       if (error) {

--- a/plugins/resource-police.ts
+++ b/plugins/resource-police.ts
@@ -213,7 +213,11 @@ function wrappedLaunch(launch: Launch): Launch | null {
   };
 }
 
-function detectUnboundedCommand(command: string, depth = 0): Finding | null {
+function detectUnboundedCommand(
+  command: string,
+  depth = 0,
+  delegatedOk = false,
+): Finding | null {
   if (depth > 3) return { segment: command, delegated: false };
   for (const segment of splitShellSegments(command)) {
     const launch = parseLaunch(segment);
@@ -221,21 +225,26 @@ function detectUnboundedCommand(command: string, depth = 0): Finding | null {
     if (launch.executable === 'agentkit-run') {
       if (!isTrustedRunner(launch.token)) return { segment, delegated: true };
       const nested = wrappedLaunch(launch);
-      if (nested && isDelegating(nested)) return { segment, delegated: true };
+      if (nested && !delegatedOk && isDelegating(nested)) return { segment, delegated: true };
       continue;
     }
     if (isShell(launch.executable)) {
       const payload = shellCommandPayload(launch);
       if (payload !== null) {
-        const finding = detectUnboundedCommand(payload, depth + 1);
+        const finding = detectUnboundedCommand(payload, depth + 1, delegatedOk);
         if (finding) return finding;
         continue;
       }
     }
-    if (isDelegating(launch)) return { segment, delegated: true };
+    if (!delegatedOk && isDelegating(launch)) return { segment, delegated: true };
     if (isHeavy(launch)) return { segment, delegated: false };
   }
   return null;
+}
+
+function isDelegatedOverride(command: string): boolean {
+  return process.env.AGENTKIT_ALLOW_DELEGATED === '1'
+    || /(^|[\s;&|])AGENTKIT_ALLOW_DELEGATED=1([\s;&|]|$)/.test(command);
 }
 
 function isTrustedRunner(token: string): boolean {
@@ -257,12 +266,13 @@ export default async function resourcePolice(_ctx: PluginInput) {
       if (input.tool?.toLowerCase() !== 'bash') return;
       const command = output.args.command as string | undefined;
       if (!command) return;
-      const finding = detectUnboundedCommand(command);
+      const finding = detectUnboundedCommand(command, 0, isDelegatedOverride(command));
       if (!finding) return;
       if (finding.delegated) {
         throw new Error(
           `BLOCKED: delegated workload cannot be contained by agentkit-run: ${finding.segment}\n` +
-            'Use a separately approved dedicated runner or verified engine-native limits.',
+            'Use a separately approved dedicated runner or verified engine-native limits.\n' +
+            'User-approved delegated workloads: prefix with AGENTKIT_ALLOW_DELEGATED=1.',
         );
       }
       throw new Error(

--- a/tests/fixtures/resource-commands.ts
+++ b/tests/fixtures/resource-commands.ts
@@ -31,6 +31,7 @@ export const blockedResourceCommands = [
   'python -m pytest -q',
   "bash -c 'bun install'",
   "sh -lc 'cargo test'",
+  'AGENTKIT_ALLOW_DELEGATED=1 bun install',
   '/usr/bin/env CI=1 bun test',
   'sudo -n cargo test',
   'time bun run typecheck',
@@ -58,6 +59,7 @@ export const unsupportedResourceCommands = [
   "agentkit-run --profile compile -- env CI=1 sh -c 'bun test'",
   "bash -c 'ssh build-host bun test'",
   "bash -xc 'systemd-run --user cargo test'",
+  'ansible-playbook playbooks/server.yml --check --diff',
 ];
 
 export const allowedResourceCommands = [
@@ -79,6 +81,7 @@ export const allowedResourceCommands = [
   'systemctl show code-server.service',
   'systemctl --user cat agent-work.slice',
   'systemctl --user is-active agent-work.slice',
+  'AGENTKIT_ALLOW_DELEGATED=1 ansible-playbook playbooks/server.yml --check --diff',
   'kubectl get pods -A',
   'kubectl logs deploy/cloudflared -n infra',
   'docker ps',

--- a/tests/pkg-police.test.ts
+++ b/tests/pkg-police.test.ts
@@ -1,0 +1,70 @@
+import { beforeAll, describe, expect, test } from 'bun:test';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import pkgPolice from '../plugins/pkg-police';
+
+const repoRoot = dirname(import.meta.dir);
+const hook = join(repoRoot, 'hooks', 'claude', 'pkg-police.sh');
+const mockCtx = {
+  client: {},
+  project: {},
+  directory: '/tmp',
+  worktree: '/tmp',
+  serverUrl: new URL('http://localhost'),
+  $: {},
+} as any;
+
+function makeInput(command: string) {
+  return {
+    input: { tool: 'bash', sessionID: 'test', callID: 'test' },
+    output: { args: { command } },
+  };
+}
+
+function runHook(command: string, env: Record<string, string> = {}): string {
+  const input = JSON.stringify({ tool_input: { command } });
+  return spawnSync('bash', [hook], {
+    input,
+    encoding: 'utf-8',
+    env: { ...process.env, AGENTKIT_ALLOW_PKG: '', ...env },
+  }).stdout ?? '';
+}
+
+beforeAll(() => {
+  // Point the plugin's config lookup at an empty dir so a developer's local
+  // pkg-police.enabled=false cannot flip the blocked-case expectations.
+  process.env.XDG_CONFIG_HOME = mkdtempSync(join(tmpdir(), 'pkg-police-test-'));
+  delete process.env.AGENTKIT_ALLOW_PKG;
+});
+
+describe('Claude pkg-police override', () => {
+  test('denies package managers without the override', () => {
+    expect(runHook('npm ci')).toContain('"permissionDecision": "deny"');
+    expect(runHook('yarn build')).toContain('"permissionDecision": "deny"');
+  });
+
+  test('inline AGENTKIT_ALLOW_PKG=1 allows the command', () => {
+    expect(runHook('AGENTKIT_ALLOW_PKG=1 npm ci')).not.toContain('deny');
+    expect(runHook('AGENTKIT_ALLOW_PKG=1 yarn build')).not.toContain('deny');
+  });
+
+  test('environment AGENTKIT_ALLOW_PKG=1 allows the command', () => {
+    expect(runHook('npm ci', { AGENTKIT_ALLOW_PKG: '1' })).not.toContain('deny');
+  });
+
+  test('unrelated assignments do not unlock the override', () => {
+    expect(runHook('AGENTKIT_ALLOW_PKG=10 npm ci')).toContain('"permissionDecision": "deny"');
+  });
+});
+
+describe('OpenCode pkg-police override', () => {
+  test('denies without and allows with the inline override', async () => {
+    const hooks = await pkgPolice(mockCtx);
+    const blocked = makeInput('npm ci');
+    expect(hooks['tool.execute.before']!(blocked.input, blocked.output)).rejects.toThrow('bun');
+    const allowed = makeInput('AGENTKIT_ALLOW_PKG=1 npm ci');
+    expect(hooks['tool.execute.before']!(allowed.input, allowed.output)).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- `AGENTKIT_ALLOW_PKG=1 npm ci` — pkg-police's deny text claimed an override existed but none did; this adds the mechanical one (inline or env), for tools that only work with npm/yarn/pnpm. Only to be used on explicit user approval.
- `AGENTKIT_ALLOW_DELEGATED=1 ansible-playbook …` — resource-police blanket-denied sanctioned infra applies with no escape hatch (hit live during an approved deploy). Delegated denials honor the override; **heavy commands stay bounded regardless** (`AGENTKIT_ALLOW_DELEGATED=1 bun install` still denies).
- Same inline-text convention as git-police's `AGENTKIT_ALLOW_STALE_PUSH` (inline assignments never reach the hook process). Codex prefix rules cannot express this; unchanged.
- Bonus false-positive fixed by shipping this: the old pkg-police denied any command whose *text* mentioned a package manager (e.g. a commit message documenting one).

## Validation

- 325 tests pass, 0 fail — new behavioral suite for pkg-police (both engines, inline + env + near-miss `=10` case) and override fixtures for resource-police
- Hook mirrors byte-identical
