### PR TITLE
fix(review-police): push-option false positive + review record lifecycle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 node_modules/
 bun.lock
 .omc/
+
+# Review records are intentionally LOCAL. Committing one moves HEAD, which
+# stales the record against the branch it reviews — the gate would then deny
+# its own merge and invite regenerating records to suit, the exact loop the
+# gate exists to stop. The durable artifact is ~/.agentkit/review-audit.log,
+# outside the repo.
+.agentkit/

--- a/hooks/claude/review-police.sh
+++ b/hooks/claude/review-police.sh
@@ -30,8 +30,23 @@ set -euo pipefail
 
 INPUT=$(cat)
 TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty')
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+RAW_COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 SESSION=$(echo "$INPUT" | jq -r '.session_id // "unknown"')
+
+# Match against the command with QUOTED SPANS AND HEREDOCS REMOVED. Every
+# false positive this hook has produced came from matching a pattern that
+# appeared inside a string: a commit message describing the rule, a grep for
+# it, a test fixture containing it. Three separate times the hook blocked the
+# very commit that was fixing it. git-police strips the same way
+# (stripQuotedContent) for the same reason.
+#
+# The tradeoff, stated plainly: a merge hidden inside quotes (bash -c "glab mr
+# merge 12") is no longer seen. That is a real bypass, and acceptable only
+# because this gate is friction plus an audit trail, never security — see the
+# header. Forge-side required approvals are what actually prevent a merge.
+COMMAND=$(printf '%s' "$RAW_COMMAND" |
+	perl -0777 -pe 's/<<-?\s*['"'"'"]?(\w+)['"'"'"]?.*?\n\1\b//gs; s/"(?:[^"\\]|\\.)*"/""/g; s/'"'"'[^'"'"']*'"'"'/'"''"'/g' 2>/dev/null ||
+	printf '%s' "$RAW_COMMAND")
 
 AUDIT="${HOME}/.agentkit/review-audit.log"
 

--- a/hooks/claude/review-police.sh
+++ b/hooks/claude/review-police.sh
@@ -79,7 +79,11 @@ if echo "$COMMAND" | grep -qiE 'merge_requests?/[0-9]+/merge|/pulls/[0-9]+/merge
 # merge_requests/pulls reference AND a /merge path segment in the same command.
 if echo "$COMMAND" | grep -qiE 'merge_requests?|/pulls?/' &&
 	echo "$COMMAND" | grep -qiE '/merge\b|"\$\{?[A-Za-z_]+\}?/merge'; then is_merge=1; fi
-if echo "$COMMAND" | grep -qiE '(-o|--push-option)[= ][^ ]*merge_request\.merge'; then
+# Gate on an actual `git push` — `-o` is ubiquitous (grep -o, curl -o, cc -o),
+# and matching it bare denied any command that merely MENTIONED the pattern,
+# including grepping for the rule this hook enforces.
+if echo "$COMMAND" | grep -qiE '\bgit([[:space:]]+-{1,2}[A-Za-z][^[:space:]]*)*[[:space:]]+push\b' &&
+	echo "$COMMAND" | grep -qiE '(-o|--push-option)[= ][^ ]*merge_request\.merge'; then
 	deny "BLOCKED: a merge-on-pipeline push option queues a merge no review has seen.
 
 Push the branch without the merge push-option, then merge explicitly so the

--- a/hooks/claude/review-police.sh
+++ b/hooks/claude/review-police.sh
@@ -28,6 +28,16 @@
 # never the local checkout, which says nothing about what is being merged.
 set -euo pipefail
 
+# A hook that DIES emits no decision, and the harness reads silence as ALLOW —
+# so every abort path here is a fail-open. Two were reachable from the
+# environment alone: `jq` missing (exit 127 on the first parse) and HOME unset
+# (set -u on the audit path). Neither is exotic; both silently disarmed the
+# gate. Refuse loudly instead of dying quietly.
+if ! command -v jq >/dev/null 2>&1; then
+	printf '%s\n' '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"BLOCKED: review-police cannot run — jq is not installed, so the merge cannot be checked against its review record. Install jq."}}'
+	exit 0
+fi
+
 INPUT=$(cat)
 TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty')
 RAW_COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
@@ -51,14 +61,19 @@ SESSION=$(echo "$INPUT" | jq -r '.session_id // "unknown"')
 # one family: a quoted string that a shell then EXECUTES. `bash -c "glab mr
 # merge 999"` would otherwise collapse to one inert token and fail open.
 #
-# The rule, stated exactly as implemented: IF the command mentions a shell
-# interpreter (bash/sh/zsh/dash/ksh, by BASENAME so /bin/bash counts) or `eval`
-# ANYWHERE, then EVERY token of that command is re-tokenised and added to the
-# set, recursively. Not "the argument of -c" — that shape has been narrowed
-# wrong twice (`bash -lc`, `bash -e -u -c`, `bash -c -- …`, `bash <<< …`,
-# `echo … | bash` all evaded it), and enumerating shell calling conventions is
-# a losing game. Once a shell is in the line, treat every string in it as
-# potentially executed.
+# The rule, stated exactly as implemented: IF the command mentions any name in
+# SHELLS below (by BASENAME, so /bin/bash counts) ANYWHERE, then EVERY token of
+# that command is re-tokenised and added to the set, recursively and
+# unconditionally — the interpreter test gates the TOP level only.
+#
+# Not "the argument of -c". That shape was narrowed wrong twice (`bash -lc`,
+# `bash -e -u -c`, `bash -c -- …`, `bash <<< …`, `echo … | bash` all evaded
+# it), and enumerating calling conventions is a losing game.
+#
+# LIMITS, stated plainly rather than implied: SHELLS is a NAME LIST, so an
+# interpreter not on it (say `busybox`, or a wrapper script) is not expanded.
+# Widen the list when one turns up; do not read this as "all execution is
+# covered".
 #
 # This deliberately OVER-expands: `bash -c "echo hi" && git commit -m "glab mr
 # merge 12 is gated"` denies. That is the correct direction for a gate — a
