### PR TITLE
feat(review-police): make review a hard merge gate the agent cannot dismiss

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Reusable AI agent skills, rules, plugins, hooks, and tools for OpenCode, Claude 
 | **resource-police.sh** | PreToolUse        | Requires `bounded-run` for heavy commands and blocks cgroup delegation escapes                                                                                                                                  |
 | **chime.sh**           | Notification/Stop | Audible nudge when Claude needs you: springy boing on permission prompts/questions, soft ping when a turn finishes. Mute: `touch ~/.claude/.chime-off` or `CLAUDE_CHIME=0`                                      |
 | **mr-police.sh**       | PreToolUse        | Blocks opening a new MR while you already have an open MR you authored on the repo — stops unmerged MRs from stacking up                                                                                        |
-| **review-police.sh**   | PreToolUse        | Blocks a merge (glab/gh CLI or REST) unless an independent review passed for the exact head sha. Unresolved BLOCKER/HIGH findings block; the agent cannot dismiss them — only the user can override, in writing |
+| **review-police.sh**   | PreToolUse        | Blocks CLI/REST/MCP merges unless a review record passes for the MR's real source branch and head sha (resolved from the forge). Unresolved BLOCKER/HIGH block; overrides need the user's written consent, logged to `~/.agentkit/review-audit.log`. NOT security — the record is agent-writable; forge-side required approvals are the only real enforcement |
 
 ### Policies (Codex CLI -- exec policy)
 

--- a/README.md
+++ b/README.md
@@ -43,16 +43,17 @@ Reusable AI agent skills, rules, plugins, hooks, and tools for OpenCode, Claude 
 
 ### Hooks (Claude Code -- PreToolUse / PostToolUse)
 
-| Hook                   | Type              | Description                                                                                                                                                                |
-| ---------------------- | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **git-police.sh**      | PreToolUse        | Blocks force push, --no-verify, Co-authored-by trailers, commits to protected branches, stale pushes (feature branch behind the default branch)                            |
-| **kubectl-police.sh**  | PreToolUse        | Blocks kubectl create/apply on Kargo CRDs                                                                                                                                  |
-| **format-police.sh**   | PostToolUse       | Auto-formats files after edit/write using dprint                                                                                                                           |
-| **coding-police.sh**   | PostToolUse       | Enforces DRY code, modular files (<1000 lines), short functions, single responsibility, and capped directory file counts                                                   |
-| **pkg-police.sh**      | PreToolUse        | Enforces bun as package manager — blocks npm, npx, yarn, pnpm commands                                                                                                     |
-| **resource-police.sh** | PreToolUse        | Requires `bounded-run` for heavy commands and blocks cgroup delegation escapes                                                                                             |
-| **chime.sh**           | Notification/Stop | Audible nudge when Claude needs you: springy boing on permission prompts/questions, soft ping when a turn finishes. Mute: `touch ~/.claude/.chime-off` or `CLAUDE_CHIME=0` |
-| **mr-police.sh**       | PreToolUse        | Blocks opening a new MR while you already have an open MR you authored on the repo — stops unmerged MRs from stacking up                                                   |
+| Hook                   | Type              | Description                                                                                                                                                                                                     |
+| ---------------------- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **git-police.sh**      | PreToolUse        | Blocks force push, --no-verify, Co-authored-by trailers, commits to protected branches, stale pushes (feature branch behind the default branch)                                                                 |
+| **kubectl-police.sh**  | PreToolUse        | Blocks kubectl create/apply on Kargo CRDs                                                                                                                                                                       |
+| **format-police.sh**   | PostToolUse       | Auto-formats files after edit/write using dprint                                                                                                                                                                |
+| **coding-police.sh**   | PostToolUse       | Enforces DRY code, modular files (<1000 lines), short functions, single responsibility, and capped directory file counts                                                                                        |
+| **pkg-police.sh**      | PreToolUse        | Enforces bun as package manager — blocks npm, npx, yarn, pnpm commands                                                                                                                                          |
+| **resource-police.sh** | PreToolUse        | Requires `bounded-run` for heavy commands and blocks cgroup delegation escapes                                                                                                                                  |
+| **chime.sh**           | Notification/Stop | Audible nudge when Claude needs you: springy boing on permission prompts/questions, soft ping when a turn finishes. Mute: `touch ~/.claude/.chime-off` or `CLAUDE_CHIME=0`                                      |
+| **mr-police.sh**       | PreToolUse        | Blocks opening a new MR while you already have an open MR you authored on the repo — stops unmerged MRs from stacking up                                                                                        |
+| **review-police.sh**   | PreToolUse        | Blocks a merge (glab/gh CLI or REST) unless an independent review passed for the exact head sha. Unresolved BLOCKER/HIGH findings block; the agent cannot dismiss them — only the user can override, in writing |
 
 ### Policies (Codex CLI -- exec policy)
 

--- a/hooks/claude/review-police.sh
+++ b/hooks/claude/review-police.sh
@@ -1,45 +1,43 @@
 #!/usr/bin/env bash
-# review-police.sh — Claude Code PreToolUse hook (matcher: Bash)
+# review-police.sh — Claude Code PreToolUse hook (matchers: Bash + MCP merges)
 #
-# Blocks a forge merge unless an independent review has PASSED for exactly the
-# commit being merged. The agent cannot clear a blocking finding by reasoning
-# about it; only the user can, and only in writing.
+# Blocks a forge merge unless an independent review PASSED for exactly the
+# commit that merge would land. The agent cannot clear a blocking finding by
+# reasoning about it; the path is fix-properly-then-re-review.
 #
-# Why this exists: on 2026-07-19 a reviewer returned "HIGH — don't expose the
-# menu item yet", the merge had already been started in parallel, and the agent
-# judged the finding inert and shipped it. The feature then broke the user's
-# machine exactly as the reviewer predicted. Severity is the reviewer's call;
-# the override is the user's. Neither belongs to the agent.
+# Why: on 2026-07-19 a reviewer returned "HIGH — don't expose the menu item
+# yet", the merge was already running in parallel, the agent judged the finding
+# inert and shipped it, and it broke the user's machine exactly as predicted.
 #
-# Contract (a review record is JSON, written by the REVIEWING agent):
-#   .agentkit/reviews/<branch-slug>.json
+# WHAT THIS IS NOT: security. The review record lives in the repo and the agent
+# can write it, so a determined agent can forge a pass. This hook makes the
+# honest path correct, makes a stale or missing review mechanically impossible
+# to merge past, and leaves an out-of-repo audit trail when a record is used.
+# Only forge-side required approvals can actually prevent a merge.
+#
+# Review record, written by the REVIEWING agent:
+#   .agentkit/reviews/<source-branch-slug>.json
 #     { "head_sha": "<full sha reviewed>",
-#       "reviewer":  "<agent/session id — must differ from the merger>",
-#       "verdict":   "pass" | "blocked",
-#       "findings":  [ { "severity": "BLOCKER|HIGH|MEDIUM|LOW",
-#                        "summary": "...", "resolved": true|false } ],
+#       "verdict":  "pass" | "blocked",
+#       "findings": [ { "severity": "BLOCKER|HIGH|MEDIUM|LOW",
+#                       "summary": "...", "resolved": true|false } ],
 #       "user_consent": {            # ONLY the user may add this
-#          "granted": true,
-#          "quote":  "<their words, verbatim>",
-#          "at":     "<ISO timestamp>" } }
+#          "granted": true, "quote": "<their words>", "at": "<ISO>" } }
 #
-# A merge passes when: the record exists, its head_sha equals the branch head
-# being merged (a stale review is no review), and no unresolved BLOCKER/HIGH
-# remains — or the user granted consent in writing for that same sha.
+# The gate resolves the MR/PR's REAL source branch and head sha from the forge —
+# never the local checkout, which says nothing about what is being merged.
 set -euo pipefail
 
 INPUT=$(cat)
+TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty')
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
-[[ -z "$COMMAND" ]] && exit 0
+SESSION=$(echo "$INPUT" | jq -r '.session_id // "unknown"')
 
