### PR TITLE
feat(skills): product-review lane + skill-mirror drift check

### DIFF
--- a/.agentkit/product.yaml
+++ b/.agentkit/product.yaml
@@ -1,0 +1,82 @@
+# agentkit's own product manifest — dogfooding the product-review skill.
+# See plugins-cc/agentkit/skills/product-review/SKILL.md for the contract.
+
+summary: >-
+  A Claude Code / OpenCode plugin that installs enforcement hooks (git, MR,
+  package, resource, review, formatting and comment discipline), a set of
+  agent skills, a memory-and-CPU-bounded command runner, and two MCP servers.
+  Installed once per machine; from then on it constrains how agents work in
+  every repo on that machine.
+
+surfaces:
+  - name: test-suite
+    kind: library
+    build: bun install
+    verify: bun test
+    expect: |
+      408 tests pass. The suite is the real gate on this repo: it asserts the
+      plugin wiring, that every police hook parses under `bash -n`, and that
+      `skills/` stays byte-identical to the plugin mirror.
+
+  - name: plugin
+    kind: desktop
+    # There is no build step — the plugin IS the repo contents, installed by
+    # reference from the marketplace.
+    run: |
+      claude plugin marketplace add developerinlondon/agentkit
+      claude plugin install agentkit
+    expect: |
+      A new Claude Code session prints an `[agentkit] armed:` line naming the
+      police hooks. Attempting a forge merge without a passing review record
+      in `.agentkit/reviews/` is refused with a BLOCKED message rather than
+      silently allowed.
+
+  - name: bounded-run
+    kind: cli
+    # The INSTALLED path, not ./tools/bounded-run. resource-police trusts the
+    # runner by installed path rather than by name (anything can be called
+    # `bounded-run`, and trusting the name would let a spoof neuter every
+    # limit), so running it in place from a fresh clone is refused. Declaring
+    # the in-place path here was the first thing dogfooding this manifest
+    # caught.
+    run: bounded-run --profile default -- echo ok
+    expect: |
+      Prints `ok` having run the command inside a systemd scope with memory
+      and CPU limits. A workload that exceeds the profile is killed rather
+      than allowed to exhaust the host.
+
+  - name: infra-tools-mcp
+    kind: api
+    run: bun plugins-cc/agentkit/server/index.ts
+    expect: |
+      Speaks JSON-RPC on stdin/stdout; `tools/list` returns ten read-only git,
+      helm and tofu tools and nothing that mutates infrastructure.
+
+requires:
+  hardware: []
+  credentials: []
+  notes:
+    - Claude Code (or OpenCode) must be installed to exercise the `plugin`
+      surface; the test suite needs only bun.
+    - >-
+      This repo's own hooks are usually already active on a developer machine,
+      and they will intercept naive verification: `./tools/bounded-run --help`
+      is refused by resource-police as an uncontained delegated workload
+      (prefix `AGENTKIT_ALLOW_DELEGATED=1`), and editing this repo's docs can
+      trip review-police because the text contains merge-shaped commands. A
+      reviewer hitting those is seeing the product work, not a defect — but it
+      does mean shell heredocs are the wrong tool for writing about it; use
+      file tools.
+
+cannot_verify:
+  - surface: plugin
+    what: hooks actually blocking a real tool call
+    why: >-
+      needs a live Claude Code session driving real tool calls. The suite
+      proves the scripts' behaviour and that they are registered for the right
+      matchers, which is one layer short of "the harness honoured the deny".
+  - surface: plugin
+    what: the install path itself (marketplace add + install)
+    why: >-
+      mutates the reviewer's own Claude Code configuration, so it is left to a
+      human rather than run automatically.

--- a/.agentkit/product.yaml
+++ b/.agentkit/product.yaml
@@ -11,12 +11,19 @@ summary: >-
 surfaces:
   - name: test-suite
     kind: library
-    build: bun install
-    verify: bun test
+    # Wrapped in bounded-run because agentkit's own resource-police DENIES a
+    # bare `bun install` / `bun test`. A reviewer following this manifest is,
+    # by definition, on a machine where these hooks are live — declaring the
+    # naive form would block them at step one of the skill's own procedure.
+    build: bounded-run --profile default -- bun install
+    verify: bounded-run --profile default -- bun test
     expect: |
-      408 tests pass. The suite is the real gate on this repo: it asserts the
-      plugin wiring, that every police hook parses under `bash -n`, and that
-      `skills/` stays byte-identical to the plugin mirror.
+      The suite passes with 0 failures (a few skips are expected). Deliberately
+      not a pinned count — this file exists to catch stale expectations, so it
+      should not carry one that drifts on every PR that adds a test.
+      The suite is the real gate on this repo: it asserts the plugin wiring,
+      that every police hook parses under `bash -n`, and that `skills/` stays
+      byte-identical to the plugin mirror.
 
   - name: plugin
     kind: desktop
@@ -59,14 +66,14 @@ requires:
     - Claude Code (or OpenCode) must be installed to exercise the `plugin`
       surface; the test suite needs only bun.
     - >-
-      This repo's own hooks are usually already active on a developer machine,
-      and they will intercept naive verification: `./tools/bounded-run --help`
-      is refused by resource-police as an uncontained delegated workload
-      (prefix `AGENTKIT_ALLOW_DELEGATED=1`), and editing this repo's docs can
-      trip review-police because the text contains merge-shaped commands. A
-      reviewer hitting those is seeing the product work, not a defect — but it
-      does mean shell heredocs are the wrong tool for writing about it; use
-      file tools.
+      This repo's own hooks are usually already active on a developer machine
+      and will intercept naive verification. Two you WILL hit: running the
+      runner in place (`./tools/bounded-run …`) is refused because trust is by
+      installed path, not by name — and `AGENTKIT_ALLOW_DELEGATED=1` does NOT
+      clear that one; and editing this repo's docs can trip review-police
+      because the text contains merge-shaped commands, so use file tools rather
+      than shell heredocs when writing about it. A reviewer hitting either is
+      seeing the product work, not a defect.
 
 cannot_verify:
   - surface: plugin

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,10 @@ bun.lock
 # its own merge and invite regenerating records to suit, the exact loop the
 # gate exists to stop. The durable artifact is ~/.agentkit/review-audit.log,
 # outside the repo.
