### PR TITLE
fix(coding-police): make Claude hook configuration portable

### DIFF
--- a/hooks/claude/coding-police.sh
+++ b/hooks/claude/coding-police.sh
@@ -14,22 +14,30 @@ MAX_EXPORTS_PER_FILE=15
 
 load_config() {
   [[ -f "$AGENTKIT_CONFIG" ]] || return 0
-  local section
-  section=$(sed -n '/^coding-police:/,/^[^ ]/p' "$AGENTKIT_CONFIG" | head -n -1)
-  [[ -z "$section" ]] && return 0
-
-  local val
-  val=$(echo "$section" | grep -oP 'max-file-lines:\s*\K\d+' || true)
-  [[ -n "$val" ]] && MAX_FILE_LINES="$val"
-
-  val=$(echo "$section" | grep -oP 'max-function-lines:\s*\K\d+' || true)
-  [[ -n "$val" ]] && MAX_FUNCTION_LINES="$val"
-
-  val=$(echo "$section" | grep -oP 'min-duplicate-lines:\s*\K\d+' || true)
-  [[ -n "$val" ]] && MIN_DUPLICATE_LINES="$val"
-
-  val=$(echo "$section" | grep -oP 'max-exports-per-file:\s*\K\d+' || true)
-  [[ -n "$val" ]] && MAX_EXPORTS_PER_FILE="$val"
+  local key value
+  while IFS='=' read -r key value; do
+    case "$key" in
+      max-file-lines) MAX_FILE_LINES="$value" ;;
+      max-function-lines) MAX_FUNCTION_LINES="$value" ;;
+      min-duplicate-lines) MIN_DUPLICATE_LINES="$value" ;;
+      max-exports-per-file) MAX_EXPORTS_PER_FILE="$value" ;;
+    esac
+  done < <(awk '
+    /^[^[:space:]#]/ {
+      in_section = ($0 ~ /^coding-police:/)
+      next
+    }
+    in_section {
+      line = $0
+      sub(/^[[:space:]]+/, "", line)
+      if (line !~ /^(max-file-lines|max-function-lines|min-duplicate-lines|max-exports-per-file):[[:space:]]*[0-9]+([[:space:]]*#.*)?$/) next
+      key = line
+      sub(/:.*/, "", key)
+      sub(/^[^:]*:[[:space:]]*/, "", line)
+      sub(/[[:space:]#].*$/, "", line)
+      print key "=" line
+    }
+  ' "$AGENTKIT_CONFIG")
 }
 load_config
 
@@ -228,7 +236,7 @@ check_export_count() {
   esac
 
   local count
-  count=$(grep -cE '^\s*export\s+(default\s+)?(function|class|const|let|var|type|interface|enum|async)' "$FILE_PATH" 2>/dev/null || true)
+  count=$(grep -cE '^[[:space:]]*export[[:space:]]+(default[[:space:]]+)?(function|class|const|let|var|type|interface|enum|async)' "$FILE_PATH" 2>/dev/null || true)
   count=${count:-0}
   if (( count > MAX_EXPORTS_PER_FILE )); then
     VIOLATIONS+=("TOO MANY EXPORTS: ${count} exports in this file (limit: ${MAX_EXPORTS_PER_FILE}). This suggests the file has multiple responsibilities. Group related exports into separate modules (e.g., types.ts, helpers.ts, constants.ts).")

--- a/plugins-cc/agentkit/hooks/chime.sh
+++ b/plugins-cc/agentkit/hooks/chime.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# chime.sh — audible nudge when Claude Code needs the human.
+#
+# Wired as a Notification hook (permission prompt / question waiting → a
+# springy "boing") and a Stop hook (turn finished, reply awaiting you → a
+# soft ping) so you hear it when you're not looking at the terminal.
+#
+# Toggle off without editing settings:
+#   touch ~/.claude/.chime-off      # mute
+#   rm ~/.claude/.chime-off         # unmute
+# or export CLAUDE_CHIME=0 in the environment.
+#
+# Usage: chime.sh [attention|done]   (default: attention)
+
+[ "${CLAUDE_CHIME:-1}" = "0" ] && exit 0
+[ -f "$HOME/.claude/.chime-off" ] && exit 0
+
+kind="${1:-attention}"
+
+# macOS: "Sosumi" is the springiest stock sound — distinctive enough to
+# register as "Claude needs me" from across the room (Funk and Frog are the
+# other boingy options under /System/Library/Sounds/).
+if command -v afplay >/dev/null 2>&1; then
+  case "$kind" in
+    done) afplay /System/Library/Sounds/Ping.aiff >/dev/null 2>&1 ;;
+    *) afplay /System/Library/Sounds/Sosumi.aiff >/dev/null 2>&1 ;;
+  esac
+  exit 0
+fi
+
+# Linux: freedesktop sound theme via PulseAudio/PipeWire, if present.
+if command -v paplay >/dev/null 2>&1; then
+  base=/usr/share/sounds/freedesktop/stereo
+  case "$kind" in
+    done) f="$base/complete.oga" ;;
+    *) f="$base/bell.oga" ;;
+  esac
+  [ -f "$f" ] && paplay "$f" >/dev/null 2>&1 && exit 0
+fi
+
+# Last resort: the terminal bell.
+printf '\a'
+exit 0

--- a/plugins-cc/agentkit/hooks/coding-police.sh
+++ b/plugins-cc/agentkit/hooks/coding-police.sh
@@ -14,22 +14,30 @@ MAX_EXPORTS_PER_FILE=15
 
 load_config() {
   [[ -f "$AGENTKIT_CONFIG" ]] || return 0
-  local section
-  section=$(sed -n '/^coding-police:/,/^[^ ]/p' "$AGENTKIT_CONFIG" | head -n -1)
-  [[ -z "$section" ]] && return 0
-
-  local val
-  val=$(echo "$section" | grep -oP 'max-file-lines:\s*\K\d+' || true)
-  [[ -n "$val" ]] && MAX_FILE_LINES="$val"
-
-  val=$(echo "$section" | grep -oP 'max-function-lines:\s*\K\d+' || true)
-  [[ -n "$val" ]] && MAX_FUNCTION_LINES="$val"
-
-  val=$(echo "$section" | grep -oP 'min-duplicate-lines:\s*\K\d+' || true)
-  [[ -n "$val" ]] && MIN_DUPLICATE_LINES="$val"
-
-  val=$(echo "$section" | grep -oP 'max-exports-per-file:\s*\K\d+' || true)
-  [[ -n "$val" ]] && MAX_EXPORTS_PER_FILE="$val"
+  local key value
+  while IFS='=' read -r key value; do
+    case "$key" in
+      max-file-lines) MAX_FILE_LINES="$value" ;;
+      max-function-lines) MAX_FUNCTION_LINES="$value" ;;
+      min-duplicate-lines) MIN_DUPLICATE_LINES="$value" ;;
+      max-exports-per-file) MAX_EXPORTS_PER_FILE="$value" ;;
+    esac
+  done < <(awk '
+    /^[^[:space:]#]/ {
+      in_section = ($0 ~ /^coding-police:/)
+      next
+    }
+    in_section {
+      line = $0
+      sub(/^[[:space:]]+/, "", line)
+      if (line !~ /^(max-file-lines|max-function-lines|min-duplicate-lines|max-exports-per-file):[[:space:]]*[0-9]+([[:space:]]*#.*)?$/) next
+      key = line
+      sub(/:.*/, "", key)
+      sub(/^[^:]*:[[:space:]]*/, "", line)
+      sub(/[[:space:]#].*$/, "", line)
+      print key "=" line
+    }
+  ' "$AGENTKIT_CONFIG")
 }
 load_config
 
@@ -228,7 +236,7 @@ check_export_count() {
   esac
 
   local count
-  count=$(grep -cE '^\s*export\s+(default\s+)?(function|class|const|let|var|type|interface|enum|async)' "$FILE_PATH" 2>/dev/null || true)
+  count=$(grep -cE '^[[:space:]]*export[[:space:]]+(default[[:space:]]+)?(function|class|const|let|var|type|interface|enum|async)' "$FILE_PATH" 2>/dev/null || true)
   count=${count:-0}
   if (( count > MAX_EXPORTS_PER_FILE )); then
     VIOLATIONS+=("TOO MANY EXPORTS: ${count} exports in this file (limit: ${MAX_EXPORTS_PER_FILE}). This suggests the file has multiple responsibilities. Group related exports into separate modules (e.g., types.ts, helpers.ts, constants.ts).")

--- a/plugins-cc/agentkit/hooks/git-police.sh
+++ b/plugins-cc/agentkit/hooks/git-police.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # git-police.sh — Claude Code PreToolUse hook (matcher: Bash)
-# Blocks: force push, --no-verify, Co-authored-by trailers, commits to protected branches, stale branch creation
+# Blocks: force push, --no-verify, AI attribution (commit trailers AND MR/PR/issue
+# content), commits to protected branches, stale branch creation
 # Equivalent to: plugins/git-police.ts (OpenCode)
 set -euo pipefail
 
@@ -176,12 +177,19 @@ fi
 # inside a config key like `git config commit.gpgsign`).
 GIT_COMMIT_RE='\bgit([[:space:]]+(-[A-Za-z][^[:space:]]*|--[A-Za-z][A-Za-z0-9-]*(=[^[:space:]]+)?)([[:space:]]+[^-[:space:]][^[:space:]]*)?)*[[:space:]]+commit\b'
 
-# 5. Block AI attribution trailers / signatures in commit commands.
+# Commands that publish authored content to the forge — MR/PR/issue bodies,
+# comments, release notes. Same no-AI-attribution rule as commit messages:
+# everything published under the user's name is theirs, not the agent's.
+FORGE_WRITE_RE='\bglab[[:space:]]+(mr|issue)[[:space:]]+(create|update|edit|note|comment)\b|\bgh[[:space:]]+(pr|issue|release)[[:space:]]+(create|edit|comment)\b'
+
+# 5. Block AI attribution trailers / signatures in commit commands AND in
+#    forge-content commands (MR/PR descriptions slipped through when this
+#    was gated on `git commit` only).
 #    $INPUT is the full PreToolUse JSON payload from stdin; the previous
 #    version referenced an undefined $TOOL_INPUT and silently never matched.
-if echo "$STRIPPED" | grep -qiE "$GIT_COMMIT_RE" \
-	&& echo "$INPUT" | grep -qiE 'co-authored-by|generated with \[claude code\]|🤖 generated|claude\.ai/code|noreply@anthropic\.com'; then
-	deny "BLOCKED: AI attribution in commit messages is forbidden. Do not add Co-authored-by, Signed-off-by, '🤖 Generated with [Claude Code]', claude.ai/code links, noreply@anthropic.com co-authors, or any other AI agent attribution. The commit author is whoever owns the git config. Remove the attribution and retry."
+if { echo "$STRIPPED" | grep -qiE "$GIT_COMMIT_RE" || echo "$STRIPPED" | grep -qiE "$FORGE_WRITE_RE"; } \
+	&& echo "$INPUT" | grep -qiE 'co-authored-by|generated with \[claude code\]|🤖 generated|claude\.ai/code|claude\.com/claude-code|noreply@anthropic\.com'; then
+	deny "BLOCKED: AI attribution is forbidden — in commit messages and in MR/PR/issue descriptions or comments alike. Do not add Co-authored-by, Signed-off-by, '🤖 Generated with [Claude Code]', claude.ai/code or claude.com/claude-code links, noreply@anthropic.com co-authors, or any other AI agent attribution. The author is whoever owns the git config. Remove the attribution and retry."
 fi
 
 # 6. Block direct commits to protected branches

--- a/plugins-cc/agentkit/hooks/hooks.json
+++ b/plugins-cc/agentkit/hooks/hooks.json
@@ -54,6 +54,30 @@
           }
         ]
       }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/chime.sh attention",
+            "async": true,
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/chime.sh done",
+            "async": true,
+            "timeout": 10
+          }
+        ]
+      }
     ]
   }
 }