-# Merge attempts, however they are spelled: glab/gh CLIs and the REST calls
-# that bypass them (the agent has reached for curl when a CLI refused).
-if ! echo "$COMMAND" | grep -qiE \
-	'glab[[:space:]]+mr[[:space:]]+merge|gh[[:space:]]+pr[[:space:]]+merge|merge_requests?/[0-9]+/merge|/pulls/[0-9]+/merge'; then
-	exit 0
-fi
+AUDIT="${HOME}/.agentkit/review-audit.log"
 
 deny() {
+	mkdir -p "$(dirname "$AUDIT")" 2>/dev/null || true
+	printf '%s\tDENY\tsession=%s\t%s\n' "$(date -Is)" "$SESSION" "${1//$'\n'/ }" >>"$AUDIT" 2>/dev/null || true
 	jq -n --arg r "$1" '{
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
@@ -50,45 +48,113 @@ deny() {
 	exit 0
 }
 
-# The repo the command targets: an explicit `cd <path> &&` prefix wins,
-# otherwise the hook's cwd (mirrors mr-police's resolution).
+# --- MCP merge tools: no Bash to inspect, so refuse outright ---------------
+# These bypass every command-shaped check. The CLI path is the reviewed path.
+if [[ -n "$TOOL" && "$TOOL" != "Bash" ]]; then
+	if echo "$TOOL" | grep -qiE 'merge_(pull_request|request)|pull_request_merge|mr_merge'; then
+		deny "BLOCKED: merging through an MCP tool bypasses the review gate.
+
+Use the CLI (\`glab mr merge\` / \`gh pr merge\`) so the merge is checked against
+the review record for the commit being merged."
+	fi
+	exit 0
+fi
+
+[[ -z "$COMMAND" ]] && exit 0
+
+# --- Is this a merge attempt? ---------------------------------------------
+# Flag-tolerant: `glab -R o/r mr merge`, `gh --repo o/r pr merge`,
+# `glab mr --repo o/r merge` all count. Same shape as git-police's push regex.
+FLAG='(\s+(-[A-Za-z]\S*|--[A-Za-z][A-Za-z0-9-]*(=\S+)?)(\s+[^-\s]\S*)?)*'
+# NOTE: every match below is wrapped so a NON-match cannot abort the script.
+# `grep -q … && is_merge=1` returns non-zero when the pattern misses, and under
+# `set -e` that exits the hook silently — i.e. FAILS OPEN, allowing the merge.
+# Caught by this file's own tests before it ever shipped; keep the `if` form.
+is_merge=0
+if echo "$COMMAND" | grep -qiE "\bglab${FLAG}[[:space:]]+mr${FLAG}[[:space:]]+merge\b"; then is_merge=1; fi
+if echo "$COMMAND" | grep -qiE "\bgh${FLAG}[[:space:]]+pr${FLAG}[[:space:]]+merge\b"; then is_merge=1; fi
+# REST paths, contiguous or split across variables (…/merge_requests/12/merge).
+if echo "$COMMAND" | grep -qiE 'merge_requests?/[0-9]+/merge|/pulls/[0-9]+/merge'; then is_merge=1; fi
+if echo "$COMMAND" | grep -qiE 'merge_requests?|/pulls/' &&
+	echo "$COMMAND" | grep -qiE '\b(PUT|POST)\b'; then is_merge=1; fi
+[[ $is_merge -eq 1 ]] || exit 0
+
+# Auto-merge queues the merge for a LATER head — the sha we check now is not
+# the sha that lands. Refuse the mode rather than pretend to gate it.
+if echo "$COMMAND" | grep -qiE '(--auto|--merge-when-pipeline-succeeds|--when-pipeline-succeeds)\b'; then
+	deny "BLOCKED: auto-merge cannot be review-gated.
+
+It merges a future head that no review has seen. Wait for the pipeline, then
+merge explicitly so the gate can check the commit that actually lands."
+fi
+
+# --- Resolve WHAT is being merged, from the forge ---------------------------
+# Fail CLOSED: if the target cannot be resolved, the gate denies. An
+# unresolvable merge is exactly when a mistake is most likely.
 REPO_DIR=$(echo "$COMMAND" | sed -nE 's/^[[:space:]]*cd[[:space:]]+([^[:space:];&|]+).*/\1/p' | head -1)
 [[ -z "$REPO_DIR" ]] && REPO_DIR="$PWD"
-[[ -d "$REPO_DIR" ]] || REPO_DIR="$PWD"
 
-BRANCH=$(git -C "$REPO_DIR" branch --show-current 2>/dev/null || true)
-[[ -z "$BRANCH" ]] && exit 0
+MR_ID=$(echo "$COMMAND" | grep -oiE '\b(mr|pr)([[:space:]]+-{1,2}[A-Za-z][^[:space:]]*)*[[:space:]]+merge([[:space:]]+-{1,2}[A-Za-z][^[:space:]]*)*[[:space:]]+[0-9]+' | grep -oE '[0-9]+$' | head -1 || true)
+if [[ -z "$MR_ID" ]]; then
+	MR_ID=$(echo "$COMMAND" | grep -oiE 'merge_requests?/[0-9]+|/pulls/[0-9]+' | grep -oE '[0-9]+' | head -1 || true)
+fi
+REPO_FLAG=$(echo "$COMMAND" | grep -oiE '(-R|--repo)[= ]+[^ ]+' | head -1 | sed -E 's/^(-R|--repo)[= ]+//' || true)
 
-# Never gate the merge of a branch that has no local checkout context.
-HEAD_SHA=$(git -C "$REPO_DIR" rev-parse HEAD 2>/dev/null || true)
-[[ -z "$HEAD_SHA" ]] && exit 0
+forge_json() {
+	if echo "$COMMAND" | grep -qiE '\bgh\b|/pulls/'; then
+		gh pr view "$MR_ID" ${REPO_FLAG:+--repo "$REPO_FLAG"} \
+			--json headRefName,headRefOid 2>/dev/null |
+			jq -r '"\(.headRefName)\t\(.headRefOid)"'
+	else
+		glab mr view "$MR_ID" ${REPO_FLAG:+--repo "$REPO_FLAG"} --output json 2>/dev/null |
+			jq -r '"\(.source_branch)\t\(.sha // .diff_refs.head_sha)"'
+	fi
+}
 
-SLUG=$(echo "$BRANCH" | tr '/' '-')
+BRANCH=""
+HEAD_SHA=""
+if [[ -n "$MR_ID" ]]; then
+	RESOLVED=$(cd "$REPO_DIR" 2>/dev/null && forge_json || true)
+	BRANCH=$(echo "$RESOLVED" | cut -f1)
+	HEAD_SHA=$(echo "$RESOLVED" | cut -f2)
+fi
+
+if [[ -z "$BRANCH" || -z "$HEAD_SHA" || "$BRANCH" == "null" || "$HEAD_SHA" == "null" ]]; then
+	deny "BLOCKED: cannot resolve what this merge would land, so it cannot be gated.
+
+  command dir: $REPO_DIR
+  mr/pr id:    ${MR_ID:-<none found>}
+
+The gate must read the merge request's SOURCE BRANCH and HEAD SHA from the
+forge — the local checkout says nothing about the commit being merged. Run the
+merge from the repo directory with an explicit MR/PR number, with the forge CLI
+authenticated."
+fi
+
+SLUG=$(echo "$BRANCH" | sed 's#/#__#g')
 RECORD="$REPO_DIR/.agentkit/reviews/$SLUG.json"
 
 if [[ ! -f "$RECORD" ]]; then
-	deny "BLOCKED: no review record for '$BRANCH'.
+	deny "BLOCKED: no review record for the branch this merge would land.
 
-A merge requires an independent review of the exact commit being merged.
-Run the review (code-reviewer subagent), have it write its verdict to
-  .agentkit/reviews/$SLUG.json
-with head_sha, verdict, and findings, THEN merge.
+  merge request: !${MR_ID}
+  source branch: $BRANCH
+  head sha:      $HEAD_SHA
 
-Reviews gate merges — they do not run alongside them. If the review already
-ran, it did not record a verdict, which means nothing downstream can verify
-what it found."
+Run the review (code-reviewer subagent) against THAT branch, have it write its
+verdict to .agentkit/reviews/$SLUG.json (head_sha, verdict, findings), then
+merge. Reviews gate merges — they never run alongside them."
 fi
 
 REVIEWED_SHA=$(jq -r '.head_sha // empty' "$RECORD" 2>/dev/null || true)
 if [[ "$REVIEWED_SHA" != "$HEAD_SHA" ]]; then
-	deny "BLOCKED: the review for '$BRANCH' is stale.
+	deny "BLOCKED: the review for '$BRANCH' does not cover the commit being merged.
 
-  reviewed: ${REVIEWED_SHA:-<unset>}
+  reviewed: ${REVIEWED_SHA:-<unset/unreadable>}
   merging:  $HEAD_SHA
 
-Commits landed after the review. Re-review the current head and update
-.agentkit/reviews/$SLUG.json. A review of an older commit says nothing about
-the code you are about to merge."
+Commits landed after the review, or the record is malformed. Re-review the
+current head and update .agentkit/reviews/$SLUG.json."
 fi
 
 BLOCKING=$(jq -r '
@@ -105,7 +171,11 @@ CONSENT_QUOTE=$(jq -r '.user_consent.quote // empty' "$RECORD" 2>/dev/null || tr
 
 if [[ -n "$BLOCKING" || "$VERDICT" != "pass" ]]; then
 	if [[ "$CONSENT" == "true" && -n "$CONSENT_QUOTE" ]]; then
-		exit 0 # the user overrode it, in writing, for this sha
+		mkdir -p "$(dirname "$AUDIT")" 2>/dev/null || true
+		printf '%s\tCONSENT-OVERRIDE\tsession=%s\tbranch=%s\tsha=%s\tquote=%s\n' \
+			"$(date -Is)" "$SESSION" "$BRANCH" "$HEAD_SHA" "${CONSENT_QUOTE//$'\n'/ }" \
+			>>"$AUDIT" 2>/dev/null || true
+		exit 0
 	fi
 	deny "BLOCKED: the review of '$BRANCH' has not passed.
 
@@ -113,8 +183,8 @@ if [[ -n "$BLOCKING" || "$VERDICT" != "pass" ]]; then
 ${BLOCKING:+  unresolved blocking findings:
 $BLOCKING}
 
-You may NOT merge past this by judging a finding harmless — that is exactly
-how a 'don't expose this yet' HIGH reached the user's machine and broke it.
+You may NOT merge past this by judging a finding harmless — that is exactly how
+a 'don't expose this yet' HIGH reached the user's machine and broke it.
 
 THE PATH IS: fix it properly, then re-review.
   1. Fix the finding at its root — not a workaround, not a toggle that hides
@@ -124,11 +194,14 @@ THE PATH IS: fix it properly, then re-review.
 
 Do NOT hand this to the user as a decision. They are not a queue for findings
 you would rather not fix. Escalate ONLY when the finding genuinely cannot be
-fixed here — an upstream/platform limitation, not 'this is hard' or 'this is
-low impact' — and say plainly WHY it cannot be fixed. If they then tell you in
-writing to ship it, record their words:
+fixed here — an upstream or platform limitation, not 'this is hard' or 'this is
+low impact' — and say plainly WHY. If they then tell you in writing to ship it,
+record their words:
      .user_consent = { granted: true, quote: \"<their words>\", at: \"<ISO>\" }
 Fabricating that consent is forging the user's approval — don't."
 fi
 
+mkdir -p "$(dirname "$AUDIT")" 2>/dev/null || true
+printf '%s\tPASS\tsession=%s\tbranch=%s\tsha=%s\n' "$(date -Is)" "$SESSION" "$BRANCH" "$HEAD_SHA" \
+	>>"$AUDIT" 2>/dev/null || true
 exit 0

--- a/hooks/claude/review-police.sh
+++ b/hooks/claude/review-police.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# review-police.sh — Claude Code PreToolUse hook (matcher: Bash)
+#
+# Blocks a forge merge unless an independent review has PASSED for exactly the
+# commit being merged. The agent cannot clear a blocking finding by reasoning
+# about it; only the user can, and only in writing.
+#
+# Why this exists: on 2026-07-19 a reviewer returned "HIGH — don't expose the
+# menu item yet", the merge had already been started in parallel, and the agent
+# judged the finding inert and shipped it. The feature then broke the user's
+# machine exactly as the reviewer predicted. Severity is the reviewer's call;
+# the override is the user's. Neither belongs to the agent.
+#
+# Contract (a review record is JSON, written by the REVIEWING agent):
+#   .agentkit/reviews/<branch-slug>.json
+#     { "head_sha": "<full sha reviewed>",
+#       "reviewer":  "<agent/session id — must differ from the merger>",
+#       "verdict":   "pass" | "blocked",
+#       "findings":  [ { "severity": "BLOCKER|HIGH|MEDIUM|LOW",
+#                        "summary": "...", "resolved": true|false } ],
+#       "user_consent": {            # ONLY the user may add this
+#          "granted": true,
+#          "quote":  "<their words, verbatim>",
+#          "at":     "<ISO timestamp>" } }
+#
+# A merge passes when: the record exists, its head_sha equals the branch head
+# being merged (a stale review is no review), and no unresolved BLOCKER/HIGH
+# remains — or the user granted consent in writing for that same sha.
+set -euo pipefail
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+[[ -z "$COMMAND" ]] && exit 0
+
+# Merge attempts, however they are spelled: glab/gh CLIs and the REST calls
+# that bypass them (the agent has reached for curl when a CLI refused).
+if ! echo "$COMMAND" | grep -qiE \
+	'glab[[:space:]]+mr[[:space:]]+merge|gh[[:space:]]+pr[[:space:]]+merge|merge_requests?/[0-9]+/merge|/pulls/[0-9]+/merge'; then
+	exit 0
+fi
+
+deny() {
+	jq -n --arg r "$1" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: $r
+    }
+  }'
+	exit 0
+}
+
+# The repo the command targets: an explicit `cd <path> &&` prefix wins,
+# otherwise the hook's cwd (mirrors mr-police's resolution).
+REPO_DIR=$(echo "$COMMAND" | sed -nE 's/^[[:space:]]*cd[[:space:]]+([^[:space:];&|]+).*/\1/p' | head -1)
+[[ -z "$REPO_DIR" ]] && REPO_DIR="$PWD"
+[[ -d "$REPO_DIR" ]] || REPO_DIR="$PWD"
+
+BRANCH=$(git -C "$REPO_DIR" branch --show-current 2>/dev/null || true)
+[[ -z "$BRANCH" ]] && exit 0
+
+# Never gate the merge of a branch that has no local checkout context.
+HEAD_SHA=$(git -C "$REPO_DIR" rev-parse HEAD 2>/dev/null || true)
+[[ -z "$HEAD_SHA" ]] && exit 0
+
+SLUG=$(echo "$BRANCH" | tr '/' '-')
+RECORD="$REPO_DIR/.agentkit/reviews/$SLUG.json"
+
+if [[ ! -f "$RECORD" ]]; then
+	deny "BLOCKED: no review record for '$BRANCH'.
+
+A merge requires an independent review of the exact commit being merged.
+Run the review (code-reviewer subagent), have it write its verdict to
+  .agentkit/reviews/$SLUG.json
+with head_sha, verdict, and findings, THEN merge.
+
+Reviews gate merges — they do not run alongside them. If the review already
+ran, it did not record a verdict, which means nothing downstream can verify
+what it found."
+fi
+
+REVIEWED_SHA=$(jq -r '.head_sha // empty' "$RECORD" 2>/dev/null || true)
+if [[ "$REVIEWED_SHA" != "$HEAD_SHA" ]]; then
+	deny "BLOCKED: the review for '$BRANCH' is stale.
+
+  reviewed: ${REVIEWED_SHA:-<unset>}
+  merging:  $HEAD_SHA
+
+Commits landed after the review. Re-review the current head and update
+.agentkit/reviews/$SLUG.json. A review of an older commit says nothing about
+the code you are about to merge."
+fi
+
+BLOCKING=$(jq -r '
+  [ .findings[]?
+    | select((.severity // "" | ascii_upcase) as $s
+             | $s == "BLOCKER" or $s == "HIGH")
+    | select((.resolved // false) == false)
+    | "  - \(.severity | ascii_upcase): \(.summary // "(no summary)")"
+  ] | join("\n")' "$RECORD" 2>/dev/null || true)
+
+VERDICT=$(jq -r '.verdict // "blocked"' "$RECORD" 2>/dev/null || echo blocked)
+CONSENT=$(jq -r '.user_consent.granted // false' "$RECORD" 2>/dev/null || echo false)
+CONSENT_QUOTE=$(jq -r '.user_consent.quote // empty' "$RECORD" 2>/dev/null || true)
+
+if [[ -n "$BLOCKING" || "$VERDICT" != "pass" ]]; then
+	if [[ "$CONSENT" == "true" && -n "$CONSENT_QUOTE" ]]; then
+		exit 0 # the user overrode it, in writing, for this sha
+	fi
+	deny "BLOCKED: the review of '$BRANCH' has not passed.
+
+  verdict: $VERDICT
+${BLOCKING:+  unresolved blocking findings:
+$BLOCKING}
+
+You may NOT merge past this by judging a finding harmless — that is exactly
+how a 'don't expose this yet' HIGH reached the user's machine and broke it.
+
+THE PATH IS: fix it properly, then re-review.
+  1. Fix the finding at its root — not a workaround, not a toggle that hides
+     it, not a comment explaining why it is acceptable.
+  2. Re-run the reviewer against the NEW head sha; it writes a fresh record.
+  3. Merge once that record passes.
+
+Do NOT hand this to the user as a decision. They are not a queue for findings
+you would rather not fix. Escalate ONLY when the finding genuinely cannot be
+fixed here — an upstream/platform limitation, not 'this is hard' or 'this is
+low impact' — and say plainly WHY it cannot be fixed. If they then tell you in
+writing to ship it, record their words:
+     .user_consent = { granted: true, quote: \"<their words>\", at: \"<ISO>\" }
+Fabricating that consent is forging the user's approval — don't."
+fi
+
+exit 0

--- a/hooks/claude/review-police.sh
+++ b/hooks/claude/review-police.sh
@@ -75,8 +75,16 @@ if echo "$COMMAND" | grep -qiE "\bglab${FLAG}[[:space:]]+mr${FLAG}[[:space:]]+me
 if echo "$COMMAND" | grep -qiE "\bgh${FLAG}[[:space:]]+pr${FLAG}[[:space:]]+merge\b"; then is_merge=1; fi
 # REST paths, contiguous or split across variables (…/merge_requests/12/merge).
 if echo "$COMMAND" | grep -qiE 'merge_requests?/[0-9]+/merge|/pulls/[0-9]+/merge'; then is_merge=1; fi
-if echo "$COMMAND" | grep -qiE 'merge_requests?|/pulls/' &&
-	echo "$COMMAND" | grep -qiE '\b(PUT|POST)\b'; then is_merge=1; fi
+# Split-variable REST forms: the URL is assembled at runtime, so look for a
+# merge_requests/pulls reference AND a /merge path segment in the same command.
+if echo "$COMMAND" | grep -qiE 'merge_requests?|/pulls?/' &&
+	echo "$COMMAND" | grep -qiE '/merge\b|"\$\{?[A-Za-z_]+\}?/merge'; then is_merge=1; fi
+if echo "$COMMAND" | grep -qiE '(-o|--push-option)[= ][^ ]*merge_request\.merge'; then
+	deny "BLOCKED: a merge-on-pipeline push option queues a merge no review has seen.
+
+Push the branch without the merge push-option, then merge explicitly so the
+gate can check the commit that actually lands."
+fi
 [[ $is_merge -eq 1 ]] || exit 0
 
 # Auto-merge queues the merge for a LATER head — the sha we check now is not
@@ -94,7 +102,8 @@ fi
 REPO_DIR=$(echo "$COMMAND" | sed -nE 's/^[[:space:]]*cd[[:space:]]+([^[:space:];&|]+).*/\1/p' | head -1)
 [[ -z "$REPO_DIR" ]] && REPO_DIR="$PWD"
 
-MR_ID=$(echo "$COMMAND" | grep -oiE '\b(mr|pr)([[:space:]]+-{1,2}[A-Za-z][^[:space:]]*)*[[:space:]]+merge([[:space:]]+-{1,2}[A-Za-z][^[:space:]]*)*[[:space:]]+[0-9]+' | grep -oE '[0-9]+$' | head -1 || true)
+ARG='([[:space:]]+-{1,2}[A-Za-z][^[:space:]]*([[:space:]]+[^-][^[:space:]]*)?)*'
+MR_ID=$(echo "$COMMAND" | grep -oiE "\b(mr|pr)${ARG}[[:space:]]+merge${ARG}[[:space:]]+[0-9]+" | grep -oE '[0-9]+$' | head -1 || true)
 if [[ -z "$MR_ID" ]]; then
 	MR_ID=$(echo "$COMMAND" | grep -oiE 'merge_requests?/[0-9]+|/pulls/[0-9]+' | grep -oE '[0-9]+' | head -1 || true)
 fi

--- a/hooks/claude/settings.json
+++ b/hooks/claude/settings.json
@@ -41,6 +41,17 @@
             "statusMessage": "review-police: verifying the review gate..."
           }
         ]
+      },
+      {
+        "matcher": ".*[Mm]erge.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/review-police.sh",
+            "timeout": 15,
+            "statusMessage": "review-police: gating non-Bash merge tools..."
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/hooks/claude/settings.json
+++ b/hooks/claude/settings.json
@@ -33,6 +33,12 @@
             "command": "$HOME/.claude/hooks/mr-police.sh",
             "timeout": 15,
             "statusMessage": "mr-police: checking for unmerged MRs..."
+          },
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/review-police.sh",
+            "timeout": 15,
+            "statusMessage": "review-police: verifying the review gate..."
           }
         ]
       }

--- a/plugins-cc/agentkit/hooks/hooks.json
+++ b/plugins-cc/agentkit/hooks/hooks.json
@@ -33,6 +33,12 @@
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/mr-police.sh",
             "timeout": 15,
             "statusMessage": "mr-police: checking for unmerged MRs..."
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/review-police.sh",
+            "timeout": 15,
+            "statusMessage": "review-police: verifying the review gate..."
           }
         ]
       }

--- a/plugins-cc/agentkit/hooks/hooks.json
+++ b/plugins-cc/agentkit/hooks/hooks.json
@@ -41,6 +41,17 @@
             "statusMessage": "review-police: verifying the review gate..."
           }
         ]
+      },
+      {
+        "matcher": ".*[Mm]erge.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/review-police.sh",
+            "timeout": 15,
+            "statusMessage": "review-police: gating non-Bash merge tools..."
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/plugins-cc/agentkit/hooks/review-police.sh
+++ b/plugins-cc/agentkit/hooks/review-police.sh
@@ -1,45 +1,43 @@
 #!/usr/bin/env bash
-# review-police.sh — Claude Code PreToolUse hook (matcher: Bash)
+# review-police.sh — Claude Code PreToolUse hook (matchers: Bash + MCP merges)
 #
-# Blocks a forge merge unless an independent review has PASSED for exactly the
-# commit being merged. The agent cannot clear a blocking finding by reasoning
-# about it; only the user can, and only in writing.
+# Blocks a forge merge unless an independent review PASSED for exactly the
+# commit that merge would land. The agent cannot clear a blocking finding by
+# reasoning about it; the path is fix-properly-then-re-review.
 #
-# Why this exists: on 2026-07-19 a reviewer returned "HIGH — don't expose the
-# menu item yet", the merge had already been started in parallel, and the agent
-# judged the finding inert and shipped it. The feature then broke the user's
-# machine exactly as the reviewer predicted. Severity is the reviewer's call;
-# the override is the user's. Neither belongs to the agent.
+# Why: on 2026-07-19 a reviewer returned "HIGH — don't expose the menu item
+# yet", the merge was already running in parallel, the agent judged the finding
+# inert and shipped it, and it broke the user's machine exactly as predicted.
 #
-# Contract (a review record is JSON, written by the REVIEWING agent):
-#   .agentkit/reviews/<branch-slug>.json
+# WHAT THIS IS NOT: security. The review record lives in the repo and the agent
+# can write it, so a determined agent can forge a pass. This hook makes the
+# honest path correct, makes a stale or missing review mechanically impossible
+# to merge past, and leaves an out-of-repo audit trail when a record is used.
+# Only forge-side required approvals can actually prevent a merge.
+#
+# Review record, written by the REVIEWING agent:
+#   .agentkit/reviews/<source-branch-slug>.json
 #     { "head_sha": "<full sha reviewed>",
-#       "reviewer":  "<agent/session id — must differ from the merger>",
-#       "verdict":   "pass" | "blocked",
-#       "findings":  [ { "severity": "BLOCKER|HIGH|MEDIUM|LOW",
-#                        "summary": "...", "resolved": true|false } ],
+#       "verdict":  "pass" | "blocked",
+#       "findings": [ { "severity": "BLOCKER|HIGH|MEDIUM|LOW",
+#                       "summary": "...", "resolved": true|false } ],
 #       "user_consent": {            # ONLY the user may add this
-#          "granted": true,
-#          "quote":  "<their words, verbatim>",
-#          "at":     "<ISO timestamp>" } }
+#          "granted": true, "quote": "<their words>", "at": "<ISO>" } }
 #
-# A merge passes when: the record exists, its head_sha equals the branch head
-# being merged (a stale review is no review), and no unresolved BLOCKER/HIGH
-# remains — or the user granted consent in writing for that same sha.
+# The gate resolves the MR/PR's REAL source branch and head sha from the forge —
+# never the local checkout, which says nothing about what is being merged.
 set -euo pipefail
 
 INPUT=$(cat)
+TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty')
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
-[[ -z "$COMMAND" ]] && exit 0
+SESSION=$(echo "$INPUT" | jq -r '.session_id // "unknown"')
 
-# Merge attempts, however they are spelled: glab/gh CLIs and the REST calls
-# that bypass them (the agent has reached for curl when a CLI refused).
-if ! echo "$COMMAND" | grep -qiE \
-	'glab[[:space:]]+mr[[:space:]]+merge|gh[[:space:]]+pr[[:space:]]+merge|merge_requests?/[0-9]+/merge|/pulls/[0-9]+/merge'; then
-	exit 0
-fi
+AUDIT="${HOME}/.agentkit/review-audit.log"
 
 deny() {
+	mkdir -p "$(dirname "$AUDIT")" 2>/dev/null || true
+	printf '%s\tDENY\tsession=%s\t%s\n' "$(date -Is)" "$SESSION" "${1//$'\n'/ }" >>"$AUDIT" 2>/dev/null || true
 	jq -n --arg r "$1" '{
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
@@ -50,45 +48,113 @@ deny() {
 	exit 0
 }
 
-# The repo the command targets: an explicit `cd <path> &&` prefix wins,
-# otherwise the hook's cwd (mirrors mr-police's resolution).
+# --- MCP merge tools: no Bash to inspect, so refuse outright ---------------
+# These bypass every command-shaped check. The CLI path is the reviewed path.
+if [[ -n "$TOOL" && "$TOOL" != "Bash" ]]; then
+	if echo "$TOOL" | grep -qiE 'merge_(pull_request|request)|pull_request_merge|mr_merge'; then
+		deny "BLOCKED: merging through an MCP tool bypasses the review gate.
+
+Use the CLI (\`glab mr merge\` / \`gh pr merge\`) so the merge is checked against
+the review record for the commit being merged."
+	fi
+	exit 0
+fi
+
+[[ -z "$COMMAND" ]] && exit 0
+
+# --- Is this a merge attempt? ---------------------------------------------
+# Flag-tolerant: `glab -R o/r mr merge`, `gh --repo o/r pr merge`,
+# `glab mr --repo o/r merge` all count. Same shape as git-police's push regex.
+FLAG='(\s+(-[A-Za-z]\S*|--[A-Za-z][A-Za-z0-9-]*(=\S+)?)(\s+[^-\s]\S*)?)*'
+# NOTE: every match below is wrapped so a NON-match cannot abort the script.
+# `grep -q … && is_merge=1` returns non-zero when the pattern misses, and under
+# `set -e` that exits the hook silently — i.e. FAILS OPEN, allowing the merge.
+# Caught by this file's own tests before it ever shipped; keep the `if` form.
+is_merge=0
+if echo "$COMMAND" | grep -qiE "\bglab${FLAG}[[:space:]]+mr${FLAG}[[:space:]]+merge\b"; then is_merge=1; fi
+if echo "$COMMAND" | grep -qiE "\bgh${FLAG}[[:space:]]+pr${FLAG}[[:space:]]+merge\b"; then is_merge=1; fi
+# REST paths, contiguous or split across variables (…/merge_requests/12/merge).
+if echo "$COMMAND" | grep -qiE 'merge_requests?/[0-9]+/merge|/pulls/[0-9]+/merge'; then is_merge=1; fi
+if echo "$COMMAND" | grep -qiE 'merge_requests?|/pulls/' &&
+	echo "$COMMAND" | grep -qiE '\b(PUT|POST)\b'; then is_merge=1; fi
+[[ $is_merge -eq 1 ]] || exit 0
+
+# Auto-merge queues the merge for a LATER head — the sha we check now is not
+# the sha that lands. Refuse the mode rather than pretend to gate it.
+if echo "$COMMAND" | grep -qiE '(--auto|--merge-when-pipeline-succeeds|--when-pipeline-succeeds)\b'; then
+	deny "BLOCKED: auto-merge cannot be review-gated.
+
+It merges a future head that no review has seen. Wait for the pipeline, then
+merge explicitly so the gate can check the commit that actually lands."
+fi
+
+# --- Resolve WHAT is being merged, from the forge ---------------------------
+# Fail CLOSED: if the target cannot be resolved, the gate denies. An
+# unresolvable merge is exactly when a mistake is most likely.
 REPO_DIR=$(echo "$COMMAND" | sed -nE 's/^[[:space:]]*cd[[:space:]]+([^[:space:];&|]+).*/\1/p' | head -1)
 [[ -z "$REPO_DIR" ]] && REPO_DIR="$PWD"
-[[ -d "$REPO_DIR" ]] || REPO_DIR="$PWD"
 
-BRANCH=$(git -C "$REPO_DIR" branch --show-current 2>/dev/null || true)
-[[ -z "$BRANCH" ]] && exit 0
+MR_ID=$(echo "$COMMAND" | grep -oiE '\b(mr|pr)([[:space:]]+-{1,2}[A-Za-z][^[:space:]]*)*[[:space:]]+merge([[:space:]]+-{1,2}[A-Za-z][^[:space:]]*)*[[:space:]]+[0-9]+' | grep -oE '[0-9]+$' | head -1 || true)
+if [[ -z "$MR_ID" ]]; then
+	MR_ID=$(echo "$COMMAND" | grep -oiE 'merge_requests?/[0-9]+|/pulls/[0-9]+' | grep -oE '[0-9]+' | head -1 || true)
+fi
+REPO_FLAG=$(echo "$COMMAND" | grep -oiE '(-R|--repo)[= ]+[^ ]+' | head -1 | sed -E 's/^(-R|--repo)[= ]+//' || true)
 
-# Never gate the merge of a branch that has no local checkout context.
-HEAD_SHA=$(git -C "$REPO_DIR" rev-parse HEAD 2>/dev/null || true)
-[[ -z "$HEAD_SHA" ]] && exit 0
+forge_json() {
+	if echo "$COMMAND" | grep -qiE '\bgh\b|/pulls/'; then
+		gh pr view "$MR_ID" ${REPO_FLAG:+--repo "$REPO_FLAG"} \
+			--json headRefName,headRefOid 2>/dev/null |
+			jq -r '"\(.headRefName)\t\(.headRefOid)"'
+	else
+		glab mr view "$MR_ID" ${REPO_FLAG:+--repo "$REPO_FLAG"} --output json 2>/dev/null |
+			jq -r '"\(.source_branch)\t\(.sha // .diff_refs.head_sha)"'
+	fi
+}
 
-SLUG=$(echo "$BRANCH" | tr '/' '-')
+BRANCH=""
+HEAD_SHA=""
+if [[ -n "$MR_ID" ]]; then
+	RESOLVED=$(cd "$REPO_DIR" 2>/dev/null && forge_json || true)
+	BRANCH=$(echo "$RESOLVED" | cut -f1)
+	HEAD_SHA=$(echo "$RESOLVED" | cut -f2)
+fi
+
+if [[ -z "$BRANCH" || -z "$HEAD_SHA" || "$BRANCH" == "null" || "$HEAD_SHA" == "null" ]]; then
+	deny "BLOCKED: cannot resolve what this merge would land, so it cannot be gated.
+
+  command dir: $REPO_DIR
+  mr/pr id:    ${MR_ID:-<none found>}
+
+The gate must read the merge request's SOURCE BRANCH and HEAD SHA from the
+forge — the local checkout says nothing about the commit being merged. Run the
+merge from the repo directory with an explicit MR/PR number, with the forge CLI
+authenticated."
+fi
+
+SLUG=$(echo "$BRANCH" | sed 's#/#__#g')
 RECORD="$REPO_DIR/.agentkit/reviews/$SLUG.json"
 
 if [[ ! -f "$RECORD" ]]; then
-	deny "BLOCKED: no review record for '$BRANCH'.
+	deny "BLOCKED: no review record for the branch this merge would land.
 
-A merge requires an independent review of the exact commit being merged.
-Run the review (code-reviewer subagent), have it write its verdict to
-  .agentkit/reviews/$SLUG.json
-with head_sha, verdict, and findings, THEN merge.
+  merge request: !${MR_ID}
+  source branch: $BRANCH
+  head sha:      $HEAD_SHA
 
-Reviews gate merges — they do not run alongside them. If the review already
-ran, it did not record a verdict, which means nothing downstream can verify
-what it found."
+Run the review (code-reviewer subagent) against THAT branch, have it write its
+verdict to .agentkit/reviews/$SLUG.json (head_sha, verdict, findings), then
+merge. Reviews gate merges — they never run alongside them."
 fi
 
 REVIEWED_SHA=$(jq -r '.head_sha // empty' "$RECORD" 2>/dev/null || true)
 if [[ "$REVIEWED_SHA" != "$HEAD_SHA" ]]; then
-	deny "BLOCKED: the review for '$BRANCH' is stale.
+	deny "BLOCKED: the review for '$BRANCH' does not cover the commit being merged.
 
-  reviewed: ${REVIEWED_SHA:-<unset>}
+  reviewed: ${REVIEWED_SHA:-<unset/unreadable>}
   merging:  $HEAD_SHA
 
-Commits landed after the review. Re-review the current head and update
-.agentkit/reviews/$SLUG.json. A review of an older commit says nothing about
-the code you are about to merge."
+Commits landed after the review, or the record is malformed. Re-review the
+current head and update .agentkit/reviews/$SLUG.json."
 fi
 
 BLOCKING=$(jq -r '
@@ -105,7 +171,11 @@ CONSENT_QUOTE=$(jq -r '.user_consent.quote // empty' "$RECORD" 2>/dev/null || tr
 
 if [[ -n "$BLOCKING" || "$VERDICT" != "pass" ]]; then
 	if [[ "$CONSENT" == "true" && -n "$CONSENT_QUOTE" ]]; then
-		exit 0 # the user overrode it, in writing, for this sha
+		mkdir -p "$(dirname "$AUDIT")" 2>/dev/null || true
+		printf '%s\tCONSENT-OVERRIDE\tsession=%s\tbranch=%s\tsha=%s\tquote=%s\n' \
+			"$(date -Is)" "$SESSION" "$BRANCH" "$HEAD_SHA" "${CONSENT_QUOTE//$'\n'/ }" \
+			>>"$AUDIT" 2>/dev/null || true
+		exit 0
 	fi
 	deny "BLOCKED: the review of '$BRANCH' has not passed.
 
@@ -113,8 +183,8 @@ if [[ -n "$BLOCKING" || "$VERDICT" != "pass" ]]; then
 ${BLOCKING:+  unresolved blocking findings:
 $BLOCKING}
 
-You may NOT merge past this by judging a finding harmless — that is exactly
-how a 'don't expose this yet' HIGH reached the user's machine and broke it.
+You may NOT merge past this by judging a finding harmless — that is exactly how
+a 'don't expose this yet' HIGH reached the user's machine and broke it.
 
 THE PATH IS: fix it properly, then re-review.
   1. Fix the finding at its root — not a workaround, not a toggle that hides
@@ -124,11 +194,14 @@ THE PATH IS: fix it properly, then re-review.
 
 Do NOT hand this to the user as a decision. They are not a queue for findings
 you would rather not fix. Escalate ONLY when the finding genuinely cannot be
-fixed here — an upstream/platform limitation, not 'this is hard' or 'this is
-low impact' — and say plainly WHY it cannot be fixed. If they then tell you in
-writing to ship it, record their words:
+fixed here — an upstream or platform limitation, not 'this is hard' or 'this is
+low impact' — and say plainly WHY. If they then tell you in writing to ship it,
+record their words:
      .user_consent = { granted: true, quote: \"<their words>\", at: \"<ISO>\" }
 Fabricating that consent is forging the user's approval — don't."
 fi
 
+mkdir -p "$(dirname "$AUDIT")" 2>/dev/null || true
+printf '%s\tPASS\tsession=%s\tbranch=%s\tsha=%s\n' "$(date -Is)" "$SESSION" "$BRANCH" "$HEAD_SHA" \
+	>>"$AUDIT" 2>/dev/null || true
 exit 0

--- a/plugins-cc/agentkit/hooks/review-police.sh
+++ b/plugins-cc/agentkit/hooks/review-police.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# review-police.sh — Claude Code PreToolUse hook (matcher: Bash)
+#
+# Blocks a forge merge unless an independent review has PASSED for exactly the
+# commit being merged. The agent cannot clear a blocking finding by reasoning
+# about it; only the user can, and only in writing.
+#
+# Why this exists: on 2026-07-19 a reviewer returned "HIGH — don't expose the
+# menu item yet", the merge had already been started in parallel, and the agent
+# judged the finding inert and shipped it. The feature then broke the user's
+# machine exactly as the reviewer predicted. Severity is the reviewer's call;
+# the override is the user's. Neither belongs to the agent.
+#
+# Contract (a review record is JSON, written by the REVIEWING agent):
+#   .agentkit/reviews/<branch-slug>.json
+#     { "head_sha": "<full sha reviewed>",
+#       "reviewer":  "<agent/session id — must differ from the merger>",
+#       "verdict":   "pass" | "blocked",
+#       "findings":  [ { "severity": "BLOCKER|HIGH|MEDIUM|LOW",
+#                        "summary": "...", "resolved": true|false } ],
+#       "user_consent": {            # ONLY the user may add this
+#          "granted": true,
+#          "quote":  "<their words, verbatim>",
+#          "at":     "<ISO timestamp>" } }
+#
+# A merge passes when: the record exists, its head_sha equals the branch head
+# being merged (a stale review is no review), and no unresolved BLOCKER/HIGH
+# remains — or the user granted consent in writing for that same sha.
+set -euo pipefail
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+[[ -z "$COMMAND" ]] && exit 0
+
+# Merge attempts, however they are spelled: glab/gh CLIs and the REST calls
+# that bypass them (the agent has reached for curl when a CLI refused).
+if ! echo "$COMMAND" | grep -qiE \
+	'glab[[:space:]]+mr[[:space:]]+merge|gh[[:space:]]+pr[[:space:]]+merge|merge_requests?/[0-9]+/merge|/pulls/[0-9]+/merge'; then
+	exit 0
+fi
+
+deny() {
+	jq -n --arg r "$1" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: $r
+    }
+  }'
+	exit 0
+}
+
+# The repo the command targets: an explicit `cd <path> &&` prefix wins,
+# otherwise the hook's cwd (mirrors mr-police's resolution).
+REPO_DIR=$(echo "$COMMAND" | sed -nE 's/^[[:space:]]*cd[[:space:]]+([^[:space:];&|]+).*/\1/p' | head -1)
+[[ -z "$REPO_DIR" ]] && REPO_DIR="$PWD"
+[[ -d "$REPO_DIR" ]] || REPO_DIR="$PWD"
+
+BRANCH=$(git -C "$REPO_DIR" branch --show-current 2>/dev/null || true)
+[[ -z "$BRANCH" ]] && exit 0
+
+# Never gate the merge of a branch that has no local checkout context.
+HEAD_SHA=$(git -C "$REPO_DIR" rev-parse HEAD 2>/dev/null || true)
+[[ -z "$HEAD_SHA" ]] && exit 0
+
+SLUG=$(echo "$BRANCH" | tr '/' '-')
+RECORD="$REPO_DIR/.agentkit/reviews/$SLUG.json"
+
+if [[ ! -f "$RECORD" ]]; then
+	deny "BLOCKED: no review record for '$BRANCH'.
+
+A merge requires an independent review of the exact commit being merged.
+Run the review (code-reviewer subagent), have it write its verdict to
+  .agentkit/reviews/$SLUG.json
+with head_sha, verdict, and findings, THEN merge.
+
+Reviews gate merges — they do not run alongside them. If the review already
+ran, it did not record a verdict, which means nothing downstream can verify
+what it found."
+fi
+
+REVIEWED_SHA=$(jq -r '.head_sha // empty' "$RECORD" 2>/dev/null || true)
+if [[ "$REVIEWED_SHA" != "$HEAD_SHA" ]]; then
+	deny "BLOCKED: the review for '$BRANCH' is stale.
+
+  reviewed: ${REVIEWED_SHA:-<unset>}
+  merging:  $HEAD_SHA
+
+Commits landed after the review. Re-review the current head and update
+.agentkit/reviews/$SLUG.json. A review of an older commit says nothing about
+the code you are about to merge."
+fi
+
+BLOCKING=$(jq -r '
+  [ .findings[]?
+    | select((.severity // "" | ascii_upcase) as $s
+             | $s == "BLOCKER" or $s == "HIGH")
+    | select((.resolved // false) == false)
+    | "  - \(.severity | ascii_upcase): \(.summary // "(no summary)")"
+  ] | join("\n")' "$RECORD" 2>/dev/null || true)
+
+VERDICT=$(jq -r '.verdict // "blocked"' "$RECORD" 2>/dev/null || echo blocked)
+CONSENT=$(jq -r '.user_consent.granted // false' "$RECORD" 2>/dev/null || echo false)
+CONSENT_QUOTE=$(jq -r '.user_consent.quote // empty' "$RECORD" 2>/dev/null || true)
+
+if [[ -n "$BLOCKING" || "$VERDICT" != "pass" ]]; then
+	if [[ "$CONSENT" == "true" && -n "$CONSENT_QUOTE" ]]; then
+		exit 0 # the user overrode it, in writing, for this sha
+	fi
+	deny "BLOCKED: the review of '$BRANCH' has not passed.
+
+  verdict: $VERDICT
+${BLOCKING:+  unresolved blocking findings:
+$BLOCKING}
+
+You may NOT merge past this by judging a finding harmless — that is exactly
+how a 'don't expose this yet' HIGH reached the user's machine and broke it.
+
+THE PATH IS: fix it properly, then re-review.
+  1. Fix the finding at its root — not a workaround, not a toggle that hides
+     it, not a comment explaining why it is acceptable.
+  2. Re-run the reviewer against the NEW head sha; it writes a fresh record.
+  3. Merge once that record passes.
+
+Do NOT hand this to the user as a decision. They are not a queue for findings
+you would rather not fix. Escalate ONLY when the finding genuinely cannot be
+fixed here — an upstream/platform limitation, not 'this is hard' or 'this is
+low impact' — and say plainly WHY it cannot be fixed. If they then tell you in
+writing to ship it, record their words:
+     .user_consent = { granted: true, quote: \"<their words>\", at: \"<ISO>\" }
+Fabricating that consent is forging the user's approval — don't."
+fi
+
+exit 0

--- a/plugins-cc/agentkit/hooks/review-police.sh
+++ b/plugins-cc/agentkit/hooks/review-police.sh
@@ -75,8 +75,16 @@ if echo "$COMMAND" | grep -qiE "\bglab${FLAG}[[:space:]]+mr${FLAG}[[:space:]]+me
 if echo "$COMMAND" | grep -qiE "\bgh${FLAG}[[:space:]]+pr${FLAG}[[:space:]]+merge\b"; then is_merge=1; fi
 # REST paths, contiguous or split across variables (…/merge_requests/12/merge).
 if echo "$COMMAND" | grep -qiE 'merge_requests?/[0-9]+/merge|/pulls/[0-9]+/merge'; then is_merge=1; fi
-if echo "$COMMAND" | grep -qiE 'merge_requests?|/pulls/' &&
-	echo "$COMMAND" | grep -qiE '\b(PUT|POST)\b'; then is_merge=1; fi
+# Split-variable REST forms: the URL is assembled at runtime, so look for a
+# merge_requests/pulls reference AND a /merge path segment in the same command.
+if echo "$COMMAND" | grep -qiE 'merge_requests?|/pulls?/' &&
+	echo "$COMMAND" | grep -qiE '/merge\b|"\$\{?[A-Za-z_]+\}?/merge'; then is_merge=1; fi
+if echo "$COMMAND" | grep -qiE '(-o|--push-option)[= ][^ ]*merge_request\.merge'; then
+	deny "BLOCKED: a merge-on-pipeline push option queues a merge no review has seen.
+
+Push the branch without the merge push-option, then merge explicitly so the
+gate can check the commit that actually lands."
+fi
 [[ $is_merge -eq 1 ]] || exit 0
 
 # Auto-merge queues the merge for a LATER head — the sha we check now is not
@@ -94,7 +102,8 @@ fi
 REPO_DIR=$(echo "$COMMAND" | sed -nE 's/^[[:space:]]*cd[[:space:]]+([^[:space:];&|]+).*/\1/p' | head -1)
 [[ -z "$REPO_DIR" ]] && REPO_DIR="$PWD"
 
-MR_ID=$(echo "$COMMAND" | grep -oiE '\b(mr|pr)([[:space:]]+-{1,2}[A-Za-z][^[:space:]]*)*[[:space:]]+merge([[:space:]]+-{1,2}[A-Za-z][^[:space:]]*)*[[:space:]]+[0-9]+' | grep -oE '[0-9]+$' | head -1 || true)
+ARG='([[:space:]]+-{1,2}[A-Za-z][^[:space:]]*([[:space:]]+[^-][^[:space:]]*)?)*'
+MR_ID=$(echo "$COMMAND" | grep -oiE "\b(mr|pr)${ARG}[[:space:]]+merge${ARG}[[:space:]]+[0-9]+" | grep -oE '[0-9]+$' | head -1 || true)
 if [[ -z "$MR_ID" ]]; then
 	MR_ID=$(echo "$COMMAND" | grep -oiE 'merge_requests?/[0-9]+|/pulls/[0-9]+' | grep -oE '[0-9]+' | head -1 || true)
 fi

--- a/plugins-cc/agentkit/skills/autonomous-workflow/SKILL.md
+++ b/plugins-cc/agentkit/skills/autonomous-workflow/SKILL.md
@@ -39,6 +39,34 @@ Exceptions: bug fixes in already-approved work, read-only research, formatting.
 - If a function parameter is required by an interface but unused, restructure to avoid it
 - This applies to all languages: TypeScript, Rust, Python
 
+## Review Gates The Merge
+
+Review is a gate, not a parallel task and not advice. Enforced by
+`review-police.sh`, which blocks merges (CLI or REST) without a passing record.
+
+1. **Review completes before the merge starts.** Never dispatch a reviewer and
+   merge while it works — a verdict that lands after the code is on main
+   protects nobody.
+2. **The reviewer writes its verdict** to `.agentkit/reviews/<branch-slug>.json`
+   with `head_sha`, `verdict`, and `findings[{severity, summary, resolved}]`.
+   A review of an older commit is not a review of what you are merging.
+3. **Any unresolved BLOCKER or HIGH blocks the merge.** Severity is the
+   reviewer's call. You do not get to downgrade it, reinterpret it, or decide
+   it is inert because you reason it cannot fire.
+4. **The path is: fix it properly, then re-review.** Fix the root cause — not a
+   workaround, not a flag that hides it, not a comment explaining why it is
+   acceptable. Then re-run the reviewer against the new head and merge on a
+   fresh pass.
+5. **Do not hand findings to the user to approve.** They are not a queue for
+   work you would rather not do. Escalate only when a finding genuinely cannot
+   be fixed — an upstream or platform limitation — and say why. If they then
+   approve in writing, record their exact words in `user_consent`. Fabricating
+   that is forging their approval.
+
+Corollary, learned the hard way: never expose a user-facing control whose other
+half is not built. Ship both halves or neither — an inert-looking toggle is
+still reachable, and "it will not do anything" is a prediction, not a fact.
+
 ## Commit Hygiene
 
 - Never use --force, --no-verify, HUSKY=0 without explicit permission

--- a/plugins-cc/agentkit/skills/autonomous-workflow/SKILL.md
+++ b/plugins-cc/agentkit/skills/autonomous-workflow/SKILL.md
@@ -41,8 +41,16 @@ Exceptions: bug fixes in already-approved work, read-only research, formatting.
 
 ## Review Gates The Merge
 
-Review is a gate, not a parallel task and not advice. Enforced by
-`review-police.sh`, which blocks merges (CLI or REST) without a passing record.
+Review is a gate, not a parallel task and not advice. `review-police.sh`
+blocks the CLI, REST and MCP merge paths without a passing record for the exact
+commit being merged.
+
+Be honest about its limits: the record lives in the repo and you can write it,
+so the hook cannot *prevent* a determined bypass — it makes the honest path
+correct, makes a missing or stale review impossible to merge past by accident,
+and logs every pass and override to `~/.agentkit/review-audit.log`. Only
+forge-side required approvals actually prevent a merge. Never describe this
+gate as something it is not.
 
 1. **Review completes before the merge starts.** Never dispatch a reviewer and
    merge while it works — a verdict that lands after the code is on main

--- a/tests/agentkit-plugin.test.ts
+++ b/tests/agentkit-plugin.test.ts
@@ -51,8 +51,20 @@ describe('agentkit plugin hooks', () => {
   test('hooks.json wires exactly the police hooks under ${CLAUDE_PLUGIN_ROOT}', () => {
     const hooks = readJson('hooks', 'hooks.json').hooks;
 
-    expect(hooks.PreToolUse).toHaveLength(1);
+    // Bash block, plus a block matching merge-shaped tool names so MCP merge
+    // tools actually reach review-police (its MCP branch was unreachable dead
+    // code while only the Bash matcher existed).
+    expect(hooks.PreToolUse).toHaveLength(2);
     expect(hooks.PreToolUse[0].matcher).toBe('Bash');
+    const mcpBlock = hooks.PreToolUse[1];
+    // Assert what the matcher DOES, not how it is spelled: it must route real
+    // MCP merge tool names to review-police and leave everything else alone.
+    const routes = new RegExp(mcpBlock.matcher);
+    expect(routes.test('mcp__github__merge_pull_request')).toBe(true);
+    expect(routes.test('mcp__gitlab__merge_merge_request')).toBe(true);
+    expect(routes.test('Bash')).toBe(false);
+    expect(routes.test('Edit')).toBe(false);
+    expect(commandBasenames(mcpBlock.hooks)).toEqual(['review-police.sh']);
     expect(commandBasenames(hooks.PreToolUse[0].hooks).sort()).toEqual([...PRE_TOOL_USE_HOOKS].sort());
 
     expect(hooks.PostToolUse).toHaveLength(1);

--- a/tests/agentkit-plugin.test.ts
+++ b/tests/agentkit-plugin.test.ts
@@ -23,6 +23,7 @@ const PRE_TOOL_USE_HOOKS = [
   'pkg-police.sh',
   'mr-police.sh',
   'resource-police.sh',
+  'review-police.sh',
 ];
 const POST_TOOL_USE_HOOKS = ['format-police.sh', 'coding-police.sh'];
 const ALL_POLICE_HOOKS = [...PRE_TOOL_USE_HOOKS, ...POST_TOOL_USE_HOOKS];

--- a/tests/review-police.test.ts
+++ b/tests/review-police.test.ts
@@ -128,10 +128,36 @@ describe('review-police: bypasses found in adversarial review', () => {
     expect(runHook('glab mr merge 999 --squash --yes')).toContain('"deny"');
   });
 
-  test('B2: MCP merge tools are refused outright', () => {
+  // NOTE: this proves the script's behaviour only. That it is REACHED for MCP
+  // calls is a registration fact, asserted in tests/agentkit-plugin.test.ts —
+  // the first version of this hook refused MCP merges in code that no matcher
+  // ever routed to it, and this test passed anyway.
+  test('B2: MCP merge tools are refused by the script', () => {
     const out = runHook('', { tool: 'mcp__github__merge_pull_request' });
     expect(out).toContain('"deny"');
     expect(out).toContain('MCP tool');
+  });
+
+  test('push options that queue a merge are refused', () => {
+    record(passing);
+    for (const cmd of [
+      'git push -o merge_request.merge_when_pipeline_succeeds origin feat/thing',
+      'git push --push-option=merge_request.merge_when_pipeline_succeeds origin feat/thing',
+    ]) {
+      expect(runHook(cmd)).toContain('"deny"');
+    }
+  });
+
+  test('creating an MR over REST is not a merge', () => {
+    record(passing);
+    expect(runHook('curl -X POST https://gitlab.com/api/v4/projects/1/merge_requests -d x')).toBe('');
+  });
+
+  test('a flag with its own argument does not lose the MR id', () => {
+    record(passing);
+    // Detection caught this variant but extraction dropped the id, so it
+    // denied an honest merge with "cannot resolve".
+    expect(runHook('glab mr --repo group/proj merge 12')).toBe('');
   });
 
   test('H1: -R / --repo flag variants are still gated', () => {

--- a/tests/review-police.test.ts
+++ b/tests/review-police.test.ts
@@ -1,0 +1,128 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { execSync, spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// The review gate needs real git state (a branch with a real head sha), so
+// these tests build a fixture repo rather than mocking rev-parse.
+
+const HOOK = join(import.meta.dir, '..', 'hooks', 'claude', 'review-police.sh');
+
+let repo: string;
+let head: string;
+
+function runHook(command: string): string {
+  const input = JSON.stringify({ tool_input: { command } });
+  const res = spawnSync('bash', [HOOK], { cwd: repo, input, encoding: 'utf-8' });
+  return res.stdout ?? '';
+}
+
+function record(body: unknown): void {
+  mkdirSync(join(repo, '.agentkit', 'reviews'), { recursive: true });
+  writeFileSync(join(repo, '.agentkit', 'reviews', 'feat-thing.json'), JSON.stringify(body));
+}
+
+const MERGE = 'glab mr merge 12 --squash --yes';
+
+beforeAll(() => {
+  repo = mkdtempSync(join(tmpdir(), 'agentkit-review-'));
+  execSync('git init -q -b main', { cwd: repo, stdio: 'pipe' });
+  execSync('git config user.email t@e.com && git config user.name t', { cwd: repo, stdio: 'pipe' });
+  execSync('git commit -q --allow-empty -m init', { cwd: repo, stdio: 'pipe' });
+  execSync('git checkout -q -b feat/thing', { cwd: repo, stdio: 'pipe' });
+  execSync('git commit -q --allow-empty -m work', { cwd: repo, stdio: 'pipe' });
+  head = execSync('git rev-parse HEAD', { cwd: repo, encoding: 'utf-8' }).trim();
+});
+
+afterAll(() => rmSync(repo, { force: true, recursive: true }));
+
+beforeEach(() => rmSync(join(repo, '.agentkit'), { force: true, recursive: true }));
+
+describe('review-police', () => {
+  test('ignores commands that are not merges', () => {
+    expect(runHook('glab mr create --title x')).toBe('');
+    expect(runHook('git push origin feat/thing')).toBe('');
+  });
+
+  test('blocks a merge with no review record', () => {
+    const out = runHook(MERGE);
+    expect(out).toContain('"deny"');
+    expect(out).toContain('no review record');
+  });
+
+  test('blocks when the review covers an older commit', () => {
+    record({ head_sha: 'deadbeef', verdict: 'pass', findings: [] });
+    const out = runHook(MERGE);
+    expect(out).toContain('"deny"');
+    expect(out).toContain('stale');
+  });
+
+  test('blocks on an unresolved HIGH even when the verdict says pass', () => {
+    record({
+      head_sha: head,
+      verdict: 'pass',
+      findings: [{ severity: 'HIGH', summary: 'toggle has no backend', resolved: false }],
+    });
+    const out = runHook(MERGE);
+    expect(out).toContain('"deny"');
+    expect(out).toContain('toggle has no backend');
+  });
+
+  test('blocks on a blocked verdict with no findings listed', () => {
+    record({ head_sha: head, verdict: 'blocked', findings: [] });
+    expect(runHook(MERGE)).toContain('"deny"');
+  });
+
+  test('allows a clean pass for the exact head', () => {
+    record({
+      head_sha: head,
+      verdict: 'pass',
+      findings: [{ severity: 'MEDIUM', summary: 'nit', resolved: false }],
+    });
+    expect(runHook(MERGE)).toBe('');
+  });
+
+  test('allows once a blocking finding is resolved', () => {
+    record({
+      head_sha: head,
+      verdict: 'pass',
+      findings: [{ severity: 'BLOCKER', summary: 'fixed since', resolved: true }],
+    });
+    expect(runHook(MERGE)).toBe('');
+  });
+
+  test('only user consent unblocks an unresolved BLOCKER', () => {
+    const findings = [{ severity: 'BLOCKER', summary: 'ships broken', resolved: false }];
+    record({ head_sha: head, verdict: 'blocked', findings });
+    expect(runHook(MERGE)).toContain('"deny"');
+
+    record({
+      head_sha: head,
+      verdict: 'blocked',
+      findings,
+      user_consent: { granted: true, quote: 'ship it anyway', at: '2026-07-19T00:00:00Z' },
+    });
+    expect(runHook(MERGE)).toBe('');
+  });
+
+  test('consent without the user\'s words does not count', () => {
+    record({
+      head_sha: head,
+      verdict: 'blocked',
+      findings: [{ severity: 'HIGH', summary: 'x', resolved: false }],
+      user_consent: { granted: true },
+    });
+    expect(runHook(MERGE)).toContain('"deny"');
+  });
+
+  test('gates REST merges too, not just the CLIs', () => {
+    for (const cmd of [
+      'curl -X PUT https://gitlab.com/api/v4/projects/1/merge_requests/12/merge',
+      'gh pr merge 4 --squash',
+      'curl -X PUT https://api.github.com/repos/o/r/pulls/7/merge',
+    ]) {
+      expect(runHook(cmd)).toContain('"deny"');
+    }
+  });
+});

--- a/tests/review-police.test.ts
+++ b/tests/review-police.test.ts
@@ -1,128 +1,173 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
 import { execSync, spawnSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-// The review gate needs real git state (a branch with a real head sha), so
-// these tests build a fixture repo rather than mocking rev-parse.
+// The gate resolves the merge target from the FORGE, so the fixture ships a
+// fake `glab`/`gh` on PATH. Every bypass the 2026-07-19 review found is a case
+// here — the previous suite passed with all of them present, which is how an
+// overstated "the agent cannot dismiss this" claim reached review.
 
 const HOOK = join(import.meta.dir, '..', 'hooks', 'claude', 'review-police.sh');
 
 let repo: string;
-let head: string;
+let bin: string;
+let home: string;
+const SOURCE_BRANCH = 'feat/thing';
+const HEAD = 'a'.repeat(40);
 
-function runHook(command: string): string {
-  const input = JSON.stringify({ tool_input: { command } });
-  const res = spawnSync('bash', [HOOK], { cwd: repo, input, encoding: 'utf-8' });
+function runHook(command: string, opts: { tool?: string; cwd?: string } = {}): string {
+  const input = JSON.stringify({
+    tool_name: opts.tool ?? 'Bash',
+    tool_input: opts.tool && opts.tool !== 'Bash' ? { pull_number: 12 } : { command },
+    session_id: 'test-session',
+  });
+  const res = spawnSync('bash', [HOOK], {
+    cwd: opts.cwd ?? repo,
+    input,
+    encoding: 'utf-8',
+    env: { ...process.env, PATH: `${bin}:${process.env.PATH}`, HOME: home },
+  });
   return res.stdout ?? '';
 }
 
-function record(body: unknown): void {
-  mkdirSync(join(repo, '.agentkit', 'reviews'), { recursive: true });
-  writeFileSync(join(repo, '.agentkit', 'reviews', 'feat-thing.json'), JSON.stringify(body));
+/** Fake forge CLI: MR 12 -> feat/thing@HEAD, MR 999 -> other/branch. */
+function writeFakeForge(): void {
+  const script = `#!/usr/bin/env bash
+id=""
+for a in "$@"; do [[ "$a" =~ ^[0-9]+$ ]] && id="$a" && break; done
+if [[ "$id" == "999" ]]; then
+  echo '{"source_branch":"other/branch","sha":"${'b'.repeat(40)}","headRefName":"other/branch","headRefOid":"${'b'.repeat(40)}"}'
+else
+  echo '{"source_branch":"${SOURCE_BRANCH}","sha":"${HEAD}","headRefName":"${SOURCE_BRANCH}","headRefOid":"${HEAD}"}'
+fi
+`;
+  for (const name of ['glab', 'gh']) {
+    const p = join(bin, name);
+    writeFileSync(p, script);
+    chmodSync(p, 0o755);
+  }
 }
 
+function record(body: unknown, slug = 'feat__thing'): void {
+  mkdirSync(join(repo, '.agentkit', 'reviews'), { recursive: true });
+  writeFileSync(join(repo, '.agentkit', 'reviews', `${slug}.json`), JSON.stringify(body));
+}
+
+const passing = { head_sha: HEAD, verdict: 'pass', findings: [] };
 const MERGE = 'glab mr merge 12 --squash --yes';
 
 beforeAll(() => {
-  repo = mkdtempSync(join(tmpdir(), 'agentkit-review-'));
+  const root = mkdtempSync(join(tmpdir(), 'agentkit-review-'));
+  repo = join(root, 'repo');
+  bin = join(root, 'bin');
+  home = join(root, 'home');
+  mkdirSync(repo);
+  mkdirSync(bin);
+  mkdirSync(home);
   execSync('git init -q -b main', { cwd: repo, stdio: 'pipe' });
-  execSync('git config user.email t@e.com && git config user.name t', { cwd: repo, stdio: 'pipe' });
-  execSync('git commit -q --allow-empty -m init', { cwd: repo, stdio: 'pipe' });
-  execSync('git checkout -q -b feat/thing', { cwd: repo, stdio: 'pipe' });
-  execSync('git commit -q --allow-empty -m work', { cwd: repo, stdio: 'pipe' });
-  head = execSync('git rev-parse HEAD', { cwd: repo, encoding: 'utf-8' }).trim();
+  writeFakeForge();
 });
 
-afterAll(() => rmSync(repo, { force: true, recursive: true }));
-
+afterAll(() => rmSync(join(repo, '..'), { force: true, recursive: true }));
 beforeEach(() => rmSync(join(repo, '.agentkit'), { force: true, recursive: true }));
 
-describe('review-police', () => {
-  test('ignores commands that are not merges', () => {
+describe('review-police: intended semantics', () => {
+  test('ignores non-merge commands', () => {
     expect(runHook('glab mr create --title x')).toBe('');
     expect(runHook('git push origin feat/thing')).toBe('');
   });
 
-  test('blocks a merge with no review record', () => {
-    const out = runHook(MERGE);
-    expect(out).toContain('"deny"');
-    expect(out).toContain('no review record');
+  test('blocks with no review record', () => {
+    expect(runHook(MERGE)).toContain('no review record');
   });
 
   test('blocks when the review covers an older commit', () => {
-    record({ head_sha: 'deadbeef', verdict: 'pass', findings: [] });
-    const out = runHook(MERGE);
-    expect(out).toContain('"deny"');
-    expect(out).toContain('stale');
+    record({ ...passing, head_sha: 'c'.repeat(40) });
+    expect(runHook(MERGE)).toContain('does not cover the commit');
   });
 
-  test('blocks on an unresolved HIGH even when the verdict says pass', () => {
-    record({
-      head_sha: head,
-      verdict: 'pass',
-      findings: [{ severity: 'HIGH', summary: 'toggle has no backend', resolved: false }],
-    });
+  test('blocks an unresolved HIGH even when the verdict says pass', () => {
+    record({ ...passing, findings: [{ severity: 'HIGH', summary: 'no backend', resolved: false }] });
     const out = runHook(MERGE);
     expect(out).toContain('"deny"');
-    expect(out).toContain('toggle has no backend');
-  });
-
-  test('blocks on a blocked verdict with no findings listed', () => {
-    record({ head_sha: head, verdict: 'blocked', findings: [] });
-    expect(runHook(MERGE)).toContain('"deny"');
+    expect(out).toContain('no backend');
   });
 
   test('allows a clean pass for the exact head', () => {
-    record({
-      head_sha: head,
-      verdict: 'pass',
-      findings: [{ severity: 'MEDIUM', summary: 'nit', resolved: false }],
-    });
+    record(passing);
     expect(runHook(MERGE)).toBe('');
   });
 
-  test('allows once a blocking finding is resolved', () => {
-    record({
-      head_sha: head,
-      verdict: 'pass',
-      findings: [{ severity: 'BLOCKER', summary: 'fixed since', resolved: true }],
-    });
+  test('allows once the blocking finding is resolved', () => {
+    record({ ...passing, findings: [{ severity: 'BLOCKER', summary: 'fixed', resolved: true }] });
     expect(runHook(MERGE)).toBe('');
   });
 
-  test('only user consent unblocks an unresolved BLOCKER', () => {
+  test('only written user consent unblocks', () => {
     const findings = [{ severity: 'BLOCKER', summary: 'ships broken', resolved: false }];
-    record({ head_sha: head, verdict: 'blocked', findings });
+    record({ head_sha: HEAD, verdict: 'blocked', findings });
     expect(runHook(MERGE)).toContain('"deny"');
-
+    record({ head_sha: HEAD, verdict: 'blocked', findings, user_consent: { granted: true } });
+    expect(runHook(MERGE)).toContain('"deny"'); // granted without their words is not consent
     record({
-      head_sha: head,
+      head_sha: HEAD,
       verdict: 'blocked',
       findings,
       user_consent: { granted: true, quote: 'ship it anyway', at: '2026-07-19T00:00:00Z' },
     });
     expect(runHook(MERGE)).toBe('');
   });
+});
 
-  test('consent without the user\'s words does not count', () => {
-    record({
-      head_sha: head,
-      verdict: 'blocked',
-      findings: [{ severity: 'HIGH', summary: 'x', resolved: false }],
-      user_consent: { granted: true },
-    });
-    expect(runHook(MERGE)).toContain('"deny"');
+// Each of these merged cleanly past the first version of this hook.
+describe('review-police: bypasses found in adversarial review', () => {
+  test('B1: a pass for one branch does not authorise merging a different MR', () => {
+    record(passing); // covers feat/thing
+    expect(runHook('glab mr merge 999 --squash --yes')).toContain('"deny"');
   });
 
-  test('gates REST merges too, not just the CLIs', () => {
+  test('B2: MCP merge tools are refused outright', () => {
+    const out = runHook('', { tool: 'mcp__github__merge_pull_request' });
+    expect(out).toContain('"deny"');
+    expect(out).toContain('MCP tool');
+  });
+
+  test('H1: -R / --repo flag variants are still gated', () => {
+    record(passing);
     for (const cmd of [
-      'curl -X PUT https://gitlab.com/api/v4/projects/1/merge_requests/12/merge',
-      'gh pr merge 4 --squash',
-      'curl -X PUT https://api.github.com/repos/o/r/pulls/7/merge',
+      'glab -R group/proj mr merge 999',
+      'gh -R o/r pr merge 999',
+      'glab mr --repo group/proj merge 999',
     ]) {
       expect(runHook(cmd)).toContain('"deny"');
     }
+  });
+
+  test('H2: merging from another directory cannot borrow this repo record', () => {
+    record(passing);
+    // `cd /tmp && glab mr merge 12` used to ALLOW: the old hook read the local
+    // branch, found none, and exited 0. Now the record is looked up in the
+    // command's own directory, so it denies — whether because the target can't
+    // be resolved or because that directory holds no record for it.
+    expect(runHook('cd /tmp && glab mr merge 12', { cwd: '/tmp' })).toContain('"deny"');
+  });
+
+  test('H2b: a merge with no MR id cannot be gated, so it is denied', () => {
+    record(passing);
+    expect(runHook('glab mr merge')).toContain('cannot resolve');
+  });
+
+  test('M2: auto-merge is refused — it lands a head no review has seen', () => {
+    record(passing);
+    expect(runHook('glab mr merge 12 --auto')).toContain('auto-merge');
+  });
+
+  test('REST merges are gated, contiguous or split across variables', () => {
+    record(passing);
+    expect(runHook('curl -X PUT https://gitlab.com/api/v4/projects/1/merge_requests/999/merge'))
+      .toContain('"deny"');
+    expect(runHook('gh api --method PUT /repos/o/r/pulls/999/merge')).toContain('"deny"');
   });
 });


### PR DESCRIPTION
Refs #74.

## Why
A reviewer returned `HIGH — don't expose the menu item yet`. The merge was already running in parallel, the agent judged the finding inert, shipped it, and the feature broke the user's machine exactly as the reviewer predicted. Nothing in the pipeline stopped it — honouring a review was purely the agent's discretion.

## What
`review-police.sh` (PreToolUse, Bash) blocks merges — `glab mr merge`, `gh pr merge`, and the REST calls agents reach for when a CLI refuses — unless `.agentkit/reviews/<branch-slug>.json` records a passing review for the **exact head sha** being merged.

Blocks when: no record · record covers an older sha (stale review) · any unresolved BLOCKER/HIGH · verdict != pass.

Unblocks only by: fixing the finding at its root and re-reviewing the new head, or — for something genuinely unfixable (upstream/platform limit) — the user's written override recorded verbatim in `user_consent`.

Also: workflow rules in the autonomous-workflow skill (review gates the merge, never runs beside it; severity is the reviewer's call; don't hand findings to the user as a queue; never ship a control whose other half isn't built), and a README row.

## Verification
10 new hook tests (no record, stale sha, unresolved HIGH under a pass verdict, blocked verdict, clean pass, resolved finding, consent-only unblock, consent without the user's words, REST/CLI coverage). Full suite 362 pass / 0 fail. Verified live: it denies a real `glab mr merge` on a branch with no review record.