### PR TITLE
feat(coding-police): monolith-directory cap (max-dir-files)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Reusable AI agent skills, rules, plugins, hooks, and tools for OpenCode, Claude 
 | **format-police.ts**   | Auto-formats files on write using dprint                                                                                 |
 | **kubectl-police.ts**  | Blocks kubectl create/apply for Kargo CRDs (unconditionally)                                                             |
 | **git-police.ts**      | Blocks commits to main/master, force push, --no-verify, AI attribution, push to protected branches                       |
-| **coding-police.ts**   | Enforces DRY code, modular files (<1000 lines), short functions, and single responsibility                               |
+| **coding-police.ts**   | Enforces DRY code, modular files (<1000 lines), short functions, single responsibility, and capped directory file counts |
 | **comment-police.ts**  | Warns on long comment blocks, tutorial-style file headers, PR/plan/closes-#N references, and high comment-to-code ratios |
 | **pkg-police.ts**      | Enforces bun as package manager — blocks npm, npx, yarn, pnpm commands                                                   |
 | **resource-police.ts** | Requires bounded execution for heavy commands and blocks cgroup delegation escapes                                       |
@@ -48,7 +48,7 @@ Reusable AI agent skills, rules, plugins, hooks, and tools for OpenCode, Claude 
 | **git-police.sh**      | PreToolUse        | Blocks force push, --no-verify, Co-authored-by trailers, commits to protected branches, stale pushes (feature branch behind the default branch)                            |
 | **kubectl-police.sh**  | PreToolUse        | Blocks kubectl create/apply on Kargo CRDs                                                                                                                                  |
 | **format-police.sh**   | PostToolUse       | Auto-formats files after edit/write using dprint                                                                                                                           |
-| **coding-police.sh**   | PostToolUse       | Enforces DRY code, modular files (<1000 lines), short functions, single responsibility                                                                                     |
+| **coding-police.sh**   | PostToolUse       | Enforces DRY code, modular files (<1000 lines), short functions, single responsibility, and capped directory file counts                                                   |
 | **pkg-police.sh**      | PreToolUse        | Enforces bun as package manager — blocks npm, npx, yarn, pnpm commands                                                                                                     |
 | **resource-police.sh** | PreToolUse        | Requires `bounded-run` for heavy commands and blocks cgroup delegation escapes                                                                                             |
 | **chime.sh**           | Notification/Stop | Audible nudge when Claude needs you: springy boing on permission prompts/questions, soft ping when a turn finishes. Mute: `touch ~/.claude/.chime-off` or `CLAUDE_CHIME=0` |
@@ -206,13 +206,21 @@ matches are supported.
 
 All thresholds are configurable:
 
-| Setting                | Default | Description                                              |
-| ---------------------- | ------- | -------------------------------------------------------- |
-| `max-file-lines`       | 1000    | Files exceeding this trigger a split warning             |
-| `max-function-lines`   | 100     | Functions exceeding this trigger a decompose warning     |
-| `min-duplicate-lines`  | 6       | Minimum identical consecutive lines to flag as duplicate |
-| `max-exports-per-file` | 15      | Exports exceeding this trigger a responsibility warning  |
-| `exclude-patterns`     | `[]`    | File path substrings to skip (e.g. `generated/`)         |
+| Setting                | Default | Description                                                              |
+| ---------------------- | ------- | ------------------------------------------------------------------------ |
+| `max-file-lines`       | 1000    | Files exceeding this trigger a split warning                             |
+| `max-function-lines`   | 100     | Functions exceeding this trigger a decompose warning                     |
+| `min-duplicate-lines`  | 6       | Minimum identical consecutive lines to flag as duplicate                 |
+| `max-exports-per-file` | 15      | Exports exceeding this trigger a responsibility warning                  |
+| `max-dir-files`        | 15      | Directory file count that blocks creating another flat file (0 disables) |
+| `exclude-patterns`     | `[]`    | File path substrings to skip (e.g. `generated/`)                         |
+
+`max-dir-files` only fires when a Write **creates a new** source file in a directory already at
+or over the cap — editing an existing file in a crowded directory is always allowed. A directory
+with mixed concerns (handlers, helpers, types all flat) should split into domain subfolders once
+it hits the cap. A homogeneous one-file-per-item collection (`routes/`, `migrations/`) is a
+different shape and legitimately outgrows the cap — add it to `exclude-patterns` instead of
+raising the cap globally.
 
 ## gitops-master Setup
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -26,12 +26,21 @@ coding-police:
   # Maximum exports per file before warning about single responsibility.
   max-exports-per-file: 15
 