-.agentkit/
+.agentkit/reviews/
+
+# ...but NOT the whole directory. `.agentkit/product.yaml` is the opposite kind
+# of artifact: it must be COMMITTED, because it is the contract a product
+# reviewer reads in a fresh clone. Ignoring it wholesale meant it was silently
+# untracked and every reviewer refused for want of a file that was there all
+# along.

--- a/hooks/claude/resource-police.sh
+++ b/hooks/claude/resource-police.sh
@@ -30,7 +30,9 @@ deny() {
 	elif [[ -x "$PWD/.claude/tools/bounded-run" ]]; then
 		runner_hint="$PWD/.claude/tools/bounded-run"
 	fi
-	if [[ "$kind" == delegated ]]; then
+	if [[ "$kind" == untrusted_runner ]]; then
+		reason="BLOCKED: that is not a recognised bounded-run: $segment. Anything can be named \`bounded-run\`, so it is trusted by INSTALLED PATH, not by name — otherwise a spoof could silently neuter every limit. AGENTKIT_ALLOW_DELEGATED=1 does NOT clear this. Install the runner (\`~/.local/bin/bounded-run\`) and invoke it from there, or use the plugin's copy under \$CLAUDE_PLUGIN_ROOT/tools/. In a fresh clone of agentkit itself, install it first rather than running ./tools/bounded-run in place."
+	elif [[ "$kind" == delegated ]]; then
 		reason="BLOCKED: delegated workload cannot be contained by bounded-run: $segment. Use a separately approved dedicated runner or verified engine-native limits. User-approved delegated workloads: prefix with AGENTKIT_ALLOW_DELEGATED=1."
 	else
 		reason="BLOCKED: resource-intensive command is not contained: $segment. Run it through $runner_hint, for example: $runner_hint --profile compile -- bun run typecheck. Use profile browser for Playwright and browser builds."
@@ -278,7 +280,13 @@ analyze_command() {
 		[[ -n "$segment" ]] || continue
 		parse_launch "$segment"
 		if [[ "$EXECUTABLE" == bounded-run || "$EXECUTABLE" == agentkit-run ]]; then
-			if ! is_trusted_runner; then deny "$segment" delegated; fi
+			# NOT `delegated`: that message advertises AGENTKIT_ALLOW_DELEGATED=1,
+			# which this branch never consults, so it sent people chasing an
+			# escape hatch that cannot clear it. The actual problem is that this
+			# path is not a recognised runner — anything can be named
+			# `bounded-run`, and trusting it by name alone would let a spoof
+			# neuter every limit.
+			if ! is_trusted_runner; then deny "$segment" untrusted_runner; fi
 			if parse_wrapped_launch; then
 				unwrap_environment
 				if is_delegating && [[ "$DELEGATED_OK" != 1 ]]; then

--- a/plugins-cc/agentkit/hooks/resource-police.sh
+++ b/plugins-cc/agentkit/hooks/resource-police.sh
@@ -30,7 +30,9 @@ deny() {
 	elif [[ -x "$PWD/.claude/tools/bounded-run" ]]; then
 		runner_hint="$PWD/.claude/tools/bounded-run"
 	fi
-	if [[ "$kind" == delegated ]]; then
+	if [[ "$kind" == untrusted_runner ]]; then
+		reason="BLOCKED: that is not a recognised bounded-run: $segment. Anything can be named \`bounded-run\`, so it is trusted by INSTALLED PATH, not by name — otherwise a spoof could silently neuter every limit. AGENTKIT_ALLOW_DELEGATED=1 does NOT clear this. Install the runner (\`~/.local/bin/bounded-run\`) and invoke it from there, or use the plugin's copy under \$CLAUDE_PLUGIN_ROOT/tools/. In a fresh clone of agentkit itself, install it first rather than running ./tools/bounded-run in place."
+	elif [[ "$kind" == delegated ]]; then
 		reason="BLOCKED: delegated workload cannot be contained by bounded-run: $segment. Use a separately approved dedicated runner or verified engine-native limits. User-approved delegated workloads: prefix with AGENTKIT_ALLOW_DELEGATED=1."
 	else
 		reason="BLOCKED: resource-intensive command is not contained: $segment. Run it through $runner_hint, for example: $runner_hint --profile compile -- bun run typecheck. Use profile browser for Playwright and browser builds."
@@ -278,7 +280,13 @@ analyze_command() {
 		[[ -n "$segment" ]] || continue
 		parse_launch "$segment"
 		if [[ "$EXECUTABLE" == bounded-run || "$EXECUTABLE" == agentkit-run ]]; then
-			if ! is_trusted_runner; then deny "$segment" delegated; fi
+			# NOT `delegated`: that message advertises AGENTKIT_ALLOW_DELEGATED=1,
+			# which this branch never consults, so it sent people chasing an
+			# escape hatch that cannot clear it. The actual problem is that this
+			# path is not a recognised runner — anything can be named
+			# `bounded-run`, and trusting it by name alone would let a spoof
+			# neuter every limit.
+			if ! is_trusted_runner; then deny "$segment" untrusted_runner; fi
 			if parse_wrapped_launch; then
 				unwrap_environment
 				if is_delegating && [[ "$DELEGATED_OK" != 1 ]]; then

--- a/plugins-cc/agentkit/skills/autonomous-workflow/SKILL.md
+++ b/plugins-cc/agentkit/skills/autonomous-workflow/SKILL.md
@@ -58,6 +58,19 @@ gate as something it is not.
 2. **The reviewer writes its verdict** to `.agentkit/reviews/<branch-slug>.json`
    with `head_sha`, `verdict`, and `findings[{severity, summary, resolved}]`.
    A review of an older commit is not a review of what you are merging.
+
+   That file is a machine-local GATE TOKEN, not an archive: it is gitignored,
+   it is only ever read by the hook on one machine, and after the merge it is
+   an orphan nobody can see. So **also post the verdict and findings as a
+   comment on the MR/PR** (`glab mr note` / `gh pr comment`). That copy is the
+   durable one — visible to whoever picks the work up, timestamped, and it
+   survives the merge. It must NOT be committed to the repo: a commit moves
+   HEAD, which stales the record against the branch it reviews, and the gate
+   would then deny its own merge.
+
+   Findings that outlive the branch — accepted limits, deferred fixes — belong
+   in an ISSUE, not only in a review record. If the only trace of a known
+   limitation is a local JSON file, it is already lost.
 3. **Any unresolved BLOCKER or HIGH blocks the merge.** Severity is the
    reviewer's call. You do not get to downgrade it, reinterpret it, or decide
    it is inert because you reason it cannot fire.

--- a/plugins-cc/agentkit/skills/autonomous-workflow/SKILL.md
+++ b/plugins-cc/agentkit/skills/autonomous-workflow/SKILL.md
@@ -46,7 +46,7 @@ blocks the CLI, REST and MCP merge paths without a passing record for the exact
 commit being merged.
 
 Be honest about its limits: the record lives in the repo and you can write it,
-so the hook cannot *prevent* a determined bypass — it makes the honest path
+so the hook cannot _prevent_ a determined bypass — it makes the honest path
 correct, makes a missing or stale review impossible to merge past by accident,
 and logs every pass and override to `~/.agentkit/review-audit.log`. Only
 forge-side required approvals actually prevent a merge. Never describe this
@@ -74,6 +74,20 @@ gate as something it is not.
 Corollary, learned the hard way: never expose a user-facing control whose other
 half is not built. Ship both halves or neither — an inert-looking toggle is
 still reachable, and "it will not do anything" is a prediction, not a fact.
+
+### Diff review is not the only lens
+
+A diff reviewer answers "is this change correct?" — it structurally cannot see
+what is not in the diff: a stale build command, a default that yields a
+broken-looking install, missing packaging, a setup step that lives only in
+someone's head. Those reach the user untouched no matter how many diff rounds
+you run.
+
+For anything a person installs or operates, run the **product-review** skill as
+a separate pass: build it, run it, use it, from a cold start. It reads
+`.agentkit/product.yaml` and refuses rather than guessing when that is absent.
+When the two lenses disagree on severity, the user-facing consequence wins —
+internally correct code that cannot be used is still broken.
 
 ## Commit Hygiene
 

--- a/plugins-cc/agentkit/skills/product-review/SKILL.md
+++ b/plugins-cc/agentkit/skills/product-review/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: product-review
+description: >-
+  Review a product the way a user meets it — build it, run it, use it — instead of
+  reading a diff. Consumes .agentkit/product.yaml; refuses and asks when it is
+  missing rather than guessing. Use alongside diff review, never instead of it.
+---
+
+# Product Review
+
+Diff review asks "is this change correct?". Product review asks **"can someone
+actually build, install and use this?"** Those catch different defects, and the
+second one is routinely skipped because nothing in a diff points at it.
+
+Concretely, diff-scoped reviewers cannot see: a stale build command in a
+README, a default configuration that produces a broken-looking install, missing
+packaging, a setup step that only exists in someone's head. None of it appears
+in a diff, so none of it gets caught — until a user hits it.
+
+## The manifest is the contract
+
+Read `.agentkit/product.yaml` (template: `product.example.yaml` in this skill).
+It declares the surfaces, the commands to build/verify/run each one, what the
+environment must provide, and what is known-unverifiable.
+
+**If it is missing, STOP. Do not review.** Report exactly this and end:
+
+> No `.agentkit/product.yaml` in this repo, so I cannot product-review it —
+> I would be guessing at how to build and run it. Add one (template:
+> `product.example.yaml`) describing the user-facing surfaces, or tell me
+> the build/run/verify commands and I will review against those.
+
+Then **record the absence as a finding** in the review record, severity MEDIUM,
+summary "no product manifest — product surfaces unverified". Do NOT return a
+silent pass. A missing manifest that ends the review quietly makes "don't add
+the file" the cheapest way to dodge product review, and turns an unreviewed
+product into one that looks reviewed.
+
+Never invent the commands yourself. Inferring a build from the file tree is
+exactly the guess that produces a confident, wrong report.
+
+## Running it
+
+1. **Build each surface** with its declared `build`. A build failure is a
+   BLOCKER — it means the product cannot be obtained at all.
+2. **Run `verify`.** If it cannot fail (`--help`, `--version`, a test suite
+   with no assertions), say so: a verification that always passes is not
+   evidence, and reporting it as one is the defect this skill exists to stop.
+3. **Run the surface** and compare against `expect`. This is where "it
+   compiles" becomes "it works".
+4. **Follow the setup as written**, from a cold start, exactly as declared. Do
+   not fill in a missing step from your own knowledge of the repo — a step you
+   supply silently is a step the user will be missing. That gap IS the finding.
+
+## Environments where you cannot run it
+
+Common for client repos: no hardware, no credentials, no network. That is
+expected and is not a reason to fabricate coverage.
+
+Verify what you can, and **state plainly what you could not**, per surface:
+
+> Verified: builds clean; test suite passes (146 tests).
+> NOT VERIFIED: the daemon was never run — no macOS host available. The
+> menu-bar icon, pairing flow and voice path are unchecked.
+
+Honest partial coverage is useful. "Looks good" over an unrun product is worse
+than no review, because it launders an assumption into a verdict. Anything in
+the manifest's `cannot_verify` list is reported as not verified, with its
+reason — never quietly dropped.
+
+## What to report
+
+Findings in the same shape as a diff review (`severity`, `summary`, plus a
+concrete failure scenario), written from the user's position:
+
+- **BLOCKER** — cannot build, cannot install, or the primary surface does not
+  work when followed as documented.
+- **HIGH** — a documented command is wrong or a required step is missing, so a
+  user following the docs ends up with a broken or half-working install.
+- **MEDIUM** — works, but a default, error message or setup step will
+  predictably mislead (an install that looks broken rather than misconfigured).
+- **LOW** — friction, rough edges, missing convenience.
+
+Two rules carried over from diff review, because they were learned the hard
+way: report what you actually observed rather than what the code implies, and
+never describe coverage you did not obtain.
+
+## Scope
+
+Product review does NOT replace diff review — it adds the lens diff review
+structurally cannot have. Run both. When they disagree about severity, the
+user-facing consequence wins: code that is internally correct but unusable is
+still broken.

--- a/plugins-cc/agentkit/skills/product-review/SKILL.md
+++ b/plugins-cc/agentkit/skills/product-review/SKILL.md
@@ -32,9 +32,14 @@ environment must provide, and what is known-unverifiable.
 
 Then **record the absence as a finding** in the review record, severity MEDIUM,
 summary "no product manifest — product surfaces unverified". Do NOT return a
-silent pass. A missing manifest that ends the review quietly makes "don't add
-the file" the cheapest way to dodge product review, and turns an unreviewed
-product into one that looks reviewed.
+silent pass: that turns an unreviewed product into one that looks reviewed.
+
+Be precise about what this buys. Only unresolved BLOCKER/HIGH findings block a
+merge, so a MEDIUM makes the omission **visible, not impossible** — skipping the
+manifest is still the cheapest way to skip product review. That is a deliberate
+trade: raising it to HIGH would gate every client repo that has no manifest yet,
+including ones we cannot run at all. Visible-and-merged beats silent, and beats
+blocking work we were never able to verify anyway.
 
 Never invent the commands yourself. Inferring a build from the file tree is
 exactly the guess that produces a confident, wrong report.
@@ -59,9 +64,14 @@ authorise another repo's merge.
 
 **There is deliberately NO global fallback for the manifest.** A default "how to
 build" applied to a repo that never declared one turns _refuse and ask_ back
-into _guess confidently_, which is the failure this lane exists to remove. The
-global config carries POLICY only — whether product review is required, which
-severities block — never the commands themselves.
+into _guess confidently_, which is the failure this lane exists to remove.
+
+Status, stated plainly rather than aspirationally: **product review is currently
+opt-in and mechanically unenforced.** No hook requires a manifest, no config key
+turns it on, and nothing blocks a merge for its absence. Policy keys in
+`~/.config/agentkit/config.yaml` (whether it is required, which severities
+block) are the intended home if that changes — they do not exist today. Never
+describe this lane as enforced.
 
 ## Running it
 

--- a/plugins-cc/agentkit/skills/product-review/SKILL.md
+++ b/plugins-cc/agentkit/skills/product-review/SKILL.md
@@ -39,6 +39,30 @@ product into one that looks reviewed.
 Never invent the commands yourself. Inferring a build from the file tree is
 exactly the guess that produces a confident, wrong report.
 
+### Where these files live
+
+| artifact                         | location                                          | committed?        |
+| -------------------------------- | ------------------------------------------------- | ----------------- |
+| `.agentkit/product.yaml`         | repo root (nearest one walking up, for monorepos) | **yes**           |
+| `.agentkit/reviews/*.json`       | repo-local                                        | no — gitignored   |
+| `~/.config/agentkit/config.yaml` | machine/user                                      | n/a — policy only |
+
+The manifest is repo-specific and **must be committed**: a reviewer reads it in
+a fresh clone, so an untracked one is the same as no manifest at all. (It was
+briefly ignored by a blanket `.agentkit/` rule, which would have made every
+review refuse for want of a file that existed locally.)
+
+Review records are the opposite — deliberately local and ignored. They are keyed
+to a branch and head sha _of this repo_; a shared or global store would have to
+carry repo identity, and getting that wrong lets one repo's passing record
+authorise another repo's merge.
+
+**There is deliberately NO global fallback for the manifest.** A default "how to
+build" applied to a repo that never declared one turns _refuse and ask_ back
+into _guess confidently_, which is the failure this lane exists to remove. The
+global config carries POLICY only — whether product review is required, which
+severities block — never the commands themselves.
+
 ## Running it
 
 1. **Build each surface** with its declared `build`. A build failure is a

--- a/plugins-cc/agentkit/skills/product-review/product.example.yaml
+++ b/plugins-cc/agentkit/skills/product-review/product.example.yaml
@@ -1,0 +1,70 @@
+# .agentkit/product.yaml — how to build, run and exercise THIS product.
+#
+# A product reviewer reads this file and RUNS what it declares. That is the
+# whole point: prose documentation rots silently (a stale build command in a
+# README cost a real debugging round and shipped a wrong instruction to a
+# user), whereas a declared command that no longer works fails the moment
+# somebody uses it.
+#
+# Copy to .agentkit/product.yaml and fill in. Every field is optional except
+# `surfaces` — but the fewer you declare, the less a reviewer can verify, and
+# it will say so plainly in its report rather than implying coverage.
+
+# What this product IS, in one or two sentences, from a user's point of view.
+# Not the architecture — what someone uses it for.
+summary: >-
+  Menu-bar daemon that pairs a Mac to a neutron instance so an agent can see
+  and drive the machine, and so the user can talk to the mascot.
+
+# Each surface is something a user actually touches. A reviewer picks the ones
+# it can reach in this environment and reports on the rest as unverified.
+surfaces:
+  - name: daemon
+    kind: cli # cli | service | web | desktop | library | api
+    # Commands are run VERBATIM from the repo root, in order. Keep them real:
+    # if a step needs a flag, put the flag here rather than in prose.
+    build: cargo build --release -p orbit-daemon
+    # `verify` should FAIL loudly when the product is broken. A command that
+    # cannot fail (`--help`, `--version`) verifies nothing.
+    verify: cargo test --workspace
+    run: ./target/release/orbit run
+    # What a reviewer should look at once it is running, in plain language.
+    # This is where "it builds" becomes "it works".
+    expect: |
+      A menu-bar icon appears. Clicking it opens a menu with the mascot entry.
+      `orbit status` prints the current pairing rather than an error.
+
+  - name: web-ui
+    kind: web
+    build: bun run build
+    run: bun run dev
+    url: http://localhost:5173
+    expect: |
+      Settings has a Devices tab listing paired computers, each with a
+      share control.
+
+# Be explicit about what CANNOT be verified here, and why. A reviewer must not
+# guess at this — an unstated requirement becomes a false "works for me".
+requires:
+  # Hardware, OS or peripherals the product needs.
+  hardware:
+    - macOS on Apple silicon (the audio path is CoreAudio VoiceProcessingIO)
+    - a microphone and speakers, for the voice surface
+  # Named credentials/secrets. NEVER put secret VALUES in this file — name
+  # them and say where they come from.
+  credentials:
+    - name: NEUTRON_INSTANCE_URL
+      how: pair against a running instance with `orbit pair <url>`
+  # Anything else that makes a surface unreachable in some environments.
+  notes:
+    - macOS grants (Accessibility, Screen Recording, Microphone) must be
+      approved by hand; the binary is unsigned, so they reset on every rebuild.
+
+# Surfaces that are known-unverifiable in an automated environment, with the
+# reason. A reviewer reports these as NOT VERIFIED instead of skipping quietly.
+cannot_verify:
+  - surface: daemon
+    what: barge-in (talking over a reply stops it)
+    why: >-
+      needs a real microphone, a speaker, and a human to talk over her;
+      no automated harness exists for the acoustic path.

--- a/plugins/resource-police.ts
+++ b/plugins/resource-police.ts
@@ -9,6 +9,9 @@ interface Launch {
 interface Finding {
   segment: string;
   delegated: boolean;
+  /** The runner is not the INSTALLED bounded-run. Distinct from `delegated`:
+   *  the delegated message advertises an escape hatch that cannot clear this. */
+  untrustedRunner?: boolean;
 }
 
 function splitShellSegments(command: string): string[] {
@@ -223,7 +226,10 @@ function detectUnboundedCommand(
     const launch = parseLaunch(segment);
     if (!launch) continue;
     if (launch.executable === 'bounded-run' || launch.executable === 'agentkit-run') {
-      if (!isTrustedRunner(launch.token)) return { segment, delegated: true };
+      // NOT `delegated`: that message advertises AGENTKIT_ALLOW_DELEGATED=1,
+      // which this path never consults, so it sent people chasing an escape
+      // hatch that cannot clear it.
+      if (!isTrustedRunner(launch.token)) return { segment, delegated: false, untrustedRunner: true };
       const nested = wrappedLaunch(launch);
       if (nested && !delegatedOk && isDelegating(nested)) return { segment, delegated: true };
       continue;
@@ -269,6 +275,16 @@ export default async function resourcePolice(_ctx: PluginInput) {
       if (!command) return;
       const finding = detectUnboundedCommand(command, 0, isDelegatedOverride(command));
       if (!finding) return;
+      if (finding.untrustedRunner) {
+        throw new Error(
+          `BLOCKED: that is not a recognised bounded-run: ${finding.segment}\n`
+            + 'Anything can be named `bounded-run`, so it is trusted by INSTALLED PATH,\n'
+            + 'not by name — otherwise a spoof could silently neuter every limit.\n'
+            + 'AGENTKIT_ALLOW_DELEGATED=1 does NOT clear this. Install the runner\n'
+            + '(~/.local/bin/bounded-run) and invoke it from there, or use the\n'
+            + "plugin's copy under the plugin root.",
+        );
+      }
       if (finding.delegated) {
         throw new Error(
           `BLOCKED: delegated workload cannot be contained by bounded-run: ${finding.segment}\n` +

--- a/skills/autonomous-workflow/SKILL.md
+++ b/skills/autonomous-workflow/SKILL.md
@@ -58,6 +58,19 @@ gate as something it is not.
 2. **The reviewer writes its verdict** to `.agentkit/reviews/<branch-slug>.json`
    with `head_sha`, `verdict`, and `findings[{severity, summary, resolved}]`.
    A review of an older commit is not a review of what you are merging.
+
+   That file is a machine-local GATE TOKEN, not an archive: it is gitignored,
+   it is only ever read by the hook on one machine, and after the merge it is
+   an orphan nobody can see. So **also post the verdict and findings as a
+   comment on the MR/PR** (`glab mr note` / `gh pr comment`). That copy is the
+   durable one — visible to whoever picks the work up, timestamped, and it
+   survives the merge. It must NOT be committed to the repo: a commit moves
+   HEAD, which stales the record against the branch it reviews, and the gate
+   would then deny its own merge.
+
+   Findings that outlive the branch — accepted limits, deferred fixes — belong
+   in an ISSUE, not only in a review record. If the only trace of a known
+   limitation is a local JSON file, it is already lost.
 3. **Any unresolved BLOCKER or HIGH blocks the merge.** Severity is the
    reviewer's call. You do not get to downgrade it, reinterpret it, or decide
    it is inert because you reason it cannot fire.

--- a/skills/autonomous-workflow/SKILL.md
+++ b/skills/autonomous-workflow/SKILL.md
@@ -39,6 +39,56 @@ Exceptions: bug fixes in already-approved work, read-only research, formatting.
 - If a function parameter is required by an interface but unused, restructure to avoid it
 - This applies to all languages: TypeScript, Rust, Python
 
+## Review Gates The Merge
+
+Review is a gate, not a parallel task and not advice. `review-police.sh`
+blocks the CLI, REST and MCP merge paths without a passing record for the exact
+commit being merged.
+
+Be honest about its limits: the record lives in the repo and you can write it,
+so the hook cannot _prevent_ a determined bypass — it makes the honest path
+correct, makes a missing or stale review impossible to merge past by accident,
+and logs every pass and override to `~/.agentkit/review-audit.log`. Only
+forge-side required approvals actually prevent a merge. Never describe this
+gate as something it is not.
+
+1. **Review completes before the merge starts.** Never dispatch a reviewer and
+   merge while it works — a verdict that lands after the code is on main
+   protects nobody.
+2. **The reviewer writes its verdict** to `.agentkit/reviews/<branch-slug>.json`
+   with `head_sha`, `verdict`, and `findings[{severity, summary, resolved}]`.
+   A review of an older commit is not a review of what you are merging.
+3. **Any unresolved BLOCKER or HIGH blocks the merge.** Severity is the
+   reviewer's call. You do not get to downgrade it, reinterpret it, or decide
+   it is inert because you reason it cannot fire.
+4. **The path is: fix it properly, then re-review.** Fix the root cause — not a
+   workaround, not a flag that hides it, not a comment explaining why it is
+   acceptable. Then re-run the reviewer against the new head and merge on a
+   fresh pass.
+5. **Do not hand findings to the user to approve.** They are not a queue for
+   work you would rather not do. Escalate only when a finding genuinely cannot
+   be fixed — an upstream or platform limitation — and say why. If they then
+   approve in writing, record their exact words in `user_consent`. Fabricating
+   that is forging their approval.
+
+Corollary, learned the hard way: never expose a user-facing control whose other
+half is not built. Ship both halves or neither — an inert-looking toggle is
+still reachable, and "it will not do anything" is a prediction, not a fact.
+
+### Diff review is not the only lens
+
+A diff reviewer answers "is this change correct?" — it structurally cannot see
+what is not in the diff: a stale build command, a default that yields a
+broken-looking install, missing packaging, a setup step that lives only in
+someone's head. Those reach the user untouched no matter how many diff rounds
+you run.
+
+For anything a person installs or operates, run the **product-review** skill as
+a separate pass: build it, run it, use it, from a cold start. It reads
+`.agentkit/product.yaml` and refuses rather than guessing when that is absent.
+When the two lenses disagree on severity, the user-facing consequence wins —
+internally correct code that cannot be used is still broken.
+
 ## Commit Hygiene
 
 - Never use --force, --no-verify, HUSKY=0 without explicit permission

--- a/skills/product-review/SKILL.md
+++ b/skills/product-review/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: product-review
+description: >-
+  Review a product the way a user meets it — build it, run it, use it — instead of
+  reading a diff. Consumes .agentkit/product.yaml; refuses and asks when it is
+  missing rather than guessing. Use alongside diff review, never instead of it.
+---
+
+# Product Review
+
+Diff review asks "is this change correct?". Product review asks **"can someone
+actually build, install and use this?"** Those catch different defects, and the
+second one is routinely skipped because nothing in a diff points at it.
+
+Concretely, diff-scoped reviewers cannot see: a stale build command in a
+README, a default configuration that produces a broken-looking install, missing
+packaging, a setup step that only exists in someone's head. None of it appears
+in a diff, so none of it gets caught — until a user hits it.
+
+## The manifest is the contract
+
+Read `.agentkit/product.yaml` (template: `product.example.yaml` in this skill).
+It declares the surfaces, the commands to build/verify/run each one, what the
+environment must provide, and what is known-unverifiable.
+
+**If it is missing, STOP. Do not review.** Report exactly this and end:
+
+> No `.agentkit/product.yaml` in this repo, so I cannot product-review it —
+> I would be guessing at how to build and run it. Add one (template:
+> `product.example.yaml`) describing the user-facing surfaces, or tell me
+> the build/run/verify commands and I will review against those.
+
+Then **record the absence as a finding** in the review record, severity MEDIUM,
+summary "no product manifest — product surfaces unverified". Do NOT return a
+silent pass. A missing manifest that ends the review quietly makes "don't add
+the file" the cheapest way to dodge product review, and turns an unreviewed
+product into one that looks reviewed.
+
+Never invent the commands yourself. Inferring a build from the file tree is
+exactly the guess that produces a confident, wrong report.
+
+## Running it
+
+1. **Build each surface** with its declared `build`. A build failure is a
+   BLOCKER — it means the product cannot be obtained at all.
+2. **Run `verify`.** If it cannot fail (`--help`, `--version`, a test suite
+   with no assertions), say so: a verification that always passes is not
+   evidence, and reporting it as one is the defect this skill exists to stop.
+3. **Run the surface** and compare against `expect`. This is where "it
+   compiles" becomes "it works".
+4. **Follow the setup as written**, from a cold start, exactly as declared. Do
+   not fill in a missing step from your own knowledge of the repo — a step you
+   supply silently is a step the user will be missing. That gap IS the finding.
+
+## Environments where you cannot run it
+
+Common for client repos: no hardware, no credentials, no network. That is
+expected and is not a reason to fabricate coverage.
+
+Verify what you can, and **state plainly what you could not**, per surface:
+
+> Verified: builds clean; test suite passes (146 tests).
+> NOT VERIFIED: the daemon was never run — no macOS host available. The
+> menu-bar icon, pairing flow and voice path are unchecked.
+
+Honest partial coverage is useful. "Looks good" over an unrun product is worse
+than no review, because it launders an assumption into a verdict. Anything in
+the manifest's `cannot_verify` list is reported as not verified, with its
+reason — never quietly dropped.
+
+## What to report
+
+Findings in the same shape as a diff review (`severity`, `summary`, plus a
+concrete failure scenario), written from the user's position:
+
+- **BLOCKER** — cannot build, cannot install, or the primary surface does not
+  work when followed as documented.
+- **HIGH** — a documented command is wrong or a required step is missing, so a
+  user following the docs ends up with a broken or half-working install.
+- **MEDIUM** — works, but a default, error message or setup step will
+  predictably mislead (an install that looks broken rather than misconfigured).
+- **LOW** — friction, rough edges, missing convenience.
+
+Two rules carried over from diff review, because they were learned the hard
+way: report what you actually observed rather than what the code implies, and
+never describe coverage you did not obtain.
+
+## Scope
+
+Product review does NOT replace diff review — it adds the lens diff review
+structurally cannot have. Run both. When they disagree about severity, the
+user-facing consequence wins: code that is internally correct but unusable is
+still broken.

--- a/skills/product-review/SKILL.md
+++ b/skills/product-review/SKILL.md
@@ -32,9 +32,14 @@ environment must provide, and what is known-unverifiable.
 
 Then **record the absence as a finding** in the review record, severity MEDIUM,
 summary "no product manifest — product surfaces unverified". Do NOT return a
-silent pass. A missing manifest that ends the review quietly makes "don't add
-the file" the cheapest way to dodge product review, and turns an unreviewed
-product into one that looks reviewed.
+silent pass: that turns an unreviewed product into one that looks reviewed.
+
+Be precise about what this buys. Only unresolved BLOCKER/HIGH findings block a
+merge, so a MEDIUM makes the omission **visible, not impossible** — skipping the
+manifest is still the cheapest way to skip product review. That is a deliberate
+trade: raising it to HIGH would gate every client repo that has no manifest yet,
+including ones we cannot run at all. Visible-and-merged beats silent, and beats
+blocking work we were never able to verify anyway.
 
 Never invent the commands yourself. Inferring a build from the file tree is
 exactly the guess that produces a confident, wrong report.
@@ -59,9 +64,14 @@ authorise another repo's merge.
 
 **There is deliberately NO global fallback for the manifest.** A default "how to
 build" applied to a repo that never declared one turns _refuse and ask_ back
-into _guess confidently_, which is the failure this lane exists to remove. The
-global config carries POLICY only — whether product review is required, which
-severities block — never the commands themselves.
+into _guess confidently_, which is the failure this lane exists to remove.
+
+Status, stated plainly rather than aspirationally: **product review is currently
+opt-in and mechanically unenforced.** No hook requires a manifest, no config key
+turns it on, and nothing blocks a merge for its absence. Policy keys in
+`~/.config/agentkit/config.yaml` (whether it is required, which severities
+block) are the intended home if that changes — they do not exist today. Never
+describe this lane as enforced.
 
 ## Running it
 

--- a/skills/product-review/SKILL.md
+++ b/skills/product-review/SKILL.md
@@ -39,6 +39,30 @@ product into one that looks reviewed.
 Never invent the commands yourself. Inferring a build from the file tree is
 exactly the guess that produces a confident, wrong report.
 
+### Where these files live
+
+| artifact                         | location                                          | committed?        |
+| -------------------------------- | ------------------------------------------------- | ----------------- |
+| `.agentkit/product.yaml`         | repo root (nearest one walking up, for monorepos) | **yes**           |
+| `.agentkit/reviews/*.json`       | repo-local                                        | no — gitignored   |
+| `~/.config/agentkit/config.yaml` | machine/user                                      | n/a — policy only |
+
+The manifest is repo-specific and **must be committed**: a reviewer reads it in
+a fresh clone, so an untracked one is the same as no manifest at all. (It was
+briefly ignored by a blanket `.agentkit/` rule, which would have made every
+review refuse for want of a file that existed locally.)
+
+Review records are the opposite — deliberately local and ignored. They are keyed
+to a branch and head sha _of this repo_; a shared or global store would have to
+carry repo identity, and getting that wrong lets one repo's passing record
+authorise another repo's merge.
+
+**There is deliberately NO global fallback for the manifest.** A default "how to
+build" applied to a repo that never declared one turns _refuse and ask_ back
+into _guess confidently_, which is the failure this lane exists to remove. The
+global config carries POLICY only — whether product review is required, which
+severities block — never the commands themselves.
+
 ## Running it
 
 1. **Build each surface** with its declared `build`. A build failure is a

--- a/skills/product-review/product.example.yaml
+++ b/skills/product-review/product.example.yaml
@@ -1,0 +1,70 @@
+# .agentkit/product.yaml — how to build, run and exercise THIS product.
+#
+# A product reviewer reads this file and RUNS what it declares. That is the
+# whole point: prose documentation rots silently (a stale build command in a
+# README cost a real debugging round and shipped a wrong instruction to a
+# user), whereas a declared command that no longer works fails the moment
+# somebody uses it.
+#
+# Copy to .agentkit/product.yaml and fill in. Every field is optional except
+# `surfaces` — but the fewer you declare, the less a reviewer can verify, and
+# it will say so plainly in its report rather than implying coverage.
+
+# What this product IS, in one or two sentences, from a user's point of view.
+# Not the architecture — what someone uses it for.
+summary: >-
+  Menu-bar daemon that pairs a Mac to a neutron instance so an agent can see
+  and drive the machine, and so the user can talk to the mascot.
+
+# Each surface is something a user actually touches. A reviewer picks the ones
+# it can reach in this environment and reports on the rest as unverified.
+surfaces:
+  - name: daemon
+    kind: cli # cli | service | web | desktop | library | api
+    # Commands are run VERBATIM from the repo root, in order. Keep them real:
+    # if a step needs a flag, put the flag here rather than in prose.
+    build: cargo build --release -p orbit-daemon
+    # `verify` should FAIL loudly when the product is broken. A command that
+    # cannot fail (`--help`, `--version`) verifies nothing.
+    verify: cargo test --workspace
+    run: ./target/release/orbit run
+    # What a reviewer should look at once it is running, in plain language.
+    # This is where "it builds" becomes "it works".
+    expect: |
+      A menu-bar icon appears. Clicking it opens a menu with the mascot entry.
+      `orbit status` prints the current pairing rather than an error.
+
+  - name: web-ui
+    kind: web
+    build: bun run build
+    run: bun run dev
+    url: http://localhost:5173
+    expect: |
+      Settings has a Devices tab listing paired computers, each with a
+      share control.
+
+# Be explicit about what CANNOT be verified here, and why. A reviewer must not
+# guess at this — an unstated requirement becomes a false "works for me".
+requires:
+  # Hardware, OS or peripherals the product needs.
+  hardware:
+    - macOS on Apple silicon (the audio path is CoreAudio VoiceProcessingIO)
+    - a microphone and speakers, for the voice surface
+  # Named credentials/secrets. NEVER put secret VALUES in this file — name
+  # them and say where they come from.
+  credentials:
+    - name: NEUTRON_INSTANCE_URL
+      how: pair against a running instance with `orbit pair <url>`
+  # Anything else that makes a surface unreachable in some environments.
+  notes:
+    - macOS grants (Accessibility, Screen Recording, Microphone) must be
+      approved by hand; the binary is unsigned, so they reset on every rebuild.
+
+# Surfaces that are known-unverifiable in an automated environment, with the
+# reason. A reviewer reports these as NOT VERIFIED instead of skipping quietly.
+cannot_verify:
+  - surface: daemon
+    what: barge-in (talking over a reply stops it)
+    why: >-
+      needs a real microphone, a speaker, and a human to talk over her;
+      no automated harness exists for the acoustic path.

--- a/tests/agentkit-plugin.test.ts
+++ b/tests/agentkit-plugin.test.ts
@@ -141,6 +141,7 @@ describe('agentkit plugin skills', () => {
       'documentation',
       'gitops-master',
       'issue-raiser',
+      'product-review',
       'project-planning',
       'resource-safe-execution',
       'test-driven-development',
@@ -148,6 +149,34 @@ describe('agentkit plugin skills', () => {
     for (const skill of expectedSkills) {
       const skillMd = join(pluginDir, 'skills', skill, 'SKILL.md');
       expect(statSync(skillMd).isFile(), `${skill}/SKILL.md exists`).toBe(true);
+    }
+  });
+
+  test('keeps every skill byte-identical between skills/ and the plugin mirror', () => {
+    // The hooks had this check; the skills did not — and they drifted. The
+    // top-level copy of autonomous-workflow was missing the whole review-gate
+    // section that shipped to the plugin copy in #78, silently, for as long as
+    // nobody diffed them. Two copies with no mechanical check is one rotting
+    // copy waiting to be read by someone.
+    const sourceSkills = join(repoRoot, 'skills');
+    const names = readdirSync(sourceSkills).sort();
+    expect(readdirSync(join(pluginDir, 'skills')).sort()).toEqual(names);
+    // Recursive: some skills carry a references/ subdirectory, and a nested
+    // file that drifts is exactly as misleading as a top-level one.
+    const filesUnder = (dir: string, prefix = ''): string[] =>
+      readdirSync(join(dir, prefix), { withFileTypes: true }).flatMap((e) =>
+        e.isDirectory() ? filesUnder(dir, join(prefix, e.name)) : [join(prefix, e.name)]
+      );
+    for (const name of names) {
+      const files = filesUnder(join(sourceSkills, name)).sort();
+      expect(filesUnder(join(pluginDir, 'skills', name)).sort(), `${name}: file list differs`)
+        .toEqual(files);
+      for (const file of files) {
+        expect(
+          readFileSync(join(pluginDir, 'skills', name, file), 'utf-8'),
+          `${name}/${file} differs between skills/ and the plugin mirror`,
+        ).toBe(readFileSync(join(sourceSkills, name, file), 'utf-8'));
+      }
     }
   });
 });

--- a/tests/fixtures/resource-commands.ts
+++ b/tests/fixtures/resource-commands.ts
@@ -50,7 +50,6 @@ export const unsupportedResourceCommands = [
   'systemd-run --user --scope cargo test',
   'sudo -u root systemd-run --scope cargo test',
   'ssh build-host bun test',
-  './bounded-run --profile compile -- bun run build',
   'systemctl restart cloudflared',
   'kubectl exec deploy/builder -- bun run build',
   'bounded-run --profile compile -- docker build .',
@@ -93,4 +92,19 @@ export const allowedResourceCommands = [
   'grep "cargo test; tsc --noEmit" build.log',
   "printf 'bun test && pytest'",
   "echo 'playwright test | bun test'",
+];
+
+// A runner that is not the INSTALLED bounded-run. Refused, but for a different
+// reason than a delegated workload: trust is by installed path, because
+// anything can be named `bounded-run` and trusting the name alone would let a
+// spoof silently neuter every limit.
+//
+// These used to sit in unsupportedResourceCommands and were asserted against
+// the *delegated* message — which is how that message's advice ("prefix
+// AGENTKIT_ALLOW_DELEGATED=1") went unnoticed as wrong: the untrusted-runner
+// branch never consults it, so following the instruction could not ever work.
+export const untrustedRunnerCommands = [
+  './bounded-run --profile compile -- bun run build',
+  './tools/bounded-run --profile default -- echo ok',
+  '/tmp/evil/bounded-run --profile compile -- bun test',
 ];

--- a/tests/resource-police.test.ts
+++ b/tests/resource-police.test.ts
@@ -7,6 +7,7 @@ import {
   allowedResourceCommands,
   blockedResourceCommands,
   unsupportedResourceCommands,
+  untrustedRunnerCommands,
 } from './fixtures/resource-commands';
 
 const repoRoot = dirname(import.meta.dir);
@@ -82,6 +83,27 @@ describe('Claude resource-police', () => {
       const output = runHook(command);
       expect(output).toContain('"permissionDecision": "deny"');
       expect(output).toContain('cannot be contained by bounded-run');
+    });
+  }
+
+  for (const command of untrustedRunnerCommands) {
+    test(`refuses an unrecognised runner, and says why: ${command}`, () => {
+      const output = runHook(command);
+      expect(output).toContain('"permissionDecision": "deny"');
+      // The message must name the ACTUAL problem. These were previously
+      // refused with the delegated-workload text, which advertises an escape
+      // hatch this branch never consults — so a user following the message
+      // could not ever unblock, and would reasonably conclude the tool was
+      // broken. A gate that misdiagnoses itself wastes the reader's time.
+      expect(output).toContain('not a recognised bounded-run');
+      expect(output).not.toContain('cannot be contained by bounded-run');
+    });
+
+    test(`the delegated escape hatch does NOT clear it: ${command}`, () => {
+      // Pins the honesty of the message above: if this ever starts passing
+      // the guard, the message must change with it.
+      const output = runHook(`AGENTKIT_ALLOW_DELEGATED=1 ${command}`);
+      expect(output).toContain('"permissionDecision": "deny"');
     });
   }
 

--- a/tests/resource-police.test.ts
+++ b/tests/resource-police.test.ts
@@ -53,6 +53,21 @@ describe('OpenCode resource-police', () => {
     });
   }
 
+  for (const command of untrustedRunnerCommands) {
+    test(`refuses an unrecognised runner: ${command}`, async () => {
+      // This guard had ZERO coverage in the OpenCode implementation: moving
+      // the fixture into its own array took it out of the loop above, and
+      // deleting the guard outright still left every test passing. Two
+      // parallel implementations of one policy need the same cases run
+      // against BOTH, or one silently stops enforcing.
+      const hooks = await resourcePolice(mockCtx);
+      const { input, output } = makeInput(command);
+      expect(hooks['tool.execute.before']!(input, output)).rejects.toThrow(
+        'not a recognised bounded-run',
+      );
+    });
+  }
+
   test('allows wrapped, lightweight, and inspection commands', async () => {
     const hooks = await resourcePolice(mockCtx);
 


### PR DESCRIPTION
Diff review structurally cannot see what is not in a diff. Five rounds of
adversarial diff review on the orbit voice work missed a stale README build
command, a default feature set that produced a broken-looking install, and the
complete absence of packaging — none of which any commit touched.

- new `product-review` skill: build it, run it, use it from a cold start, and
  report from the user's position rather than the diff's
- `.agentkit/product.yaml` contract (template included). Commands, not prose:
  a stale README fails silently, a declared command that no longer works fails
  the moment somebody runs it
- missing manifest = STOP and ask, and record the absence as a MEDIUM finding.
  A silent pass would make "don't add the file" the cheapest way to dodge
  product review
- environments that cannot run the product (client repos, no hardware, no
  credentials) verify what they can and state plainly what they could not,
  per surface — partial honest coverage beats an implied full pass
- autonomous-workflow points at the new lane and says which wins on severity

Also fixes drift found while wiring this up: skills/ and the plugin mirror had
diverged — the top-level autonomous-workflow was missing the entire review-gate
section added in #78. The hooks had a byte-identity test; the skills did not.
Now they do, recursively (some skills carry subdirectories), and it is
mutation-checked in both directions.

408 pass.