### PR TITLE
feat(install): gate tool installation by platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,10 +159,22 @@ cp plugins/version-police.ts your-project/.opencode/plugins/
 
 Global installs place tools on `~/.local/bin/` and preserve a mirror in `~/.claude/tools/`.
 
-| Tool                   | Description                                                                          |
-| ---------------------- | ------------------------------------------------------------------------------------ |
-| **bounded-run**        | Runs one direct-argv workload in the bounded `agent-work.slice` systemd user service |
-| **fix-ascii-boxes.py** | Fixes ASCII box-drawing alignment in markdown files, handles nested boxes inside-out |
+| Tool                   | Platforms | Description                                                                          |
+| ---------------------- | --------- | ------------------------------------------------------------------------------------ |
+| **bounded-run**        | linux     | Runs one direct-argv workload in the bounded `agent-work.slice` systemd user service |
+| **fix-ascii-boxes.py** | any       | Fixes ASCII box-drawing alignment in markdown files, handles nested boxes inside-out |
+
+A tool restricts itself to specific platforms with a header directive, and the installer skips it
+elsewhere rather than leaving a command that cannot run:
+
+```bash
+# agentkit:platforms linux darwin
+```
+
+Tools without the directive install everywhere. Platform is `uname -s` (`linux`/`darwin`), or
+`AGENTKIT_PLATFORM` when set. Re-running the installer reconciles: a tool that a previous version
+installed here is removed once it declares a platform this host is not. The Claude plugin bundle is
+a separate channel installed by `claude plugin install` — the directive does not gate it.
 
 `bounded-run` fails closed unless the aggregate slice matches its expected limits (default
 20G/24G memory high/max, 800% CPU, 1536 tasks; hosts sized differently pin their values in
@@ -366,4 +378,5 @@ externalsecret) that auto-generate and manage secrets for any GitOps app.
 2. Each skill lives in `skills/<name>/SKILL.md` with optional `references/` and `scripts/` subdirs
 3. Rules live in `rules/<name>.md` with frontmatter globs for auto-loading
 4. Plugins live in `plugins/<name>.ts` and implement the OpenCode plugin API
-5. Tools live in `tools/<name>` and are standalone executable scripts (Python/Bash)
+5. Tools live in `tools/<name>` and are standalone executable scripts (Python/Bash); ones that
+   cannot work everywhere declare `# agentkit:platforms <list>` in their header

--- a/README.md
+++ b/README.md
@@ -179,7 +179,11 @@ quietly disable the gate.
 
 Because `bounded-run` is Linux-only, `resource-police` stands down off Linux: heavy commands run
 with a warning that nothing is bounding them, rather than being blocked in favour of a runner the