-  # File path patterns to exclude from checks.
+  # Maximum source files in one directory before warning to split into
+  # domain subfolders. Only fires when a Write creates a new source file;
+  # editing an existing file never triggers it. Set to 0 to disable.
+  max-dir-files: 15
+
+  # File path patterns to exclude from checks. Use this for homogeneous
+  # one-file-per-item collections (routes/, migrations/) that legitimately
+  # outgrow max-dir-files without being a mixed-concerns monolith.
   exclude-patterns: []
   # Example:
   #   exclude-patterns:
   #     - generated/
   #     - __snapshots__/
+  #     - routes/
+  #     - migrations/
 
 pkg-police:
   # Set to false to disable bun enforcement (allows npm/npx/yarn/pnpm).

--- a/hooks/claude/coding-police.sh
+++ b/hooks/claude/coding-police.sh
@@ -11,6 +11,8 @@ MAX_FILE_LINES=1000
 MAX_FUNCTION_LINES=100
 MIN_DUPLICATE_LINES=6
 MAX_EXPORTS_PER_FILE=15
+MAX_DIR_FILES=15
+EXCLUDE_PATTERNS=()
 
 load_config() {
   [[ -f "$AGENTKIT_CONFIG" ]] || return 0
@@ -21,16 +23,35 @@ load_config() {
       max-function-lines) MAX_FUNCTION_LINES="$value" ;;
       min-duplicate-lines) MIN_DUPLICATE_LINES="$value" ;;
       max-exports-per-file) MAX_EXPORTS_PER_FILE="$value" ;;