--- a/tests/agentkit-plugin.test.ts
+++ b/tests/agentkit-plugin.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { readFileSync, statSync } from 'node:fs';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { basename, join } from 'node:path';
 
 // The comprehensive "agentkit" Claude Code plugin bundles, in one install:
@@ -68,6 +68,13 @@ describe('agentkit plugin hooks', () => {
     }
   });
 
+  test('mirrors every global hook event with plugin-relative commands', () => {
+    const source = readFileSync(join(repoRoot, 'hooks', 'claude', 'settings.json'), 'utf-8');
+    const expected = JSON.parse(source.replaceAll('$HOME/.claude', '${CLAUDE_PLUGIN_ROOT}'));
+
+    expect(readJson('hooks', 'hooks.json')).toEqual(expected);
+  });
+
   test('every referenced police script exists and is executable', () => {
     // hooks.json must reference these and they must be present + runnable.
     const referenced = new Set(
@@ -80,6 +87,20 @@ describe('agentkit plugin hooks', () => {
       expect(referenced.has(script), `${script} referenced in hooks.json`).toBe(true);
       const mode = statSync(join(pluginDir, 'hooks', script)).mode;
       expect((mode & 0o111) !== 0, `${script} is executable`).toBe(true);
+    }
+  });
+
+  test('keeps every source hook byte-identical in the plugin mirror', () => {
+    const sourceHooks = join(repoRoot, 'hooks', 'claude');
+    const sourceScripts = readdirSync(sourceHooks).filter((name) => name.endsWith('.sh')).sort();
+    const pluginScripts = readdirSync(join(pluginDir, 'hooks'))
+      .filter((name) => name.endsWith('.sh'))
+      .sort();
+    expect(pluginScripts).toEqual(sourceScripts);
+    for (const script of sourceScripts) {
+      expect(readFileSync(join(pluginDir, 'hooks', script), 'utf-8')).toBe(
+        readFileSync(join(sourceHooks, script), 'utf-8'),
+      );
     }
   });
 });