@@ -78,11 +93,19 @@ SESSION=$(echo "$INPUT" | jq -r '.session_id // "unknown"')
 COMMAND=$(printf '%s' "$RAW_COMMAND" | python3 -c '
 import os, shlex, sys
 
-SHELLS = {"bash", "sh", "zsh", "dash", "ksh", "eval"}
+# Anything that takes a string and RUNS it — not only shells. `ssh host "<a
+# merge>"` and `python3 -c "os.system(...)"` execute their argument exactly as
+# surely as `bash -c` does, and each was a hole while this set said "shells".
+SHELLS = {"bash", "sh", "zsh", "dash", "ksh", "eval", "ssh",
+          "perl", "python", "python3", "ruby", "node", "xargs"}
 DEPTH = 6
 
 def split(raw):
-    lex = shlex.shlex(raw, posix=True, punctuation_chars=True)
+    # Explicit punctuation set, NOT True: shlex default omits the backtick, so
+    # it stayed glued to the command word and exact-token matching missed it.
+    # Command substitution with $() was caught while the backtick form was not
+    # — an arbitrary split rather than a principled boundary.
+    lex = shlex.shlex(raw, posix=True, punctuation_chars="();<>|&" + chr(96))
     lex.whitespace_split = True
     lex.commenters = ""  # a `#` in a URL fragment is not a comment
     return list(lex)
@@ -100,7 +123,12 @@ def expand(raw, depth=0):
         toks = split(raw)
     except ValueError:
         return rough(raw)
-    if not any(os.path.basename(t) in SHELLS for t in toks):
+    # The interpreter test gates the TOP level only. Once a line is known to
+    # run one, every level below it expands unconditionally — the payload is
+    # usually wrapped in a layer that mentions no interpreter of its own
+    # (perl -e "system(<a merge>)" nests it inside a call), and re-testing per
+    # level stopped the recursion exactly one layer short of the command.
+    if depth == 0 and not any(os.path.basename(t) in SHELLS for t in toks):
         return toks
     if depth >= DEPTH:
         return toks + rough(raw)
@@ -116,7 +144,9 @@ print("\n".join(expand(raw)))
 # Some checks still need the flat line (a URL split across variables never
 # survives tokenisation as one piece); those use RAW_COMMAND deliberately.
 
-AUDIT="${HOME}/.agentkit/review-audit.log"
+# :-/tmp so an unset HOME cannot trip `set -u` here — losing the audit trail is
+# survivable, aborting the gate is not.
+AUDIT="${HOME:-/tmp}/.agentkit/review-audit.log"
 
 deny() {
 	mkdir -p "$(dirname "$AUDIT")" 2>/dev/null || true

--- a/hooks/claude/review-police.sh
+++ b/hooks/claude/review-police.sh
@@ -33,20 +33,38 @@ TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty')
 RAW_COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 SESSION=$(echo "$INPUT" | jq -r '.session_id // "unknown"')
 
-# Match against the command with QUOTED SPANS AND HEREDOCS REMOVED. Every
-# false positive this hook has produced came from matching a pattern that
-# appeared inside a string: a commit message describing the rule, a grep for
-# it, a test fixture containing it. Three separate times the hook blocked the
-# very commit that was fixing it. git-police strips the same way
-# (stripQuotedContent) for the same reason.
+# TOKENISE the way a shell does, then match on tokens joined by newlines.
 #
-# The tradeoff, stated plainly: a merge hidden inside quotes (bash -c "glab mr
-# merge 12") is no longer seen. That is a real bypass, and acceptable only
-# because this gate is friction plus an audit trail, never security — see the
-# header. Forge-side required approvals are what actually prevent a merge.
-COMMAND=$(printf '%s' "$RAW_COMMAND" |
-	perl -0777 -pe 's/<<-?\s*['"'"'"]?(\w+)['"'"'"]?.*?\n\1\b//gs; s/"(?:[^"\\]|\\.)*"/""/g; s/'"'"'[^'"'"']*'"'"'/'"''"'/g' 2>/dev/null ||
-	printf '%s' "$RAW_COMMAND")
+# Quoting is not the distinction that matters — POSITION is. Blanking quoted
+# spans (the previous attempt) fixed commit messages but silently defeated the
+# idiomatic REST forms, whose URLs are legitimately quoted: it turned a false
+# positive into a fail-OPEN, which is the wrong direction for a gate.
+#
+# Tokenising keeps both properties. `git commit -m "git push -o …"` yields the
+# message as ONE token, so it can never be read as the command word `push` or
+# the flag `-o`; while `curl -X PUT ".../merge_requests/12/merge"` keeps the
+# URL as a token whose value still matches. Checks below therefore anchor on
+# tokens (a token that IS `push`, a token that IS `-o`), not on substrings of
+# the raw line.
+#
+# If tokenising is unavailable or the line does not parse (unbalanced quotes),
+# fall back to splitting on whitespace. Quoted prose then yields several tokens
+# instead of one, so the gate over-matches — a false deny, never a missed merge.
+# It must NOT fall back to the raw line: these checks match whole tokens, and a
+# single blob matches nothing, which would fail OPEN.
+COMMAND=$(printf '%s' "$RAW_COMMAND" | python3 -c '
+import shlex, sys
+raw = sys.stdin.read()
+try:
+    lex = shlex.shlex(raw, posix=True, punctuation_chars=True)
+    lex.whitespace_split = True
+    lex.commenters = ""  # a `#` in a URL fragment is not a comment
+    print("\n".join(lex))
+except ValueError:
+    print("\n".join(raw.split()))
+' 2>/dev/null || printf '%s' "$RAW_COMMAND" | tr -s '[:space:]' '\n')
+# Some checks still need the flat line (a URL split across variables never
+# survives tokenisation as one piece); those use RAW_COMMAND deliberately.
 
 AUDIT="${HOME}/.agentkit/review-audit.log"
 
@@ -77,40 +95,45 @@ fi
 
 [[ -z "$COMMAND" ]] && exit 0
 
-# A run of flags, each optionally taking its own ARGUMENT (`-C <dir>`, `-R o/r`).
-# Matching flags but not their arguments has now been a bug in this file twice.
-ARG='([[:space:]]+-{1,2}[A-Za-z][^[:space:]]*([[:space:]]+[^-][^[:space:]]*)?)*'
 # An actual HTTP caller, as opposed to a command that merely mentions a URL.
-HTTP='(curl|wget|http|https|gh[[:space:]]+api|glab[[:space:]]+api|fetch|axios|requests\.)'
+HTTP='^(curl|wget|http|https|fetch|axios)$'
+
+# Token predicates. `has tok` is an EXACT token match, which is the whole point
+# of tokenising: the word `push` inside a commit message is one token of prose,
+# never the command word.
+has() { printf '%s' "$COMMAND" | grep -qxF -- "$1"; }
+# Any token matching a regex (URLs keep their value through tokenisation).
+tok_match() { printf '%s' "$COMMAND" | grep -qiE -- "$1"; }
+# The token following the first occurrence of a given token.
+after() { printf '%s' "$COMMAND" | awk -v k="$1" 'p { print; exit } $0 == k { p = 1 }'; }
 
 # --- Is this a merge attempt? ---------------------------------------------
-# Flag-tolerant: `glab -R o/r mr merge`, `gh --repo o/r pr merge`,
-# `glab mr --repo o/r merge` all count. Same shape as git-police's push regex.
-FLAG='(\s+(-[A-Za-z]\S*|--[A-Za-z][A-Za-z0-9-]*(=\S+)?)(\s+[^-\s]\S*)?)*'
+# Subcommands are separate tokens, so flags and their arguments no longer need
+# tolerating in a regex — `glab -R o/r mr merge` and `glab mr --repo o/r merge`
+# both simply contain the tokens glab, mr, merge.
 # NOTE: every match below is wrapped so a NON-match cannot abort the script.
 # `grep -q … && is_merge=1` returns non-zero when the pattern misses, and under
 # `set -e` that exits the hook silently — i.e. FAILS OPEN, allowing the merge.
-# Caught by this file's own tests before it ever shipped; keep the `if` form.
 is_merge=0
-if echo "$COMMAND" | grep -qiE "\bglab${FLAG}[[:space:]]+mr${FLAG}[[:space:]]+merge\b"; then is_merge=1; fi
-if echo "$COMMAND" | grep -qiE "\bgh${FLAG}[[:space:]]+pr${FLAG}[[:space:]]+merge\b"; then is_merge=1; fi
-# REST paths, contiguous or split across variables (…/merge_requests/12/merge).
-# …and only when something is actually CALLING it: grepping or editing a merge
-# URL is not merging. Every check here matches raw command text, so requiring
-# the verb narrows the mention-vs-do confusion rather than eliminating it.
-if echo "$COMMAND" | grep -qiE 'merge_requests?/[0-9]+/merge|/pulls/[0-9]+/merge' &&
-	echo "$COMMAND" | grep -qiE "$HTTP"; then is_merge=1; fi
-# Split-variable REST forms: the URL is assembled at runtime, so look for a
-# merge_requests/pulls reference AND a /merge path segment in the same command.
-if echo "$COMMAND" | grep -qiE 'merge_requests?|/pulls?/' &&
-	echo "$COMMAND" | grep -qiE '/merge\b|"\$\{?[A-Za-z_]+\}?/merge' &&
-	echo "$COMMAND" | grep -qiE "$HTTP"; then is_merge=1; fi
+if has glab && has mr && has merge; then is_merge=1; fi
+if has gh && has pr && has merge; then is_merge=1; fi
+# A REST merge: a token carrying the merge path, called by an HTTP client (or
+# `gh api` / `glab api`). Grepping or editing such a URL is not merging it.
+if tok_match 'merge_requests?/[0-9]+/merge|/pulls/[0-9]+/merge' &&
+	{ tok_match "$HTTP" || { has api && { has gh || has glab; }; }; }; then is_merge=1; fi
+# Split-variable REST forms: the URL is assembled at runtime, so no single token
+# carries the whole path — this one check reads RAW_COMMAND deliberately, and is
+# narrowed by requiring an HTTP caller among the TOKENS.
+if echo "$RAW_COMMAND" | grep -qiE 'merge_requests?|/pulls?/' &&
+	echo "$RAW_COMMAND" | grep -qiE '/merge\b|\$\{?[A-Za-z_]+\}?/merge' &&
+	tok_match "$HTTP"; then is_merge=1; fi
 # Gate on an actual `git push` — `-o` is ubiquitous (grep -o, curl -o, cc -o),
 # so matching it bare denied commands that merely MENTIONED the pattern,
-# including grepping for the rule this hook enforces. ${ARG} so a flag's own
-# argument (`git -C <dir> push`) doesn't break the match.
-if echo "$COMMAND" | grep -qiE "\bgit${ARG}[[:space:]]+push\b" &&
-	echo "$COMMAND" | grep -qiE '(-o|--push-option)[= ][^ ]*merge_request\.merge'; then
+# including grepping for the rule this hook enforces. As tokens: the option's
+# value is the token after `-o`, or is fused into `--push-option=…`.
+if has git && has push &&
+	{ printf '%s\n' "$(after -o)" | grep -qiE 'merge_request\.merge' ||
+		tok_match '^--push-option=.*merge_request\.merge'; }; then
 	deny "BLOCKED: a merge-on-pipeline push option queues a merge no review has seen.
 
 Push the branch without the merge push-option, then merge explicitly so the
@@ -120,7 +143,7 @@ fi
 
 # Auto-merge queues the merge for a LATER head — the sha we check now is not
 # the sha that lands. Refuse the mode rather than pretend to gate it.
-if echo "$COMMAND" | grep -qiE '(--auto|--merge-when-pipeline-succeeds|--when-pipeline-succeeds)\b'; then
+if tok_match '^--(auto|merge-when-pipeline-succeeds|when-pipeline-succeeds)$'; then
 	deny "BLOCKED: auto-merge cannot be review-gated.
 
 It merges a future head that no review has seen. Wait for the pipeline, then
@@ -130,18 +153,22 @@ fi
 # --- Resolve WHAT is being merged, from the forge ---------------------------
 # Fail CLOSED: if the target cannot be resolved, the gate denies. An
 # unresolvable merge is exactly when a mistake is most likely.
-REPO_DIR=$(echo "$COMMAND" | sed -nE 's/^[[:space:]]*cd[[:space:]]+([^[:space:];&|]+).*/\1/p' | head -1)
+REPO_DIR=$(after cd)
 [[ -z "$REPO_DIR" ]] && REPO_DIR="$PWD"
 
-ARG='([[:space:]]+-{1,2}[A-Za-z][^[:space:]]*([[:space:]]+[^-][^[:space:]]*)?)*'
-MR_ID=$(echo "$COMMAND" | grep -oiE "\b(mr|pr)${ARG}[[:space:]]+merge${ARG}[[:space:]]+[0-9]+" | grep -oE '[0-9]+$' | head -1 || true)
+# The id is simply the token after `merge` — flags and their arguments are
+# separate tokens now, so `glab mr --repo group/proj merge 12` needs no special
+# case. Extraction losing the id used to deny honest merges with "cannot resolve".
+MR_ID=$(after merge | grep -xE '[0-9]+' || true)
 if [[ -z "$MR_ID" ]]; then
-	MR_ID=$(echo "$COMMAND" | grep -oiE 'merge_requests?/[0-9]+|/pulls/[0-9]+' | grep -oE '[0-9]+' | head -1 || true)
+	MR_ID=$(printf '%s' "$COMMAND" | grep -oiE 'merge_requests?/[0-9]+|/pulls/[0-9]+' | grep -oE '[0-9]+' | head -1 || true)
 fi
-REPO_FLAG=$(echo "$COMMAND" | grep -oiE '(-R|--repo)[= ]+[^ ]+' | head -1 | sed -E 's/^(-R|--repo)[= ]+//' || true)
+REPO_FLAG=$(after -R)
+[[ -z "$REPO_FLAG" ]] && REPO_FLAG=$(after --repo)
+[[ -z "$REPO_FLAG" ]] && REPO_FLAG=$(printf '%s' "$COMMAND" | sed -nE 's/^--repo=(.+)$/\1/p' | head -1 || true)
 
 forge_json() {
-	if echo "$COMMAND" | grep -qiE '\bgh\b|/pulls/'; then
+	if has gh || tok_match '/pulls/'; then
 		gh pr view "$MR_ID" ${REPO_FLAG:+--repo "$REPO_FLAG"} \
 			--json headRefName,headRefOid 2>/dev/null |
 			jq -r '"\(.headRefName)\t\(.headRefOid)"'

--- a/hooks/claude/review-police.sh
+++ b/hooks/claude/review-police.sh
@@ -48,22 +48,38 @@ SESSION=$(echo "$INPUT" | jq -r '.session_id // "unknown"')
 # the raw line.
 #
 # The boundary this draws is "quoted text is DATA" — which is wrong for exactly
-# one family: a quoted string that a shell-invoking command then EXECUTES.
-# `bash -c "glab mr merge 999"` would otherwise collapse to one inert token and
-# fail open. So the tokeniser recursively expands the script argument of
-# bash/sh/zsh/dash/ksh -c and of eval, and the checks see the union. Quoted
-# text that is not handed to a shell stays data.
+# one family: a quoted string that a shell then EXECUTES. `bash -c "glab mr
+# merge 999"` would otherwise collapse to one inert token and fail open.
+#
+# The rule, stated exactly as implemented: IF the command mentions a shell
+# interpreter (bash/sh/zsh/dash/ksh, by BASENAME so /bin/bash counts) or `eval`
+# ANYWHERE, then EVERY token of that command is re-tokenised and added to the
+# set, recursively. Not "the argument of -c" — that shape has been narrowed
+# wrong twice (`bash -lc`, `bash -e -u -c`, `bash -c -- …`, `bash <<< …`,
+# `echo … | bash` all evaded it), and enumerating shell calling conventions is
+# a losing game. Once a shell is in the line, treat every string in it as
+# potentially executed.
+#
+# This deliberately OVER-expands: `bash -c "echo hi" && git commit -m "glab mr
+# merge 12 is gated"` denies. That is the correct direction for a gate — a
+# false deny is an inconvenience, a missed merge is the failure this exists to
+# prevent. Commands with no shell word (the overwhelming majority, including
+# every plain `git commit -m "…"`) are unaffected, which is what keeps the
+# commit-message false positives fixed.
+#
+# Depth is bounded, and exhausting the bound falls back to whitespace-splitting
+# the remaining text rather than returning it unexpanded — a 5-deep nest must
+# not become a hole.
 #
 # If tokenising is unavailable or the line does not parse (unbalanced quotes),
-# fall back to splitting on whitespace. Quoted prose then yields several tokens
-# instead of one, so the gate over-matches — a false deny, never a missed merge.
-# It must NOT fall back to the raw line: these checks match whole tokens, and a
-# single blob matches nothing, which would fail OPEN.
+# fall back to whitespace-splitting with quote characters stripped. Keeping the
+# quotes glued on (`"glab`) makes exact-token matching miss, which fails OPEN —
+# the one direction this must never take.
 COMMAND=$(printf '%s' "$RAW_COMMAND" | python3 -c '
-import shlex, sys
+import os, shlex, sys
 
-SHELLS = {"bash", "sh", "zsh", "dash", "ksh"}
-DEPTH = 4  # bash -c "bash -c ..." is pathological; bound it rather than recurse freely
+SHELLS = {"bash", "sh", "zsh", "dash", "ksh", "eval"}
+DEPTH = 6
 
 def split(raw):
     lex = shlex.shlex(raw, posix=True, punctuation_chars=True)
@@ -71,34 +87,32 @@ def split(raw):
     lex.commenters = ""  # a `#` in a URL fragment is not a comment
     return list(lex)
 
+def rough(raw):
+    # chr(34)/chr(39) rather than literal quote characters: this script is
+    # embedded in a single-quoted shell string, where a literal quote silently
+    # ends the block. That broke the hook once — and a hook that dies emits no
+    # decision, which the harness reads as ALLOW. Quote-free by construction.
+    drop = str.maketrans("", "", chr(34) + chr(39) + chr(92))
+    return [t.translate(drop) for t in raw.split()]
+
 def expand(raw, depth=0):
-    toks = split(raw)
-    if depth >= DEPTH:
+    try:
+        toks = split(raw)
+    except ValueError:
+        return rough(raw)
+    if not any(os.path.basename(t) in SHELLS for t in toks):
         return toks
+    if depth >= DEPTH:
+        return toks + rough(raw)
     out = list(toks)
-    for i, t in enumerate(toks):
-        # A script argument is EXECUTED, so its contents are command words, not
-        # data: bash -c "glab mr merge 999" is a merge. `eval` treats all of
-        # its arguments that way.
-        run = None
-        if t in SHELLS and "-c" in toks[i + 1:i + 3]:
-            j = toks.index("-c", i + 1)
-            run = toks[j + 1:j + 2]
-        elif t == "eval":
-            run = toks[i + 1:]
-        for arg in run or []:
-            try:
-                out.extend(expand(arg, depth + 1))
-            except ValueError:
-                out.extend(arg.split())
+    for t in toks:
+        if t != raw:
+            out.extend(expand(t, depth + 1))
     return out
 
 raw = sys.stdin.read()
-try:
-    print("\n".join(expand(raw)))
-except ValueError:
-    print("\n".join(raw.split()))
-' 2>/dev/null || printf '%s' "$RAW_COMMAND" | tr -s '[:space:]' '\n')
+print("\n".join(expand(raw)))
+' 2>/dev/null || printf '%s' "$RAW_COMMAND" | tr -s '[:space:]' '\n' | tr -d '\042\047\134')
 # Some checks still need the flat line (a URL split across variables never
 # survives tokenisation as one piece); those use RAW_COMMAND deliberately.
 

--- a/hooks/claude/review-police.sh
+++ b/hooks/claude/review-police.sh
@@ -40,12 +40,19 @@ SESSION=$(echo "$INPUT" | jq -r '.session_id // "unknown"')
 # idiomatic REST forms, whose URLs are legitimately quoted: it turned a false
 # positive into a fail-OPEN, which is the wrong direction for a gate.
 #
-# Tokenising keeps both properties. `git commit -m "git push -o …"` yields the
+# Tokenising separates the two. `git commit -m "git push -o …"` yields the
 # message as ONE token, so it can never be read as the command word `push` or
 # the flag `-o`; while `curl -X PUT ".../merge_requests/12/merge"` keeps the
 # URL as a token whose value still matches. Checks below therefore anchor on
 # tokens (a token that IS `push`, a token that IS `-o`), not on substrings of
 # the raw line.
+#
+# The boundary this draws is "quoted text is DATA" — which is wrong for exactly
+# one family: a quoted string that a shell-invoking command then EXECUTES.
+# `bash -c "glab mr merge 999"` would otherwise collapse to one inert token and
+# fail open. So the tokeniser recursively expands the script argument of
+# bash/sh/zsh/dash/ksh -c and of eval, and the checks see the union. Quoted
+# text that is not handed to a shell stays data.
 #
 # If tokenising is unavailable or the line does not parse (unbalanced quotes),
 # fall back to splitting on whitespace. Quoted prose then yields several tokens
@@ -54,12 +61,41 @@ SESSION=$(echo "$INPUT" | jq -r '.session_id // "unknown"')
 # single blob matches nothing, which would fail OPEN.
 COMMAND=$(printf '%s' "$RAW_COMMAND" | python3 -c '
 import shlex, sys
-raw = sys.stdin.read()
-try:
+
+SHELLS = {"bash", "sh", "zsh", "dash", "ksh"}
+DEPTH = 4  # bash -c "bash -c ..." is pathological; bound it rather than recurse freely
+
+def split(raw):
     lex = shlex.shlex(raw, posix=True, punctuation_chars=True)
     lex.whitespace_split = True
     lex.commenters = ""  # a `#` in a URL fragment is not a comment
-    print("\n".join(lex))
+    return list(lex)
+
+def expand(raw, depth=0):
+    toks = split(raw)
+    if depth >= DEPTH:
+        return toks
+    out = list(toks)
+    for i, t in enumerate(toks):
+        # A script argument is EXECUTED, so its contents are command words, not
+        # data: bash -c "glab mr merge 999" is a merge. `eval` treats all of
+        # its arguments that way.
+        run = None
+        if t in SHELLS and "-c" in toks[i + 1:i + 3]:
+            j = toks.index("-c", i + 1)
+            run = toks[j + 1:j + 2]
+        elif t == "eval":
+            run = toks[i + 1:]
+        for arg in run or []:
+            try:
+                out.extend(expand(arg, depth + 1))
+            except ValueError:
+                out.extend(arg.split())
+    return out
+
+raw = sys.stdin.read()
+try:
+    print("\n".join(expand(raw)))
 except ValueError:
     print("\n".join(raw.split()))
 ' 2>/dev/null || printf '%s' "$RAW_COMMAND" | tr -s '[:space:]' '\n')
@@ -131,9 +167,23 @@ if echo "$RAW_COMMAND" | grep -qiE 'merge_requests?|/pulls?/' &&
 # so matching it bare denied commands that merely MENTIONED the pattern,
 # including grepping for the rule this hook enforces. As tokens: the option's
 # value is the token after `-o`, or is fused into `--push-option=…`.
-if has git && has push &&
-	{ printf '%s\n' "$(after -o)" | grep -qiE 'merge_request\.merge' ||
-		tok_match '^--push-option=.*merge_request\.merge'; }; then
+# Scan EVERY option, not just the first: `git push -o ci.skip -o
+# merge_request.merge_when_pipeline_succeeds` is the idiomatic multi-option
+# form, and reading only the token after the first `-o` let it through.
+# A push-option value counts when its PREDECESSOR token is -o/--push-option
+# (covering both the short and the space-separated long form), or when it is
+# fused as --push-option=<value>.
+push_option_merge() {
+	printf '%s' "$COMMAND" | awk '
+		/^--push-option=.*merge_request\.merge/ { found = 1 }
+		prev == "-o" || prev == "--push-option" {
+			if ($0 ~ /^merge_request\.merge/) found = 1
+		}
+		{ prev = $0 }
+		END { exit(found ? 0 : 1) }
+	'
+}
+if has git && has push && push_option_merge; then
 	deny "BLOCKED: a merge-on-pipeline push option queues a merge no review has seen.
 
 Push the branch without the merge push-option, then merge explicitly so the
@@ -156,10 +206,14 @@ fi
 REPO_DIR=$(after cd)
 [[ -z "$REPO_DIR" ]] && REPO_DIR="$PWD"
 
-# The id is simply the token after `merge` — flags and their arguments are
-# separate tokens now, so `glab mr --repo group/proj merge 12` needs no special
-# case. Extraction losing the id used to deny honest merges with "cannot resolve".
-MR_ID=$(after merge | grep -xE '[0-9]+' || true)
+# The FIRST NUMERIC token after `merge` — not the immediately-next one. Flags
+# before `merge` are separate tokens and so take care of themselves, but a flag
+# AFTER it (`gh pr merge --squash 999`) still sits between the verb and the id.
+# Extraction losing the id denies honest merges with a misleading reason.
+MR_ID=$(printf '%s' "$COMMAND" | awk '
+	p && /^[0-9]+$/ { print; exit }
+	$0 == "merge" { p = 1 }
+' || true)
 if [[ -z "$MR_ID" ]]; then
 	MR_ID=$(printf '%s' "$COMMAND" | grep -oiE 'merge_requests?/[0-9]+|/pulls/[0-9]+' | grep -oE '[0-9]+' | head -1 || true)
 fi

--- a/hooks/claude/review-police.sh
+++ b/hooks/claude/review-police.sh
@@ -62,6 +62,12 @@ fi
 
 [[ -z "$COMMAND" ]] && exit 0
 
+# A run of flags, each optionally taking its own ARGUMENT (`-C <dir>`, `-R o/r`).
+# Matching flags but not their arguments has now been a bug in this file twice.
+ARG='([[:space:]]+-{1,2}[A-Za-z][^[:space:]]*([[:space:]]+[^-][^[:space:]]*)?)*'
+# An actual HTTP caller, as opposed to a command that merely mentions a URL.
+HTTP='(curl|wget|http|https|gh[[:space:]]+api|glab[[:space:]]+api|fetch|axios|requests\.)'
+
 # --- Is this a merge attempt? ---------------------------------------------
 # Flag-tolerant: `glab -R o/r mr merge`, `gh --repo o/r pr merge`,
 # `glab mr --repo o/r merge` all count. Same shape as git-police's push regex.
@@ -74,15 +80,21 @@ is_merge=0
 if echo "$COMMAND" | grep -qiE "\bglab${FLAG}[[:space:]]+mr${FLAG}[[:space:]]+merge\b"; then is_merge=1; fi
 if echo "$COMMAND" | grep -qiE "\bgh${FLAG}[[:space:]]+pr${FLAG}[[:space:]]+merge\b"; then is_merge=1; fi
 # REST paths, contiguous or split across variables (…/merge_requests/12/merge).
-if echo "$COMMAND" | grep -qiE 'merge_requests?/[0-9]+/merge|/pulls/[0-9]+/merge'; then is_merge=1; fi
+# …and only when something is actually CALLING it: grepping or editing a merge
+# URL is not merging. Every check here matches raw command text, so requiring
+# the verb narrows the mention-vs-do confusion rather than eliminating it.
+if echo "$COMMAND" | grep -qiE 'merge_requests?/[0-9]+/merge|/pulls/[0-9]+/merge' &&
+	echo "$COMMAND" | grep -qiE "$HTTP"; then is_merge=1; fi
 # Split-variable REST forms: the URL is assembled at runtime, so look for a
 # merge_requests/pulls reference AND a /merge path segment in the same command.
 if echo "$COMMAND" | grep -qiE 'merge_requests?|/pulls?/' &&
-	echo "$COMMAND" | grep -qiE '/merge\b|"\$\{?[A-Za-z_]+\}?/merge'; then is_merge=1; fi
+	echo "$COMMAND" | grep -qiE '/merge\b|"\$\{?[A-Za-z_]+\}?/merge' &&
+	echo "$COMMAND" | grep -qiE "$HTTP"; then is_merge=1; fi
 # Gate on an actual `git push` — `-o` is ubiquitous (grep -o, curl -o, cc -o),
-# and matching it bare denied any command that merely MENTIONED the pattern,
-# including grepping for the rule this hook enforces.
-if echo "$COMMAND" | grep -qiE '\bgit([[:space:]]+-{1,2}[A-Za-z][^[:space:]]*)*[[:space:]]+push\b' &&
+# so matching it bare denied commands that merely MENTIONED the pattern,
+# including grepping for the rule this hook enforces. ${ARG} so a flag's own
+# argument (`git -C <dir> push`) doesn't break the match.
+if echo "$COMMAND" | grep -qiE "\bgit${ARG}[[:space:]]+push\b" &&
 	echo "$COMMAND" | grep -qiE '(-o|--push-option)[= ][^ ]*merge_request\.merge'; then
 	deny "BLOCKED: a merge-on-pipeline push option queues a merge no review has seen.
 

--- a/plugins-cc/agentkit/hooks/review-police.sh
+++ b/plugins-cc/agentkit/hooks/review-police.sh
@@ -30,8 +30,23 @@ set -euo pipefail
 
 INPUT=$(cat)
 TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty')
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+RAW_COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 SESSION=$(echo "$INPUT" | jq -r '.session_id // "unknown"')
+
+# Match against the command with QUOTED SPANS AND HEREDOCS REMOVED. Every
+# false positive this hook has produced came from matching a pattern that
+# appeared inside a string: a commit message describing the rule, a grep for
+# it, a test fixture containing it. Three separate times the hook blocked the
+# very commit that was fixing it. git-police strips the same way
+# (stripQuotedContent) for the same reason.
+#
+# The tradeoff, stated plainly: a merge hidden inside quotes (bash -c "glab mr
+# merge 12") is no longer seen. That is a real bypass, and acceptable only
+# because this gate is friction plus an audit trail, never security — see the
+# header. Forge-side required approvals are what actually prevent a merge.
+COMMAND=$(printf '%s' "$RAW_COMMAND" |
+	perl -0777 -pe 's/<<-?\s*['"'"'"]?(\w+)['"'"'"]?.*?\n\1\b//gs; s/"(?:[^"\\]|\\.)*"/""/g; s/'"'"'[^'"'"']*'"'"'/'"''"'/g' 2>/dev/null ||
+	printf '%s' "$RAW_COMMAND")
 
 AUDIT="${HOME}/.agentkit/review-audit.log"
 

--- a/plugins-cc/agentkit/hooks/review-police.sh
+++ b/plugins-cc/agentkit/hooks/review-police.sh
@@ -79,7 +79,11 @@ if echo "$COMMAND" | grep -qiE 'merge_requests?/[0-9]+/merge|/pulls/[0-9]+/merge
 # merge_requests/pulls reference AND a /merge path segment in the same command.
 if echo "$COMMAND" | grep -qiE 'merge_requests?|/pulls?/' &&
 	echo "$COMMAND" | grep -qiE '/merge\b|"\$\{?[A-Za-z_]+\}?/merge'; then is_merge=1; fi
-if echo "$COMMAND" | grep -qiE '(-o|--push-option)[= ][^ ]*merge_request\.merge'; then
+# Gate on an actual `git push` — `-o` is ubiquitous (grep -o, curl -o, cc -o),
+# and matching it bare denied any command that merely MENTIONED the pattern,
+# including grepping for the rule this hook enforces.
+if echo "$COMMAND" | grep -qiE '\bgit([[:space:]]+-{1,2}[A-Za-z][^[:space:]]*)*[[:space:]]+push\b' &&
+	echo "$COMMAND" | grep -qiE '(-o|--push-option)[= ][^ ]*merge_request\.merge'; then
 	deny "BLOCKED: a merge-on-pipeline push option queues a merge no review has seen.
 
 Push the branch without the merge push-option, then merge explicitly so the

--- a/plugins-cc/agentkit/hooks/review-police.sh
+++ b/plugins-cc/agentkit/hooks/review-police.sh
@@ -28,6 +28,16 @@
 # never the local checkout, which says nothing about what is being merged.
 set -euo pipefail
 
+# A hook that DIES emits no decision, and the harness reads silence as ALLOW —
+# so every abort path here is a fail-open. Two were reachable from the
+# environment alone: `jq` missing (exit 127 on the first parse) and HOME unset
+# (set -u on the audit path). Neither is exotic; both silently disarmed the
+# gate. Refuse loudly instead of dying quietly.
+if ! command -v jq >/dev/null 2>&1; then
+	printf '%s\n' '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"BLOCKED: review-police cannot run — jq is not installed, so the merge cannot be checked against its review record. Install jq."}}'
+	exit 0
+fi
+
 INPUT=$(cat)
 TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty')
 RAW_COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
@@ -51,14 +61,19 @@ SESSION=$(echo "$INPUT" | jq -r '.session_id // "unknown"')
 # one family: a quoted string that a shell then EXECUTES. `bash -c "glab mr
 # merge 999"` would otherwise collapse to one inert token and fail open.
 #
-# The rule, stated exactly as implemented: IF the command mentions a shell
-# interpreter (bash/sh/zsh/dash/ksh, by BASENAME so /bin/bash counts) or `eval`
-# ANYWHERE, then EVERY token of that command is re-tokenised and added to the
-# set, recursively. Not "the argument of -c" — that shape has been narrowed
-# wrong twice (`bash -lc`, `bash -e -u -c`, `bash -c -- …`, `bash <<< …`,
-# `echo … | bash` all evaded it), and enumerating shell calling conventions is
-# a losing game. Once a shell is in the line, treat every string in it as
-# potentially executed.
+# The rule, stated exactly as implemented: IF the command mentions any name in
+# SHELLS below (by BASENAME, so /bin/bash counts) ANYWHERE, then EVERY token of
+# that command is re-tokenised and added to the set, recursively and
+# unconditionally — the interpreter test gates the TOP level only.
+#
+# Not "the argument of -c". That shape was narrowed wrong twice (`bash -lc`,
+# `bash -e -u -c`, `bash -c -- …`, `bash <<< …`, `echo … | bash` all evaded
+# it), and enumerating calling conventions is a losing game.
+#
+# LIMITS, stated plainly rather than implied: SHELLS is a NAME LIST, so an
+# interpreter not on it (say `busybox`, or a wrapper script) is not expanded.
+# Widen the list when one turns up; do not read this as "all execution is
+# covered".
 #
 # This deliberately OVER-expands: `bash -c "echo hi" && git commit -m "glab mr
 # merge 12 is gated"` denies. That is the correct direction for a gate — a
@@ -78,11 +93,19 @@ SESSION=$(echo "$INPUT" | jq -r '.session_id // "unknown"')
 COMMAND=$(printf '%s' "$RAW_COMMAND" | python3 -c '
 import os, shlex, sys
 
-SHELLS = {"bash", "sh", "zsh", "dash", "ksh", "eval"}
+# Anything that takes a string and RUNS it — not only shells. `ssh host "<a
+# merge>"` and `python3 -c "os.system(...)"` execute their argument exactly as
+# surely as `bash -c` does, and each was a hole while this set said "shells".
+SHELLS = {"bash", "sh", "zsh", "dash", "ksh", "eval", "ssh",
+          "perl", "python", "python3", "ruby", "node", "xargs"}
 DEPTH = 6
 
 def split(raw):
-    lex = shlex.shlex(raw, posix=True, punctuation_chars=True)
+    # Explicit punctuation set, NOT True: shlex default omits the backtick, so
+    # it stayed glued to the command word and exact-token matching missed it.
+    # Command substitution with $() was caught while the backtick form was not
+    # — an arbitrary split rather than a principled boundary.
+    lex = shlex.shlex(raw, posix=True, punctuation_chars="();<>|&" + chr(96))
     lex.whitespace_split = True
     lex.commenters = ""  # a `#` in a URL fragment is not a comment
     return list(lex)
@@ -100,7 +123,12 @@ def expand(raw, depth=0):
         toks = split(raw)
     except ValueError:
         return rough(raw)
-    if not any(os.path.basename(t) in SHELLS for t in toks):
+    # The interpreter test gates the TOP level only. Once a line is known to
+    # run one, every level below it expands unconditionally — the payload is
+    # usually wrapped in a layer that mentions no interpreter of its own
+    # (perl -e "system(<a merge>)" nests it inside a call), and re-testing per
+    # level stopped the recursion exactly one layer short of the command.
+    if depth == 0 and not any(os.path.basename(t) in SHELLS for t in toks):
         return toks
     if depth >= DEPTH:
         return toks + rough(raw)
@@ -116,7 +144,9 @@ print("\n".join(expand(raw)))
 # Some checks still need the flat line (a URL split across variables never
 # survives tokenisation as one piece); those use RAW_COMMAND deliberately.
 
-AUDIT="${HOME}/.agentkit/review-audit.log"
+# :-/tmp so an unset HOME cannot trip `set -u` here — losing the audit trail is
+# survivable, aborting the gate is not.
+AUDIT="${HOME:-/tmp}/.agentkit/review-audit.log"
 
 deny() {
 	mkdir -p "$(dirname "$AUDIT")" 2>/dev/null || true

--- a/plugins-cc/agentkit/hooks/review-police.sh
+++ b/plugins-cc/agentkit/hooks/review-police.sh
@@ -33,20 +33,38 @@ TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty')
 RAW_COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 SESSION=$(echo "$INPUT" | jq -r '.session_id // "unknown"')
 
-# Match against the command with QUOTED SPANS AND HEREDOCS REMOVED. Every
-# false positive this hook has produced came from matching a pattern that
-# appeared inside a string: a commit message describing the rule, a grep for
-# it, a test fixture containing it. Three separate times the hook blocked the
-# very commit that was fixing it. git-police strips the same way
-# (stripQuotedContent) for the same reason.
+# TOKENISE the way a shell does, then match on tokens joined by newlines.
 #
-# The tradeoff, stated plainly: a merge hidden inside quotes (bash -c "glab mr
-# merge 12") is no longer seen. That is a real bypass, and acceptable only
-# because this gate is friction plus an audit trail, never security — see the
-# header. Forge-side required approvals are what actually prevent a merge.
-COMMAND=$(printf '%s' "$RAW_COMMAND" |
-	perl -0777 -pe 's/<<-?\s*['"'"'"]?(\w+)['"'"'"]?.*?\n\1\b//gs; s/"(?:[^"\\]|\\.)*"/""/g; s/'"'"'[^'"'"']*'"'"'/'"''"'/g' 2>/dev/null ||
-	printf '%s' "$RAW_COMMAND")
+# Quoting is not the distinction that matters — POSITION is. Blanking quoted
+# spans (the previous attempt) fixed commit messages but silently defeated the
+# idiomatic REST forms, whose URLs are legitimately quoted: it turned a false
+# positive into a fail-OPEN, which is the wrong direction for a gate.
+#
+# Tokenising keeps both properties. `git commit -m "git push -o …"` yields the
+# message as ONE token, so it can never be read as the command word `push` or
+# the flag `-o`; while `curl -X PUT ".../merge_requests/12/merge"` keeps the
+# URL as a token whose value still matches. Checks below therefore anchor on
+# tokens (a token that IS `push`, a token that IS `-o`), not on substrings of
+# the raw line.
+#
+# If tokenising is unavailable or the line does not parse (unbalanced quotes),
+# fall back to splitting on whitespace. Quoted prose then yields several tokens
+# instead of one, so the gate over-matches — a false deny, never a missed merge.
+# It must NOT fall back to the raw line: these checks match whole tokens, and a
+# single blob matches nothing, which would fail OPEN.
+COMMAND=$(printf '%s' "$RAW_COMMAND" | python3 -c '
+import shlex, sys
+raw = sys.stdin.read()
+try:
+    lex = shlex.shlex(raw, posix=True, punctuation_chars=True)
+    lex.whitespace_split = True
+    lex.commenters = ""  # a `#` in a URL fragment is not a comment
+    print("\n".join(lex))
+except ValueError:
+    print("\n".join(raw.split()))
+' 2>/dev/null || printf '%s' "$RAW_COMMAND" | tr -s '[:space:]' '\n')
+# Some checks still need the flat line (a URL split across variables never
+# survives tokenisation as one piece); those use RAW_COMMAND deliberately.
 
 AUDIT="${HOME}/.agentkit/review-audit.log"
 
@@ -77,40 +95,45 @@ fi
 
 [[ -z "$COMMAND" ]] && exit 0
 
-# A run of flags, each optionally taking its own ARGUMENT (`-C <dir>`, `-R o/r`).
-# Matching flags but not their arguments has now been a bug in this file twice.
-ARG='([[:space:]]+-{1,2}[A-Za-z][^[:space:]]*([[:space:]]+[^-][^[:space:]]*)?)*'
 # An actual HTTP caller, as opposed to a command that merely mentions a URL.
-HTTP='(curl|wget|http|https|gh[[:space:]]+api|glab[[:space:]]+api|fetch|axios|requests\.)'
+HTTP='^(curl|wget|http|https|fetch|axios)$'
+
+# Token predicates. `has tok` is an EXACT token match, which is the whole point
+# of tokenising: the word `push` inside a commit message is one token of prose,
+# never the command word.
+has() { printf '%s' "$COMMAND" | grep -qxF -- "$1"; }
+# Any token matching a regex (URLs keep their value through tokenisation).
+tok_match() { printf '%s' "$COMMAND" | grep -qiE -- "$1"; }
+# The token following the first occurrence of a given token.
+after() { printf '%s' "$COMMAND" | awk -v k="$1" 'p { print; exit } $0 == k { p = 1 }'; }
 
 # --- Is this a merge attempt? ---------------------------------------------
-# Flag-tolerant: `glab -R o/r mr merge`, `gh --repo o/r pr merge`,
-# `glab mr --repo o/r merge` all count. Same shape as git-police's push regex.
-FLAG='(\s+(-[A-Za-z]\S*|--[A-Za-z][A-Za-z0-9-]*(=\S+)?)(\s+[^-\s]\S*)?)*'
+# Subcommands are separate tokens, so flags and their arguments no longer need
+# tolerating in a regex — `glab -R o/r mr merge` and `glab mr --repo o/r merge`
+# both simply contain the tokens glab, mr, merge.
 # NOTE: every match below is wrapped so a NON-match cannot abort the script.
 # `grep -q … && is_merge=1` returns non-zero when the pattern misses, and under
 # `set -e` that exits the hook silently — i.e. FAILS OPEN, allowing the merge.
-# Caught by this file's own tests before it ever shipped; keep the `if` form.
 is_merge=0
-if echo "$COMMAND" | grep -qiE "\bglab${FLAG}[[:space:]]+mr${FLAG}[[:space:]]+merge\b"; then is_merge=1; fi
-if echo "$COMMAND" | grep -qiE "\bgh${FLAG}[[:space:]]+pr${FLAG}[[:space:]]+merge\b"; then is_merge=1; fi
-# REST paths, contiguous or split across variables (…/merge_requests/12/merge).
-# …and only when something is actually CALLING it: grepping or editing a merge
-# URL is not merging. Every check here matches raw command text, so requiring
-# the verb narrows the mention-vs-do confusion rather than eliminating it.
-if echo "$COMMAND" | grep -qiE 'merge_requests?/[0-9]+/merge|/pulls/[0-9]+/merge' &&
-	echo "$COMMAND" | grep -qiE "$HTTP"; then is_merge=1; fi
-# Split-variable REST forms: the URL is assembled at runtime, so look for a
-# merge_requests/pulls reference AND a /merge path segment in the same command.
-if echo "$COMMAND" | grep -qiE 'merge_requests?|/pulls?/' &&
-	echo "$COMMAND" | grep -qiE '/merge\b|"\$\{?[A-Za-z_]+\}?/merge' &&
-	echo "$COMMAND" | grep -qiE "$HTTP"; then is_merge=1; fi
+if has glab && has mr && has merge; then is_merge=1; fi
+if has gh && has pr && has merge; then is_merge=1; fi
+# A REST merge: a token carrying the merge path, called by an HTTP client (or
+# `gh api` / `glab api`). Grepping or editing such a URL is not merging it.
+if tok_match 'merge_requests?/[0-9]+/merge|/pulls/[0-9]+/merge' &&
+	{ tok_match "$HTTP" || { has api && { has gh || has glab; }; }; }; then is_merge=1; fi
+# Split-variable REST forms: the URL is assembled at runtime, so no single token
+# carries the whole path — this one check reads RAW_COMMAND deliberately, and is
+# narrowed by requiring an HTTP caller among the TOKENS.
+if echo "$RAW_COMMAND" | grep -qiE 'merge_requests?|/pulls?/' &&
+	echo "$RAW_COMMAND" | grep -qiE '/merge\b|\$\{?[A-Za-z_]+\}?/merge' &&
+	tok_match "$HTTP"; then is_merge=1; fi
 # Gate on an actual `git push` — `-o` is ubiquitous (grep -o, curl -o, cc -o),
 # so matching it bare denied commands that merely MENTIONED the pattern,
-# including grepping for the rule this hook enforces. ${ARG} so a flag's own
-# argument (`git -C <dir> push`) doesn't break the match.
-if echo "$COMMAND" | grep -qiE "\bgit${ARG}[[:space:]]+push\b" &&
-	echo "$COMMAND" | grep -qiE '(-o|--push-option)[= ][^ ]*merge_request\.merge'; then
+# including grepping for the rule this hook enforces. As tokens: the option's
+# value is the token after `-o`, or is fused into `--push-option=…`.
+if has git && has push &&
+	{ printf '%s\n' "$(after -o)" | grep -qiE 'merge_request\.merge' ||
+		tok_match '^--push-option=.*merge_request\.merge'; }; then
 	deny "BLOCKED: a merge-on-pipeline push option queues a merge no review has seen.
 
 Push the branch without the merge push-option, then merge explicitly so the
@@ -120,7 +143,7 @@ fi
 
 # Auto-merge queues the merge for a LATER head — the sha we check now is not
 # the sha that lands. Refuse the mode rather than pretend to gate it.
-if echo "$COMMAND" | grep -qiE '(--auto|--merge-when-pipeline-succeeds|--when-pipeline-succeeds)\b'; then
+if tok_match '^--(auto|merge-when-pipeline-succeeds|when-pipeline-succeeds)$'; then
 	deny "BLOCKED: auto-merge cannot be review-gated.
 
 It merges a future head that no review has seen. Wait for the pipeline, then
@@ -130,18 +153,22 @@ fi
 # --- Resolve WHAT is being merged, from the forge ---------------------------
 # Fail CLOSED: if the target cannot be resolved, the gate denies. An
 # unresolvable merge is exactly when a mistake is most likely.
-REPO_DIR=$(echo "$COMMAND" | sed -nE 's/^[[:space:]]*cd[[:space:]]+([^[:space:];&|]+).*/\1/p' | head -1)
+REPO_DIR=$(after cd)
 [[ -z "$REPO_DIR" ]] && REPO_DIR="$PWD"
 
-ARG='([[:space:]]+-{1,2}[A-Za-z][^[:space:]]*([[:space:]]+[^-][^[:space:]]*)?)*'
-MR_ID=$(echo "$COMMAND" | grep -oiE "\b(mr|pr)${ARG}[[:space:]]+merge${ARG}[[:space:]]+[0-9]+" | grep -oE '[0-9]+$' | head -1 || true)
+# The id is simply the token after `merge` — flags and their arguments are
+# separate tokens now, so `glab mr --repo group/proj merge 12` needs no special
+# case. Extraction losing the id used to deny honest merges with "cannot resolve".
+MR_ID=$(after merge | grep -xE '[0-9]+' || true)
 if [[ -z "$MR_ID" ]]; then
-	MR_ID=$(echo "$COMMAND" | grep -oiE 'merge_requests?/[0-9]+|/pulls/[0-9]+' | grep -oE '[0-9]+' | head -1 || true)
+	MR_ID=$(printf '%s' "$COMMAND" | grep -oiE 'merge_requests?/[0-9]+|/pulls/[0-9]+' | grep -oE '[0-9]+' | head -1 || true)
 fi
-REPO_FLAG=$(echo "$COMMAND" | grep -oiE '(-R|--repo)[= ]+[^ ]+' | head -1 | sed -E 's/^(-R|--repo)[= ]+//' || true)
+REPO_FLAG=$(after -R)
+[[ -z "$REPO_FLAG" ]] && REPO_FLAG=$(after --repo)
+[[ -z "$REPO_FLAG" ]] && REPO_FLAG=$(printf '%s' "$COMMAND" | sed -nE 's/^--repo=(.+)$/\1/p' | head -1 || true)
 
 forge_json() {
-	if echo "$COMMAND" | grep -qiE '\bgh\b|/pulls/'; then
+	if has gh || tok_match '/pulls/'; then
 		gh pr view "$MR_ID" ${REPO_FLAG:+--repo "$REPO_FLAG"} \
 			--json headRefName,headRefOid 2>/dev/null |
 			jq -r '"\(.headRefName)\t\(.headRefOid)"'

--- a/plugins-cc/agentkit/hooks/review-police.sh
+++ b/plugins-cc/agentkit/hooks/review-police.sh
@@ -48,22 +48,38 @@ SESSION=$(echo "$INPUT" | jq -r '.session_id // "unknown"')
 # the raw line.
 #
 # The boundary this draws is "quoted text is DATA" — which is wrong for exactly
-# one family: a quoted string that a shell-invoking command then EXECUTES.
-# `bash -c "glab mr merge 999"` would otherwise collapse to one inert token and
-# fail open. So the tokeniser recursively expands the script argument of
-# bash/sh/zsh/dash/ksh -c and of eval, and the checks see the union. Quoted
-# text that is not handed to a shell stays data.
+# one family: a quoted string that a shell then EXECUTES. `bash -c "glab mr
+# merge 999"` would otherwise collapse to one inert token and fail open.
+#
+# The rule, stated exactly as implemented: IF the command mentions a shell
+# interpreter (bash/sh/zsh/dash/ksh, by BASENAME so /bin/bash counts) or `eval`
+# ANYWHERE, then EVERY token of that command is re-tokenised and added to the
+# set, recursively. Not "the argument of -c" — that shape has been narrowed
+# wrong twice (`bash -lc`, `bash -e -u -c`, `bash -c -- …`, `bash <<< …`,
+# `echo … | bash` all evaded it), and enumerating shell calling conventions is
+# a losing game. Once a shell is in the line, treat every string in it as
+# potentially executed.
+#
+# This deliberately OVER-expands: `bash -c "echo hi" && git commit -m "glab mr
+# merge 12 is gated"` denies. That is the correct direction for a gate — a
+# false deny is an inconvenience, a missed merge is the failure this exists to
+# prevent. Commands with no shell word (the overwhelming majority, including
+# every plain `git commit -m "…"`) are unaffected, which is what keeps the
+# commit-message false positives fixed.
+#
+# Depth is bounded, and exhausting the bound falls back to whitespace-splitting
+# the remaining text rather than returning it unexpanded — a 5-deep nest must
+# not become a hole.
 #
 # If tokenising is unavailable or the line does not parse (unbalanced quotes),
-# fall back to splitting on whitespace. Quoted prose then yields several tokens
-# instead of one, so the gate over-matches — a false deny, never a missed merge.
-# It must NOT fall back to the raw line: these checks match whole tokens, and a
-# single blob matches nothing, which would fail OPEN.
+# fall back to whitespace-splitting with quote characters stripped. Keeping the
+# quotes glued on (`"glab`) makes exact-token matching miss, which fails OPEN —
+# the one direction this must never take.
 COMMAND=$(printf '%s' "$RAW_COMMAND" | python3 -c '
-import shlex, sys
+import os, shlex, sys
 
-SHELLS = {"bash", "sh", "zsh", "dash", "ksh"}
-DEPTH = 4  # bash -c "bash -c ..." is pathological; bound it rather than recurse freely
+SHELLS = {"bash", "sh", "zsh", "dash", "ksh", "eval"}
+DEPTH = 6
 
 def split(raw):
     lex = shlex.shlex(raw, posix=True, punctuation_chars=True)
@@ -71,34 +87,32 @@ def split(raw):
     lex.commenters = ""  # a `#` in a URL fragment is not a comment
     return list(lex)
 
+def rough(raw):
+    # chr(34)/chr(39) rather than literal quote characters: this script is
+    # embedded in a single-quoted shell string, where a literal quote silently
+    # ends the block. That broke the hook once — and a hook that dies emits no
+    # decision, which the harness reads as ALLOW. Quote-free by construction.
+    drop = str.maketrans("", "", chr(34) + chr(39) + chr(92))
+    return [t.translate(drop) for t in raw.split()]
+
 def expand(raw, depth=0):
-    toks = split(raw)
-    if depth >= DEPTH:
+    try:
+        toks = split(raw)
+    except ValueError:
+        return rough(raw)
+    if not any(os.path.basename(t) in SHELLS for t in toks):
         return toks
+    if depth >= DEPTH:
+        return toks + rough(raw)
     out = list(toks)
-    for i, t in enumerate(toks):
-        # A script argument is EXECUTED, so its contents are command words, not
-        # data: bash -c "glab mr merge 999" is a merge. `eval` treats all of
-        # its arguments that way.
-        run = None
-        if t in SHELLS and "-c" in toks[i + 1:i + 3]:
-            j = toks.index("-c", i + 1)
-            run = toks[j + 1:j + 2]
-        elif t == "eval":
-            run = toks[i + 1:]
-        for arg in run or []:
-            try:
-                out.extend(expand(arg, depth + 1))
-            except ValueError:
-                out.extend(arg.split())
+    for t in toks:
+        if t != raw:
+            out.extend(expand(t, depth + 1))
     return out
 
 raw = sys.stdin.read()
-try:
-    print("\n".join(expand(raw)))
-except ValueError:
-    print("\n".join(raw.split()))
-' 2>/dev/null || printf '%s' "$RAW_COMMAND" | tr -s '[:space:]' '\n')
+print("\n".join(expand(raw)))
+' 2>/dev/null || printf '%s' "$RAW_COMMAND" | tr -s '[:space:]' '\n' | tr -d '\042\047\134')
 # Some checks still need the flat line (a URL split across variables never
 # survives tokenisation as one piece); those use RAW_COMMAND deliberately.
 

--- a/plugins-cc/agentkit/hooks/review-police.sh
+++ b/plugins-cc/agentkit/hooks/review-police.sh
@@ -40,12 +40,19 @@ SESSION=$(echo "$INPUT" | jq -r '.session_id // "unknown"')
 # idiomatic REST forms, whose URLs are legitimately quoted: it turned a false
 # positive into a fail-OPEN, which is the wrong direction for a gate.
 #
-# Tokenising keeps both properties. `git commit -m "git push -o …"` yields the
+# Tokenising separates the two. `git commit -m "git push -o …"` yields the
 # message as ONE token, so it can never be read as the command word `push` or
 # the flag `-o`; while `curl -X PUT ".../merge_requests/12/merge"` keeps the
 # URL as a token whose value still matches. Checks below therefore anchor on
 # tokens (a token that IS `push`, a token that IS `-o`), not on substrings of
 # the raw line.
+#
+# The boundary this draws is "quoted text is DATA" — which is wrong for exactly
+# one family: a quoted string that a shell-invoking command then EXECUTES.
+# `bash -c "glab mr merge 999"` would otherwise collapse to one inert token and
+# fail open. So the tokeniser recursively expands the script argument of
+# bash/sh/zsh/dash/ksh -c and of eval, and the checks see the union. Quoted
+# text that is not handed to a shell stays data.
 #
 # If tokenising is unavailable or the line does not parse (unbalanced quotes),
 # fall back to splitting on whitespace. Quoted prose then yields several tokens
@@ -54,12 +61,41 @@ SESSION=$(echo "$INPUT" | jq -r '.session_id // "unknown"')
 # single blob matches nothing, which would fail OPEN.
 COMMAND=$(printf '%s' "$RAW_COMMAND" | python3 -c '
 import shlex, sys
-raw = sys.stdin.read()
-try:
+
+SHELLS = {"bash", "sh", "zsh", "dash", "ksh"}
+DEPTH = 4  # bash -c "bash -c ..." is pathological; bound it rather than recurse freely
+
+def split(raw):
     lex = shlex.shlex(raw, posix=True, punctuation_chars=True)
     lex.whitespace_split = True
     lex.commenters = ""  # a `#` in a URL fragment is not a comment
-    print("\n".join(lex))
+    return list(lex)
+
+def expand(raw, depth=0):
+    toks = split(raw)
+    if depth >= DEPTH:
+        return toks
+    out = list(toks)
+    for i, t in enumerate(toks):
+        # A script argument is EXECUTED, so its contents are command words, not
+        # data: bash -c "glab mr merge 999" is a merge. `eval` treats all of
+        # its arguments that way.
+        run = None
+        if t in SHELLS and "-c" in toks[i + 1:i + 3]:
+            j = toks.index("-c", i + 1)
+            run = toks[j + 1:j + 2]
+        elif t == "eval":
+            run = toks[i + 1:]
+        for arg in run or []:
+            try:
+                out.extend(expand(arg, depth + 1))
+            except ValueError:
+                out.extend(arg.split())
+    return out
+
+raw = sys.stdin.read()
+try:
+    print("\n".join(expand(raw)))
 except ValueError:
     print("\n".join(raw.split()))
 ' 2>/dev/null || printf '%s' "$RAW_COMMAND" | tr -s '[:space:]' '\n')
@@ -131,9 +167,23 @@ if echo "$RAW_COMMAND" | grep -qiE 'merge_requests?|/pulls?/' &&
 # so matching it bare denied commands that merely MENTIONED the pattern,
 # including grepping for the rule this hook enforces. As tokens: the option's
 # value is the token after `-o`, or is fused into `--push-option=…`.
-if has git && has push &&
-	{ printf '%s\n' "$(after -o)" | grep -qiE 'merge_request\.merge' ||
-		tok_match '^--push-option=.*merge_request\.merge'; }; then
+# Scan EVERY option, not just the first: `git push -o ci.skip -o
+# merge_request.merge_when_pipeline_succeeds` is the idiomatic multi-option
+# form, and reading only the token after the first `-o` let it through.
+# A push-option value counts when its PREDECESSOR token is -o/--push-option
+# (covering both the short and the space-separated long form), or when it is
+# fused as --push-option=<value>.
+push_option_merge() {
+	printf '%s' "$COMMAND" | awk '
+		/^--push-option=.*merge_request\.merge/ { found = 1 }
+		prev == "-o" || prev == "--push-option" {
+			if ($0 ~ /^merge_request\.merge/) found = 1
+		}
+		{ prev = $0 }
+		END { exit(found ? 0 : 1) }
+	'
+}
+if has git && has push && push_option_merge; then
 	deny "BLOCKED: a merge-on-pipeline push option queues a merge no review has seen.
 
 Push the branch without the merge push-option, then merge explicitly so the
@@ -156,10 +206,14 @@ fi
 REPO_DIR=$(after cd)
 [[ -z "$REPO_DIR" ]] && REPO_DIR="$PWD"
 
-# The id is simply the token after `merge` — flags and their arguments are
-# separate tokens now, so `glab mr --repo group/proj merge 12` needs no special
-# case. Extraction losing the id used to deny honest merges with "cannot resolve".
-MR_ID=$(after merge | grep -xE '[0-9]+' || true)
+# The FIRST NUMERIC token after `merge` — not the immediately-next one. Flags
+# before `merge` are separate tokens and so take care of themselves, but a flag
+# AFTER it (`gh pr merge --squash 999`) still sits between the verb and the id.
+# Extraction losing the id denies honest merges with a misleading reason.
+MR_ID=$(printf '%s' "$COMMAND" | awk '
+	p && /^[0-9]+$/ { print; exit }
+	$0 == "merge" { p = 1 }
+' || true)
 if [[ -z "$MR_ID" ]]; then
 	MR_ID=$(printf '%s' "$COMMAND" | grep -oiE 'merge_requests?/[0-9]+|/pulls/[0-9]+' | grep -oE '[0-9]+' | head -1 || true)
 fi

--- a/plugins-cc/agentkit/hooks/review-police.sh
+++ b/plugins-cc/agentkit/hooks/review-police.sh
@@ -62,6 +62,12 @@ fi
 
 [[ -z "$COMMAND" ]] && exit 0
 
+# A run of flags, each optionally taking its own ARGUMENT (`-C <dir>`, `-R o/r`).
+# Matching flags but not their arguments has now been a bug in this file twice.
+ARG='([[:space:]]+-{1,2}[A-Za-z][^[:space:]]*([[:space:]]+[^-][^[:space:]]*)?)*'
+# An actual HTTP caller, as opposed to a command that merely mentions a URL.
+HTTP='(curl|wget|http|https|gh[[:space:]]+api|glab[[:space:]]+api|fetch|axios|requests\.)'
+
 # --- Is this a merge attempt? ---------------------------------------------
 # Flag-tolerant: `glab -R o/r mr merge`, `gh --repo o/r pr merge`,
 # `glab mr --repo o/r merge` all count. Same shape as git-police's push regex.
@@ -74,15 +80,21 @@ is_merge=0
 if echo "$COMMAND" | grep -qiE "\bglab${FLAG}[[:space:]]+mr${FLAG}[[:space:]]+merge\b"; then is_merge=1; fi
 if echo "$COMMAND" | grep -qiE "\bgh${FLAG}[[:space:]]+pr${FLAG}[[:space:]]+merge\b"; then is_merge=1; fi
 # REST paths, contiguous or split across variables (…/merge_requests/12/merge).
-if echo "$COMMAND" | grep -qiE 'merge_requests?/[0-9]+/merge|/pulls/[0-9]+/merge'; then is_merge=1; fi
+# …and only when something is actually CALLING it: grepping or editing a merge
+# URL is not merging. Every check here matches raw command text, so requiring
+# the verb narrows the mention-vs-do confusion rather than eliminating it.
+if echo "$COMMAND" | grep -qiE 'merge_requests?/[0-9]+/merge|/pulls/[0-9]+/merge' &&
+	echo "$COMMAND" | grep -qiE "$HTTP"; then is_merge=1; fi
 # Split-variable REST forms: the URL is assembled at runtime, so look for a
 # merge_requests/pulls reference AND a /merge path segment in the same command.
 if echo "$COMMAND" | grep -qiE 'merge_requests?|/pulls?/' &&
-	echo "$COMMAND" | grep -qiE '/merge\b|"\$\{?[A-Za-z_]+\}?/merge'; then is_merge=1; fi
+	echo "$COMMAND" | grep -qiE '/merge\b|"\$\{?[A-Za-z_]+\}?/merge' &&
+	echo "$COMMAND" | grep -qiE "$HTTP"; then is_merge=1; fi
 # Gate on an actual `git push` — `-o` is ubiquitous (grep -o, curl -o, cc -o),
-# and matching it bare denied any command that merely MENTIONED the pattern,
-# including grepping for the rule this hook enforces.
-if echo "$COMMAND" | grep -qiE '\bgit([[:space:]]+-{1,2}[A-Za-z][^[:space:]]*)*[[:space:]]+push\b' &&
+# so matching it bare denied commands that merely MENTIONED the pattern,
+# including grepping for the rule this hook enforces. ${ARG} so a flag's own
+# argument (`git -C <dir> push`) doesn't break the match.
+if echo "$COMMAND" | grep -qiE "\bgit${ARG}[[:space:]]+push\b" &&
 	echo "$COMMAND" | grep -qiE '(-o|--push-option)[= ][^ ]*merge_request\.merge'; then
 	deny "BLOCKED: a merge-on-pipeline push option queues a merge no review has seen.
 

--- a/tests/probe-cases.txt
+++ b/tests/probe-cases.txt
@@ -1,0 +1,14 @@
+DENY	result=`glab mr merge 999`
+DENY	`glab mr merge 999`
+DENY	bash -c "`glab mr merge 999`"
+DENY	echo $(glab mr merge 999)
+DENY	ssh host "glab mr merge 999"
+DENY	perl -e "system('glab mr merge 999')"
+DENY	python3 -c "import os; os.system('glab mr merge 999')"
+DENY	bash -lc "glab mr merge 999"
+DENY	/bin/bash -c "glab mr merge 999"
+DENY	echo "glab mr merge 999" | bash
+ALLOW	git commit -m "docs: glab mr merge 12 is gated"
+ALLOW	grep -rn "merge_requests/12/merge" docs/
+ALLOW	grep -o merge_request.merge_when_pipeline_succeeds README.md
+ALLOW	rg -o "merge_request.merge" docs/

--- a/tests/probe.sh
+++ b/tests/probe.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Manual probe harness: feeds each tab-separated "EXPECT<TAB>command" line from
+# probe-cases.txt to the hook and reports mismatches. Cases live in a data file
+# so this script never contains a merge-shaped command itself.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+HOOK=hooks/claude/review-police.sh
+fail=0
+while IFS=$'\t' read -r want cmd; do
+	[[ -z "${want:-}" || "${want:0:1}" == "#" ]] && continue
+	payload=$(cmd="$cmd" python3 -c 'import json,os;print(json.dumps({"tool_name":"Bash","tool_input":{"command":os.environ["cmd"]},"session_id":"probe"}))')
+	if printf '%s' "$payload" | bash "$HOOK" 2>/dev/null | grep -q deny; then got=DENY; else got=ALLOW; fi
+	if [[ "$got" == "$want" ]]; then
+		printf 'ok   %-5s %s\n' "$got" "$cmd"
+	else
+		printf 'FAIL want=%-5s got=%-5s %s\n' "$want" "$got" "$cmd"
+		fail=1
+	fi
+done <tests/probe-cases.txt
+exit $fail

--- a/tests/review-police.test.ts
+++ b/tests/review-police.test.ts
@@ -239,4 +239,32 @@ describe('review-police: bypasses found in adversarial review', () => {
       .toContain('"deny"');
     expect(runHook('gh api --method PUT /repos/o/r/pulls/999/merge')).toContain('"deny"');
   });
+
+  test('QUOTING a merge URL does not evade the gate', () => {
+    record(passing);
+    // The regression that made quote-STRIPPING the wrong fix: URLs are quoted
+    // in every idiomatic REST call, so blanking quoted spans turned these from
+    // gated into allowed — a fail-OPEN, the one direction a gate must not fail.
+    for (const cmd of [
+      'curl -X PUT "https://gitlab.com/api/v4/projects/1/merge_requests/999/merge"',
+      "curl -X PUT 'https://gitlab.com/api/v4/projects/1/merge_requests/999/merge'",
+      'gh api --method PUT "/repos/o/r/pulls/999/merge"',
+    ]) {
+      expect(runHook(cmd), cmd).toContain('"deny"');
+    }
+  });
+
+  test('quoting a CLI merge does not evade the gate either', () => {
+    record(passing);
+    expect(runHook('glab mr merge "999" --squash --yes')).toContain('"deny"');
+    expect(runHook('glab mr merge 999 --repo "group/proj"')).toContain('"deny"');
+  });
+
+  test('an unparseable command line still gates the merge', () => {
+    record(passing);
+    // Unbalanced quotes cannot be tokenised; the fallback splits on whitespace,
+    // which over-matches. A merge must never slip through because the line
+    // failed to parse.
+    expect(runHook('glab mr merge 999 --squash "oops')).toContain('"deny"');
+  });
 });

--- a/tests/review-police.test.ts
+++ b/tests/review-police.test.ts
@@ -175,6 +175,15 @@ describe('review-police: bypasses found in adversarial review', () => {
     }
   });
 
+  test('quoted text is not a command: commit messages describing the rules', () => {
+    record(passing);
+    // This hook blocked the very commits that were fixing it, three times,
+    // because the rule it enforces appeared inside a commit message.
+    const msg = 'git commit -m "fix: git push -o merge_request.merge_when_pipeline_succeeds is refused"';
+    expect(runHook(msg)).toBe('');
+    expect(runHook('git commit -m "docs: glab mr merge 12 is gated" && git push')).toBe('');
+  });
+
   test('reading a merge URL is not calling it', () => {
     record(passing);
     // Only an actual HTTP caller counts; grepping or editing the text does not.

--- a/tests/review-police.test.ts
+++ b/tests/review-police.test.ts
@@ -148,6 +148,21 @@ describe('review-police: bypasses found in adversarial review', () => {
     }
   });
 
+  test('commands that merely mention the push option are not merges', () => {
+    record(passing);
+    // `-o` is everywhere, so matching it bare denied ordinary work — including
+    // grepping for the very rule this hook enforces. That bit for real: the
+    // pre-fix hook blocked the command that was installing its own fix.
+    for (const cmd of [
+      'grep -o merge_request.merge_when_pipeline_succeeds README.md',
+      'rg -o "merge_request.merge" docs/',
+      'curl -o merge_request.merge.json https://example.com/x',
+      'gcc -o merge_request.merge main.c',
+    ]) {
+      expect(runHook(cmd)).toBe('');
+    }
+  });
+
   test('creating an MR over REST is not a merge', () => {
     record(passing);
     expect(runHook('curl -X POST https://gitlab.com/api/v4/projects/1/merge_requests -d x')).toBe('');

--- a/tests/review-police.test.ts
+++ b/tests/review-police.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
 import { execSync, spawnSync } from 'node:child_process';
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -72,6 +72,22 @@ beforeAll(() => {
 
 afterAll(() => rmSync(join(repo, '..'), { force: true, recursive: true }));
 beforeEach(() => rmSync(join(repo, '.agentkit'), { force: true, recursive: true }));
+
+describe('every police hook parses', () => {
+  // A hook with a shell syntax error prints nothing and exits non-zero, which
+  // the harness reads as ALLOW — so a typo in ANY of these silently disarms
+  // the gate it implements. This happened for real: an embedded python block
+  // quoted with "'"'" sequences terminated the shell string early, and the
+  // whole hook stopped running while the suite still passed.
+  const hookDir = join(import.meta.dir, '..', 'hooks', 'claude');
+  for (const name of readdirSync(hookDir).filter((f) => f.endsWith('.sh'))) {
+    test(`${name} is syntactically valid bash`, () => {
+      const res = spawnSync('bash', ['-n', join(hookDir, name)], { encoding: 'utf-8' });
+      expect(res.stderr, `${name}: ${res.stderr}`).toBe('');
+      expect(res.status).toBe(0);
+    });
+  }
+});
 
 describe('review-police: intended semantics', () => {
   test('ignores non-merge commands', () => {
@@ -240,18 +256,66 @@ describe('review-police: bypasses found in adversarial review', () => {
     expect(runHook('gh api --method PUT /repos/o/r/pulls/999/merge')).toContain('"deny"');
   });
 
-  test('a shell-wrapped merge is still a merge', () => {
+  test('a shell-wrapped merge is still a merge, in every calling convention', () => {
     record(passing);
     // Tokenising treats quoted text as data — correct, EXCEPT when a shell is
     // handed it to execute. These collapsed to one inert token and failed open.
+    // The first attempt at this recognised only `<bare shell> -c <script>`, and
+    // every form below EXCEPT that one still evaded it. Enumerating shell
+    // calling conventions is a losing game, which is why the rule is now
+    // "a shell is mentioned ⇒ expand every token".
     for (const cmd of [
       'bash -c "glab mr merge 999"',
       "sh -c 'gh pr merge 999 --squash'",
       'eval "glab mr merge 999"',
-      'bash -c "bash -c \'glab mr merge 999\'"',
+      'bash -lc "glab mr merge 999"', // combined flags
+      '/bin/bash -c "glab mr merge 999"', // path-qualified interpreter
+      'bash -e -u -c "glab mr merge 999"', // extra leading flags
+      'sh -euc "gh pr merge 999"',
+      'bash -c -- "glab mr merge 999"', // -- separator before the script
+      'bash <<< "glab mr merge 999"', // here-string, no -c at all
+      'echo "glab mr merge 999" | bash', // piped into a shell
+      'env bash -c "glab mr merge 999"',
+      'timeout 5 bash -c "glab mr merge 999"',
     ]) {
       expect(runHook(cmd), cmd).toContain('"deny"');
     }
+  });
+
+  test('nesting deeper than the expansion bound does not become a hole', () => {
+    record(passing);
+    // The bound existed to stop runaway recursion, but returning the level's
+    // tokens unexpanded at the cap made nest-5 ALLOW. Exhausting the bound now
+    // falls back to whitespace splitting, which over-matches.
+    let cmd = 'glab mr merge 999';
+    for (let i = 0; i < 8; i++) {
+      cmd = `bash -c ${JSON.stringify(cmd)}`;
+      expect(runHook(cmd), `nest ${i + 1}`).toContain('"deny"');
+    }
+  });
+
+  test('a shell-wrapped merge is caught even without python3', () => {
+    record(passing);
+    // The tokeniser needs python3; without it the hook splits on whitespace.
+    // That left quotes glued to the first word (`"glab`), so exact-token
+    // matching missed and the merge was ALLOWED — a fail-open on a machine
+    // that merely lacks python3.
+    const stub = join(bin, '..', 'stub');
+    mkdirSync(stub, { recursive: true });
+    const p = join(stub, 'python3');
+    writeFileSync(p, '#!/bin/sh\nexit 127\n');
+    chmodSync(p, 0o755);
+    const res = spawnSync('bash', [HOOK], {
+      cwd: repo,
+      input: JSON.stringify({
+        tool_name: 'Bash',
+        tool_input: { command: 'bash -c "glab mr merge 999"' },
+        session_id: 'test-session',
+      }),
+      encoding: 'utf-8',
+      env: { ...process.env, PATH: `${stub}:${bin}:${process.env.PATH}`, HOME: home },
+    });
+    expect(res.stdout ?? '').toContain('"deny"');
   });
 
   test('every push option is scanned, not just the first', () => {

--- a/tests/review-police.test.ts
+++ b/tests/review-police.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
 import { execSync, spawnSync } from 'node:child_process';
-import { chmodSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -87,6 +87,79 @@ describe('every police hook parses', () => {
       expect(res.status).toBe(0);
     });
   }
+});
+
+describe('review-police: evasion probe table', () => {
+  // Cases live in tests/probe-cases.txt (tab-separated EXPECT<TAB>command) so
+  // the table can be extended without editing code, and so neither this file
+  // nor the harness contains a merge-shaped shell command of its own — the
+  // gate is installed in this very session and denies those in tool calls.
+  const lines = readFileSync(join(import.meta.dir, 'probe-cases.txt'), 'utf-8')
+    .split('\n')
+    .filter((l) => l.trim().length > 0 && !l.startsWith('#'));
+
+  test('the probe table is not silently empty', () => {
+    expect(lines.length).toBeGreaterThan(10);
+  });
+
+  for (const line of lines) {
+    const [want, cmd] = line.split('\t');
+    test(`${want}: ${cmd}`, () => {
+      record(passing);
+      const out = runHook(cmd);
+      if (want === 'DENY') expect(out).toContain('"deny"');
+      else expect(out).toBe('');
+    });
+  }
+});
+
+describe('review-police: the hook itself cannot fail open', () => {
+  // Every abort path is a fail-open: a hook that dies prints no decision and
+  // the harness allows the tool call. These two were reachable from the
+  // environment alone.
+  function runBare(env: Record<string, string | undefined>): ReturnType<typeof spawnSync> {
+    return spawnSync('bash', [HOOK], {
+      cwd: repo,
+      input: JSON.stringify({
+        tool_name: 'Bash',
+        tool_input: { command: MERGE },
+        session_id: 'test-session',
+      }),
+      encoding: 'utf-8',
+      env: { PATH: `${bin}:${process.env.PATH}`, HOME: home, ...env },
+    });
+  }
+
+  test('an unset HOME does not abort the gate', () => {
+    record(passing);
+    // AUDIT="${HOME}/..." tripped `set -u`, exiting 1 with no decision.
+    const res = runBare({ HOME: undefined });
+    expect(res.stderr).not.toContain('unbound variable');
+    expect(res.status).toBe(0);
+  });
+
+  test('a missing jq denies rather than dying', () => {
+    record(passing);
+    const stub = mkdtempSync(join(tmpdir(), 'nojq-'));
+    // A PATH with no jq: the hook used to exit 127 on its first parse.
+    // bash is invoked by ABSOLUTE path — an empty PATH would otherwise fail to
+    // locate bash itself, and the spawn error would masquerade as the hook
+    // staying silent (i.e. the test would "pass" for the wrong reason).
+    const bash = execSync('command -v bash', { encoding: 'utf-8' }).trim();
+    const res = spawnSync(bash, [HOOK], {
+      cwd: repo,
+      input: JSON.stringify({
+        tool_name: 'Bash',
+        tool_input: { command: MERGE },
+        session_id: 'test-session',
+      }),
+      encoding: 'utf-8',
+      env: { PATH: stub, HOME: home },
+    });
+    expect(res.stdout).toContain('"deny"');
+    expect(res.stdout).toContain('jq');
+    rmSync(stub, { force: true, recursive: true });
+  });
 });
 
 describe('review-police: intended semantics', () => {

--- a/tests/review-police.test.ts
+++ b/tests/review-police.test.ts
@@ -240,6 +240,50 @@ describe('review-police: bypasses found in adversarial review', () => {
     expect(runHook('gh api --method PUT /repos/o/r/pulls/999/merge')).toContain('"deny"');
   });
 
+  test('a shell-wrapped merge is still a merge', () => {
+    record(passing);
+    // Tokenising treats quoted text as data — correct, EXCEPT when a shell is
+    // handed it to execute. These collapsed to one inert token and failed open.
+    for (const cmd of [
+      'bash -c "glab mr merge 999"',
+      "sh -c 'gh pr merge 999 --squash'",
+      'eval "glab mr merge 999"',
+      'bash -c "bash -c \'glab mr merge 999\'"',
+    ]) {
+      expect(runHook(cmd), cmd).toContain('"deny"');
+    }
+  });
+
+  test('every push option is scanned, not just the first', () => {
+    record(passing);
+    // The idiomatic GitLab form passes several -o flags. Reading only the
+    // token after the FIRST one let the merge option through.
+    for (const cmd of [
+      'git push -o ci.skip -o merge_request.merge_when_pipeline_succeeds origin b',
+      'git push -o merge_request.target_branch=main -o merge_request.merge_when_pipeline_succeeds origin b',
+      'git push --push-option merge_request.merge_when_pipeline_succeeds origin b',
+      'git push -o "merge_request.merge_when_pipeline_succeeds" origin b',
+      "git push -o 'merge_request.merge_when_pipeline_succeeds' origin b",
+      'git push --push-option="merge_request.merge_when_pipeline_succeeds" origin b',
+    ]) {
+      expect(runHook(cmd), cmd).toContain('"deny"');
+    }
+  });
+
+  test('a flag AFTER merge does not lose the MR id', () => {
+    record(passing);
+    // Fails closed rather than open, but it denies an honest merge with a
+    // reason that misdiagnoses the cause.
+    expect(runHook('gh pr merge --squash 12')).toBe('');
+    expect(runHook('glab mr merge --yes 12')).toBe('');
+    // The allow-cases alone cannot catch a broken extraction: an unresolvable
+    // id makes the fake forge fall back to MR 12's branch, so they pass either
+    // way. These pin that the id READ is the id GIVEN — a different MR must
+    // still be denied when a flag sits between the verb and the number.
+    expect(runHook('gh pr merge --squash 999')).toContain('"deny"');
+    expect(runHook('glab mr merge --yes 999')).toContain('"deny"');
+  });
+
   test('QUOTING a merge URL does not evade the gate', () => {
     record(passing);
     // The regression that made quote-STRIPPING the wrong fix: URLs are quoted

--- a/tests/review-police.test.ts
+++ b/tests/review-police.test.ts
@@ -163,6 +163,25 @@ describe('review-police: bypasses found in adversarial review', () => {
     }
   });
 
+  test('a push option is caught even behind a flag with its own argument', () => {
+    record(passing);
+    // `git -C <dir> push` — the guard tolerated flags but not their arguments,
+    // the same shape that had already broken MR-id extraction once.
+    for (const cmd of [
+      'git -C /repo push -o merge_request.merge_when_pipeline_succeeds origin b',
+      'git --git-dir=/r/.git push --push-option=merge_request.merge_when_pipeline_succeeds origin b',
+    ]) {
+      expect(runHook(cmd)).toContain('"deny"');
+    }
+  });
+
+  test('reading a merge URL is not calling it', () => {
+    record(passing);
+    // Only an actual HTTP caller counts; grepping or editing the text does not.
+    expect(runHook('grep -rn "merge_requests/12/merge" docs/')).toBe('');
+    expect(runHook('rg "/pulls/7/merge" .')).toBe('');
+  });
+
   test('creating an MR over REST is not a merge', () => {
     record(passing);
     expect(runHook('curl -X POST https://gitlab.com/api/v4/projects/1/merge_requests -d x')).toBe('');


### PR DESCRIPTION
Follow-ups the reviewer flagged on #77 as worth doing but not blocking.

**Push-option false positive (MEDIUM).** The merge-on-pipeline refusal wasn't gated on the command actually being a `git push`, so anything containing `-o` plus that text was denied: `grep -o`, `rg -o`, `curl -o`, `gcc -o`. It blocked grepping for the very rule the hook enforces — and in practice it blocked the command that was installing its own fix. Now requires a git push; four regression cases added.

**Review record lifecycle (MEDIUM, was undefined).** `.agentkit/` is now gitignored and records are documented as intentionally local. Committing a record moves HEAD, which stales it against the branch it reviews — the gate would deny its own merge, and the tempting response is regenerating records to suit, which is the loop the gate exists to prevent. The durable artifact is `~/.agentkit/review-audit.log`, outside the repo.

370 pass / 0 fail.