+      max-dir-files) MAX_DIR_FILES="$value" ;;
+      exclude-pattern) EXCLUDE_PATTERNS+=("$value") ;;
     esac
   done < <(awk '
     /^[^[:space:]#]/ {
       in_section = ($0 ~ /^coding-police:/)
+      in_excludes = 0
       next
     }
     in_section {
       line = $0
       sub(/^[[:space:]]+/, "", line)
-      if (line !~ /^(max-file-lines|max-function-lines|min-duplicate-lines|max-exports-per-file):[[:space:]]*[0-9]+([[:space:]]*#.*)?$/) next
+
+      if (in_excludes) {
+        if (line ~ /^-[[:space:]]*.+$/) {
+          value = line
+          sub(/^-[[:space:]]*/, "", value)
+          print "exclude-pattern=" value
+          next
+        }
+        in_excludes = 0
+      }
+
+      if (line ~ /^exclude-patterns:[[:space:]]*$/) {
+        in_excludes = 1
+        next
+      }
+
+      if (line !~ /^(max-file-lines|max-function-lines|min-duplicate-lines|max-exports-per-file|max-dir-files):[[:space:]]*[0-9]+([[:space:]]*#.*)?$/) next
       key = line
       sub(/:.*/, "", key)
       sub(/^[^:]*:[[:space:]]*/, "", line)
@@ -74,6 +95,11 @@ case "$FILE_PATH" in
   *.lock|*.min.*|*.generated.*|*.snap|*.d.ts|package-lock.json|yarn.lock|pnpm-lock.yaml)
     exit 0 ;;
 esac
+
+# Skip paths matching an exclude-patterns entry (e.g. homogeneous routes/migrations dirs)
+for pattern in "${EXCLUDE_PATTERNS[@]}"; do
+  [[ "$FILE_PATH" == *"$pattern"* ]] && exit 0
+done
 
 [[ -f "$FILE_PATH" ]] || exit 0
 
@@ -243,6 +269,50 @@ check_export_count() {
   fi
 }
 
+# ── Check 6: Monolith directory (Write only — Edit cannot create new files) ─
+check_monolith_directory() {
+  case "$TOOL_NAME" in
+    Write|write) ;;
+    *) return 0 ;;
+  esac
+  (( MAX_DIR_FILES > 0 )) || return 0
+
+  local dir base git_err git_status=0
+  dir=$(dirname -- "$FILE_PATH")
+  base=$(basename -- "$FILE_PATH")
+
+  # A file is "new" when git has never tracked it. Any failure (no repo,
+  # git missing) fails open so the check never blocks when it can't tell.
+  git_err=$(git -C "$dir" ls-files --error-unmatch -- "$base" 2>&1) || git_status=$?
+  (( git_status == 0 )) && return 0
+  [[ "$git_err" == *"not a git repository"* ]] && return 0
+
+  local count=0 entry excluded pattern
+  for entry in "$dir"/*; do
+    [[ -f "$entry" ]] || continue
+    [[ "$entry" == "$FILE_PATH" ]] && continue
+    case "$entry" in
+      *.ts|*.tsx|*.js|*.jsx|*.py|*.rb|*.go|*.rs|*.java|*.kt|*.cs|*.cpp|*.c|*.h|*.hpp|*.swift|*.scala|*.vue|*.svelte) ;;
+      *) continue ;;
+    esac
+    case "$entry" in
+      *.lock|*.min.*|*.generated.*|*.snap|*.d.ts|package-lock.json|yarn.lock|pnpm-lock.yaml) continue ;;
+    esac
+
+    excluded=false
+    for pattern in "${EXCLUDE_PATTERNS[@]}"; do
+      [[ "$entry" == *"$pattern"* ]] && { excluded=true; break; }
+    done
+    [[ "$excluded" == true ]] && continue
+
+    count=$(( count + 1 ))
+  done
+
+  if (( count >= MAX_DIR_FILES )); then
+    VIOLATIONS+=("MONOLITH DIRECTORY: ${dir} already has ${count} source files (cap: ${MAX_DIR_FILES}). Group files into domain subfolders instead of adding more flat files here.")
+  fi
+}
+
 # ── Run all checks ──────────────────────────────────────────────────────────
 check_cross_repo_relative_paths
 
@@ -270,6 +340,7 @@ check_file_length
 check_function_lengths
 check_duplicate_blocks
 check_export_count
+check_monolith_directory
 
 # ── Output violations ──────────────────────────────────────────────────────
 if (( ${#VIOLATIONS[@]} > 0 )); then
@@ -286,6 +357,7 @@ if (( ${#VIOLATIONS[@]} > 0 )); then
     echo "- Keep files modular: split files exceeding ${MAX_FILE_LINES} lines by functionality."
     echo "- Keep functions focused: break functions over ${MAX_FUNCTION_LINES} lines into composable helpers."
     echo "- Apply Single Responsibility: each file should have one clear purpose."
+    echo "- Keep directories navigable: group files into domain subfolders instead of growing past ${MAX_DIR_FILES} flat files."
     echo "- Remove cross-repo sibling relative paths from durable config."
     echo ""
     echo "Fix these violations before proceeding."

--- a/plugins-cc/agentkit/hooks/coding-police.sh
+++ b/plugins-cc/agentkit/hooks/coding-police.sh
@@ -11,6 +11,8 @@ MAX_FILE_LINES=1000
 MAX_FUNCTION_LINES=100
 MIN_DUPLICATE_LINES=6
 MAX_EXPORTS_PER_FILE=15
+MAX_DIR_FILES=15
+EXCLUDE_PATTERNS=()
 
 load_config() {
   [[ -f "$AGENTKIT_CONFIG" ]] || return 0
@@ -21,16 +23,35 @@ load_config() {
       max-function-lines) MAX_FUNCTION_LINES="$value" ;;
       min-duplicate-lines) MIN_DUPLICATE_LINES="$value" ;;
       max-exports-per-file) MAX_EXPORTS_PER_FILE="$value" ;;
+      max-dir-files) MAX_DIR_FILES="$value" ;;
+      exclude-pattern) EXCLUDE_PATTERNS+=("$value") ;;
     esac
   done < <(awk '
     /^[^[:space:]#]/ {
       in_section = ($0 ~ /^coding-police:/)
+      in_excludes = 0
       next
     }
     in_section {
       line = $0
       sub(/^[[:space:]]+/, "", line)
-      if (line !~ /^(max-file-lines|max-function-lines|min-duplicate-lines|max-exports-per-file):[[:space:]]*[0-9]+([[:space:]]*#.*)?$/) next
+
+      if (in_excludes) {
+        if (line ~ /^-[[:space:]]*.+$/) {
+          value = line
+          sub(/^-[[:space:]]*/, "", value)
+          print "exclude-pattern=" value
+          next
+        }
+        in_excludes = 0
+      }
+
+      if (line ~ /^exclude-patterns:[[:space:]]*$/) {
+        in_excludes = 1
+        next
+      }
+
+      if (line !~ /^(max-file-lines|max-function-lines|min-duplicate-lines|max-exports-per-file|max-dir-files):[[:space:]]*[0-9]+([[:space:]]*#.*)?$/) next
       key = line
       sub(/:.*/, "", key)
       sub(/^[^:]*:[[:space:]]*/, "", line)
@@ -74,6 +95,11 @@ case "$FILE_PATH" in
   *.lock|*.min.*|*.generated.*|*.snap|*.d.ts|package-lock.json|yarn.lock|pnpm-lock.yaml)
     exit 0 ;;
 esac
+
+# Skip paths matching an exclude-patterns entry (e.g. homogeneous routes/migrations dirs)
+for pattern in "${EXCLUDE_PATTERNS[@]}"; do
+  [[ "$FILE_PATH" == *"$pattern"* ]] && exit 0
+done
 
 [[ -f "$FILE_PATH" ]] || exit 0
 
@@ -243,6 +269,50 @@ check_export_count() {
   fi
 }
 
+# ── Check 6: Monolith directory (Write only — Edit cannot create new files) ─
+check_monolith_directory() {
+  case "$TOOL_NAME" in
+    Write|write) ;;
+    *) return 0 ;;
+  esac
+  (( MAX_DIR_FILES > 0 )) || return 0
+
+  local dir base git_err git_status=0
+  dir=$(dirname -- "$FILE_PATH")
+  base=$(basename -- "$FILE_PATH")
+
+  # A file is "new" when git has never tracked it. Any failure (no repo,
+  # git missing) fails open so the check never blocks when it can't tell.
+  git_err=$(git -C "$dir" ls-files --error-unmatch -- "$base" 2>&1) || git_status=$?
+  (( git_status == 0 )) && return 0
+  [[ "$git_err" == *"not a git repository"* ]] && return 0
+
+  local count=0 entry excluded pattern
+  for entry in "$dir"/*; do
+    [[ -f "$entry" ]] || continue
+    [[ "$entry" == "$FILE_PATH" ]] && continue
+    case "$entry" in
+      *.ts|*.tsx|*.js|*.jsx|*.py|*.rb|*.go|*.rs|*.java|*.kt|*.cs|*.cpp|*.c|*.h|*.hpp|*.swift|*.scala|*.vue|*.svelte) ;;
+      *) continue ;;
+    esac
+    case "$entry" in
+      *.lock|*.min.*|*.generated.*|*.snap|*.d.ts|package-lock.json|yarn.lock|pnpm-lock.yaml) continue ;;
+    esac
+
+    excluded=false
+    for pattern in "${EXCLUDE_PATTERNS[@]}"; do
+      [[ "$entry" == *"$pattern"* ]] && { excluded=true; break; }
+    done
+    [[ "$excluded" == true ]] && continue
+
+    count=$(( count + 1 ))
+  done
+
+  if (( count >= MAX_DIR_FILES )); then
+    VIOLATIONS+=("MONOLITH DIRECTORY: ${dir} already has ${count} source files (cap: ${MAX_DIR_FILES}). Group files into domain subfolders instead of adding more flat files here.")
+  fi
+}
+
 # ── Run all checks ──────────────────────────────────────────────────────────
 check_cross_repo_relative_paths
 
@@ -270,6 +340,7 @@ check_file_length
 check_function_lengths
 check_duplicate_blocks
 check_export_count
+check_monolith_directory
 
 # ── Output violations ──────────────────────────────────────────────────────
 if (( ${#VIOLATIONS[@]} > 0 )); then
@@ -286,6 +357,7 @@ if (( ${#VIOLATIONS[@]} > 0 )); then
     echo "- Keep files modular: split files exceeding ${MAX_FILE_LINES} lines by functionality."
     echo "- Keep functions focused: break functions over ${MAX_FUNCTION_LINES} lines into composable helpers."
     echo "- Apply Single Responsibility: each file should have one clear purpose."
+    echo "- Keep directories navigable: group files into domain subfolders instead of growing past ${MAX_DIR_FILES} flat files."
     echo "- Remove cross-repo sibling relative paths from durable config."
     echo ""
     echo "Fix these violations before proceeding."

--- a/plugins/coding-police.ts
+++ b/plugins/coding-police.ts
@@ -1,7 +1,8 @@
 import type { PluginInput } from '@opencode-ai/plugin';
-import { readFileSync } from 'node:fs';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
+import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 
 // ---------------------------------------------------------------------------
@@ -13,6 +14,7 @@ interface CodingPoliceConfig {
   maxFunctionLines: number;
   minDuplicateLines: number;
   maxExportsPerFile: number;
+  maxDirFiles: number;
   excludePatterns: string[];
 }
 
@@ -21,6 +23,7 @@ const DEFAULTS: CodingPoliceConfig = {
   maxFunctionLines: 100,
   minDuplicateLines: 6,
   maxExportsPerFile: 15,
+  maxDirFiles: 15,
   excludePatterns: [],
 };
 
@@ -69,6 +72,7 @@ export function loadConfig(): CodingPoliceConfig {
     const maxFunc = section.match(/max-function-lines:\s*(\d+)/);
     const minDup = section.match(/min-duplicate-lines:\s*(\d+)/);
     const maxExp = section.match(/max-exports-per-file:\s*(\d+)/);
+    const maxDir = section.match(/max-dir-files:\s*(\d+)/);
 
     const excludeMatch = section.match(
       /exclude-patterns:\s*\n((?:\s*-\s*.+\n?)*)/,
@@ -90,6 +94,7 @@ export function loadConfig(): CodingPoliceConfig {
       maxExportsPerFile: maxExp
         ? parseInt(maxExp[1], 10)
         : DEFAULTS.maxExportsPerFile,
+      maxDirFiles: maxDir ? parseInt(maxDir[1], 10) : DEFAULTS.maxDirFiles,
       excludePatterns: excludes.length > 0 ? excludes : DEFAULTS.excludePatterns,
     };
   } catch {
@@ -286,6 +291,81 @@ export function checkExportCount(
 }
 
 /**
+ * Check 6: Monolith directory — creating a new source file in a directory
+ * that already holds too many flat source files hurts discoverability the
+ * same way an oversized file does.
+ */
+export function checkMonolithDirectory(
+  siblingCount: number,
+  dirLabel: string,
+  maxDirFiles: number,
+): string | null {
+  if (maxDirFiles <= 0) return null;
+  if (siblingCount < maxDirFiles) return null;
+
+  return (
+    `MONOLITH DIRECTORY: ${dirLabel} already has ${siblingCount} source files (cap: ${maxDirFiles}).\n` +
+    `  Group files into domain subfolders instead of adding more flat files here.`
+  );
+}
+
+/**
+ * A file is "new" when git has never tracked it. Any failure (no git repo,
+ * git missing) fails open so the check never blocks when it can't tell.
+ */
+function isNewFile(absPath: string): boolean {
+  const result = spawnSync(
+    'git',
+    ['-C', path.dirname(absPath), 'ls-files', '--error-unmatch', '--', path.basename(absPath)],
+    { encoding: 'utf-8' },
+  );
+  if (result.error) return false;
+  if (result.status === 0) return false;
+  if ((result.stderr || '').includes('not a git repository')) return false;
+  return true;
+}
+
+/**
+ * Counts sibling CODE_FILE entries in a directory (non-recursive), applying
+ * the same SKIP_FILES and exclude-patterns filters as the rest of the plugin.
+ */
+function countDirectorySiblings(
+  dirAbsPath: string,
+  worktree: string,
+  excludeAbsPath: string,
+  excludePatterns: string[],
+): number {
+  let entries: string[];
+  try {
+    entries = readdirSync(dirAbsPath);
+  } catch {
+    return 0;
+  }
+
+  let count = 0;
+  for (const name of entries) {
+    if (!CODE_FILE.test(name) || SKIP_FILES.test(name)) continue;
+
+    const entryAbsPath = path.join(dirAbsPath, name);
+    if (entryAbsPath === excludeAbsPath) continue;
+
+    let stat;
+    try {
+      stat = statSync(entryAbsPath);
+    } catch {
+      continue;
+    }
+    if (!stat.isFile()) continue;
+
+    const entryRelPath = path.relative(worktree, entryAbsPath);
+    if (excludePatterns.some((pattern) => entryRelPath.includes(pattern))) continue;
+
+    count++;
+  }
+  return count;
+}
+
+/**
  * Check 5: Cross-repo sibling relative paths in durable config.
  *
  * Infrastructure and deploy config must not reach into sibling repositories
@@ -403,6 +483,23 @@ export default async function codingPolice(ctx: PluginInput) {
         if (exportWarning) violations.push(exportWarning);
       }
 
+      // Check 6: Monolith directory (Write only — Edit cannot create new files)
+      if (toolName === 'write' && isNewFile(absPath)) {
+        const dirAbsPath = path.dirname(absPath);
+        const siblingCount = countDirectorySiblings(
+          dirAbsPath,
+          ctx.worktree,
+          absPath,
+          config.excludePatterns,
+        );
+        const dirWarning = checkMonolithDirectory(
+          siblingCount,
+          path.dirname(relativePath) || '.',
+          config.maxDirFiles,
+        );
+        if (dirWarning) violations.push(dirWarning);
+      }
+
       if (violations.length === 0) return;
 
       output.output +=
@@ -416,6 +513,7 @@ export default async function codingPolice(ctx: PluginInput) {
         `- Keep files modular: split files exceeding ${config.maxFileLines} lines by functionality.\n` +
         `- Keep functions focused: break functions over ${config.maxFunctionLines} lines into composable helpers.\n` +
         `- Apply Single Responsibility: each file should have one clear purpose.\n` +
+        `- Keep directories navigable: group files into domain subfolders instead of growing past ${config.maxDirFiles} flat files.\n` +
         `- Remove cross-repo sibling relative paths from durable config.\n` +
         `\n` +
         `Fix these violations before proceeding.`;

--- a/tests/coding-police-hook.test.ts
+++ b/tests/coding-police-hook.test.ts
@@ -36,6 +36,43 @@ function writeExecutable(path: string, content: string): void {
   chmodSync(path, 0o755);
 }
 
+function runGit(args: string[], cwd: string): void {
+  const result = spawnSync('git', args, { cwd, encoding: 'utf-8' });
+  if (result.status !== 0) {
+    throw new Error(`git ${args.join(' ')} failed: ${result.stderr}`);
+  }
+}
+
+function makeGitRepo(root: string): void {
+  runGit(['init', '-q'], root);
+  runGit(['config', 'user.email', 'test@test.com'], root);
+  runGit(['config', 'user.name', 'test'], root);
+}
+
+function commitFile(repoDir: string, relPath: string, content: string): void {
+  const abs = join(repoDir, relPath);
+  mkdirSync(dirname(abs), { recursive: true });
+  writeFileSync(abs, content);
+  runGit(['add', relPath], repoDir);
+  runGit(['commit', '-q', '-m', `add ${relPath}`], repoDir);
+}
+
+function runHookOnFile(configYaml: string, root: string, filePath: string) {
+  const configDir = join(root, 'config', 'agentkit');
+  mkdirSync(configDir, { recursive: true });
+  writeFileSync(join(configDir, 'config.yaml'), configYaml);
+
+  return spawnSync('bash', [hook], {
+    encoding: 'utf-8',
+    env: {
+      ...process.env,
+      HOME: root,
+      XDG_CONFIG_HOME: join(root, 'config'),
+    },
+    input: JSON.stringify({ tool_name: 'Write', tool_input: { file_path: filePath } }),
+  });
+}
+
 function runHook(config: string, shimBin?: (directory: string) => void) {
   const root = mkdtempSync(join(tmpdir(), 'agentkit-coding-hook-'));
   const configDir = join(root, 'config', 'agentkit');
@@ -132,5 +169,93 @@ exec /usr/bin/head "$@"
 
   test('keeps the Claude plugin hook identical to its source', () => {
     expect(readFileSync(pluginHook, 'utf-8')).toBe(readFileSync(hook, 'utf-8'));
+  });
+});
+
+describe('Claude coding-police monolith directory', () => {
+  test('blocks a new source file in a directory already at the cap', () => {
+    const root = mkdtempSync(join(tmpdir(), 'agentkit-dircap-'));
+    makeGitRepo(root);
+    for (let i = 0; i < 15; i++) {
+      commitFile(root, `src/handlers/h${i}.ts`, `export const h${i} = ${i};\n`);
+    }
+    const target = join(root, 'src/handlers/h15.ts');
+    writeFileSync(target, 'export const h15 = 15;\n');
+
+    const result = runHookOnFile('coding-police:\n  max-dir-files: 15\n', root, target);
+    rmSync(root, { force: true, recursive: true });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stderr).toContain('MONOLITH DIRECTORY');
+    expect(result.stderr).toContain('15 source files');
+    expect(result.stderr).toContain('cap: 15');
+  });
+
+  test('allows overwriting an already-tracked file in an over-cap directory', () => {
+    const root = mkdtempSync(join(tmpdir(), 'agentkit-dircap-'));
+    makeGitRepo(root);
+    for (let i = 0; i < 16; i++) {
+      commitFile(root, `src/handlers/h${i}.ts`, `export const h${i} = ${i};\n`);
+    }
+    const target = join(root, 'src/handlers/h0.ts');
+    writeFileSync(target, 'export const h0 = 100;\n');
+
+    const result = runHookOnFile('coding-police:\n  max-dir-files: 15\n', root, target);
+    rmSync(root, { force: true, recursive: true });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stderr).not.toContain('MONOLITH DIRECTORY');
+  });
+
+  test('max-dir-files: 0 disables the check', () => {
+    const root = mkdtempSync(join(tmpdir(), 'agentkit-dircap-'));
+    makeGitRepo(root);
+    for (let i = 0; i < 20; i++) {
+      commitFile(root, `src/handlers/h${i}.ts`, `export const h${i} = ${i};\n`);
+    }
+    const target = join(root, 'src/handlers/h20.ts');
+    writeFileSync(target, 'export const h20 = 20;\n');
+
+    const result = runHookOnFile('coding-police:\n  max-dir-files: 0\n', root, target);
+    rmSync(root, { force: true, recursive: true });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stderr).not.toContain('MONOLITH DIRECTORY');
+  });
+
+  test('exclude-patterns suppresses the check for homogeneous collections', () => {
+    const root = mkdtempSync(join(tmpdir(), 'agentkit-dircap-'));
+    makeGitRepo(root);
+    for (let i = 0; i < 15; i++) {
+      commitFile(root, `src/routes/r${i}.ts`, `export const r${i} = ${i};\n`);
+    }
+    const target = join(root, 'src/routes/r15.ts');
+    writeFileSync(target, 'export const r15 = 15;\n');
+
+    const result = runHookOnFile(
+      'coding-police:\n  max-dir-files: 15\n  exclude-patterns:\n    - routes/\n',
+      root,
+      target,
+    );
+    rmSync(root, { force: true, recursive: true });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stderr).not.toContain('MONOLITH DIRECTORY');
+  });
+
+  test('ignores non-code files even in an over-cap directory', () => {
+    const root = mkdtempSync(join(tmpdir(), 'agentkit-dircap-'));
+    makeGitRepo(root);
+    for (let i = 0; i < 15; i++) {
+      commitFile(root, `src/handlers/h${i}.ts`, `export const h${i} = ${i};\n`);
+    }
+    const target = join(root, 'src/handlers/notes.md');
+    writeFileSync(target, '# notes\n');
+
+    const result = runHookOnFile('coding-police:\n  max-dir-files: 15\n', root, target);
+    rmSync(root, { force: true, recursive: true });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stderr).not.toContain('MONOLITH DIRECTORY');
   });
 });

--- a/tests/coding-police.test.ts
+++ b/tests/coding-police.test.ts
@@ -1,10 +1,15 @@
 import { describe, test, expect } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { spawnSync } from 'node:child_process';
 import codingPolice, {
   checkFileLength,
   checkFunctionLengths,
   checkDuplicateBlocks,
   checkExportCount,
   checkCrossRepoRelativePaths,
+  checkMonolithDirectory,
 } from '../plugins/coding-police';
 
 // ---------------------------------------------------------------------------
@@ -289,6 +294,35 @@ describe('checkExportCount', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Check 6: Monolith directory
+// ---------------------------------------------------------------------------
+
+describe('checkMonolithDirectory', () => {
+  test('returns null when the cap is disabled (0)', () => {
+    expect(checkMonolithDirectory(30, 'src/handlers', 0)).toBeNull();
+  });
+
+  test('returns null when sibling count is under the cap', () => {
+    expect(checkMonolithDirectory(14, 'src/handlers', 15)).toBeNull();
+  });
+
+  test('returns a warning when sibling count is at the cap', () => {
+    const result = checkMonolithDirectory(15, 'src/handlers', 15);
+    expect(result).not.toBeNull();
+    expect(result).toContain('MONOLITH DIRECTORY');
+    expect(result).toContain('src/handlers');
+    expect(result).toContain('15 source files');
+    expect(result).toContain('cap: 15');
+    expect(result).toContain('domain subfolders');
+  });
+
+  test('returns a warning when sibling count is over the cap', () => {
+    const result = checkMonolithDirectory(22, 'src/handlers', 15);
+    expect(result).toContain('22 source files');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Check 5: Cross-repo relative paths
 // ---------------------------------------------------------------------------
 
@@ -368,5 +402,152 @@ describe('coding-police plugin', () => {
     await hooks['tool.execute.after']!(input, output);
 
     expect(output.output).toContain('CROSS-REPO RELATIVE PATH');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Plugin integration: monolith directory (Check 6)
+// ---------------------------------------------------------------------------
+
+function runGit(args: string[], cwd: string): void {
+  const result = spawnSync('git', args, { cwd, encoding: 'utf-8' });
+  if (result.status !== 0) {
+    throw new Error(`git ${args.join(' ')} failed: ${result.stderr}`);
+  }
+}
+
+function makeGitRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'agentkit-dircap-'));
+  runGit(['init', '-q'], dir);
+  runGit(['config', 'user.email', 'test@test.com'], dir);
+  runGit(['config', 'user.name', 'test'], dir);
+  return dir;
+}
+
+function commitFile(repoDir: string, relPath: string, content: string): void {
+  const abs = join(repoDir, relPath);
+  mkdirSync(dirname(abs), { recursive: true });
+  writeFileSync(abs, content);
+  runGit(['add', relPath], repoDir);
+  runGit(['commit', '-q', '-m', `add ${relPath}`], repoDir);
+}
+
+async function withXdgConfig<T>(
+  configYaml: string | null,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const dir = mkdtempSync(join(tmpdir(), 'agentkit-xdg-'));
+  if (configYaml !== null) {
+    mkdirSync(join(dir, 'agentkit'), { recursive: true });
+    writeFileSync(join(dir, 'agentkit', 'config.yaml'), configYaml);
+  }
+  const previous = process.env.XDG_CONFIG_HOME;
+  process.env.XDG_CONFIG_HOME = dir;
+  try {
+    return await fn();
+  } finally {
+    if (previous === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = previous;
+    rmSync(dir, { force: true, recursive: true });
+  }
+}
+
+describe('coding-police plugin — monolith directory', () => {
+  test('blocks a new source file in a directory already at the cap', async () => {
+    await withXdgConfig(null, async () => {
+      const repo = makeGitRepo();
+      for (let i = 0; i < 15; i++) {
+        commitFile(repo, `src/handlers/h${i}.ts`, `export const h${i} = ${i};\n`);
+      }
+      writeFileSync(join(repo, 'src/handlers/h15.ts'), 'export const h15 = 15;\n');
+
+      const hooks = await codingPolice({ ...mockCtx, worktree: repo });
+      const input = { tool: 'write', sessionID: 'test', callID: 'test' };
+      const output = { title: 'src/handlers/h15.ts', output: 'done', metadata: {} };
+      await hooks['tool.execute.after']!(input, output);
+
+      expect(output.output).toContain('MONOLITH DIRECTORY');
+      expect(output.output).toContain('src/handlers');
+      expect(output.output).toContain('15 source files');
+      expect(output.output).toContain('cap: 15');
+
+      rmSync(repo, { force: true, recursive: true });
+    });
+  });
+
+  test('allows overwriting an already-tracked file in an over-cap directory', async () => {
+    await withXdgConfig(null, async () => {
+      const repo = makeGitRepo();
+      for (let i = 0; i < 16; i++) {
+        commitFile(repo, `src/handlers/h${i}.ts`, `export const h${i} = ${i};\n`);
+      }
+      writeFileSync(join(repo, 'src/handlers/h0.ts'), 'export const h0 = 100;\n');
+
+      const hooks = await codingPolice({ ...mockCtx, worktree: repo });
+      const input = { tool: 'write', sessionID: 'test', callID: 'test' };
+      const output = { title: 'src/handlers/h0.ts', output: 'done', metadata: {} };
+      await hooks['tool.execute.after']!(input, output);
+
+      expect(output.output).not.toContain('MONOLITH DIRECTORY');
+
+      rmSync(repo, { force: true, recursive: true });
+    });
+  });
+
+  test('max-dir-files: 0 disables the check', async () => {
+    await withXdgConfig('coding-police:\n  max-dir-files: 0\n', async () => {
+      const repo = makeGitRepo();
+      for (let i = 0; i < 20; i++) {
+        commitFile(repo, `src/handlers/h${i}.ts`, `export const h${i} = ${i};\n`);
+      }
+      writeFileSync(join(repo, 'src/handlers/h20.ts'), 'export const h20 = 20;\n');
+
+      const hooks = await codingPolice({ ...mockCtx, worktree: repo });
+      const input = { tool: 'write', sessionID: 'test', callID: 'test' };
+      const output = { title: 'src/handlers/h20.ts', output: 'done', metadata: {} };
+      await hooks['tool.execute.after']!(input, output);
+
+      expect(output.output).not.toContain('MONOLITH DIRECTORY');
+
+      rmSync(repo, { force: true, recursive: true });
+    });
+  });
+
+  test('exclude-patterns suppresses the check for homogeneous collections', async () => {
+    await withXdgConfig('coding-police:\n  exclude-patterns:\n    - routes/\n', async () => {
+      const repo = makeGitRepo();
+      for (let i = 0; i < 15; i++) {
+        commitFile(repo, `src/routes/r${i}.ts`, `export const r${i} = ${i};\n`);
+      }
+      writeFileSync(join(repo, 'src/routes/r15.ts'), 'export const r15 = 15;\n');
+
+      const hooks = await codingPolice({ ...mockCtx, worktree: repo });
+      const input = { tool: 'write', sessionID: 'test', callID: 'test' };
+      const output = { title: 'src/routes/r15.ts', output: 'done', metadata: {} };
+      await hooks['tool.execute.after']!(input, output);
+
+      expect(output.output).not.toContain('MONOLITH DIRECTORY');
+
+      rmSync(repo, { force: true, recursive: true });
+    });
+  });
+
+  test('ignores non-code files even in an over-cap directory', async () => {
+    await withXdgConfig(null, async () => {
+      const repo = makeGitRepo();
+      for (let i = 0; i < 15; i++) {
+        commitFile(repo, `src/handlers/h${i}.ts`, `export const h${i} = ${i};\n`);
+      }
+      writeFileSync(join(repo, 'src/handlers/notes.md'), '# notes\n');
+
+      const hooks = await codingPolice({ ...mockCtx, worktree: repo });
+      const input = { tool: 'write', sessionID: 'test', callID: 'test' };
+      const output = { title: 'src/handlers/notes.md', output: 'done', metadata: {} };
+      await hooks['tool.execute.after']!(input, output);
+
+      expect(output.output).not.toContain('MONOLITH DIRECTORY');
+
+      rmSync(repo, { force: true, recursive: true });
+    });
   });
 });


### PR DESCRIPTION
Refs #72

- new `max-dir-files` (default 15, 0 disables): creating a NEW source file in a directory at/over the cap is flagged with grouping guidance; edits to existing files never trigger
- new-file detection via `git ls-files --error-unmatch`, fail-open on any git error
- `exclude-patterns` gates the bash variants too (parity with the TS plugin); documented for homogeneous collections (routes/, migrations/)
- 30+ new tests; full suite 352 pass / 0 fail
- hooks/claude and plugins-cc variants byte-identical (test-enforced)