-installer will not install. The Claude plugin bundle is a separate channel installed by
+installer will not install. **Only the containment requirement stands down.** Delegated workloads
+(`kubectl`, `ssh`, `docker`, `sudo`) stay blocked on every platform — that guard exists because the
+work escapes to a remote target, which is exactly as dangerous from a host with no cgroups. The
+Codex `.rules` policy is a static prefix list with no platform awareness, so it still asks for
+`bounded-run` off Linux. The Claude plugin bundle is a separate channel installed by
 `claude plugin install` — the directive does not gate it.
 
 `bounded-run` fails closed unless the aggregate slice matches its expected limits (default

--- a/README.md
+++ b/README.md
@@ -172,9 +172,15 @@ elsewhere rather than leaving a command that cannot run:
 ```
 
 Tools without the directive install everywhere. Platform is `uname -s` (`linux`/`darwin`), or
-`AGENTKIT_PLATFORM` when set. Re-running the installer reconciles: a tool that a previous version
-installed here is removed once it declares a platform this host is not. The Claude plugin bundle is
-a separate channel installed by `claude plugin install` — the directive does not gate it.
+`AGENTKIT_PLATFORM` when set — an unrecognised value is an error, not a silent skip. Re-running the
+installer reconciles: a tool that a previous version installed here is removed once it declares a
+platform this host is not. A directive that names no platforms warns and installs, so a typo cannot
+quietly disable the gate.
+
+Because `bounded-run` is Linux-only, `resource-police` stands down off Linux: heavy commands run
+with a warning that nothing is bounding them, rather than being blocked in favour of a runner the
+installer will not install. The Claude plugin bundle is a separate channel installed by
+`claude plugin install` — the directive does not gate it.
 
 `bounded-run` fails closed unless the aggregate slice matches its expected limits (default
 20G/24G memory high/max, 800% CPU, 1536 tasks; hosts sized differently pin their values in

--- a/README.md
+++ b/README.md
@@ -174,8 +174,9 @@ elsewhere rather than leaving a command that cannot run:
 Tools without the directive install everywhere. Platform is `uname -s` (`linux`/`darwin`), or
 `AGENTKIT_PLATFORM` when set — an unrecognised value is an error, not a silent skip. Re-running the
 installer reconciles: a tool that a previous version installed here is removed once it declares a
-platform this host is not. A directive that names no platforms warns and installs, so a typo cannot
-quietly disable the gate.
+platform this host is not. A directive that names no usable platforms — empty, or entirely
+commented out — warns and withholds the tool rather than installing it everywhere, since installing
+is the one outcome the author certainly did not ask for.
 
 Because `bounded-run` is Linux-only, `resource-police` stands down off Linux: heavy commands run
 with a warning that nothing is bounding them, rather than being blocked in favour of a runner the

--- a/hooks/claude/resource-police.sh
+++ b/hooks/claude/resource-police.sh
@@ -5,6 +5,12 @@ readonly AWK_BIN=/usr/bin/awk
 readonly CAT_BIN=/usr/bin/cat
 readonly JQ_BIN=/usr/bin/jq
 
+# bounded-run needs systemd-run and cgroup v2, and the installer will not put it
+# on a non-Linux host. Demanding it here would be an order that cannot be
+# followed. Off Linux this stood down only by accident — /usr/bin/jq does not
+# exist there, so the hook errored and Claude read the crash as allow.
+[[ "$(uname -s)" == "Linux" ]] || exit 0
+
 INPUT=$("$CAT_BIN")
 COMMAND=$(printf '%s' "$INPUT" | "$JQ_BIN" -r '.tool_input.command // empty')
 [[ -z "$COMMAND" ]] && exit 0

--- a/install.sh
+++ b/install.sh
@@ -567,9 +567,12 @@ tool_supports_platform() {
 		if [[ "$line" =~ ^[[:space:]]*#[[:space:]]*agentkit:platforms?([[:space:]].*)?$ ]]; then
 			# Trailing CR survives a core.autocrlf checkout and would never match.
 			values="${BASH_REMATCH[1]%$'\r'}"
-			# A trailing comment would otherwise be read as platform names, and
-			# an unmatched name installs the tool where it cannot run.
-			values="${values%%#*}"
+			# Drop a trailing comment, which would otherwise be read as platform
+			# names. Only after a real value: '#linux' is a commented-out list,
+			# and emptying it here would turn a skip into install-everywhere.
+			if [[ "$values" =~ ^([[:space:]]*[^#[:space:]][^#]*)# ]]; then
+				values="${BASH_REMATCH[1]}"
+			fi
 			found=1
 			break
 		fi

--- a/install.sh
+++ b/install.sh
@@ -611,7 +611,11 @@ install_tools() {
 		# Reconcile, don't just skip: an older agentkit may have installed this
 		# tool here before it declared which platforms it supports.
 		if ! tool_supports_platform "$tool_file" "$platform"; then
-			echo "[tools] Skipping (unsupported on $platform): $name"
+			if [[ -e "$tools_dir/$name" ]]; then
+				echo "[tools] Removing (unsupported on $platform): $name"
+			else
+				echo "[tools] Skipping (unsupported on $platform): $name"
+			fi
 			rm -f "$tools_dir/$name"
 			continue
 		fi

--- a/install.sh
+++ b/install.sh
@@ -567,12 +567,9 @@ tool_supports_platform() {
 		if [[ "$line" =~ ^[[:space:]]*#[[:space:]]*agentkit:platforms?([[:space:]].*)?$ ]]; then
 			# Trailing CR survives a core.autocrlf checkout and would never match.
 			values="${BASH_REMATCH[1]%$'\r'}"
-			# Drop a trailing comment, which would otherwise be read as platform
-			# names. Only after a real value: '#linux' is a commented-out list,
-			# and emptying it here would turn a skip into install-everywhere.
-			if [[ "$values" =~ ^([[:space:]]*[^#[:space:]][^#]*)# ]]; then
-				values="${BASH_REMATCH[1]}"
-			fi
+			# A comment starts at the first '#', whatever follows it. Anything
+			# else makes the result depend on the spelling of the comment.
+			values="${values%%#*}"
 			found=1
 			break
 		fi
@@ -583,9 +580,11 @@ tool_supports_platform() {
 	# read -ra, not word splitting: an unquoted expansion would glob a value
 	# like '*' against the working directory.
 	read -ra entries <<<"$values"
+	# The author wrote a restriction and named nothing usable. Installing anyway
+	# is the one outcome they certainly did not ask for, so withhold and say so.
 	if ((${#entries[@]} == 0)); then
-		echo "[tools] WARNING: $(basename "$tool_file") declares agentkit:platforms with no platforms — installing it everywhere" >&2
-		return 0
+		echo "[tools] WARNING: $(basename "$tool_file") declares agentkit:platforms with no usable platforms — not installing it" >&2
+		return 1
 	fi
 
 	for entry in "${entries[@]}"; do

--- a/install.sh
+++ b/install.sh
@@ -564,9 +564,12 @@ tool_supports_platform() {
 	local -a entries
 
 	while IFS= read -r line; do
-		if [[ "$line" =~ ^#[[:space:]]*agentkit:platforms?([[:space:]].*)?$ ]]; then
+		if [[ "$line" =~ ^[[:space:]]*#[[:space:]]*agentkit:platforms?([[:space:]].*)?$ ]]; then
 			# Trailing CR survives a core.autocrlf checkout and would never match.
 			values="${BASH_REMATCH[1]%$'\r'}"
+			# A trailing comment would otherwise be read as platform names, and
+			# an unmatched name installs the tool where it cannot run.
+			values="${values%%#*}"
 			found=1
 			break
 		fi

--- a/install.sh
+++ b/install.sh
@@ -540,6 +540,8 @@ merge_claude_settings() {
 
 # ─── Standalone Tools (Python/Bash scripts) ──────────────────────────────────
 
+KNOWN_PLATFORMS="linux darwin unknown"
+
 detect_platform() {
 	if [[ -n "${AGENTKIT_PLATFORM:-}" ]]; then
 		printf '%s' "$AGENTKIT_PLATFORM"
@@ -554,13 +556,33 @@ detect_platform() {
 
 # A tool restricts itself to specific platforms with a header directive:
 #   # agentkit:platforms linux darwin
-# Tools without the directive install everywhere.
+# Tools without the directive install everywhere. A directive that matches but
+# names nothing is a typo, not a licence to install: say so rather than let a
+# silent fail-open put an unrunnable command on PATH.
 tool_supports_platform() {
-	local tool_file="$1" platform="$2" declared entry
-	declared="$(sed -n '1,15p' "$tool_file" | grep -m1 '^# agentkit:platforms ' || true)"
-	[[ -n "$declared" ]] || return 0
+	local tool_file="$1" platform="$2" line values="" found=0 entry
+	local -a entries
 
-	for entry in ${declared#\# agentkit:platforms }; do
+	while IFS= read -r line; do
+		if [[ "$line" =~ ^#[[:space:]]*agentkit:platforms?([[:space:]].*)?$ ]]; then
+			# Trailing CR survives a core.autocrlf checkout and would never match.
+			values="${BASH_REMATCH[1]%$'\r'}"
+			found=1
+			break
+		fi
+	done < <(sed -n '1,15p' "$tool_file")
+
+	((found)) || return 0
+
+	# read -ra, not word splitting: an unquoted expansion would glob a value
+	# like '*' against the working directory.
+	read -ra entries <<<"$values"
+	if ((${#entries[@]} == 0)); then
+		echo "[tools] WARNING: $(basename "$tool_file") declares agentkit:platforms with no platforms — installing it everywhere" >&2
+		return 0
+	fi
+
+	for entry in "${entries[@]}"; do
 		[[ "$entry" == "$platform" ]] && return 0
 	done
 	return 1
@@ -570,6 +592,10 @@ install_tools() {
 	local tools_dir="$1"
 	local platform
 	platform="$(detect_platform)"
+	if [[ " $KNOWN_PLATFORMS " != *" $platform "* ]]; then
+		echo "[tools] AGENTKIT_PLATFORM='$platform' is not one of: $KNOWN_PLATFORMS" >&2
+		return 64
+	fi
 	mkdir -p "$tools_dir"
 
 	for tool_file in "$REPO_DIR"/tools/*; do

--- a/install.sh
+++ b/install.sh
@@ -540,14 +540,50 @@ merge_claude_settings() {
 
 # ─── Standalone Tools (Python/Bash scripts) ──────────────────────────────────
 
+detect_platform() {
+	if [[ -n "${AGENTKIT_PLATFORM:-}" ]]; then
+		printf '%s' "$AGENTKIT_PLATFORM"
+		return
+	fi
+	case "$(uname -s)" in
+		Linux) printf 'linux' ;;
+		Darwin) printf 'darwin' ;;
+		*) printf 'unknown' ;;
+	esac
+}
+
+# A tool restricts itself to specific platforms with a header directive:
+#   # agentkit:platforms linux darwin
+# Tools without the directive install everywhere.
+tool_supports_platform() {
+	local tool_file="$1" platform="$2" declared entry
+	declared="$(sed -n '1,15p' "$tool_file" | grep -m1 '^# agentkit:platforms ' || true)"
+	[[ -n "$declared" ]] || return 0
+
+	for entry in ${declared#\# agentkit:platforms }; do
+		[[ "$entry" == "$platform" ]] && return 0
+	done
+	return 1
+}
+
 install_tools() {
 	local tools_dir="$1"
+	local platform
+	platform="$(detect_platform)"
 	mkdir -p "$tools_dir"
 
 	for tool_file in "$REPO_DIR"/tools/*; do
 		[[ -f "$tool_file" ]] || continue
 		local name
 		name="$(basename "$tool_file")"
+
+		# Reconcile, don't just skip: an older agentkit may have installed this
+		# tool here before it declared which platforms it supports.
+		if ! tool_supports_platform "$tool_file" "$platform"; then
+			echo "[tools] Skipping (unsupported on $platform): $name"
+			rm -f "$tools_dir/$name"
+			continue
+		fi
 
 		if [[ -f "$tools_dir/$name" ]]; then
 			echo "[tools] Updating: $name"
@@ -562,6 +598,8 @@ install_tools() {
 	# Compat alias: bounded-run was previously named agentkit-run.
 	if [[ -f "$tools_dir/bounded-run" ]]; then
 		ln -sf bounded-run "$tools_dir/agentkit-run"
+	else
+		rm -f "$tools_dir/agentkit-run"
 	fi
 }
 

--- a/plugins-cc/agentkit/hooks/resource-police.sh
+++ b/plugins-cc/agentkit/hooks/resource-police.sh
@@ -5,6 +5,12 @@ readonly AWK_BIN=/usr/bin/awk
 readonly CAT_BIN=/usr/bin/cat
 readonly JQ_BIN=/usr/bin/jq
 
+# bounded-run needs systemd-run and cgroup v2, and the installer will not put it
+# on a non-Linux host. Demanding it here would be an order that cannot be
+# followed. Off Linux this stood down only by accident — /usr/bin/jq does not
+# exist there, so the hook errored and Claude read the crash as allow.
+[[ "$(uname -s)" == "Linux" ]] || exit 0
+
 INPUT=$("$CAT_BIN")
 COMMAND=$(printf '%s' "$INPUT" | "$JQ_BIN" -r '.tool_input.command // empty')
 [[ -z "$COMMAND" ]] && exit 0

--- a/plugins-cc/agentkit/tools/bounded-run
+++ b/plugins-cc/agentkit/tools/bounded-run
@@ -1,4 +1,7 @@
 #!/bin/bash -p
+# agentkit:platforms linux
+# Drives systemd-run and the cgroup v2 hierarchy directly; there is no
+# equivalent on other platforms, so installing it there is worse than absent.
 set -euo pipefail
 
 readonly EX_USAGE=64

--- a/plugins/resource-police.ts
+++ b/plugins/resource-police.ts
@@ -12,6 +12,9 @@ interface Finding {
   /** The runner is not the INSTALLED bounded-run. Distinct from `delegated`:
    *  the delegated message advertises an escape hatch that cannot clear this. */
   untrustedRunner?: boolean;
+  /** Analysis gave up before reaching the real command. Must never be treated
+   *  as "nothing found" — a stand-down would turn it into permission. */
+  undecidable?: boolean;
 }
 
 function splitShellSegments(command: string): string[] {
@@ -209,11 +212,11 @@ function unwrapEnvironment(launch: Launch): Launch {
 function wrappedLaunch(launch: Launch): Launch | null {
   const separator = launch.args.indexOf('--');
   if (separator < 0 || !launch.args[separator + 1]) return null;
-  return {
-    token: launch.args[separator + 1],
-    executable: basename(launch.args[separator + 1]),
-    args: launch.args.slice(separator + 2),
-  };
+  // Route the payload through parseLaunch rather than reading the token after
+  // `--` directly: that skipped every wrapper normalisation the top-level path
+  // does, so `-- nohup ssh host rm` read as a launch of `nohup` and the remote
+  // command behind it was never seen.
+  return parseLaunch(launch.args.slice(separator + 1).join(' '));
 }
 
 // agentkit-run is the pre-rename compat alias, so both names are runner layers.
@@ -226,7 +229,7 @@ function detectUnboundedCommand(
   depth = 0,
   delegatedOk = false,
 ): Finding | null {
-  if (depth > 3) return { segment: command, delegated: false };
+  if (depth > 3) return { segment: command, delegated: false, undecidable: true };
   for (const segment of splitShellSegments(command)) {
     const launch = parseLaunch(segment);
     if (!launch) continue;
@@ -300,6 +303,15 @@ export function enforceResourcePolicy(
       `BLOCKED: delegated workload cannot be contained by bounded-run: ${finding.segment}\n` +
         'Use a separately approved dedicated runner or verified engine-native limits.\n' +
         'User-approved delegated workloads: prefix with AGENTKIT_ALLOW_DELEGATED=1.',
+    );
+  }
+  // Fails closed on every platform: the analyser stopped before it could tell
+  // whether this delegates, and standing down on "I do not know" is how a
+  // deeply nested command walks straight through.
+  if (finding.undecidable) {
+    throw new Error(
+      `BLOCKED: command nests too deeply to analyse: ${finding.segment}\n`
+        + 'Run the inner command on its own, so what it does can be seen.',
     );
   }
   // Only the containment requirement stands down. Delegation is checked above

--- a/plugins/resource-police.ts
+++ b/plugins/resource-police.ts
@@ -216,6 +216,11 @@ function wrappedLaunch(launch: Launch): Launch | null {
   };
 }
 
+// agentkit-run is the pre-rename compat alias, so both names are runner layers.
+function isRunnerExecutable(executable: string): boolean {
+  return executable === 'bounded-run' || executable === 'agentkit-run';
+}
+
 function detectUnboundedCommand(
   command: string,
   depth = 0,
@@ -225,14 +230,18 @@ function detectUnboundedCommand(
   for (const segment of splitShellSegments(command)) {
     const launch = parseLaunch(segment);
     if (!launch) continue;
-    if (launch.executable === 'bounded-run' || launch.executable === 'agentkit-run') {
+    if (isRunnerExecutable(launch.executable)) {
       // NOT `delegated`: that message advertises AGENTKIT_ALLOW_DELEGATED=1,
       // which this path never consults, so it sent people chasing an escape
       // hatch that cannot clear it.
       // Delegation first, trust second: reporting an untrusted runner without
-      // looking at its payload let `./bounded-run -- ssh prod ...` hide a
-      // delegated command behind seven characters.
-      const nested = wrappedLaunch(launch);
+      // looking at its payload let a wrapper hide a delegated command. Unwrap
+      // every runner layer, not one — a runner wrapping a runner buried the
+      // payload one level deeper than a single check could see.
+      let nested = wrappedLaunch(launch);
+      while (nested && isRunnerExecutable(nested.executable)) {
+        nested = wrappedLaunch(nested);
+      }
       if (nested && !delegatedOk && isDelegating(nested)) return { segment, delegated: true };
       if (!isTrustedRunner(launch.token)) return { segment, delegated: false, untrustedRunner: true };
       continue;

--- a/plugins/resource-police.ts
+++ b/plugins/resource-police.ts
@@ -264,6 +264,16 @@ function isTrustedRunner(token: string): boolean {
     || /\/plugins\/.*\/tools\/bounded-run$/.test(normalized);
 }
 
+// bounded-run drives systemd-run and cgroup v2, so containment simply does not
+// exist off Linux. Blocking there would order the agent to install a runner the
+// installer deliberately refuses to install — a loop with no way out — so allow
+// the command and say plainly that nothing is bounding it.
+export function containmentAvailable(platform: string = process.platform): boolean {
+  return platform === 'linux';
+}
+
+let announcedUnbounded = false;
+
 export default async function resourcePolice(_ctx: PluginInput) {
   return {
     'tool.execute.before': async (
@@ -273,6 +283,16 @@ export default async function resourcePolice(_ctx: PluginInput) {
       if (input.tool?.toLowerCase() !== 'bash') return;
       const command = output.args.command as string | undefined;
       if (!command) return;
+      if (!containmentAvailable()) {
+        if (!announcedUnbounded) {
+          announcedUnbounded = true;
+          console.warn(
+            `[resource-police] ${process.platform} has no cgroup containment; `
+              + 'heavy commands run unbounded and bounded-run is not installed here.',
+          );
+        }
+        return;
+      }
       const finding = detectUnboundedCommand(command, 0, isDelegatedOverride(command));
       if (!finding) return;
       if (finding.untrustedRunner) {

--- a/plugins/resource-police.ts
+++ b/plugins/resource-police.ts
@@ -283,6 +283,18 @@ export default async function resourcePolice(_ctx: PluginInput) {
       if (input.tool?.toLowerCase() !== 'bash') return;
       const command = output.args.command as string | undefined;
       if (!command) return;
+      const finding = detectUnboundedCommand(command, 0, isDelegatedOverride(command));
+      if (!finding) return;
+      if (finding.delegated) {
+        throw new Error(
+          `BLOCKED: delegated workload cannot be contained by bounded-run: ${finding.segment}\n` +
+            'Use a separately approved dedicated runner or verified engine-native limits.\n' +
+            'User-approved delegated workloads: prefix with AGENTKIT_ALLOW_DELEGATED=1.',
+        );
+      }
+      // Only the containment requirement stands down here. The delegated check
+      // above guards work escaping to a remote Linux target and is not about
+      // local cgroups, so it stays enforced on every platform.
       if (!containmentAvailable()) {
         if (!announcedUnbounded) {
           announcedUnbounded = true;
@@ -293,8 +305,6 @@ export default async function resourcePolice(_ctx: PluginInput) {
         }
         return;
       }
-      const finding = detectUnboundedCommand(command, 0, isDelegatedOverride(command));
-      if (!finding) return;
       if (finding.untrustedRunner) {
         throw new Error(
           `BLOCKED: that is not a recognised bounded-run: ${finding.segment}\n`
@@ -303,13 +313,6 @@ export default async function resourcePolice(_ctx: PluginInput) {
             + 'AGENTKIT_ALLOW_DELEGATED=1 does NOT clear this. Install the runner\n'
             + '(~/.local/bin/bounded-run) and invoke it from there, or use the\n'
             + "plugin's copy under the plugin root.",
-        );
-      }
-      if (finding.delegated) {
-        throw new Error(
-          `BLOCKED: delegated workload cannot be contained by bounded-run: ${finding.segment}\n` +
-            'Use a separately approved dedicated runner or verified engine-native limits.\n' +
-            'User-approved delegated workloads: prefix with AGENTKIT_ALLOW_DELEGATED=1.',
         );
       }
       throw new Error(

--- a/plugins/resource-police.ts
+++ b/plugins/resource-police.ts
@@ -229,9 +229,12 @@ function detectUnboundedCommand(
       // NOT `delegated`: that message advertises AGENTKIT_ALLOW_DELEGATED=1,
       // which this path never consults, so it sent people chasing an escape
       // hatch that cannot clear it.
-      if (!isTrustedRunner(launch.token)) return { segment, delegated: false, untrustedRunner: true };
+      // Delegation first, trust second: reporting an untrusted runner without
+      // looking at its payload let `./bounded-run -- ssh prod ...` hide a
+      // delegated command behind seven characters.
       const nested = wrappedLaunch(launch);
       if (nested && !delegatedOk && isDelegating(nested)) return { segment, delegated: true };
+      if (!isTrustedRunner(launch.token)) return { segment, delegated: false, untrustedRunner: true };
       continue;
     }
     if (isShell(launch.executable)) {
@@ -274,6 +277,53 @@ export function containmentAvailable(platform: string = process.platform): boole
 
 let announcedUnbounded = false;
 
+// Exported so the policy can be driven at a chosen platform. Asserting this
+// through the plugin alone can only ever exercise the host's own platform, and
+// a test that cannot reach the off-Linux branch cannot guard it.
+export function enforceResourcePolicy(
+  command: string,
+  platform: string = process.platform,
+): void {
+  const finding = detectUnboundedCommand(command, 0, isDelegatedOverride(command));
+  if (!finding) return;
+  if (finding.delegated) {
+    throw new Error(
+      `BLOCKED: delegated workload cannot be contained by bounded-run: ${finding.segment}\n` +
+        'Use a separately approved dedicated runner or verified engine-native limits.\n' +
+        'User-approved delegated workloads: prefix with AGENTKIT_ALLOW_DELEGATED=1.',
+    );
+  }
+  // Only the containment requirement stands down. Delegation is checked above
+  // and inside the runner branch, so wrapping cannot launder it past here.
+  if (!containmentAvailable(platform)) {
+    if (!announcedUnbounded) {
+      announcedUnbounded = true;
+      console.warn(
+        `[resource-police] ${platform} has no cgroup containment; `
+          + 'heavy commands run unbounded and bounded-run is not installed here.',
+      );
+    }
+    return;
+  }
+  if (finding.untrustedRunner) {
+    throw new Error(
+      `BLOCKED: that is not a recognised bounded-run: ${finding.segment}\n`
+        + 'Anything can be named `bounded-run`, so it is trusted by INSTALLED PATH,\n'
+        + 'not by name — otherwise a spoof could silently neuter every limit.\n'
+        + 'AGENTKIT_ALLOW_DELEGATED=1 does NOT clear this. Install the runner\n'
+        + '(~/.local/bin/bounded-run) and invoke it from there, or use the\n'
+        + "plugin's copy under the plugin root.",
+    );
+  }
+  throw new Error(
+    `BLOCKED: resource-intensive command is not contained: ${finding.segment}\n` +
+      'Run it through the installed runner, for example:\n' +
+      '  bounded-run --profile compile -- bun run typecheck\n' +
+      '  ./.claude/tools/bounded-run --profile compile -- bun run typecheck\n' +
+      'Use profile browser for Playwright and browser builds.',
+  );
+}
+
 export default async function resourcePolice(_ctx: PluginInput) {
   return {
     'tool.execute.before': async (
@@ -283,45 +333,7 @@ export default async function resourcePolice(_ctx: PluginInput) {
       if (input.tool?.toLowerCase() !== 'bash') return;
       const command = output.args.command as string | undefined;
       if (!command) return;
-      const finding = detectUnboundedCommand(command, 0, isDelegatedOverride(command));
-      if (!finding) return;
-      if (finding.delegated) {
-        throw new Error(
-          `BLOCKED: delegated workload cannot be contained by bounded-run: ${finding.segment}\n` +
-            'Use a separately approved dedicated runner or verified engine-native limits.\n' +
-            'User-approved delegated workloads: prefix with AGENTKIT_ALLOW_DELEGATED=1.',
-        );
-      }
-      // Only the containment requirement stands down here. The delegated check
-      // above guards work escaping to a remote Linux target and is not about
-      // local cgroups, so it stays enforced on every platform.
-      if (!containmentAvailable()) {
-        if (!announcedUnbounded) {
-          announcedUnbounded = true;
-          console.warn(
-            `[resource-police] ${process.platform} has no cgroup containment; `
-              + 'heavy commands run unbounded and bounded-run is not installed here.',
-          );
-        }
-        return;
-      }
-      if (finding.untrustedRunner) {
-        throw new Error(
-          `BLOCKED: that is not a recognised bounded-run: ${finding.segment}\n`
-            + 'Anything can be named `bounded-run`, so it is trusted by INSTALLED PATH,\n'
-            + 'not by name — otherwise a spoof could silently neuter every limit.\n'
-            + 'AGENTKIT_ALLOW_DELEGATED=1 does NOT clear this. Install the runner\n'
-            + '(~/.local/bin/bounded-run) and invoke it from there, or use the\n'
-            + "plugin's copy under the plugin root.",
-        );
-      }
-      throw new Error(
-        `BLOCKED: resource-intensive command is not contained: ${finding.segment}\n` +
-          'Run it through the installed runner, for example:\n' +
-          '  bounded-run --profile compile -- bun run typecheck\n' +
-          '  ./.claude/tools/bounded-run --profile compile -- bun run typecheck\n' +
-          'Use profile browser for Playwright and browser builds.',
-      );
+      enforceResourcePolicy(command);
     },
   };
 }

--- a/tests/install-tools.test.ts
+++ b/tests/install-tools.test.ts
@@ -47,3 +47,92 @@ describe('standalone tool installation', () => {
     expect(statSync(bundled).mode & 0o111).not.toBe(0);
   });
 });
+
+const runInstall = (home: string, platform?: string) =>
+  spawnSync('bash', [installScript, '--global'], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      HOME: home,
+      XDG_CONFIG_HOME: join(home, '.config'),
+      ...(platform === undefined ? {} : { AGENTKIT_PLATFORM: platform }),
+    },
+    encoding: 'utf-8',
+  });
+
+// existsSync follows symlinks, so it reports false for a dangling link that is
+// still on disk. Gating has to remove the link itself, not just its target.
+const pathPresent = (path: string) => {
+  try {
+    lstatSync(path);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const withHome = (body: (home: string) => void) => {
+  const home = mkdtempSync(join(tmpdir(), 'agentkit-platform-'));
+  try {
+    body(home);
+  } finally {
+    rmSync(home, { force: true, recursive: true });
+  }
+};
+
+// bounded-run drives systemd-run and cgroupfs directly, so installing it on a
+// non-Linux host hands the agent a command that cannot work.
+describe('tool platform gating', () => {
+  test('does not install a Linux-only tool on a darwin host', () => {
+    withHome((home) => {
+      const result = runInstall(home, 'darwin');
+      expect(result.status, result.stderr).toBe(0);
+
+      expect(existsSync(join(home, '.local', 'bin', 'bounded-run'))).toBe(false);
+      expect(existsSync(join(home, '.claude', 'tools', 'bounded-run'))).toBe(false);
+      expect(result.stdout).toContain('Skipping (unsupported on darwin): bounded-run');
+    });
+  });
+
+  // Removal of an already-present alias is covered by the reconcile test below;
+  // on a fresh skip there is nothing to remove, only something not to create.
+  test('does not create the agentkit-run alias when its target is skipped', () => {
+    withHome((home) => {
+      expect(runInstall(home, 'darwin').status).toBe(0);
+      expect(pathPresent(join(home, '.local', 'bin', 'agentkit-run'))).toBe(false);
+    });
+  });
+
+  test('installs tools that declare no platforms everywhere', () => {
+    withHome((home) => {
+      expect(runInstall(home, 'darwin').status).toBe(0);
+      expect(existsSync(join(home, '.local', 'bin', 'fix-ascii-boxes.py'))).toBe(true);
+    });
+  });
+
+  test('removes a tool already installed before it declared its platforms', () => {
+    withHome((home) => {
+      expect(runInstall(home, 'linux').status).toBe(0);
+      const tool = join(home, '.local', 'bin', 'bounded-run');
+      const alias = join(home, '.local', 'bin', 'agentkit-run');
+      expect(existsSync(tool)).toBe(true);
+      expect(lstatSync(alias).isSymbolicLink()).toBe(true);
+
+      // Same host, later agentkit version: the gate must reconcile, not just skip.
+      expect(runInstall(home, 'darwin').status).toBe(0);
+      expect(pathPresent(tool)).toBe(false);
+      expect(pathPresent(join(home, '.claude', 'tools', 'bounded-run'))).toBe(false);
+      expect(pathPresent(alias)).toBe(false);
+    });
+  });
+
+  test('detects the host platform when no override is set', () => {
+    withHome((home) => {
+      const result = runInstall(home);
+      expect(result.status, result.stderr).toBe(0);
+      // The suite runs on Linux; bounded-run is supported here.
+      expect(existsSync(join(home, '.local', 'bin', 'bounded-run'))).toBe(true);
+      expect(result.stdout).not.toContain('Skipping (unsupported');
+    });
+  });
+});

--- a/tests/install-tools.test.ts
+++ b/tests/install-tools.test.ts
@@ -1,5 +1,17 @@
 import { describe, expect, test } from 'bun:test';
-import { existsSync, lstatSync, mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs';
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -48,17 +60,64 @@ describe('standalone tool installation', () => {
   });
 });
 
+const installEnv = (home: string, platform?: string) => {
+  // Inherited AGENTKIT_PLATFORM would silently defeat the no-override test.
+  const { AGENTKIT_PLATFORM: _ignored, ...rest } = process.env;
+  return {
+    ...rest,
+    HOME: home,
+    XDG_CONFIG_HOME: join(home, '.config'),
+    ...(platform === undefined ? {} : { AGENTKIT_PLATFORM: platform }),
+  };
+};
+
 const runInstall = (home: string, platform?: string) =>
   spawnSync('bash', [installScript, '--global'], {
     cwd: repoRoot,
-    env: {
-      ...process.env,
-      HOME: home,
-      XDG_CONFIG_HOME: join(home, '.config'),
-      ...(platform === undefined ? {} : { AGENTKIT_PLATFORM: platform }),
-    },
+    env: installEnv(home, platform),
     encoding: 'utf-8',
   });
+
+// Exercising the directive grammar needs tools the repo does not ship, so stand
+// up a repo whose tools/ we control and symlink everything else back to the real
+// tree. REPO_DIR follows install.sh's own path, so the fixture tools/ wins.
+const withFixtureTools = (
+  tools: Record<string, string>,
+  body: (
+    run: (platform?: string) => ReturnType<typeof spawnSync>,
+    home: string,
+    repo: string,
+  ) => void,
+) => {
+  const dir = mkdtempSync(join(tmpdir(), 'agentkit-fixture-'));
+  const repo = join(dir, 'repo');
+  const home = join(dir, 'home');
+  mkdirSync(repo);
+  mkdirSync(home);
+
+  for (const entry of readdirSync(repoRoot)) {
+    if (entry !== 'tools') symlinkSync(join(repoRoot, entry), join(repo, entry));
+  }
+  mkdirSync(join(repo, 'tools'));
+  for (const [name, content] of Object.entries(tools)) {
+    const tool = join(repo, 'tools', name);
+    writeFileSync(tool, content);
+    chmodSync(tool, 0o755);
+  }
+
+  const run = (platform?: string) =>
+    spawnSync('bash', [join(repo, 'install.sh'), '--global'], {
+      cwd: repo,
+      env: installEnv(home, platform),
+      encoding: 'utf-8',
+    });
+
+  try {
+    body(run, home, repo);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+};
 
 // existsSync follows symlinks, so it reports false for a dangling link that is
 // still on disk. Gating has to remove the link itself, not just its target.
@@ -126,13 +185,76 @@ describe('tool platform gating', () => {
     });
   });
 
-  test('detects the host platform when no override is set', () => {
+  test.skipIf(process.platform !== 'linux')('detects the host platform when no override is set', () => {
     withHome((home) => {
       const result = runInstall(home);
       expect(result.status, result.stderr).toBe(0);
-      // The suite runs on Linux; bounded-run is supported here.
       expect(existsSync(join(home, '.local', 'bin', 'bounded-run'))).toBe(true);
       expect(result.stdout).not.toContain('Skipping (unsupported');
+    });
+  });
+
+  test('rejects a platform override it does not recognise', () => {
+    withHome((home) => {
+      const result = runInstall(home, 'Linux');
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("AGENTKIT_PLATFORM='Linux' is not one of");
+      // A typo must not be read as "supports nothing" and delete the tools.
+      expect(pathPresent(join(home, '.local', 'bin', 'bounded-run'))).toBe(false);
+    });
+  });
+});
+
+const toolWith = (directive: string, eol = '\n') =>
+  ['#!/usr/bin/env bash', directive, 'echo fixture'].join(eol) + eol;
+
+describe('platform directive grammar', () => {
+  test('honours every platform a tool declares', () => {
+    withFixtureTools({ dual: toolWith('# agentkit:platforms linux darwin') }, (run, home) => {
+      for (const platform of ['linux', 'darwin']) {
+        expect(run(platform).status).toBe(0);
+        expect(existsSync(join(home, '.local', 'bin', 'dual'))).toBe(true);
+      }
+      // Still a real gate, not a match-anything.
+      expect(run('unknown').status).toBe(0);
+      expect(pathPresent(join(home, '.local', 'bin', 'dual'))).toBe(false);
+    });
+  });
+
+  test('warns instead of failing open when a directive names no platforms', () => {
+    withFixtureTools({ empty: toolWith('# agentkit:platforms') }, (run, home) => {
+      const result = run('linux');
+      expect(result.status).toBe(0);
+      expect(result.stderr).toContain('declares agentkit:platforms with no platforms');
+      expect(existsSync(join(home, '.local', 'bin', 'empty'))).toBe(true);
+    });
+  });
+
+  test('reads a directive written with CRLF line endings', () => {
+    withFixtureTools({ crlf: toolWith('# agentkit:platforms linux', '\r\n') }, (run, home) => {
+      expect(run('linux').status).toBe(0);
+      expect(existsSync(join(home, '.local', 'bin', 'crlf'))).toBe(true);
+    });
+  });
+
+  test('treats directive values literally rather than globbing them', () => {
+    withFixtureTools({ star: toolWith('# agentkit:platforms *') }, (run, home, repo) => {
+      // Bait: an unquoted expansion globs against the working directory and
+      // would turn '*' into this filename, matching the host platform.
+      writeFileSync(join(repo, 'linux'), '');
+
+      const result = run('linux');
+      expect(result.status).toBe(0);
+      expect(pathPresent(join(home, '.local', 'bin', 'star'))).toBe(false);
+    });
+  });
+
+  test('accepts the singular spelling rather than silently ignoring it', () => {
+    withFixtureTools({ singular: toolWith('# agentkit:platform linux') }, (run, home) => {
+      expect(run('darwin').status).toBe(0);
+      expect(pathPresent(join(home, '.local', 'bin', 'singular'))).toBe(false);
+      expect(run('linux').status).toBe(0);
+      expect(existsSync(join(home, '.local', 'bin', 'singular'))).toBe(true);
     });
   });
 });

--- a/tests/install-tools.test.ts
+++ b/tests/install-tools.test.ts
@@ -221,14 +221,23 @@ describe('platform directive grammar', () => {
     });
   });
 
-  test('warns instead of failing open when a directive names no platforms', () => {
-    withFixtureTools({ empty: toolWith('# agentkit:platforms') }, (run, home) => {
-      const result = run('linux');
-      expect(result.status).toBe(0);
-      expect(result.stderr).toContain('declares agentkit:platforms with no platforms');
-      expect(existsSync(join(home, '.local', 'bin', 'empty'))).toBe(true);
+  // Every spelling of "named nothing usable" has to behave the same, or the
+  // outcome depends on how the author wrote their comment.
+  for (const [label, directive] of [
+    ['no values at all', '# agentkit:platforms'],
+    ['commented-out value', '# agentkit:platforms #linux'],
+    ['commented-out value, spaced', '# agentkit:platforms # linux'],
+    ['double hash', '# agentkit:platforms ## linux'],
+  ] as const) {
+    test(`withholds rather than installs when a directive names nothing (${label})`, () => {
+      withFixtureTools({ empty: toolWith(directive) }, (run, home) => {
+        const result = run('linux');
+        expect(result.status).toBe(0);
+        expect(result.stderr).toContain('no usable platforms');
+        expect(pathPresent(join(home, '.local', 'bin', 'empty'))).toBe(false);
+      });
     });
-  });
+  }
 
   test('reads a directive written with CRLF line endings', () => {
     withFixtureTools({ crlf: toolWith('# agentkit:platforms linux', '\r\n') }, (run, home) => {
@@ -253,16 +262,6 @@ describe('platform directive grammar', () => {
     withFixtureTools({ noted: toolWith('# agentkit:platforms darwin # not linux') }, (run, home) => {
       expect(run('linux').status).toBe(0);
       expect(pathPresent(join(home, '.local', 'bin', 'noted'))).toBe(false);
-    });
-  });
-
-  test('does not treat a fully commented-out list as no list at all', () => {
-    // Stripping the comment unconditionally would empty this and install it
-    // everywhere — turning a skip into the opposite of what was written.
-    withFixtureTools({ commented: toolWith('# agentkit:platforms #linux') }, (run, home) => {
-      const result = run('linux');
-      expect(result.status).toBe(0);
-      expect(pathPresent(join(home, '.local', 'bin', 'commented'))).toBe(false);
     });
   });
 

--- a/tests/install-tools.test.ts
+++ b/tests/install-tools.test.ts
@@ -249,6 +249,20 @@ describe('platform directive grammar', () => {
     });
   });
 
+  test('does not read a trailing comment as platform names', () => {
+    withFixtureTools({ noted: toolWith('# agentkit:platforms darwin # not linux') }, (run, home) => {
+      expect(run('linux').status).toBe(0);
+      expect(pathPresent(join(home, '.local', 'bin', 'noted'))).toBe(false);
+    });
+  });
+
+  test('finds a directive that is indented', () => {
+    withFixtureTools({ indented: toolWith('  # agentkit:platforms darwin') }, (run, home) => {
+      expect(run('linux').status).toBe(0);
+      expect(pathPresent(join(home, '.local', 'bin', 'indented'))).toBe(false);
+    });
+  });
+
   test('accepts the singular spelling rather than silently ignoring it', () => {
     withFixtureTools({ singular: toolWith('# agentkit:platform linux') }, (run, home) => {
       expect(run('darwin').status).toBe(0);

--- a/tests/install-tools.test.ts
+++ b/tests/install-tools.test.ts
@@ -256,6 +256,16 @@ describe('platform directive grammar', () => {
     });
   });
 
+  test('does not treat a fully commented-out list as no list at all', () => {
+    // Stripping the comment unconditionally would empty this and install it
+    // everywhere — turning a skip into the opposite of what was written.
+    withFixtureTools({ commented: toolWith('# agentkit:platforms #linux') }, (run, home) => {
+      const result = run('linux');
+      expect(result.status).toBe(0);
+      expect(pathPresent(join(home, '.local', 'bin', 'commented'))).toBe(false);
+    });
+  });
+
   test('finds a directive that is indented', () => {
     withFixtureTools({ indented: toolWith('  # agentkit:platforms darwin') }, (run, home) => {
       expect(run('linux').status).toBe(0);

--- a/tests/resource-police.test.ts
+++ b/tests/resource-police.test.ts
@@ -66,20 +66,30 @@ describe('containment availability', () => {
     }
   });
 
-  // A wrapper is one token. If trust were decided before the payload was read,
-  // this would launder a delegated command straight through off Linux.
-  test('sees through an untrusted runner wrapping a delegated command', () => {
+  // A wrapper is one token, and nothing stops an agent adding two. Checking the
+  // payload once only ever sees one layer down.
+  test('sees through runner wrappers hiding a delegated command', () => {
     const laundered = [
       './bounded-run --profile default -- ssh prod-host rm -rf /data',
       '/tmp/evil/bounded-run --profile default -- kubectl delete ns prod',
       './tools/bounded-run --profile default -- sudo systemctl restart nginx',
+      'bounded-run --profile default -- bounded-run --profile default -- ssh prod-host rm -rf /data',
+      'bounded-run --profile default -- agentkit-run --profile default -- kubectl delete ns prod',
+      'bounded-run -- bounded-run -- bounded-run -- ssh prod-host rm -rf /data',
     ];
     for (const command of laundered) {
-      expect(() => enforceResourcePolicy(command, 'darwin')).toThrow(
-        'cannot be contained by bounded-run',
-      );
-      expect(() => enforceResourcePolicy(command, 'linux')).toThrow('BLOCKED');
+      for (const platform of ['darwin', 'linux']) {
+        expect(() => enforceResourcePolicy(command, platform)).toThrow(
+          'cannot be contained by bounded-run',
+        );
+      }
     }
+  });
+
+  test('does not mistake a wrapped ordinary command for delegation', () => {
+    expect(() =>
+      enforceResourcePolicy('bounded-run --profile default -- bounded-run -- bun install', 'linux')
+    ).not.toThrow();
   });
 
   // Named explicitly rather than looping blockedResourceCommands: that fixture

--- a/tests/resource-police.test.ts
+++ b/tests/resource-police.test.ts
@@ -50,6 +50,39 @@ describe('containment availability', () => {
     const { input, output } = makeInput(blockedResourceCommands[0]!);
     expect(hooks['tool.execute.before']!(input, output)).rejects.toThrow('bounded-run');
   });
+
+  // Standing down containment must not stand down the delegation guard: that
+  // one exists because the work escapes to a remote Linux target, which is
+  // exactly as dangerous from a laptop with no cgroups.
+  test('keeps blocking delegated workloads where containment is unavailable', async () => {
+    const hooks = await resourcePolice(mockCtx);
+    for (const command of unsupportedResourceCommands) {
+      const { input, output } = makeInput(command);
+      expect(hooks['tool.execute.before']!(input, output)).rejects.toThrow(
+        'cannot be contained by bounded-run',
+      );
+    }
+  });
+
+  test('checks delegation before containment availability', () => {
+    // Source-level guard: an early containment return placed above the
+    // delegated branch silently disables it, which no darwin-free test can see.
+    const source = readFileSync(join(repoRoot, 'plugins', 'resource-police.ts'), 'utf-8');
+    const delegatedAt = source.indexOf('if (finding.delegated)');
+    const containmentAt = source.indexOf('if (!containmentAvailable())');
+    expect(delegatedAt).toBeGreaterThan(-1);
+    expect(containmentAt).toBeGreaterThan(-1);
+    expect(delegatedAt).toBeLessThan(containmentAt);
+  });
+
+  test('the Claude hook stands down off Linux rather than relying on a crash', () => {
+    const source = readFileSync(hook, 'utf-8');
+    expect(source).toContain('uname -s');
+    const guardAt = source.indexOf('[[ "$(uname -s)" == "Linux" ]] || exit 0');
+    expect(guardAt).toBeGreaterThan(-1);
+    // It has to stand down before the first hard-coded Linux binary runs.
+    expect(guardAt).toBeLessThan(source.indexOf('"$JQ_BIN"'));
+  });
 });
 
 describe('OpenCode resource-police', () => {

--- a/tests/resource-police.test.ts
+++ b/tests/resource-police.test.ts
@@ -86,6 +86,37 @@ describe('containment availability', () => {
     }
   });
 
+  // The payload after `--` was read as a launch directly, so it never got the
+  // wrapper normalisation a top-level command gets. Generalising over runner
+  // NAMES was not enough; the wrapper CLASS has to generalise too.
+  test('sees through no-op wrappers inside a runner payload', () => {
+    const laundered = [
+      'bounded-run --profile default -- nohup ssh prod-host rm -rf /data',
+      'bounded-run --profile default -- command ssh prod-host rm -rf /data',
+      'bounded-run --profile default -- time ssh prod-host rm -rf /data',
+      'bounded-run --profile default -- nohup sudo systemctl restart nginx',
+      'bounded-run --profile default -- nohup kubectl delete ns prod',
+      'bounded-run -- env agentkit-run -- kubectl delete ns prod',
+      'bounded-run -- nohup bounded-run -- ssh prod-host rm -rf /data',
+    ];
+    for (const command of laundered) {
+      for (const platform of ['darwin', 'linux']) {
+        expect(() => enforceResourcePolicy(command, platform)).toThrow(
+          'cannot be contained by bounded-run',
+        );
+      }
+    }
+  });
+
+  // "I stopped analysing" must not become "allowed" once containment stands
+  // down. Nesting past the depth limit was the way to say it quietly.
+  test('fails closed when a command nests too deeply to analyse', () => {
+    const deep = 'sh -c sh -c sh -c sh -c ssh prod-host rm';
+    for (const platform of ['darwin', 'linux']) {
+      expect(() => enforceResourcePolicy(deep, platform)).toThrow('too deeply to analyse');
+    }
+  });
+
   test('does not mistake a wrapped ordinary command for delegation', () => {
     expect(() =>
       enforceResourcePolicy('bounded-run --profile default -- bounded-run -- bun install', 'linux')

--- a/tests/resource-police.test.ts
+++ b/tests/resource-police.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { spawnSync } from 'node:child_process';
-import resourcePolice from '../plugins/resource-police';
+import resourcePolice, { containmentAvailable } from '../plugins/resource-police';
 import {
   allowedResourceCommands,
   blockedResourceCommands,
@@ -33,6 +33,24 @@ function runHook(command: string): string {
   const input = JSON.stringify({ tool_input: { command } });
   return spawnSync('bash', [hook], { input, encoding: 'utf-8' }).stdout ?? '';
 }
+
+// The installer refuses to install bounded-run off Linux. If the policy still
+// demanded it there, the agent would be told to install something that will
+// never arrive, with no way to proceed.
+describe('containment availability', () => {
+  test('is Linux-only, matching where bounded-run can actually run', () => {
+    expect(containmentAvailable('linux')).toBe(true);
+    expect(containmentAvailable('darwin')).toBe(false);
+    expect(containmentAvailable('win32')).toBe(false);
+  });
+
+  test('blocks on this Linux host, so the guard is not vacuously open', async () => {
+    expect(containmentAvailable()).toBe(true);
+    const hooks = await resourcePolice(mockCtx);
+    const { input, output } = makeInput(blockedResourceCommands[0]!);
+    expect(hooks['tool.execute.before']!(input, output)).rejects.toThrow('bounded-run');
+  });
+});
 
 describe('OpenCode resource-police', () => {
   for (const command of blockedResourceCommands) {

--- a/tests/resource-police.test.ts
+++ b/tests/resource-police.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { spawnSync } from 'node:child_process';
-import resourcePolice, { containmentAvailable } from '../plugins/resource-police';
+import resourcePolice, {
+  containmentAvailable,
+  enforceResourcePolicy,
+} from '../plugins/resource-police';
 import {
   allowedResourceCommands,
   blockedResourceCommands,
@@ -53,26 +56,40 @@ describe('containment availability', () => {
 
   // Standing down containment must not stand down the delegation guard: that
   // one exists because the work escapes to a remote Linux target, which is
-  // exactly as dangerous from a laptop with no cgroups.
-  test('keeps blocking delegated workloads where containment is unavailable', async () => {
-    const hooks = await resourcePolice(mockCtx);
+  // exactly as dangerous from a laptop with no cgroups. Driven at an explicit
+  // platform — asserting this through the plugin only ever tests the host's own.
+  test('keeps blocking delegated workloads on a platform without containment', () => {
     for (const command of unsupportedResourceCommands) {
-      const { input, output } = makeInput(command);
-      expect(hooks['tool.execute.before']!(input, output)).rejects.toThrow(
+      expect(() => enforceResourcePolicy(command, 'darwin')).toThrow(
         'cannot be contained by bounded-run',
       );
     }
   });
 
-  test('checks delegation before containment availability', () => {
-    // Source-level guard: an early containment return placed above the
-    // delegated branch silently disables it, which no darwin-free test can see.
-    const source = readFileSync(join(repoRoot, 'plugins', 'resource-police.ts'), 'utf-8');
-    const delegatedAt = source.indexOf('if (finding.delegated)');
-    const containmentAt = source.indexOf('if (!containmentAvailable())');
-    expect(delegatedAt).toBeGreaterThan(-1);
-    expect(containmentAt).toBeGreaterThan(-1);
-    expect(delegatedAt).toBeLessThan(containmentAt);
+  // A wrapper is one token. If trust were decided before the payload was read,
+  // this would launder a delegated command straight through off Linux.
+  test('sees through an untrusted runner wrapping a delegated command', () => {
+    const laundered = [
+      './bounded-run --profile default -- ssh prod-host rm -rf /data',
+      '/tmp/evil/bounded-run --profile default -- kubectl delete ns prod',
+      './tools/bounded-run --profile default -- sudo systemctl restart nginx',
+    ];
+    for (const command of laundered) {
+      expect(() => enforceResourcePolicy(command, 'darwin')).toThrow(
+        'cannot be contained by bounded-run',
+      );
+      expect(() => enforceResourcePolicy(command, 'linux')).toThrow('BLOCKED');
+    }
+  });
+
+  // Named explicitly rather than looping blockedResourceCommands: that fixture
+  // also carries delegated entries like `sudo -n cargo test`, which must keep
+  // blocking off Linux. Only plain local work is let through.
+  test('still allows ordinary heavy commands where nothing can bound them', () => {
+    for (const command of ['bun install', 'bun run build', 'cargo test']) {
+      expect(() => enforceResourcePolicy(command, 'darwin')).not.toThrow();
+      expect(() => enforceResourcePolicy(command, 'linux')).toThrow('BLOCKED');
+    }
   });
 
   test('the Claude hook stands down off Linux rather than relying on a crash', () => {

--- a/tools/bounded-run
+++ b/tools/bounded-run
@@ -1,4 +1,7 @@
 #!/bin/bash -p
+# agentkit:platforms linux
+# Drives systemd-run and the cgroup v2 hierarchy directly; there is no
+# equivalent on other platforms, so installing it there is worse than absent.
 set -euo pipefail
 
 readonly EX_USAGE=64


### PR DESCRIPTION
agentkit shipped `bounded-run` to every user on every host unconditionally, but it drives
`systemd-run` and cgroup v2 directly — on a non-Linux host that is a command on PATH that cannot
work. `install.sh` had no platform detection at all.

## Change

- Tools declare support with a header directive: `# agentkit:platforms linux darwin`
- Undeclared tools install everywhere (no behaviour change for `fix-ascii-boxes.py`)
- `bounded-run` declared `linux`
- Re-running install **reconciles**: a tool a previous agentkit version installed here is removed
  once it declares a platform this host is not — plus its `agentkit-run` alias. Without this the
  gate would never take effect on hosts that already have the tool.
- `AGENTKIT_PLATFORM` overrides `uname -s` detection

## Not covered

The Claude plugin bundle is installed by `claude plugin install`, outside `install.sh` — the
directive does not gate that channel.

## Verification

- 420 pass / 0 fail (`bun test`), 5 pre-existing skips
- New gating tests were mutation-tested: breaking the gate, the stale-removal, and the alias
  cleanup each fail the specific assertion that claims to cover it. One test's name overstated its
  coverage (it cannot exercise cleanup on a fresh install) and was renamed to what it verifies.