### PR TITLE
docs: distinguish terminal and Mermaid diagram surfaces

### DIFF
--- a/instructions/collaboration-visibility.md
+++ b/instructions/collaboration-visibility.md
@@ -21,11 +21,14 @@ Use a diagram when it makes the work easier to follow, especially for debugging,
 deployment paths, service relationships, data flow, and multi-repository changes. Pick the format
 by where the output is read.
 
-On markdown-rendered surfaces (chat UIs with Mermaid support, GitLab/GitHub issues, MRs, and
-READMEs), use a `mermaid` code fence (`flowchart LR`/`TD` or `sequenceDiagram`) so it renders as a
+Use Mermaid only on a destination explicitly known to render it. Examples include GitLab/GitHub
+issues and MRs, the Neutron Core web UI, and rendered documentation with Mermaid enabled. Use a
+`mermaid` code fence (`flowchart LR`/`TD` or `sequenceDiagram`) on those surfaces so it renders as a
 real diagram. Do not draw ASCII-art boxes there; they render poorly.
 
-On plain-text surfaces (terminals, commit messages, git diffs, logs), use compact ASCII:
+Codex and OpenCode terminal or TUI chats are plain-text diagram surfaces even when they render
+basic Markdown code fences. Terminals, SSH sessions, commit messages, git diffs, and logs also use
+compact ASCII. When Mermaid support is unknown, use ASCII:
 
 ```text
 current state ----> action ----> expected result

--- a/tests/install-prompt.test.ts
+++ b/tests/install-prompt.test.ts
@@ -99,6 +99,15 @@ describe('global prompt installation', () => {
       expect(readFileSync(collaborationVisibility, 'utf-8')).toContain(
         'agentkit:collaboration-visibility:start',
       );
+      expect(readFileSync(collaborationVisibility, 'utf-8')).toContain(
+        'Codex and OpenCode terminal or TUI chats',
+      );
+      expect(readFileSync(collaborationVisibility, 'utf-8')).toContain(
+        'Neutron Core web UI',
+      );
+      expect(readFileSync(collaborationVisibility, 'utf-8')).toContain(
+        'When Mermaid support is unknown, use ASCII',
+      );
       expect(readFileSync(resourceSafety, 'utf-8')).toContain(
         'agentkit:resource-safety:start',
       );


### PR DESCRIPTION
## Summary\n\n- Treat Codex/OpenCode terminal and TUI chats as plain-text diagram surfaces even when basic Markdown renders.\n- Use Mermaid only when the destination is explicitly known to support it.\n- Default unknown destinations to compact ASCII.\n- Keep GitHub/GitLab rendered surfaces and Neutron Core's web UI as explicit Mermaid-capable examples.\n- Verify the managed instruction reaches global Codex, Claude, and OpenCode installation paths.\n\n## Verification\n\n- targeted installer test: 2 passed, 0 failed\n- targeted dprint check: passed\n- full AgentKit suite on current main: 338 passed, 5 environment-gated systemd tests skipped, 0 failed\n- git diff check: passed\n- core host services remained active\n\nRefs #64