### PR TITLE
feat!: rename agentkit-run to bounded-run

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "agentkit",
       "source": "./plugins-cc/agentkit",
-      "description": "Claude Code bundle with enforcement hooks, skills, tools/agentkit-run, and the assay + infra-tools MCP toolchains. Requires jq, bun, assay, cgroup v2, a systemd user manager, and a provisioned agent-work.slice.",
+      "description": "Claude Code bundle with enforcement hooks, skills, tools/bounded-run, and the assay + infra-tools MCP toolchains. Requires jq, bun, assay, cgroup v2, a systemd user manager, and a provisioned agent-work.slice.",
       "version": "0.2.0"
     },
     {

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Reusable AI agent skills, rules, plugins, hooks, and tools for OpenCode, Claude 
 | **format-police.sh**   | PostToolUse       | Auto-formats files after edit/write using dprint                                                                                                                           |
 | **coding-police.sh**   | PostToolUse       | Enforces DRY code, modular files (<1000 lines), short functions, single responsibility                                                                                     |
 | **pkg-police.sh**      | PreToolUse        | Enforces bun as package manager — blocks npm, npx, yarn, pnpm commands                                                                                                     |
-| **resource-police.sh** | PreToolUse        | Requires `agentkit-run` for heavy commands and blocks cgroup delegation escapes                                                                                            |
+| **resource-police.sh** | PreToolUse        | Requires `bounded-run` for heavy commands and blocks cgroup delegation escapes                                                                                            |
 | **chime.sh**           | Notification/Stop | Audible nudge when Claude needs you: springy boing on permission prompts/questions, soft ping when a turn finishes. Mute: `touch ~/.claude/.chime-off` or `CLAUDE_CHIME=0` |
 | **mr-police.sh**       | PreToolUse        | Blocks opening a new MR while you already have an open MR you authored on the repo — stops unmerged MRs from stacking up                                                   |
 
@@ -96,7 +96,7 @@ claude plugin install infra-tools
 
 | Plugin          | Provides                                                                                                                                                                                                                                                                                                 | Source                                                                                        |
 | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| **agentkit**    | Claude bundle: enforcement police hooks, skills, `tools/agentkit-run`, and both MCP toolchains. Needs `jq`, `bun`, `assay`, cgroup v2, a systemd user manager, and a provisioned `agent-work.slice`.                                                                                                     | local `plugins-cc/agentkit/`                                                                  |
+| **agentkit**    | Claude bundle: enforcement police hooks, skills, `tools/bounded-run`, and both MCP toolchains. Needs `jq`, `bun`, `assay`, cgroup v2, a systemd user manager, and a provisioned `agent-work.slice`.                                                                                                     | local `plugins-cc/agentkit/`                                                                  |
 | **assay**       | Gated Lua infra toolkit (`assay_run` + `assay_context`) — Kubernetes, ArgoCD, Vault, Prometheus, GitLab, AWS, … through one read-only/approval-gated tool. Requires the `assay` binary on PATH.                                                                                                          | vendored from [developerinlondon/assay](https://github.com/developerinlondon/assay) `plugin/` |
 | **infra-tools** | Read-only helm / tofu / git tools (`helm_template`/`helm_list`/`helm_get_values`, `tofu_plan`/`tofu_show`/`tofu_state_list`, `git_log`/`git_diff`/`git_status`/`git_clone_ro`) as a typed MCP server — render charts, preview plans, read git history. Never applies or mutates. Requires `bun` on PATH. | local `plugins-cc/infra-tools/`                                                               |
 
@@ -160,13 +160,14 @@ Global installs place tools on `~/.local/bin/` and preserve a mirror in `~/.clau
 
 | Tool                   | Description                                                                          |
 | ---------------------- | ------------------------------------------------------------------------------------ |
-| **agentkit-run**       | Runs one direct-argv workload in the bounded `agent-work.slice` systemd user service |
+| **bounded-run**       | Runs one direct-argv workload in the bounded `agent-work.slice` systemd user service |
 | **fix-ascii-boxes.py** | Fixes ASCII box-drawing alignment in markdown files, handles nested boxes inside-out |
 
-`agentkit-run` fails closed unless the aggregate slice matches its expected limits (default
+`bounded-run` fails closed unless the aggregate slice matches its expected limits (default
 20G/24G memory high/max, 800% CPU, 1536 tasks; hosts sized differently pin their values in
 root-owned `/etc/agentkit/resource-guard.conf`), cgroup v2 is available, and host headroom
-checks pass. Its profiles are fixed and tested together with the host configuration:
+checks pass. Its profiles are fixed and tested together with the host configuration
+(`agentkit-run` remains as a compat symlink from the tool's previous name):
 
 | Profile   | Memory high/max | CPU | Tasks | Command timeout |
 | --------- | --------------- | --- | ----- | --------------- |
@@ -178,9 +179,9 @@ checks pass. Its profiles are fixed and tested together with the host configurat
 Container engines, direct `systemd-run`, and remote execution are not supported containment
 targets because they can delegate work outside the transient cgroup.
 
-Project-only installs expose the runner as `./.claude/tools/agentkit-run`. The Claude plugin bundles
-it at `$CLAUDE_PLUGIN_ROOT/tools/agentkit-run`, and its hook reports that resolved path when denying
-an unbounded command. Global installs expose `agentkit-run` through `~/.local/bin`.
+Project-only installs expose the runner as `./.claude/tools/bounded-run`. The Claude plugin bundles
+it at `$CLAUDE_PLUGIN_ROOT/tools/bounded-run`, and its hook reports that resolved path when denying
+an unbounded command. Global installs expose `bounded-run` through `~/.local/bin`.
 
 ## Configuration
 

--- a/hooks/claude/resource-police.sh
+++ b/hooks/claude/resource-police.sh
@@ -24,14 +24,14 @@ deny() {
 	local segment="$1"
 	local kind="${2:-heavy}"
 	local reason
-	local runner_hint=agentkit-run
-	if [[ -n "${CLAUDE_PLUGIN_ROOT:-}" && -x "$CLAUDE_PLUGIN_ROOT/tools/agentkit-run" ]]; then
-		runner_hint="$CLAUDE_PLUGIN_ROOT/tools/agentkit-run"
-	elif [[ -x "$PWD/.claude/tools/agentkit-run" ]]; then
-		runner_hint="$PWD/.claude/tools/agentkit-run"
+	local runner_hint=bounded-run
+	if [[ -n "${CLAUDE_PLUGIN_ROOT:-}" && -x "$CLAUDE_PLUGIN_ROOT/tools/bounded-run" ]]; then
+		runner_hint="$CLAUDE_PLUGIN_ROOT/tools/bounded-run"
+	elif [[ -x "$PWD/.claude/tools/bounded-run" ]]; then
+		runner_hint="$PWD/.claude/tools/bounded-run"
 	fi
 	if [[ "$kind" == delegated ]]; then
-		reason="BLOCKED: delegated workload cannot be contained by agentkit-run: $segment. Use a separately approved dedicated runner or verified engine-native limits. User-approved delegated workloads: prefix with AGENTKIT_ALLOW_DELEGATED=1."
+		reason="BLOCKED: delegated workload cannot be contained by bounded-run: $segment. Use a separately approved dedicated runner or verified engine-native limits. User-approved delegated workloads: prefix with AGENTKIT_ALLOW_DELEGATED=1."
 	else
 		reason="BLOCKED: resource-intensive command is not contained: $segment. Run it through $runner_hint, for example: $runner_hint --profile compile -- bun run typecheck. Use profile browser for Playwright and browser builds."
 	fi
@@ -228,10 +228,15 @@ is_read_only_diagnostic() {
 }
 
 is_trusted_runner() {
+	# agentkit-run is the pre-rename compat alias installed as a symlink.
 	case "$EXECUTABLE_TOKEN" in
+	bounded-run | '$HOME/.local/bin/bounded-run' | '~/.local/bin/bounded-run' | ./.claude/tools/bounded-run)
+		return 0
+		;;
 	agentkit-run | '$HOME/.local/bin/agentkit-run' | '~/.local/bin/agentkit-run' | ./.claude/tools/agentkit-run)
 		return 0
 		;;
+	/home/*/.local/bin/bounded-run | */plugins/*/tools/bounded-run) return 0 ;;
 	/home/*/.local/bin/agentkit-run | */plugins/*/tools/agentkit-run) return 0 ;;
 	*) return 1 ;;
 	esac
@@ -272,7 +277,7 @@ analyze_command() {
 	while IFS= read -r segment; do
 		[[ -n "$segment" ]] || continue
 		parse_launch "$segment"
-		if [[ "$EXECUTABLE" == agentkit-run ]]; then
+		if [[ "$EXECUTABLE" == bounded-run || "$EXECUTABLE" == agentkit-run ]]; then
 			if ! is_trusted_runner; then deny "$segment" delegated; fi
 			if parse_wrapped_launch; then
 				unwrap_environment

--- a/install.sh
+++ b/install.sh
@@ -558,6 +558,11 @@ install_tools() {
 		cp "$tool_file" "$tools_dir/$name"
 		chmod +x "$tools_dir/$name"
 	done
+
+	# Compat alias: bounded-run was previously named agentkit-run.
+	if [[ -f "$tools_dir/bounded-run" ]]; then
+		ln -sf bounded-run "$tools_dir/agentkit-run"
+	fi
 }
 
 # ─── Codex CLI: Starlark .rules Files ────────────────────────────────────────

--- a/instructions/resource-safety.md
+++ b/instructions/resource-safety.md
@@ -3,22 +3,22 @@
 # Resource-safe Execution
 
 Never run resource-intensive developer commands directly on a shared or production-adjacent host.
-Use `agentkit-run` for dependency changes, compilers, typechecks, builds, linters, test suites,
+Use `bounded-run` for dependency changes, compilers, typechecks, builds, linters, test suites,
 browser automation, code generation, Cargo, Go, and pytest.
 
-- Start unfamiliar tools and new toolchain versions with `agentkit-run --profile canary -- ...`.
+- Start unfamiliar tools and new toolchain versions with `bounded-run --profile canary -- ...`.
 - Use `compile` for established compilers and builds, `browser` for Playwright, and `default` for
   established test suites.
 - Pass direct argv after `--`; do not use `eval` or put credentials in command arguments.
 - Treat timeout, OOM, high load, memory pressure, or a missing aggregate slice as a failed safety
   gate. Stop and diagnose within the existing boundary; never fall back to an unbounded command.
 - Run only one heavy workload at a time. Verify host and service health before and after it.
-- Never use `agentkit-run` for delegated workloads such as `docker`, `podman`, `systemd-run`, remote
+- Never use `bounded-run` for delegated workloads such as `docker`, `podman`, `systemd-run`, remote
   execution, or container execution. The child work can escape its cgroup. Use a separately approved
   dedicated runner or verified native limits.
 - Treat shell hooks and Codex prefix policies as defense-in-depth detection, not a hostile-code
   sandbox. Arbitrary scripts can deliberately delegate through APIs or sockets. The deterministic
-  connectivity boundary combines `agentkit-run` and its aggregate slice with
+  connectivity boundary combines `bounded-run` and its aggregate slice with
   host service resource limits that reserve capacity for the agent host and ingress path.
 - Do not restart or reconfigure live services, Cloudflare tunnels, ingress, Kubernetes, networking,
   or remote access as part of a dependency or build workflow. Handle production infrastructure as a

--- a/plugins-cc/agentkit/hooks/resource-police.sh
+++ b/plugins-cc/agentkit/hooks/resource-police.sh
@@ -24,14 +24,14 @@ deny() {
 	local segment="$1"
 	local kind="${2:-heavy}"
 	local reason
-	local runner_hint=agentkit-run
-	if [[ -n "${CLAUDE_PLUGIN_ROOT:-}" && -x "$CLAUDE_PLUGIN_ROOT/tools/agentkit-run" ]]; then
-		runner_hint="$CLAUDE_PLUGIN_ROOT/tools/agentkit-run"
-	elif [[ -x "$PWD/.claude/tools/agentkit-run" ]]; then
-		runner_hint="$PWD/.claude/tools/agentkit-run"
+	local runner_hint=bounded-run
+	if [[ -n "${CLAUDE_PLUGIN_ROOT:-}" && -x "$CLAUDE_PLUGIN_ROOT/tools/bounded-run" ]]; then
+		runner_hint="$CLAUDE_PLUGIN_ROOT/tools/bounded-run"
+	elif [[ -x "$PWD/.claude/tools/bounded-run" ]]; then
+		runner_hint="$PWD/.claude/tools/bounded-run"
 	fi
 	if [[ "$kind" == delegated ]]; then
-		reason="BLOCKED: delegated workload cannot be contained by agentkit-run: $segment. Use a separately approved dedicated runner or verified engine-native limits. User-approved delegated workloads: prefix with AGENTKIT_ALLOW_DELEGATED=1."
+		reason="BLOCKED: delegated workload cannot be contained by bounded-run: $segment. Use a separately approved dedicated runner or verified engine-native limits. User-approved delegated workloads: prefix with AGENTKIT_ALLOW_DELEGATED=1."
 	else
 		reason="BLOCKED: resource-intensive command is not contained: $segment. Run it through $runner_hint, for example: $runner_hint --profile compile -- bun run typecheck. Use profile browser for Playwright and browser builds."
 	fi
@@ -228,10 +228,15 @@ is_read_only_diagnostic() {
 }
 
 is_trusted_runner() {
+	# agentkit-run is the pre-rename compat alias installed as a symlink.
 	case "$EXECUTABLE_TOKEN" in
+	bounded-run | '$HOME/.local/bin/bounded-run' | '~/.local/bin/bounded-run' | ./.claude/tools/bounded-run)
+		return 0
+		;;
 	agentkit-run | '$HOME/.local/bin/agentkit-run' | '~/.local/bin/agentkit-run' | ./.claude/tools/agentkit-run)
 		return 0
 		;;
+	/home/*/.local/bin/bounded-run | */plugins/*/tools/bounded-run) return 0 ;;
 	/home/*/.local/bin/agentkit-run | */plugins/*/tools/agentkit-run) return 0 ;;
 	*) return 1 ;;
 	esac
@@ -272,7 +277,7 @@ analyze_command() {
 	while IFS= read -r segment; do
 		[[ -n "$segment" ]] || continue
 		parse_launch "$segment"
-		if [[ "$EXECUTABLE" == agentkit-run ]]; then
+		if [[ "$EXECUTABLE" == bounded-run || "$EXECUTABLE" == agentkit-run ]]; then
 			if ! is_trusted_runner; then deny "$segment" delegated; fi
 			if parse_wrapped_launch; then
 				unwrap_environment

--- a/plugins-cc/agentkit/skills/resource-safe-execution/SKILL.md
+++ b/plugins-cc/agentkit/skills/resource-safe-execution/SKILL.md
@@ -2,7 +2,7 @@
 name: resource-safe-execution
 description: >-
   Run resource-intensive developer commands inside deterministic systemd cgroup limits with
-  agentkit-run. Use for dependency installation or upgrades, compilers, typechecks, builds, test
+  bounded-run. Use for dependency installation or upgrades, compilers, typechecks, builds, test
   suites, linters, Playwright or browser work, code generation, Cargo, Go, and pytest, especially
   on shared or production-adjacent hosts where an unbounded process could
   disrupt Kubernetes, ingress, tunnels, or other services.
@@ -10,7 +10,7 @@ description: >-
 
 # Resource-safe Execution
 
-Use `agentkit-run` for every resource-intensive command. Never fall back to an unbounded command
+Use `bounded-run` for every resource-intensive command. Never fall back to an unbounded command
 when preflight or containment fails.
 
 ## Choose a profile
@@ -30,15 +30,16 @@ reproductions with `canary`. Increase only after the canary finishes cleanly.
 Pass the executable and arguments after `--`. Do not pass a shell string.
 
 ```bash
-agentkit-run --profile canary -- bunx tsc --noEmit --singleThreaded
-agentkit-run --profile compile -- bun run typecheck
-agentkit-run --profile browser -- bunx playwright test
-agentkit-run --profile default -- cargo test
+bounded-run --profile canary -- bunx tsc --noEmit --singleThreaded
+bounded-run --profile compile -- bun run typecheck
+bounded-run --profile browser -- bunx playwright test
+bounded-run --profile default -- cargo test
 ```
 
-For a project-only AgentKit install, invoke `./.claude/tools/agentkit-run`. The one-shot Claude
+For a project-only AgentKit install, invoke `./.claude/tools/bounded-run`. The one-shot Claude
 plugin bundles the runner and its denial message prints the resolved plugin-cache path. A global
-install places `agentkit-run` in `~/.local/bin`.
+install places `bounded-run` in `~/.local/bin`, with `agentkit-run` kept as a compat
+symlink from the tool's previous name.
 
 The runner preserves argv and the current directory, but exposes only a curated environment.
 Retrieve credentials at runtime through the project's approved secrets mechanism; never put secrets
@@ -53,7 +54,7 @@ in argv.
 5. Run the established profile repeatedly, then the remaining build and test gates.
 6. Confirm no child processes remain and live services stayed healthy.
 
-If `agentkit-run` reports a missing or misconfigured `agent-work.slice`, insufficient headroom,
+If `bounded-run` reports a missing or misconfigured `agent-work.slice`, insufficient headroom,
 high load, or memory pressure, stop. Propose the required infrastructure correction and wait for
 approval.
 

--- a/plugins-cc/agentkit/tools/bounded-run
+++ b/plugins-cc/agentkit/tools/bounded-run
@@ -23,17 +23,17 @@ readonly TIMEOUT_BIN=/usr/bin/timeout
 
 usage() {
 	cat <<'USAGE'
-Usage: agentkit-run [--profile canary|default|compile|browser] -- COMMAND [ARG...]
+Usage: bounded-run [--profile canary|default|compile|browser] -- COMMAND [ARG...]
 
 Run one resource-intensive command in a bounded systemd user service. The command
-is passed as argv without shell evaluation. Only one agentkit-run may run at once.
+is passed as argv without shell evaluation. Only one bounded-run may run at once.
 USAGE
 }
 
 die() {
 	local message="$1"
 	local status="${2:-$EX_UNAVAILABLE}"
-	printf 'agentkit-run: %s\n' "$message" >&2
+	printf 'bounded-run: %s\n' "$message" >&2
 	exit "$status"
 }
 
@@ -290,9 +290,9 @@ build_clean_environment() {
 reject_command_basename() {
 	local executable="$1"
 	case "$executable" in
-	agentkit-run) die 'nested agentkit-run commands are not allowed' "$EX_USAGE" ;;
+	agentkit-run | bounded-run) die 'nested bounded-run commands are not allowed' "$EX_USAGE" ;;
 	doas | env | pkexec | run0 | su | sudo)
-		die "$executable is not allowed inside agentkit-run" "$EX_USAGE"
+		die "$executable is not allowed inside bounded-run" "$EX_USAGE"
 		;;
 	ansible | ansible-playbook | buildah | docker | kubectl | machinectl | mosh | nerdctl | podman | service | ssh | systemctl | systemd-run)
 		die "$executable delegates work outside the service cgroup" "$EX_USAGE"
@@ -338,7 +338,7 @@ inspect_command_arguments() {
 }
 
 run_bounded() {
-	local unit="agentkit-run-${PROFILE}-$$"
+	local unit="bounded-run-${PROFILE}-$$"
 	local lock_file="$CONTROL_RUNTIME_DIR/$LOCK_NAME"
 	local status
 	set +e
@@ -383,7 +383,7 @@ declare EXPECTED_MEMORY_HIGH EXPECTED_MEMORY_MAX EXPECTED_MEMORY_SWAP_MAX EXPECT
 
 parse_args "$@"
 if [[ "${AGENTKIT_RUN_ACTIVE:-0}" == 1 ]]; then
-	die 'nested agentkit-run commands are not allowed' "$EX_USAGE"
+	die 'nested bounded-run commands are not allowed' "$EX_USAGE"
 fi
 verify_control_plane
 resolve_command

--- a/plugins/resource-police.ts
+++ b/plugins/resource-police.ts
@@ -222,7 +222,7 @@ function detectUnboundedCommand(
   for (const segment of splitShellSegments(command)) {
     const launch = parseLaunch(segment);
     if (!launch) continue;
-    if (launch.executable === 'agentkit-run') {
+    if (launch.executable === 'bounded-run' || launch.executable === 'agentkit-run') {
       if (!isTrustedRunner(launch.token)) return { segment, delegated: true };
       const nested = wrappedLaunch(launch);
       if (nested && !delegatedOk && isDelegating(nested)) return { segment, delegated: true };
@@ -248,13 +248,14 @@ function isDelegatedOverride(command: string): boolean {
 }
 
 function isTrustedRunner(token: string): boolean {
-  const normalized = token.replace(/['"]/g, '');
-  return normalized === 'agentkit-run'
-    || normalized === '$HOME/.local/bin/agentkit-run'
-    || normalized === '~/.local/bin/agentkit-run'
-    || normalized === './.claude/tools/agentkit-run'
-    || /^\/home\/[^/]+\/\.local\/bin\/agentkit-run$/.test(normalized)
-    || /\/plugins\/.*\/tools\/agentkit-run$/.test(normalized);
+  // agentkit-run is the pre-rename compat alias installed as a symlink.
+  const normalized = token.replace(/['"]/g, '').replace(/agentkit-run$/, 'bounded-run');
+  return normalized === 'bounded-run'
+    || normalized === '$HOME/.local/bin/bounded-run'
+    || normalized === '~/.local/bin/bounded-run'
+    || normalized === './.claude/tools/bounded-run'
+    || /^\/home\/[^/]+\/\.local\/bin\/bounded-run$/.test(normalized)
+    || /\/plugins\/.*\/tools\/bounded-run$/.test(normalized);
 }
 
 export default async function resourcePolice(_ctx: PluginInput) {
@@ -270,7 +271,7 @@ export default async function resourcePolice(_ctx: PluginInput) {
       if (!finding) return;
       if (finding.delegated) {
         throw new Error(
-          `BLOCKED: delegated workload cannot be contained by agentkit-run: ${finding.segment}\n` +
+          `BLOCKED: delegated workload cannot be contained by bounded-run: ${finding.segment}\n` +
             'Use a separately approved dedicated runner or verified engine-native limits.\n' +
             'User-approved delegated workloads: prefix with AGENTKIT_ALLOW_DELEGATED=1.',
         );
@@ -278,8 +279,8 @@ export default async function resourcePolice(_ctx: PluginInput) {
       throw new Error(
         `BLOCKED: resource-intensive command is not contained: ${finding.segment}\n` +
           'Run it through the installed runner, for example:\n' +
-          '  agentkit-run --profile compile -- bun run typecheck\n' +
-          '  ./.claude/tools/agentkit-run --profile compile -- bun run typecheck\n' +
+          '  bounded-run --profile compile -- bun run typecheck\n' +
+          '  ./.claude/tools/bounded-run --profile compile -- bun run typecheck\n' +
           'Use profile browser for Playwright and browser builds.',
       );
     },

--- a/policies/codex/resource-police.rules
+++ b/policies/codex/resource-police.rules
@@ -1,16 +1,22 @@
 # resource-police.rules — Codex CLI exec policy
-# Heavy commands must start with agentkit-run so systemd owns and limits the process tree.
+# Heavy commands must start with bounded-run so systemd owns and limits the process tree.
+
+prefix_rule(
+    pattern = ["bounded-run"],
+    decision = "allow",
+    justification = "bounded-run applies the mandatory cgroup, timeout, and process-tree boundary.",
+)
 
 prefix_rule(
     pattern = ["agentkit-run"],
     decision = "allow",
-    justification = "agentkit-run applies the mandatory cgroup, timeout, and process-tree boundary.",
+    justification = "Pre-rename compat alias for bounded-run (installed symlink).",
 )
 
 prefix_rule(
     pattern = ["bun", ["add", "install", "update", "test"]],
     decision = "forbidden",
-    justification = "Run package changes and test suites with agentkit-run.",
+    justification = "Run package changes and test suites with bounded-run.",
 )
 
 # Deliberately broader than the Claude hook: prefix rules cannot pattern-match
@@ -18,131 +24,131 @@ prefix_rule(
 prefix_rule(
     pattern = ["bun", "run"],
     decision = "forbidden",
-    justification = "Run build, check, lint, and test scripts with agentkit-run.",
+    justification = "Run build, check, lint, and test scripts with bounded-run.",
 )
 
 prefix_rule(
     pattern = [["npm", "pnpm"], ["add", "install", "i", "ci", "update", "upgrade", "test", "run"]],
     decision = "forbidden",
-    justification = "Run package changes, test suites, and scripts with agentkit-run.",
+    justification = "Run package changes, test suites, and scripts with bounded-run.",
 )
 
 prefix_rule(
     pattern = ["yarn", ["add", "install", "up", "upgrade", "test", "run", "build", "check", "typecheck", "lint"]],
     decision = "forbidden",
-    justification = "Run package changes, test suites, and scripts with agentkit-run.",
+    justification = "Run package changes, test suites, and scripts with bounded-run.",
 )
 
 prefix_rule(
     pattern = ["npx", ["tsc", "playwright"]],
     decision = "forbidden",
-    justification = "Run the TypeScript compiler and Playwright with agentkit-run.",
+    justification = "Run the TypeScript compiler and Playwright with bounded-run.",
 )
 
 prefix_rule(
     pattern = ["bunx", "tsc"],
     decision = "forbidden",
-    justification = "Run the TypeScript compiler with agentkit-run --profile compile.",
+    justification = "Run the TypeScript compiler with bounded-run --profile compile.",
 )
 
 prefix_rule(
     pattern = ["bunx", "playwright"],
     decision = "forbidden",
-    justification = "Run Playwright with agentkit-run --profile browser.",
+    justification = "Run Playwright with bounded-run --profile browser.",
 )
 
 prefix_rule(
     pattern = ["tsc"],
     decision = "forbidden",
-    justification = "Run the TypeScript compiler with agentkit-run --profile compile.",
+    justification = "Run the TypeScript compiler with bounded-run --profile compile.",
 )
 
 prefix_rule(
     pattern = ["playwright"],
     decision = "forbidden",
-    justification = "Run Playwright with agentkit-run --profile browser.",
+    justification = "Run Playwright with bounded-run --profile browser.",
 )
 
 prefix_rule(
     pattern = ["cargo", ["build", "check", "test", "clippy"]],
     decision = "forbidden",
-    justification = "Run Rust compiler and test workloads with agentkit-run.",
+    justification = "Run Rust compiler and test workloads with bounded-run.",
 )
 
 prefix_rule(
     pattern = ["go", ["build", "test"]],
     decision = "forbidden",
-    justification = "Run Go compiler and test workloads with agentkit-run.",
+    justification = "Run Go compiler and test workloads with bounded-run.",
 )
 
 prefix_rule(
     pattern = ["docker"],
     decision = "forbidden",
-    justification = "Container builds delegate to an engine outside agentkit-run. Use a separately approved dedicated runner or verified engine-native limits.",
+    justification = "Container builds delegate to an engine outside bounded-run. Use a separately approved dedicated runner or verified engine-native limits.",
 )
 
 prefix_rule(
     pattern = ["podman"],
     decision = "forbidden",
-    justification = "Container builds may delegate outside agentkit-run. Use a separately approved dedicated runner or verified engine-native limits.",
+    justification = "Container builds may delegate outside bounded-run. Use a separately approved dedicated runner or verified engine-native limits.",
 )
 
 prefix_rule(
     pattern = ["systemd-run"],
     decision = "forbidden",
-    justification = "Direct systemd-run can create a sibling cgroup outside the mandatory agentkit-run boundary.",
+    justification = "Direct systemd-run can create a sibling cgroup outside the mandatory bounded-run boundary.",
 )
 
 prefix_rule(
     pattern = ["run0"],
     decision = "forbidden",
-    justification = "run0 delegates to systemd-run outside the mandatory agentkit-run boundary.",
+    justification = "run0 delegates to systemd-run outside the mandatory bounded-run boundary.",
 )
 
 prefix_rule(
     pattern = ["ssh"],
     decision = "forbidden",
-    justification = "Remote workloads are outside the local agentkit-run resource boundary.",
+    justification = "Remote workloads are outside the local bounded-run resource boundary.",
 )
 
 prefix_rule(
     pattern = ["sudo"],
     decision = "forbidden",
-    justification = "Privilege wrappers are not allowed inside the agentkit-run containment workflow.",
+    justification = "Privilege wrappers are not allowed inside the bounded-run containment workflow.",
 )
 
 prefix_rule(
     pattern = ["pytest"],
     decision = "forbidden",
-    justification = "Run Python test suites with agentkit-run.",
+    justification = "Run Python test suites with bounded-run.",
 )
 
 prefix_rule(
     pattern = [["python", "python3"], "-m", "pytest"],
     decision = "forbidden",
-    justification = "Run Python test suites with agentkit-run.",
+    justification = "Run Python test suites with bounded-run.",
 )
 
 prefix_rule(
     pattern = [["pip", "pip3"], "install"],
     decision = "forbidden",
-    justification = "Run Python dependency installs with agentkit-run.",
+    justification = "Run Python dependency installs with bounded-run.",
 )
 
 prefix_rule(
     pattern = ["uv", ["add", "sync"]],
     decision = "forbidden",
-    justification = "Run Python dependency installs with agentkit-run.",
+    justification = "Run Python dependency installs with bounded-run.",
 )
 
 prefix_rule(
     pattern = ["uv", "pip", "install"],
     decision = "forbidden",
-    justification = "Run Python dependency installs with agentkit-run.",
+    justification = "Run Python dependency installs with bounded-run.",
 )
 
 prefix_rule(
     pattern = ["uv", "run", "pytest"],
     decision = "forbidden",
-    justification = "Run Python test suites with agentkit-run.",
+    justification = "Run Python test suites with bounded-run.",
 )

--- a/skills/resource-safe-execution/SKILL.md
+++ b/skills/resource-safe-execution/SKILL.md
@@ -2,7 +2,7 @@
 name: resource-safe-execution
 description: >-
   Run resource-intensive developer commands inside deterministic systemd cgroup limits with
-  agentkit-run. Use for dependency installation or upgrades, compilers, typechecks, builds, test
+  bounded-run. Use for dependency installation or upgrades, compilers, typechecks, builds, test
   suites, linters, Playwright or browser work, code generation, Cargo, Go, and pytest, especially
   on shared or production-adjacent hosts where an unbounded process could
   disrupt Kubernetes, ingress, tunnels, or other services.
@@ -10,7 +10,7 @@ description: >-
 
 # Resource-safe Execution
 
-Use `agentkit-run` for every resource-intensive command. Never fall back to an unbounded command
+Use `bounded-run` for every resource-intensive command. Never fall back to an unbounded command
 when preflight or containment fails.
 
 ## Choose a profile
@@ -30,15 +30,16 @@ reproductions with `canary`. Increase only after the canary finishes cleanly.
 Pass the executable and arguments after `--`. Do not pass a shell string.
 
 ```bash
-agentkit-run --profile canary -- bunx tsc --noEmit --singleThreaded
-agentkit-run --profile compile -- bun run typecheck
-agentkit-run --profile browser -- bunx playwright test
-agentkit-run --profile default -- cargo test
+bounded-run --profile canary -- bunx tsc --noEmit --singleThreaded
+bounded-run --profile compile -- bun run typecheck
+bounded-run --profile browser -- bunx playwright test
+bounded-run --profile default -- cargo test
 ```
 
-For a project-only AgentKit install, invoke `./.claude/tools/agentkit-run`. The one-shot Claude
+For a project-only AgentKit install, invoke `./.claude/tools/bounded-run`. The one-shot Claude
 plugin bundles the runner and its denial message prints the resolved plugin-cache path. A global
-install places `agentkit-run` in `~/.local/bin`.
+install places `bounded-run` in `~/.local/bin`, with `agentkit-run` kept as a compat
+symlink from the tool's previous name.
 
 The runner preserves argv and the current directory, but exposes only a curated environment.
 Retrieve credentials at runtime through the project's approved secrets mechanism; never put secrets
@@ -53,7 +54,7 @@ in argv.
 5. Run the established profile repeatedly, then the remaining build and test gates.
 6. Confirm no child processes remain and live services stayed healthy.
 
-If `agentkit-run` reports a missing or misconfigured `agent-work.slice`, insufficient headroom,
+If `bounded-run` reports a missing or misconfigured `agent-work.slice`, insufficient headroom,
 high load, or memory pressure, stop. Propose the required infrastructure correction and wait for
 approval.
 

--- a/tests/agentkit-plugin.test.ts
+++ b/tests/agentkit-plugin.test.ts
@@ -120,9 +120,9 @@ describe('agentkit plugin skills', () => {
 
 describe('agentkit plugin tools', () => {
   test('bundles the bounded runner and keeps it executable', () => {
-    const bundledRunner = join(pluginDir, 'tools', 'agentkit-run');
+    const bundledRunner = join(pluginDir, 'tools', 'bounded-run');
     expect(readFileSync(bundledRunner, 'utf-8')).toBe(
-      readFileSync(join(repoRoot, 'tools', 'agentkit-run'), 'utf-8'),
+      readFileSync(join(repoRoot, 'tools', 'bounded-run'), 'utf-8'),
     );
     expect(statSync(bundledRunner).mode & 0o111).not.toBe(0);
   });
@@ -140,7 +140,7 @@ describe('marketplace lists the agentkit plugin', () => {
     const agentkit = marketplace.plugins.find((p: { name: string }) => p.name === 'agentkit');
     expect(agentkit.source).toBe('./plugins-cc/agentkit');
     expect(agentkit.version).toBe('0.2.0');
-    expect(agentkit.description).toContain('agentkit-run');
+    expect(agentkit.description).toContain('bounded-run');
     expect(agentkit.description).toContain('agent-work.slice');
   });
 });

--- a/tests/fixtures/resource-commands.ts
+++ b/tests/fixtures/resource-commands.ts
@@ -39,8 +39,8 @@ export const blockedResourceCommands = [
   'b""un test',
   'true & bun run typecheck',
   'env sudo -n cargo test',
-  'echo agentkit-run && bun run build',
-  'agentkit-run --profile canary -- /bin/true && bun test',
+  'echo bounded-run && bun run build',
+  'bounded-run --profile canary -- /bin/true && bun test',
 ];
 
 export const unsupportedResourceCommands = [
@@ -50,22 +50,25 @@ export const unsupportedResourceCommands = [
   'systemd-run --user --scope cargo test',
   'sudo -u root systemd-run --scope cargo test',
   'ssh build-host bun test',
-  './agentkit-run --profile compile -- bun run build',
+  './bounded-run --profile compile -- bun run build',
   'systemctl restart cloudflared',
   'kubectl exec deploy/builder -- bun run build',
+  'bounded-run --profile compile -- docker build .',
   'agentkit-run --profile compile -- docker build .',
-  'agentkit-run --profile compile -- systemd-run --user cargo test',
-  "agentkit-run --profile compile -- bash -lc 'systemd-run --user cargo test'",
-  "agentkit-run --profile compile -- env CI=1 sh -c 'bun test'",
+  'bounded-run --profile compile -- systemd-run --user cargo test',
+  "bounded-run --profile compile -- bash -lc 'systemd-run --user cargo test'",
+  "bounded-run --profile compile -- env CI=1 sh -c 'bun test'",
   "bash -c 'ssh build-host bun test'",
   "bash -xc 'systemd-run --user cargo test'",
   'ansible-playbook playbooks/server.yml --check --diff',
 ];
 
 export const allowedResourceCommands = [
+  'bounded-run --profile compile -- bun run typecheck',
   'agentkit-run --profile compile -- bun run typecheck',
   '$HOME/.local/bin/agentkit-run --profile browser -- bunx playwright test',
-  'cd /tmp/project && agentkit-run --profile compile -- cargo test',
+  '$HOME/.local/bin/bounded-run --profile browser -- bunx playwright test',
+  'cd /tmp/project && bounded-run --profile compile -- cargo test',
   'bun --version',
   'bun run dev',
   'npm run dev',

--- a/tests/install-tools.test.ts
+++ b/tests/install-tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { existsSync, mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs';
+import { existsSync, lstatSync, mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -23,11 +23,14 @@ describe('standalone tool installation', () => {
       });
       expect(result.status, result.stderr).toBe(0);
 
-      const pathTool = join(home, '.local', 'bin', 'agentkit-run');
-      const claudeTool = join(home, '.claude', 'tools', 'agentkit-run');
+      const pathTool = join(home, '.local', 'bin', 'bounded-run');
+      const claudeTool = join(home, '.claude', 'tools', 'bounded-run');
       expect(readFileSync(pathTool, 'utf-8')).toBe(readFileSync(claudeTool, 'utf-8'));
       expect(statSync(pathTool).mode & 0o111).not.toBe(0);
       expect(statSync(claudeTool).mode & 0o111).not.toBe(0);
+      const compatAlias = join(home, '.local', 'bin', 'agentkit-run');
+      expect(lstatSync(compatAlias).isSymbolicLink()).toBe(true);
+      expect(readFileSync(compatAlias, 'utf-8')).toBe(readFileSync(pathTool, 'utf-8'));
       expect(result.stdout).toContain(`PATH tools:      ${join(home, '.local', 'bin')}/`);
       expect(existsSync(join(home, '.config', 'opencode', 'plugins', 'resource-police.ts'))).toBe(
         true,
@@ -38,8 +41,8 @@ describe('standalone tool installation', () => {
   });
 
   test('ships the runner inside the one-shot Claude plugin', () => {
-    const source = readFileSync(join(repoRoot, 'tools', 'agentkit-run'), 'utf-8');
-    const bundled = join(repoRoot, 'plugins-cc', 'agentkit', 'tools', 'agentkit-run');
+    const source = readFileSync(join(repoRoot, 'tools', 'bounded-run'), 'utf-8');
+    const bundled = join(repoRoot, 'plugins-cc', 'agentkit', 'tools', 'bounded-run');
     expect(readFileSync(bundled, 'utf-8')).toBe(source);
     expect(statSync(bundled).mode & 0o111).not.toBe(0);
   });

--- a/tests/resource-police.test.ts
+++ b/tests/resource-police.test.ts
@@ -38,7 +38,7 @@ describe('OpenCode resource-police', () => {
     test(`blocks unbounded command: ${command}`, async () => {
       const hooks = await resourcePolice(mockCtx);
       const { input, output } = makeInput(command);
-      expect(hooks['tool.execute.before']!(input, output)).rejects.toThrow('agentkit-run');
+      expect(hooks['tool.execute.before']!(input, output)).rejects.toThrow('bounded-run');
     });
   }
 
@@ -47,7 +47,7 @@ describe('OpenCode resource-police', () => {
       const hooks = await resourcePolice(mockCtx);
       const { input, output } = makeInput(command);
       expect(hooks['tool.execute.before']!(input, output)).rejects.toThrow(
-        'cannot be contained by agentkit-run',
+        'cannot be contained by bounded-run',
       );
     });
   }
@@ -73,7 +73,7 @@ describe('Claude resource-police', () => {
     test(`blocks unbounded command: ${command}`, () => {
       const output = runHook(command);
       expect(output).toContain('"permissionDecision": "deny"');
-      expect(output).toContain('agentkit-run');
+      expect(output).toContain('bounded-run');
     });
   }
 
@@ -81,7 +81,7 @@ describe('Claude resource-police', () => {
     test(`blocks delegated command: ${command}`, () => {
       const output = runHook(command);
       expect(output).toContain('"permissionDecision": "deny"');
-      expect(output).toContain('cannot be contained by agentkit-run');
+      expect(output).toContain('cannot be contained by bounded-run');
     });
   }
 
@@ -96,6 +96,7 @@ describe('Codex resource policy', () => {
   test('forbids direct heavy command prefixes without interactive prompts', () => {
     const contents = readFileSync(policy, 'utf-8');
     expect(contents).not.toContain('decision = "prompt"');
+    expect(contents).toContain('pattern = ["bounded-run"]');
     expect(contents).toContain('pattern = ["agentkit-run"]');
     expect(contents).toContain('decision = "allow"');
     for (const command of [
@@ -136,6 +137,7 @@ describe('Codex resource policy', () => {
       [['docker', 'run', '--rm', 'builder'], 'forbidden'],
       [['ssh', 'build-host', 'bun', 'test'], 'forbidden'],
       [['systemd-run', '--user', 'cargo', 'test'], 'forbidden'],
+      [['bounded-run', '--profile', 'compile', '--', 'bun', 'run', 'build'], 'allow'],
       [['agentkit-run', '--profile', 'compile', '--', 'bun', 'run', 'build'], 'allow'],
     ]);
 

--- a/tests/resource-run.integration.test.ts
+++ b/tests/resource-run.integration.test.ts
@@ -14,7 +14,7 @@ import { spawnSync } from 'node:child_process';
 
 const enabled = process.env.AGENTKIT_RUN_INTEGRATION === '1';
 const repoRoot = dirname(import.meta.dir);
-const runner = join(repoRoot, 'tools', 'agentkit-run');
+const runner = join(repoRoot, 'tools', 'bounded-run');
 const uid = process.getuid?.() ?? 1000;
 const sliceRoot = `/sys/fs/cgroup/user.slice/user-${uid}.slice/user@${uid}.service/agent.slice/agent-work.slice`;
 let root: string;
@@ -38,18 +38,18 @@ function metric(contents: string, name: string): number {
 
 function runnerUnits(): string[] {
   if (!existsSync(sliceRoot)) return [];
-  return readdirSync(sliceRoot).filter((entry) => entry.startsWith('agentkit-run-canary-'));
+  return readdirSync(sliceRoot).filter((entry) => entry.startsWith('bounded-run-canary-'));
 }
 
 beforeAll(() => {
-  root = mkdtempSync(join(tmpdir(), 'agentkit-run-integration-'));
+  root = mkdtempSync(join(tmpdir(), 'bounded-run-integration-'));
 });
 
 afterAll(() => {
   rmSync(root, { force: true, recursive: true });
 });
 
-describe.skipIf(!enabled)('agentkit-run real systemd containment', () => {
+describe.skipIf(!enabled)('bounded-run real systemd containment', () => {
   test('applies the canary cgroup, privilege, and environment boundaries', () => {
     const output = join(root, 'cgroup-properties');
     const command = join(root, 'capture-cgroup');
@@ -176,7 +176,7 @@ for offset in range(0, size, 4096):
     let unit = '';
     for (let attempt = 0; attempt < 400 && !unit; attempt += 1) {
       unit = runnerUnits().find(
-        (entry) => entry.startsWith('agentkit-run-canary-') && !existingUnits.has(entry),
+        (entry) => entry.startsWith('bounded-run-canary-') && !existingUnits.has(entry),
       ) ?? '';
       await Bun.sleep(5);
     }

--- a/tests/resource-run.test.ts
+++ b/tests/resource-run.test.ts
@@ -13,7 +13,7 @@ import { dirname, join } from 'node:path';
 import { spawn, spawnSync } from 'node:child_process';
 
 const repoRoot = dirname(import.meta.dir);
-const productionRunner = join(repoRoot, 'tools', 'agentkit-run');
+const productionRunner = join(repoRoot, 'tools', 'bounded-run');
 
 let root: string;
 let binDir: string;
@@ -91,12 +91,12 @@ function runRunner(
 }
 
 beforeEach(() => {
-  root = mkdtempSync(join(tmpdir(), 'agentkit-run-'));
+  root = mkdtempSync(join(tmpdir(), 'bounded-run-'));
   binDir = join(root, 'bin');
   homeDir = join(root, 'home');
   runtimeRoot = join(root, 'run-user');
   runtimeDir = join(runtimeRoot, String(process.getuid?.() ?? 1000));
-  runner = join(root, 'agentkit-run');
+  runner = join(root, 'bounded-run');
   systemdLog = join(root, 'systemd-run.args');
   mkdirSync(binDir);
   mkdirSync(homeDir);
@@ -150,7 +150,7 @@ afterEach(() => {
   rmSync(root, { force: true, recursive: true });
 });
 
-describe('agentkit-run argument contract', () => {
+describe('bounded-run argument contract', () => {
   test('pins its interpreter and control plane to trusted absolute paths', () => {
     const source = readFileSync(productionRunner, 'utf-8');
     expect(source).toStartWith('#!/bin/bash -p\n');
@@ -247,7 +247,7 @@ printf 'secret=<%s>\n' "\${UNSAFE_SECRET:-}" >> "${output}"
     expect(result.status).toBe(37);
   });
 
-  test('rejects nested agentkit-run instead of deadlocking on its own lock', () => {
+  test('rejects nested bounded-run instead of deadlocking on its own lock', () => {
     const result = runRunner([
       '--profile',
       'canary',
@@ -260,14 +260,14 @@ printf 'secret=<%s>\n' "\${UNSAFE_SECRET:-}" >> "${output}"
     ]);
 
     expect(result.status).toBe(64);
-    expect(result.stderr).toContain('nested agentkit-run');
+    expect(result.stderr).toContain('nested bounded-run');
     expect(() => readFileSync(systemdLog, 'utf-8')).toThrow();
 
     const active = runRunner(['--profile', 'canary', '--', '/bin/true'], {
       AGENTKIT_RUN_ACTIVE: '1',
     });
     expect(active.status).toBe(64);
-    expect(active.stderr).toContain('nested agentkit-run');
+    expect(active.stderr).toContain('nested bounded-run');
   });
 
   test('rejects commands that delegate work outside the service cgroup', () => {
@@ -337,11 +337,11 @@ printf 'secret=<%s>\n' "\${UNSAFE_SECRET:-}" >> "${output}"
     const result = runRunner(['--profile', 'canary', '--', command]);
 
     expect(result.status).toBe(75);
-    expect(result.stderr).not.toContain('another agentkit-run command is active');
+    expect(result.stderr).not.toContain('another bounded-run command is active');
   });
 });
 
-describe('agentkit-run resource boundary', () => {
+describe('bounded-run resource boundary', () => {
   test('maps every profile to explicit systemd cgroup and timeout properties', () => {
     const expected = {
       canary: ['MemoryHigh=1G', 'MemoryMax=2G', 'CPUQuota=200%', 'TasksMax=64', 'RuntimeMaxSec=75s'],

--- a/tests/resource-safety-assets.test.ts
+++ b/tests/resource-safety-assets.test.ts
@@ -9,8 +9,8 @@ describe('resource-safe-execution assets', () => {
   test('ships a discoverable skill with OpenAI interface metadata', () => {
     const skill = readFileSync(join(skillDir, 'SKILL.md'), 'utf-8');
     expect(skill).toContain('name: resource-safe-execution');
-    expect(skill).toContain('agentkit-run');
-    expect(skill).not.toContain('`$CLAUDE_PLUGIN_ROOT/tools/agentkit-run`');
+    expect(skill).toContain('bounded-run');
+    expect(skill).not.toContain('`$CLAUDE_PLUGIN_ROOT/tools/bounded-run`');
     expect(existsSync(join(skillDir, 'agents', 'openai.yaml'))).toBe(true);
     const metadata = readFileSync(join(skillDir, 'agents', 'openai.yaml'), 'utf-8');
     expect(metadata).toContain('display_name: "Resource-safe Execution"');
@@ -23,7 +23,7 @@ describe('resource-safe-execution assets', () => {
       'utf-8',
     );
     expect(instruction).toContain('agentkit:resource-safety:start');
-    expect(instruction).toContain('agentkit-run');
+    expect(instruction).toContain('bounded-run');
     expect(instruction).toContain('Never run resource-intensive');
     expect(instruction).toContain('Do not restart');
     expect(instruction).toContain('delegated workloads');
@@ -36,7 +36,7 @@ describe('resource-safe-execution assets', () => {
     for (const [source, mirror] of [
       ['hooks/claude/resource-police.sh', 'hooks/resource-police.sh'],
       ['skills/resource-safe-execution/SKILL.md', 'skills/resource-safe-execution/SKILL.md'],
-      ['tools/agentkit-run', 'tools/agentkit-run'],
+      ['tools/bounded-run', 'tools/bounded-run'],
     ]) {
       expect(readFileSync(join(pluginRoot, mirror), 'utf-8')).toBe(
         readFileSync(join(repoRoot, source), 'utf-8'),

--- a/tools/bounded-run
+++ b/tools/bounded-run
@@ -23,17 +23,17 @@ readonly TIMEOUT_BIN=/usr/bin/timeout
 
 usage() {
 	cat <<'USAGE'
-Usage: agentkit-run [--profile canary|default|compile|browser] -- COMMAND [ARG...]
+Usage: bounded-run [--profile canary|default|compile|browser] -- COMMAND [ARG...]
 
 Run one resource-intensive command in a bounded systemd user service. The command
-is passed as argv without shell evaluation. Only one agentkit-run may run at once.
+is passed as argv without shell evaluation. Only one bounded-run may run at once.
 USAGE
 }
 
 die() {
 	local message="$1"
 	local status="${2:-$EX_UNAVAILABLE}"
-	printf 'agentkit-run: %s\n' "$message" >&2
+	printf 'bounded-run: %s\n' "$message" >&2
 	exit "$status"
 }
 
@@ -290,9 +290,9 @@ build_clean_environment() {
 reject_command_basename() {
 	local executable="$1"
 	case "$executable" in
-	agentkit-run) die 'nested agentkit-run commands are not allowed' "$EX_USAGE" ;;
+	agentkit-run | bounded-run) die 'nested bounded-run commands are not allowed' "$EX_USAGE" ;;
 	doas | env | pkexec | run0 | su | sudo)
-		die "$executable is not allowed inside agentkit-run" "$EX_USAGE"
+		die "$executable is not allowed inside bounded-run" "$EX_USAGE"
 		;;
 	ansible | ansible-playbook | buildah | docker | kubectl | machinectl | mosh | nerdctl | podman | service | ssh | systemctl | systemd-run)
 		die "$executable delegates work outside the service cgroup" "$EX_USAGE"
@@ -338,7 +338,7 @@ inspect_command_arguments() {
 }
 
 run_bounded() {
-	local unit="agentkit-run-${PROFILE}-$$"
+	local unit="bounded-run-${PROFILE}-$$"
 	local lock_file="$CONTROL_RUNTIME_DIR/$LOCK_NAME"
 	local status
 	set +e
@@ -383,7 +383,7 @@ declare EXPECTED_MEMORY_HIGH EXPECTED_MEMORY_MAX EXPECTED_MEMORY_SWAP_MAX EXPECT
 
 parse_args "$@"
 if [[ "${AGENTKIT_RUN_ACTIVE:-0}" == 1 ]]; then
-	die 'nested agentkit-run commands are not allowed' "$EX_USAGE"
+	die 'nested bounded-run commands are not allowed' "$EX_USAGE"
 fi
 verify_control_plane
 resolve_command


### PR DESCRIPTION
## Summary

- Renames the runner to `bounded-run` — it bounds resources; the old name read like a generic agentkit entry point and invited a security-sandbox mental model the tool explicitly disclaims.
- `agentkit-run` remains an installed compat symlink; resource-police (bash + OpenCode) and the Codex allow rule trust both names; nested-run rejection covers both.
- Internal `AGENTKIT_*` env vars and the lock filename are unchanged: they're toolkit-namespaced (like `AGENTKIT_ALLOW_*`), and keeping the lock name preserves single-flight across old/new binaries during rollout.
- Docs, skill, instructions, marketplace description, and Codex justifications updated.

## Validation

- 327 tests pass, 0 fail — compat fixtures added (wrapped `agentkit-run` still allowed/denied identically), install test asserts the symlink, Codex matrix includes both allow rules
- Mirrors byte-identical