--- a/tests/coding-police-hook.test.ts
+++ b/tests/coding-police-hook.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const repoRoot = dirname(import.meta.dir);
+const hook = join(repoRoot, 'hooks', 'claude', 'coding-police.sh');
+const pluginHook = join(repoRoot, 'plugins-cc', 'agentkit', 'hooks', 'coding-police.sh');
+
+const source = `export function alpha() {
+  const sharedAlpha = 1;
+  const sharedBeta = 2;
+}
+export function beta() {
+  const sharedAlpha = 1;
+  const sharedBeta = 2;
+}
+`;
+
+const settings = `  max-file-lines: 5
+  max-function-lines: 2
+  min-duplicate-lines: 2
+  max-exports-per-file: 1
+`;
+
+function writeExecutable(path: string, content: string): void {
+  writeFileSync(path, content);
+  chmodSync(path, 0o755);
+}
+
+function runHook(config: string, shimBin?: (directory: string) => void) {
+  const root = mkdtempSync(join(tmpdir(), 'agentkit-coding-hook-'));
+  const configDir = join(root, 'config', 'agentkit');
+  const codeFile = join(root, 'fixture.ts');
+  const binDir = join(root, 'bin');
+  mkdirSync(configDir, { recursive: true });
+  mkdirSync(binDir);
+  writeFileSync(join(configDir, 'config.yaml'), config);
+  writeFileSync(codeFile, source);
+  shimBin?.(binDir);
+
+  const result = spawnSync('bash', [hook], {
+    encoding: 'utf-8',
+    env: {
+      ...process.env,
+      HOME: root,
+      PATH: `${binDir}:${process.env.PATH}`,
+      XDG_CONFIG_HOME: join(root, 'config'),
+    },
+    input: JSON.stringify({ tool_name: 'Write', tool_input: { file_path: codeFile } }),
+  });
+  rmSync(root, { force: true, recursive: true });
+  return result;
+}
+
+function expectConfiguredThresholds(stderr: string): void {
+  expect(stderr).toContain('FILE TOO LONG: 8 lines (limit: 5');
+  expect(stderr).toContain('LONG FUNCTION: `alpha` is 4 lines (limit: 2');
+  expect(stderr).toContain('DUPLICATE CODE: 2+ line block');
+  expect(stderr).toContain('TOO MANY EXPORTS: 2 exports in this file (limit: 1');
+}
+
+describe('Claude coding-police configuration', () => {
+  test('loads every threshold before a following YAML section', () => {
+    const result = runHook(`coding-police:\n${settings}git-police:\n  enabled: true\n`);
+
+    expect(result.status, result.stderr).toBe(0);
+    expectConfiguredThresholds(result.stderr);
+  });
+
+  test('loads every threshold when coding-police is the final YAML section', () => {
+    const result = runHook(`git-police:\n  enabled: true\ncoding-police:\n${settings}`);
+
+    expect(result.status, result.stderr).toBe(0);
+    expectConfiguredThresholds(result.stderr);
+  });
+
+  test('stops before an unrelated top-level YAML scalar block', () => {
+    const result = runHook(
+      `coding-police:\n${settings}notes: |\n  max-file-lines: 1\n`,
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    expectConfiguredThresholds(result.stderr);
+    expect(result.stderr).not.toContain('FILE TOO LONG: 8 lines (limit: 1');
+  });
+
+  test('does not depend on GNU grep or negative head line counts', () => {
+    const result = runHook(`coding-police:\n${settings}`, (binDir) => {
+      writeExecutable(
+        join(binDir, 'grep'),
+        `#!/usr/bin/env bash
+for argument in "$@"; do
+  if [[ "$argument" == -*P* ]]; then
+    echo "grep: unsupported -P" >&2
+    exit 2
+  fi
+  if [[ "$argument" == *'\\s'* ]]; then
+    echo "grep: unsupported \\s" >&2
+    exit 2
+  fi
+done
+exec /usr/bin/grep "$@"
+`,
+      );
+      writeExecutable(
+        join(binDir, 'head'),
+        `#!/usr/bin/env bash
+if [[ "$*" == *"-n -1"* ]]; then
+  echo "head: illegal line count -- -1" >&2
+  exit 2
+fi
+exec /usr/bin/head "$@"
+`,
+      );
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stderr).not.toContain('unsupported -P');
+    expect(result.stderr).not.toContain('unsupported \\s');
+    expect(result.stderr).not.toContain('illegal line count');
+    expectConfiguredThresholds(result.stderr);
+  });
+
+  test('keeps the Claude plugin hook identical to its source', () => {
+    expect(readFileSync(pluginHook, 'utf-8')).toBe(readFileSync(hook, 'utf-8'));
+  });
+});


### PR DESCRIPTION
## Summary\n\n- Replace GNU-only coding-police configuration parsing with a portable POSIX-awk parser.\n- Preserve all thresholds when coding-police is the final YAML section.\n- Stop cleanly at any unrelated top-level YAML key, including block scalars.\n- Replace GNU grep spacing extensions in export detection.\n- Add Bash-hook regression coverage with BSD-like grep/head shims.\n- Synchronize every Claude plugin hook mirror and restore Notification/Stop chime wiring.\n- Enforce exact source/plugin hook event, filename, and byte parity.\n\n## Verification\n\n- RED confirmed final-section, BSD head, BSD grep-spacing, YAML block-scalar, and missing chime-event failures.\n- focused hook/plugin suite: 15 passed, 0 failed\n- Bash syntax checks: passed\n- Claude plugin validation: passed\n- full AgentKit suite: 338 passed, 5 environment-gated systemd tests skipped, 0 failed\n- independent code review: APPROVE\n- independent architecture review: CLEAR\n- core host services remained active\n\nRepository-wide dprint currently reports five pre-existing Markdown files on main; tracked separately in #68.\n\nRefs #67\nRefs #66\n\nSupersedes #27 because its contributor branch diverged before later squash merges and now carries 16 conflicts across 47 apparent files. The original portability finding is preserved and expanded here.