### PR TITLE
feat(skills): audit claims, probe external behavior, mutation-check values

### DIFF
--- a/plugins-cc/agentkit/skills/architect/SKILL.md
+++ b/plugins-cc/agentkit/skills/architect/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: architect
+description: Study a system and produce living architecture documentation — explanatory pages with high-quality diagrams. Use AUTOMATICALLY when the user asks to document, explain, map, or review an architecture ("how does this system work", "architecture diagram of this repo", "create/refresh the design docs"), or to keep architecture pages current after changes. Orchestrates the diagram and publish-page skills.
+---
+
+# architect
+
+You are producing the document a strong staff engineer would write after
+genuinely understanding a system — not a file listing with boxes around it.
+
+## Workflow
+
+1. **Scope**: name the system(s) and the audience question the page must
+   answer ("how does a request flow", "what owns what", "where does state
+   live"). One page per question; link pages rather than bloating one.
+2. **Study before drawing.** Read entry points, deploy/infra configs, service
+   boundaries, schemas, and the seams between components. Verify claims in
+   code — including absences ("nothing else writes this table" needs grepping,
+   not assuming). For third-party pieces, check the real docs; never draw from
+   memory.
+3. **Find the load-bearing structure**: the 3–7 components whose removal would
+   change the story, the flows between them, the state stores, and the
+   trust/ownership boundaries. Everything else is detail inside a zone.
+4. **Produce**:
+   - the centerpiece diagram(s) via the **diagram** skill (technical depth:
+     real names, real payloads, evidence artifacts),
+   - a page via **publish-page** (doc template): overview strip, the diagrams
+     in `.figure` blocks with semantic captions, a "decisions & constraints"
+     section (why it is shaped this way, what must not be broken), and a
+     "sharp edges" section for the traps a newcomer hits,
+   - use a stable `--name` (e.g. `<system>-architecture`) so refreshes update
+     the SAME URL.
+5. **Refresh mode**: when asked to update (or triggered after merges), diff
+   what changed since the page's last git version in the pages repo, update
+   only the affected zones/sections, republish the same name, and note the
+   delta at the top of the page.
+
+## The bar: impress a staff engineer
+
+An experienced architect looking at your centerpiece diagram should learn
+something and find nothing to correct. That means the diagram shows what
+seniors actually look for, not just boxes and arrows:
+
+- **Boundaries drawn as boundaries** — trust, ownership, network, and process
+  boundaries as visible zones, not implied by proximity.
+- **Edges that say something**: protocol + direction + what actually travels
+  (`PUT /api/pages/:slug · HTML ≤5MB`, not "sends data"). Sync vs async
+  distinguishable at a glance (solid vs dashed).
+- **State made explicit** — every store shown with what owns it and what only
+  reads it.
+- **The failure story** — what breaks when each critical edge dies, marked on
+  the diagram (error-role color), not left to the appendix.
+- **Numbers where they exist** — caps, timeouts, quotas, cardinalities pulled
+  from config/code, never invented.
+- **The why on the page** — one decisions-and-constraints section that names
+  the forces that shaped the design; a diagram that only shows "what" is half
+  a diagram.
+
+## Rules
+
+- Accuracy outranks beauty: a wrong arrow is worse than a missing one. If the
+  code contradicts the docs, the code wins and the page says so.
+- State your confidence and name what you did NOT verify.
+- Never invent architecture direction — document what exists; proposals go in
+  a clearly separated "open questions" section, not the diagrams.
+- **Publishing internal systems requires the user's explicit go-ahead**: pages
+  are public-by-slug until the accounts phase, and architecture pages are by
+  nature internal material — confirm before the first publish of a system's
+  page (refreshes of an already-approved page are fine).

--- a/plugins-cc/agentkit/skills/autonomous-workflow/SKILL.md
+++ b/plugins-cc/agentkit/skills/autonomous-workflow/SKILL.md
@@ -83,12 +83,12 @@ gate as something it is not.
    **every, always, never, all, verified, probed, cannot** — and check each
    against reality with `git grep`, a probe, or the code itself.
 
-   Three claim defects landed in one day: an MR asserting "every currently
-   paired device sends the old frame shape" (the frame did not exist on the
-   other repo's main — the population was empty); a comment citing probe
-   evidence for a correlation branch (the probe predated the change that would
-   exercise it, so it evidenced a different case); an authority table added to
-   prevent drift, carrying a row contradicted by code in the same file.
+   Three shapes this takes, all observed in a single day: a change description
+   asserted a compatibility requirement over "every" existing client, and one
+   grep showed the population was empty; a comment cited probe evidence for a
+   branch, but the probe predated the change that would exercise it, so it
+   evidenced a different case; a table added to stop drift carried a row
+   contradicted by code in the same file.
 
    Report any claim that outruns its evidence, **even when the code is
    correct**. Wrong prose is not cosmetic — it teaches the next reader a wrong
@@ -98,19 +98,19 @@ gate as something it is not.
    (machine-global, append-only — these are lessons about how the agent works,
    not about a codebase):
 
-   ```json
-   {
-     "date": "2026-07-20",
-     "repo": "neutron",
-     "gap": "asserted every paired device sends the old frame without grepping the other repo",
-     "finding": "MR !13 HIGH: claim contradicted by git grep",
-     "repeat": false
-   }
+   ```text
+   {"date":"2026-07-20","harness":"claude","repo":"<repo>","gap":"asserted a compatibility requirement over all clients without grepping for one","finding":"HIGH: claim contradicted by git grep","repeat_of":null}
    ```
+
+   One object per line, no pretty-printing — the file is appended to by many
+   sessions and must stay line-addressable. `harness` is one of `claude`,
+   `codex`, `opencode`, `other`; it is not bookkeeping, it is what shows
+   whether different harnesses fail in different ways. `repeat_of` carries the
+   date of the earlier entry when the same gap recurs, else `null`.
 
    **Keep the filter narrow or nobody will read it.** Entry-worthy: the author
    asserted something without checking; no test could have caught this; this is
-   the second time this class appeared (set `repeat`). NOT entry-worthy: an
+   the second time this class appeared (set `repeat_of`). NOT entry-worthy: an
    ordinary logic bug found in review. A bug caught by review is the system
    working; a process gap is the system missing.
 
@@ -142,12 +142,11 @@ internally correct code that cannot be used is still broken.
 
 ## Observe External Behaviour Before Building On It
 
-The most expensive defect of one session: interruption was wired to
-`response.cancelled`, an event the OpenAI Realtime API does not emit on that
-transport. It shipped green because the tests synthesised the imaginary event. A
-five-minute live probe found it — and every subsequent probe also contradicted
-an assumption (truncation after `response.done` works; `event_id` arrives
-`null`, not absent).
+The most expensive defect of one session: a feature was wired to an event name
+the vendor's streaming API does not emit on that transport. It shipped green
+because the tests synthesised the imaginary event. A five-minute live probe
+found it — and every subsequent probe also contradicted an assumption, one
+about ordering and one about a field arriving `null` rather than absent.
 
 Before you build on another system's behaviour, OBSERVE it: run a probe, capture
 a real payload, or quote the doc with its URL. Assumptions about wire protocols,
@@ -159,8 +158,8 @@ and mark it observed vs inferred (see "Observed vs inferred" in product-review).
 
 ## Mutation-Check Load-Bearing Values
 
-`played_ms` — the number the entire feature turned on — passed all 158 tests
-when replaced with a constant zero. The test double could not report a non-zero
+The one number an entire feature turned on passed all 158 of its tests when
+replaced with a constant zero. The test double could not report a non-zero
 value, so no test could observe it.
 
 For each value the feature's correctness depends on, replace it with a constant
@@ -204,18 +203,18 @@ When a reviewer disproves something you asserted, **that** is the moment to
 write or correct a memory — not at session end, not on a schedule. The
 correction is cheapest while the evidence is still in front of you.
 
-Counterweight: memories and reflections rot. On 2026-07-20 a memory the author
-had written themselves sent them chasing a poisoned-cargo-target-dir theory for
-hours when the real cause was a toolchain mismatch (`RUSTUP_TOOLCHAIN` pinned to
-an older version than the cargo binary). Correcting and pruning matters as much
-as appending — a confident stale note is worse than none, because it is trusted.
+Counterweight: stored notes and reflections rot. A note the author had written
+themselves once sent them chasing a corrupted-build-directory theory for hours
+when the real cause was a toolchain mismatch — a pinned toolchain version older
+than the build tool invoking it. Correcting and pruning matters as much as
+appending: a confident stale note is worse than none, because it is trusted.
 
 ### Batching the reflection log
 
 Reviewers append process gaps to `~/.agentkit/reflections.jsonl` (see gate step
-6). As the **author**, read it and batch entries into an agentkit MR when there
-is real signal: a `repeat`, or several entries pointing the same way. One entry
-is an anecdote.
+6). As the **author**, read it and batch entries into a proposed change to these
+disciplines when there is real signal: a `repeat_of`, or several entries
+pointing the same way. One entry is an anecdote.
 
 **Never auto-apply.** An SOP change goes through review like any other change —
 that is the whole reason the log is a queue and not a config file.

--- a/plugins-cc/agentkit/skills/autonomous-workflow/SKILL.md
+++ b/plugins-cc/agentkit/skills/autonomous-workflow/SKILL.md
@@ -98,13 +98,13 @@ gate as something it is not.
    (machine-global, append-only — these are lessons about how the agent works,
    not about a codebase):
 
-   **Read the log before appending.** Grep it for the same gap class; if one
-   matches, set `repeat_of` to that entry's `id`. Skip this and `repeat_of` is
-   null forever — and a repeat is the only thing separating a mistake from a
-   pattern, which is precisely what the batching step keys on.
+   **Read the log before appending.** `grep '"class":"<class>"'` for the same
+   class; if one matches, set `repeat_of` to that entry's `id`. Skip this and
+   `repeat_of` is null forever — and a repeat is the only thing separating a
+   mistake from a pattern, which is precisely what the batching step keys on.
 
    ```text
-   {"id":"2026-07-20T14:32:07Z","harness":"claude","repo":"<repo>","gap":"asserted a compatibility requirement over all clients without grepping for one","finding":"HIGH: claim contradicted by git grep","repeat_of":null}
+   {"id":"2026-07-20T14:32:07Z","harness":"claude","repo":"<repo>","class":"unverified-claim","gap":"asserted a compatibility requirement over all clients without grepping for one","finding":"HIGH: claim contradicted by git grep","repeat_of":null}
    ```
 
    One object per line, no pretty-printing — many sessions append here and the
@@ -113,6 +113,14 @@ gate as something it is not.
    not. `repeat_of` carries an earlier entry's `id`, else `null`. `harness` is
    one of `claude`, `codex`, `opencode`, `other` — not bookkeeping, it is what
    shows whether different harnesses fail in different ways.
+
+   `class` is a fixed vocabulary, so repeats are greppable rather than a
+   judgement about whether two sentences mean the same thing: `unverified-claim`,
+   `untested-value`, `unobserved-external-behaviour`, `duplicated-authority`,
+   `stale-doc`, `other`. Free prose in `gap` cannot be matched reliably — a
+   tired reviewer greps one wording and misses its twin, which is the failure
+   this step exists to prevent. Add to the vocabulary deliberately, in an MR;
+   do not invent a class inline.
 
    **Entry-worthy is one binary test: would the fix be a line in the SOP, or a
    line in the code?** SOP ⇒ entry (the author asserted something without
@@ -211,8 +219,10 @@ pattern, a gotcha, a convention, a lesson learned -- PROPOSE updating the releva
 
 When a reviewer disproves something you asserted, correct the stored note then —
 not at session end, not on a timer. Prune as readily as you append: a confident
-stale note is worse than none, because it is trusted. One self-written note cost
-hours of debugging down a theory it still endorsed after the cause was known.
+stale note is worse than none, because it is trusted. A note recording one cause
+for a class of build failure kept sending its own author back to that cause for
+hours after the real one — a different, unrelated misconfiguration — had been
+identified.
 
 ### Batching the reflection log
 

--- a/plugins-cc/agentkit/skills/autonomous-workflow/SKILL.md
+++ b/plugins-cc/agentkit/skills/autonomous-workflow/SKILL.md
@@ -83,67 +83,14 @@ gate as something it is not.
    **every, always, never, all, verified, probed, cannot** — and check each
    against reality with `git grep`, a probe, or the code itself.
 
-   Three shapes this takes, all observed in a single day: a change description
-   asserted a compatibility requirement over "every" existing client, and one
-   grep showed the population was empty; a comment cited probe evidence for a
-   branch, but the probe predated the change that would exercise it, so it
-   evidenced a different case; a table added to stop drift carried a row
-   contradicted by code in the same file.
+   Common failure shapes include a change description asserting compatibility
+   with clients that do not exist, a comment citing a probe that exercised a
+   different branch, or a rule table contradicted by code in the same file.
 
    Report any claim that outruns its evidence, **even when the code is
    correct**. Wrong prose is not cosmetic — it teaches the next reader a wrong
    model, and the next change is made against that model.
-6. **Log process gaps to the reflection log.** Immediately after writing the
-   verdict, append one JSON object per gap to `~/.agentkit/reflections.jsonl`
-   (machine-global, append-only — these are lessons about how the agent works,
-   not about a codebase):
-
-   **Read the log before appending.** `grep '"class":"<class>"'` for the same
-   class; if one matches, set `repeat_of` to that entry's `id`. Skip this and
-   `repeat_of` is null forever — and a repeat is the only thing separating a
-   mistake from a pattern, which is precisely what the batching step keys on.
-
-   ```text
-   {"id":"2026-07-20T14:32:07Z","harness":"claude","repo":"<repo>","class":"unverified-claim","gap":"asserted a compatibility requirement over all clients without grepping for one","finding":"HIGH: claim contradicted by git grep","repeat_of":null}
-   ```
-
-   One object per line, no pretty-printing — many sessions append here and the
-   file must stay line-addressable. `id` is an ISO-8601 timestamp to the second:
-   unique across concurrent sessions and stable to reference, which a date is
-   not. `repeat_of` carries an earlier entry's `id`, else `null`. `harness` is
-   one of `claude`, `codex`, `opencode`, `other` — not bookkeeping, it is what
-   shows whether different harnesses fail in different ways.
-
-   `class` is a fixed vocabulary, so repeats are greppable rather than a
-   judgement about whether two sentences mean the same thing: `unverified-claim`,
-   `untested-value`, `unobserved-external-behaviour`, `duplicated-authority`,
-   `stale-doc`, `other`. Free prose in `gap` cannot be matched reliably — a
-   tired reviewer greps one wording and misses its twin, which is the failure
-   this step exists to prevent. Add to the vocabulary deliberately, in an MR;
-   do not invent a class inline. Write entries compactly, with no spaces after
-   the colons, so the grep above matches.
-
-   **When a gap fits two classes, take the EARLIEST link in the chain** — the
-   step that, had it happened, would have stopped the rest. A rule table
-   contradicted by its own file is `unverified-claim` (nobody checked it against
-   the code), not `stale-doc` (what it became) or `duplicated-authority` (what it
-   was about). Consistency matters more than picking the best label, because the
-   entire value is that repeats collide.
-
-   **`other` is a debt, not an escape hatch.** It exists so a novel gap is
-   recorded rather than dropped — but name the would-be class in `gap`, and the
-   second time an `other` recurs, propose the new class in an MR. An `other`
-   that recurs unnamed has quietly restored free prose.
-
-   **Entry-worthy is one binary test: would the fix be a line in the SOP, or a
-   line in the code?** SOP ⇒ entry (the author asserted something without
-   checking; the process had no step that would have caught it). Code ⇒
-   ordinary bug, no entry. A bug caught by review is the system working; a
-   process gap is the system missing.
-
-   The signal must come from the **reviewer**, not the author — an author
-   under-reports their own errors by construction.
-7. **Do not hand findings to the user to approve.** They are not a queue for
+6. **Do not hand findings to the user to approve.** They are not a queue for
    work you would rather not do. Escalate only when a finding genuinely cannot
    be fixed — an upstream or platform limitation — and say why. If they then
    approve in writing, record their exact words in `user_consent`. Fabricating
@@ -170,18 +117,17 @@ internally correct code that cannot be used is still broken.
 ## Observe External Behaviour Before Building On It
 
 Before building on another system's behaviour, OBSERVE it: run a probe, capture
-a real payload, or quote the doc with its URL. Record the payload **verbatim,
-next to the code that depends on it**, marked observed vs inferred (see
-"Observed vs inferred" in product-review).
+a real payload, or quote the doc with its URL. Preserve the relevant evidence
+next to the code that depends on it, with secrets, tokens and personal data redacted,
+and mark it observed vs inferred (see "Observed vs inferred" in product-review).
 
 Assumptions about wire protocols, event names, error shapes and field
 nullability are the ones that bite — and tests written from an assumption
 cannot catch it, they encode it.
 
-Illustration: a feature wired to an event name the vendor's API does not emit on
-that transport shipped green, because the tests synthesised the imaginary event.
-A five-minute probe found it, and each further probe in that session also
-contradicted an assumption.
+Tests that synthesise an assumed provider event prove only that the code handles
+the invented fixture. Probe the real transport before treating that event as a
+supported contract.
 
 ## Mutation-Check Load-Bearing Values
 
@@ -190,6 +136,7 @@ the feature touches. A re-run per value is the one rule here that can eat an
 afternoon on a slow suite. Replace each with a constant and re-run.
 
 - **A green suite means that value is not covered.**
+- **Restore the original value after each run** before making any further change.
 - **If nothing can observe the value — the test double cannot report anything
   else — building that seam is part of this change, not a follow-up.** No test
   can exist until it does. This is the case that motivated the rule.
@@ -198,9 +145,8 @@ afternoon on a slow suite. Replace each with a constant and re-run.
 - **Judge by the run's output markers, never its exit status** — see
   **resource-safe-execution**. Runners report success on builds that never ran.
 
-Illustration: the one number a feature turned on passed all 158 of its tests
-when replaced with a constant zero — the double could not report a non-zero, so
-no test could observe it.
+If replacing a load-bearing value with a constant leaves the suite green, the
+tests do not observe that value yet.
 
 ## Commit Hygiene
 
@@ -232,17 +178,4 @@ pattern, a gotcha, a convention, a lesson learned -- PROPOSE updating the releva
 
 When a reviewer disproves something you asserted, correct the stored note then —
 not at session end, not on a timer. Prune as readily as you append: a confident
-stale note is worse than none, because it is trusted. A note recording one cause
-for a class of build failure kept sending its own author back to that cause for
-hours after the real one — a different, unrelated misconfiguration — had been
-identified.
-
-### Batching the reflection log
-
-Reviewers append process gaps to `~/.agentkit/reflections.jsonl` (see gate step
-6). As the **author**, read it and batch entries into a proposed change to these
-disciplines when there is real signal: a non-null `repeat_of`, or several entries
-pointing the same way. One entry is an anecdote.
-
-**Never auto-apply.** An SOP change goes through review like any other change —
-that is the whole reason the log is a queue and not a config file.
+stale note is worse than none, because later work may trust it.

--- a/plugins-cc/agentkit/skills/autonomous-workflow/SKILL.md
+++ b/plugins-cc/agentkit/skills/autonomous-workflow/SKILL.md
@@ -78,10 +78,45 @@ gate as something it is not.
    workaround, not a flag that hides it, not a comment explaining why it is
    acceptable. Then re-run the reviewer against the new head and merge on a
    fresh pass.
-5. **Audit the claims, not just the logic.** Factual assertions in comments,
-   commit messages and the MR description are part of the review — see "Claims
-   audit" in the **product-review** skill. It applies to diff review too.
-6. **Do not hand findings to the user to approve.** They are not a queue for
+5. **Audit the claims, not just the logic.** Grep the diff's comments, commit
+   messages and MR/PR description for factual assertions — especially
+   **every, always, never, all, verified, probed, cannot** — and check each
+   against reality with `git grep`, a probe, or the code itself.
+
+   Three claim defects landed in one day: an MR asserting "every currently
+   paired device sends the old frame shape" (the frame did not exist on the
+   other repo's main — the population was empty); a comment citing probe
+   evidence for a correlation branch (the probe predated the change that would
+   exercise it, so it evidenced a different case); an authority table added to
+   prevent drift, carrying a row contradicted by code in the same file.
+
+   Report any claim that outruns its evidence, **even when the code is
+   correct**. Wrong prose is not cosmetic — it teaches the next reader a wrong
+   model, and the next change is made against that model.
+6. **Log process gaps to the reflection log.** Immediately after writing the
+   verdict, append one JSON object per gap to `~/.agentkit/reflections.jsonl`
+   (machine-global, append-only — these are lessons about how the agent works,
+   not about a codebase):
+
+   ```json
+   {
+     "date": "2026-07-20",
+     "repo": "neutron",
+     "gap": "asserted every paired device sends the old frame without grepping the other repo",
+     "finding": "MR !13 HIGH: claim contradicted by git grep",
+     "repeat": false
+   }
+   ```
+
+   **Keep the filter narrow or nobody will read it.** Entry-worthy: the author
+   asserted something without checking; no test could have caught this; this is
+   the second time this class appeared (set `repeat`). NOT entry-worthy: an
+   ordinary logic bug found in review. A bug caught by review is the system
+   working; a process gap is the system missing.
+
+   The signal must come from the **reviewer**, not the author — an author
+   under-reports their own errors by construction.
+7. **Do not hand findings to the user to approve.** They are not a queue for
    work you would rather not do. Escalate only when a finding genuinely cannot
    be fixed — an upstream or platform limitation — and say why. If they then
    approve in writing, record their exact words in `user_consent`. Fabricating
@@ -169,8 +204,18 @@ When a reviewer disproves something you asserted, **that** is the moment to
 write or correct a memory — not at session end, not on a schedule. The
 correction is cheapest while the evidence is still in front of you.
 
-Counterweight: memories rot. A previously-written memory sent an author chasing
-a poisoned-cargo-target-dir theory for hours when the real cause was a toolchain
-mismatch (`RUSTUP_TOOLCHAIN` pinned to an older version than the cargo binary).
-Correcting and pruning matters as much as appending — a confident stale note is
-worse than none.
+Counterweight: memories and reflections rot. On 2026-07-20 a memory the author
+had written themselves sent them chasing a poisoned-cargo-target-dir theory for
+hours when the real cause was a toolchain mismatch (`RUSTUP_TOOLCHAIN` pinned to
+an older version than the cargo binary). Correcting and pruning matters as much
+as appending — a confident stale note is worse than none, because it is trusted.
+
+### Batching the reflection log
+
+Reviewers append process gaps to `~/.agentkit/reflections.jsonl` (see gate step
+6). As the **author**, read it and batch entries into an agentkit MR when there
+is real signal: a `repeat`, or several entries pointing the same way. One entry
+is an anecdote.
+
+**Never auto-apply.** An SOP change goes through review like any other change —
+that is the whole reason the log is a queue and not a config file.

--- a/plugins-cc/agentkit/skills/autonomous-workflow/SKILL.md
+++ b/plugins-cc/agentkit/skills/autonomous-workflow/SKILL.md
@@ -120,7 +120,20 @@ gate as something it is not.
    `stale-doc`, `other`. Free prose in `gap` cannot be matched reliably — a
    tired reviewer greps one wording and misses its twin, which is the failure
    this step exists to prevent. Add to the vocabulary deliberately, in an MR;
-   do not invent a class inline.
+   do not invent a class inline. Write entries compactly, with no spaces after
+   the colons, so the grep above matches.
+
+   **When a gap fits two classes, take the EARLIEST link in the chain** — the
+   step that, had it happened, would have stopped the rest. A rule table
+   contradicted by its own file is `unverified-claim` (nobody checked it against
+   the code), not `stale-doc` (what it became) or `duplicated-authority` (what it
+   was about). Consistency matters more than picking the best label, because the
+   entire value is that repeats collide.
+
+   **`other` is a debt, not an escape hatch.** It exists so a novel gap is
+   recorded rather than dropped — but name the would-be class in `gap`, and the
+   second time an `other` recurs, propose the new class in an MR. An `other`
+   that recurs unnamed has quietly restored free prose.
 
    **Entry-worthy is one binary test: would the fix be a line in the SOP, or a
    line in the code?** SOP ⇒ entry (the author asserted something without
@@ -167,8 +180,8 @@ cannot catch it, they encode it.
 
 Illustration: a feature wired to an event name the vendor's API does not emit on
 that transport shipped green, because the tests synthesised the imaginary event.
-A five-minute probe found it; every subsequent probe also contradicted an
-assumption.
+A five-minute probe found it, and each further probe in that session also
+contradicted an assumption.
 
 ## Mutation-Check Load-Bearing Values
 

--- a/plugins-cc/agentkit/skills/autonomous-workflow/SKILL.md
+++ b/plugins-cc/agentkit/skills/autonomous-workflow/SKILL.md
@@ -78,7 +78,10 @@ gate as something it is not.
    workaround, not a flag that hides it, not a comment explaining why it is
    acceptable. Then re-run the reviewer against the new head and merge on a
    fresh pass.
-5. **Do not hand findings to the user to approve.** They are not a queue for
+5. **Audit the claims, not just the logic.** Factual assertions in comments,
+   commit messages and the MR description are part of the review — see "Claims
+   audit" in the **product-review** skill. It applies to diff review too.
+6. **Do not hand findings to the user to approve.** They are not a queue for
    work you would rather not do. Escalate only when a finding genuinely cannot
    be fixed — an upstream or platform limitation — and say why. If they then
    approve in writing, record their exact words in `user_consent`. Fabricating
@@ -101,6 +104,38 @@ a separate pass: build it, run it, use it, from a cold start. It reads
 `.agentkit/product.yaml` and refuses rather than guessing when that is absent.
 When the two lenses disagree on severity, the user-facing consequence wins —
 internally correct code that cannot be used is still broken.
+
+## Observe External Behaviour Before Building On It
+
+The most expensive defect of one session: interruption was wired to
+`response.cancelled`, an event the OpenAI Realtime API does not emit on that
+transport. It shipped green because the tests synthesised the imaginary event. A
+five-minute live probe found it — and every subsequent probe also contradicted
+an assumption (truncation after `response.done` works; `event_id` arrives
+`null`, not absent).
+
+Before you build on another system's behaviour, OBSERVE it: run a probe, capture
+a real payload, or quote the doc with its URL. Assumptions about wire protocols,
+event names, error shapes and field nullability are the ones that bite, and
+tests you write from the assumption cannot catch it — they encode it.
+
+Record the observed payload **verbatim, next to the code that depends on it**,
+and mark it observed vs inferred (see "Observed vs inferred" in product-review).
+
+## Mutation-Check Load-Bearing Values
+
+`played_ms` — the number the entire feature turned on — passed all 158 tests
+when replaced with a constant zero. The test double could not report a non-zero
+value, so no test could observe it.
+
+For each value the feature's correctness depends on, replace it with a constant
+and re-run. **A green suite means that value is not covered.**
+
+Verify the mutation actually APPLIED and COMPILED before believing the result —
+an invalid mutation reads exactly like "covered". Note that `bounded-run`
+returns exit 0 even on a hard build failure, and the harness completion notice
+repeats that exit code, so judge by output markers (`test result:`, `N pass`)
+and treat a missing summary line as failure.
 
 ## Commit Hygiene
 
@@ -127,3 +162,15 @@ pattern, a gotcha, a convention, a lesson learned -- PROPOSE updating the releva
    patterns that should be standardized
 2. **Always propose first**: Never silently update config files. Describe what you learned and why
    it should be codified. Wait for approval.
+
+### The retro trigger is a disproof, not a timer
+
+When a reviewer disproves something you asserted, **that** is the moment to
+write or correct a memory — not at session end, not on a schedule. The
+correction is cheapest while the evidence is still in front of you.
+
+Counterweight: memories rot. A previously-written memory sent an author chasing
+a poisoned-cargo-target-dir theory for hours when the real cause was a toolchain
+mismatch (`RUSTUP_TOOLCHAIN` pinned to an older version than the cargo binary).
+Correcting and pruning matters as much as appending — a confident stale note is
+worse than none.

--- a/plugins-cc/agentkit/skills/autonomous-workflow/SKILL.md
+++ b/plugins-cc/agentkit/skills/autonomous-workflow/SKILL.md
@@ -98,21 +98,27 @@ gate as something it is not.
    (machine-global, append-only — these are lessons about how the agent works,
    not about a codebase):
 
+   **Read the log before appending.** Grep it for the same gap class; if one
+   matches, set `repeat_of` to that entry's `id`. Skip this and `repeat_of` is
+   null forever — and a repeat is the only thing separating a mistake from a
+   pattern, which is precisely what the batching step keys on.
+
    ```text
-   {"date":"2026-07-20","harness":"claude","repo":"<repo>","gap":"asserted a compatibility requirement over all clients without grepping for one","finding":"HIGH: claim contradicted by git grep","repeat_of":null}
+   {"id":"2026-07-20T14:32:07Z","harness":"claude","repo":"<repo>","gap":"asserted a compatibility requirement over all clients without grepping for one","finding":"HIGH: claim contradicted by git grep","repeat_of":null}
    ```
 
-   One object per line, no pretty-printing — the file is appended to by many
-   sessions and must stay line-addressable. `harness` is one of `claude`,
-   `codex`, `opencode`, `other`; it is not bookkeeping, it is what shows
-   whether different harnesses fail in different ways. `repeat_of` carries the
-   date of the earlier entry when the same gap recurs, else `null`.
+   One object per line, no pretty-printing — many sessions append here and the
+   file must stay line-addressable. `id` is an ISO-8601 timestamp to the second:
+   unique across concurrent sessions and stable to reference, which a date is
+   not. `repeat_of` carries an earlier entry's `id`, else `null`. `harness` is
+   one of `claude`, `codex`, `opencode`, `other` — not bookkeeping, it is what
+   shows whether different harnesses fail in different ways.
 
-   **Keep the filter narrow or nobody will read it.** Entry-worthy: the author
-   asserted something without checking; no test could have caught this; this is
-   the second time this class appeared (set `repeat_of`). NOT entry-worthy: an
-   ordinary logic bug found in review. A bug caught by review is the system
-   working; a process gap is the system missing.
+   **Entry-worthy is one binary test: would the fix be a line in the SOP, or a
+   line in the code?** SOP ⇒ entry (the author asserted something without
+   checking; the process had no step that would have caught it). Code ⇒
+   ordinary bug, no entry. A bug caught by review is the system working; a
+   process gap is the system missing.
 
    The signal must come from the **reviewer**, not the author — an author
    under-reports their own errors by construction.
@@ -142,34 +148,38 @@ internally correct code that cannot be used is still broken.
 
 ## Observe External Behaviour Before Building On It
 
-The most expensive defect of one session: a feature was wired to an event name
-the vendor's streaming API does not emit on that transport. It shipped green
-because the tests synthesised the imaginary event. A five-minute live probe
-found it — and every subsequent probe also contradicted an assumption, one
-about ordering and one about a field arriving `null` rather than absent.
+Before building on another system's behaviour, OBSERVE it: run a probe, capture
+a real payload, or quote the doc with its URL. Record the payload **verbatim,
+next to the code that depends on it**, marked observed vs inferred (see
+"Observed vs inferred" in product-review).
 
-Before you build on another system's behaviour, OBSERVE it: run a probe, capture
-a real payload, or quote the doc with its URL. Assumptions about wire protocols,
-event names, error shapes and field nullability are the ones that bite, and
-tests you write from the assumption cannot catch it — they encode it.
+Assumptions about wire protocols, event names, error shapes and field
+nullability are the ones that bite — and tests written from an assumption
+cannot catch it, they encode it.
 
-Record the observed payload **verbatim, next to the code that depends on it**,
-and mark it observed vs inferred (see "Observed vs inferred" in product-review).
+Illustration: a feature wired to an event name the vendor's API does not emit on
+that transport shipped green, because the tests synthesised the imaginary event.
+A five-minute probe found it; every subsequent probe also contradicted an
+assumption.
 
 ## Mutation-Check Load-Bearing Values
 
-The one number an entire feature turned on passed all 158 of its tests when
-replaced with a constant zero. The test double could not report a non-zero
-value, so no test could observe it.
+Take the **one or two values this change is actually about** — not every value
+the feature touches. A re-run per value is the one rule here that can eat an
+afternoon on a slow suite. Replace each with a constant and re-run.
 
-For each value the feature's correctness depends on, replace it with a constant
-and re-run. **A green suite means that value is not covered.**
+- **A green suite means that value is not covered.**
+- **If nothing can observe the value — the test double cannot report anything
+  else — building that seam is part of this change, not a follow-up.** No test
+  can exist until it does. This is the case that motivated the rule.
+- **Confirm the mutation applied and compiled** before believing any result. An
+  invalid mutation reads exactly like "covered".
+- **Judge by the run's output markers, never its exit status** — see
+  **resource-safe-execution**. Runners report success on builds that never ran.
 
-Verify the mutation actually APPLIED and COMPILED before believing the result —
-an invalid mutation reads exactly like "covered". Note that `bounded-run`
-returns exit 0 even on a hard build failure, and the harness completion notice
-repeats that exit code, so judge by output markers (`test result:`, `N pass`)
-and treat a missing summary line as failure.
+Illustration: the one number a feature turned on passed all 158 of its tests
+when replaced with a constant zero — the double could not report a non-zero, so
+no test could observe it.
 
 ## Commit Hygiene
 
@@ -197,23 +207,18 @@ pattern, a gotcha, a convention, a lesson learned -- PROPOSE updating the releva
 2. **Always propose first**: Never silently update config files. Describe what you learned and why
    it should be codified. Wait for approval.
 
-### The retro trigger is a disproof, not a timer
+### Correct notes the moment they are disproved
 
-When a reviewer disproves something you asserted, **that** is the moment to
-write or correct a memory — not at session end, not on a schedule. The
-correction is cheapest while the evidence is still in front of you.
-
-Counterweight: stored notes and reflections rot. A note the author had written
-themselves once sent them chasing a corrupted-build-directory theory for hours
-when the real cause was a toolchain mismatch — a pinned toolchain version older
-than the build tool invoking it. Correcting and pruning matters as much as
-appending: a confident stale note is worse than none, because it is trusted.
+When a reviewer disproves something you asserted, correct the stored note then —
+not at session end, not on a timer. Prune as readily as you append: a confident
+stale note is worse than none, because it is trusted. One self-written note cost
+hours of debugging down a theory it still endorsed after the cause was known.
 
 ### Batching the reflection log
 
 Reviewers append process gaps to `~/.agentkit/reflections.jsonl` (see gate step
 6). As the **author**, read it and batch entries into a proposed change to these
-disciplines when there is real signal: a `repeat_of`, or several entries
+disciplines when there is real signal: a non-null `repeat_of`, or several entries
 pointing the same way. One entry is an anecdote.
 
 **Never auto-apply.** An SOP change goes through review like any other change —

--- a/plugins-cc/agentkit/skills/diagram/.gitignore
+++ b/plugins-cc/agentkit/skills/diagram/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+renderer/bundle.js

--- a/plugins-cc/agentkit/skills/diagram/SKILL.md
+++ b/plugins-cc/agentkit/skills/diagram/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: diagram
+description: Craft high-quality hand-drawn-style diagrams (Excalidraw JSON rendered to self-contained SVG). Use AUTOMATICALLY when the user asks to visualize, draw, diagram, or sketch anything — system architectures, workflows, protocols, timelines, comparisons, mental models — or when a task needs a visual that outclasses mermaid/box kits. Renders headlessly at generation time; output embeds anywhere HTML or markdown does.
+---
+
+# diagram
+
+Turn concepts into diagrams that **make an argument**. The structure must carry
+the meaning: cover the labels and the shape should still tell the story. If a
+diagram is five identical boxes with different names, it has said nothing.
+
+Method inspired by coleam00/excalidraw-diagram-skill; text and tooling here are
+original.
+
+## 1 — Decide the depth
+
+- **Conceptual**: mental models, philosophies, quick overviews. Abstract shapes
+  and relationships are enough.
+- **Technical**: real systems, protocols, integrations. You MUST research the
+  real thing first — actual endpoint names, event names, payload shapes, config
+  keys — and show **concrete evidence inside the diagram**: a real (sanitized)
+  payload snippet, the true API call, a mini mockup of the actual output.
+  Placeholder labels like "API" or "Event 1" are a failure; write
+  `PUT /api/pages/:slug` and `RUN_STARTED`, not "endpoint" and "event".
+
+## 2 — Map each concept to a structural pattern
+
+Pick the shape that behaves like the concept. In one diagram, no two major
+concepts should reuse the same pattern.
+
+| Concept behaves like…       | Draw it as…                                                |
+| --------------------------- | ---------------------------------------------------------- |
+| one source feeding many     | fan-out: center node, radiating arrows                     |
+| many inputs producing one   | merge: arrows converging into a single node                |
+| containment / hierarchy     | tree: trunk lines + free-floating labels, no boxes         |
+| ordered steps in time       | timeline: one line, dots, labels above/below               |
+| repetition that improves    | cycle: loop of arrows returning to start                   |
+| input transformed to output | pipeline: before → machine → after, visibly different ends |
+| two options weighed         | side-by-side halves with mirrored structure                |
+| phases with a hard boundary | zones separated by whitespace or a divider line            |
+| fuzzy context or state      | overlapping ellipses (cloud), no hard border               |
+
+**Boxes are earned, not default.** Free-floating text with size/weight
+hierarchy beats a box unless the element is a focal point, an arrow target, or
+a true container.
+
+**The table is a floor, not a ceiling.** For the concept that matters most,
+invent the visual metaphor that IS that concept: a review gate drawn as an
+actual gate across the flow; backpressure as a pipe narrowing; a cache as a
+shadow copy sitting between planes; fan-out that visibly loses order.
+Two tests before you keep a metaphor: strip the labels — does the structure
+still say it? and would a newcomer _learn_ the mechanism from the picture
+alone? If either fails, the metaphor is decoration; redesign it.
+
+## 3 — Compose at three zoom levels (large diagrams)
+
+1. a one-line overview strip (the whole story at a glance),
+2. labeled zones grouping related parts,
+3. teaching detail inside zones — the evidence artifacts.
+
+Trace the eye-path before writing any JSON: where does the viewer start, what
+do they follow, where do they end.
+
+## 4 — Write the Excalidraw JSON section by section
+
+Hand-write `.excalidraw` JSON — never generate the whole file in one pass (a
+comprehensive diagram exceeds a single response's output budget and truncates):
+
+1. Start the file with the wrapper (`type`, `version`, `appState`, `files`) and
+   the first zone's elements.
+2. Add ONE zone per edit, deliberately: layout, spacing, connections to what
+   exists.
+3. Use descriptive ids (`worker_rect`, `arrow_put`) and namespace `seed` per
+   zone (100x, 200x…). When a new arrow binds to an earlier element, update
+   that element's `boundElements` in the same edit.
+4. After the last zone: re-read the whole file — bindings valid both ends,
+   spacing balanced, every referenced id exists.
+
+Palette: match the destination. For AgentKit Pages (navy figures): strokes
+`#dce7f5`, muted `#8fa8c7`, accents `#34d3a6` / `#e8b444`, fills transparent or
+`#102847`, background transparent. For READMEs/light surfaces: near-black
+strokes with classic pastel fills (`#a5d8ff`, `#b2f2bb`, `#ffec99`).
+
+## 5 — Render, LOOK, fix (mandatory loop)
+
+JSON cannot be judged as JSON. Render, view the PNG with the Read tool, fix,
+repeat — expect 2–4 rounds; one pass is never the final pass.
+
+```bash
+bun <skill-dir>/render.ts --in diagram.excalidraw --out diagram.svg --png diagram.png
+```
+
+Each round, in order:
+
+1. **Vision audit first** — compare against the plan from steps 1–3, before
+   hunting bugs: does the visual structure mirror the concepts? does each zone
+   use its intended pattern? does the eye travel the path you designed? do
+   hero elements dominate? are evidence artifacts readable where they belong?
+2. **Defect sweep** — clipped or overflowing text; unintended overlaps; arrows
+   cutting through shapes or landing in empty space; labels that don't clearly
+   belong to anything; ragged spacing between siblings; one zone cramped while
+   another floats in emptiness; text too small at render size; a lopsided
+   whole.
+3. **Fix in JSON** — widen containers for clipped text; shift `x`/`y` for
+   spacing; add waypoints to arrow `points` to route around shapes; pull
+   labels next to their subjects; resize to rebalance visual weight.
+
+**Stop only when** the render matches the planned design, nothing is clipped
+or ambiguous, arrows land exactly, spacing is deliberate — and you would show
+it to a staff engineer without a single caveat. "No critical bugs" is not the
+bar; "couldn't be composed better" is.
+
+(One-time setup: `cd <skill-dir> && bun install && bun run build`; rendering
+needs a local Chromium — set `AGENTKIT_CHROMIUM` if it isn't auto-found.)
+
+## Quality gate — every diagram answers yes to all of these
+
+- **Depth**: researched real names/formats? evidence artifacts present
+  (technical)? multi-zoom present (large)? teaches something concrete?
+- **Concept**: structure would still communicate with labels removed? shows
+  what prose could not? every major concept a different pattern? no uniform
+  card grid anywhere?
+- **Containers**: under ~30% of text boxed? trees/timelines built from lines +
+  text? size/weight/color doing the hierarchy work?
+- **Structure**: every relationship drawn? one clear eye-path? importance
+  visible through scale and surrounding space?
+- **Render**: PNG inspected this round? zero clipping/overlap? arrows exact?
+  spacing consistent? composition balanced?
+
+## 6 — Ship the SVG
+
+The SVG is fully self-contained (fonts embedded as data: URIs). Inline it
+directly into a page (wrap in `<div class="figure">` with a semantic
+`figcaption` when publishing via publish-page), drop it into a repo's docs, or
+attach the PNG where images are needed. Caption by content, never by tool.

--- a/plugins-cc/agentkit/skills/diagram/package.json
+++ b/plugins-cc/agentkit/skills/diagram/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "diagram-skill",
+  "private": true,
+  "dependencies": {
+    "@excalidraw/excalidraw": "0.18.1",
+    "react": "19.2.8",
+    "react-dom": "19.2.8"
+  },
+  "devDependencies": {
+    "playwright-core": "1.62.0",
+    "@types/bun": "^1.2.19"
+  },
+  "scripts": {
+    "build": "bun build renderer/entry.ts --bundle --outfile renderer/bundle.js --target browser --define process.env.NODE_ENV='\"production\"'"
+  }
+}

--- a/plugins-cc/agentkit/skills/diagram/references/elements.md
+++ b/plugins-cc/agentkit/skills/diagram/references/elements.md
@@ -1,0 +1,90 @@
+# Excalidraw JSON authoring reference
+
+File wrapper:
+
+```json
+{
+  "type": "excalidraw",
+  "version": 2,
+  "source": "agentkit-diagram",
+  "elements": [],
+  "appState": { "viewBackgroundColor": "transparent", "gridSize": 20 },
+  "files": {}
+}
+```
+
+## Fields every element needs
+
+`id` (descriptive string), `type`, `x`, `y`, `width`, `height`, `angle: 0`,
+`strokeColor`, `backgroundColor`, `fillStyle: "solid"`, `strokeWidth`,
+`strokeStyle: "solid"`, `roughness`, `opacity: 100`, `seed` (namespace per
+zone: 100x, 200x…), `version: 1`, `versionNonce` (any int), `isDeleted: false`,
+`groupIds: []`, `frameId: null`, `boundElements: null`, `updated: 1`,
+`link: null`, `locked: false`.
+
+## Per-type additions
+
+| Type        | Extra fields                                                                                                                                                                         | Notes                                                                 |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------- |
+| `rectangle` | `roundness: {"type":3}` for rounded                                                                                                                                                  | processes, components, evidence panels                                |
+| `ellipse`   | —                                                                                                                                                                                    | entry/exit, external systems; 10–20px dots = timeline markers/anchors |
+| `diamond`   | —                                                                                                                                                                                    | decisions and conditions only                                         |
+| `text`      | `text`, `originalText` (same words), `fontSize`, `fontFamily`, `textAlign`, `verticalAlign`, `containerId: null`, `autoResize: true`, `lineHeight: 1.25`                             | free-floating labels; `containerId` only when truly inside a shape    |
+| `arrow`     | `points: [[0,0],[dx,dy]]`, `startBinding`/`endBinding` (`{"elementId":"id","focus":0,"gap":2}` or null), `startArrowhead: null`, `endArrowhead: "arrow"`, `lastCommittedPoint: null` | when bound, add this arrow's id to the target's `boundElements`       |
+| `line`      | `points` like arrow, no arrowheads                                                                                                                                                   | tree trunks, dividers, structure                                      |
+
+Fonts: `fontFamily: 1` = hand-drawn (headers, labels — the excalidraw feel),
+`3` = monospace (evidence artifacts: payloads, endpoints, code). Sizes: titles
+20–28, labels 16, evidence text 12–14.
+
+## Look
+
+- `roughness`: 0 = crisp/professional (default), 1 = sketch/brainstorm. Pick
+  one per diagram, never mix.
+- `strokeWidth`: 1 subtle lines/dividers, 2 shapes and normal arrows, 3 only
+  for the single main flow. `opacity` always 100 — hierarchy comes from size,
+  color, and whitespace, not transparency.
+- Scale hierarchy: hero element ~300×150, primary ~180×90, secondary ~120×60,
+  markers 12px. The most important element also gets the most empty space.
+- If two elements are related, draw the connection — proximity alone reads as
+  coincidence.
+
+## Container/text pairing and arrows
+
+- Text inside a shape is a two-way link: the text carries `containerId:
+  "<shape-id>"` AND the shape carries `boundElements: [{"id": "<text-id>",
+  "type": "text"}]`. One side alone breaks centering.
+- Bound arrows likewise: the arrow holds `startBinding`/`endBinding` and each
+  bound shape lists the arrow in its `boundElements`.
+- Curved arrows: 3+ entries in `points`; waypoints are also how an arrow routes
+  around shapes instead of through them.
+- An arrow inherits the stroke color of its SOURCE's semantic role; arrows
+  never introduce colors of their own.
+
+## Semantic palettes (stroke / fill pairs — one role, one pair, always)
+
+Navy pages (background transparent, sits on the `.figure` glow):
+
+| Role                        | stroke           | fill                                                  |
+| --------------------------- | ---------------- | ----------------------------------------------------- |
+| default / neutral           | `#dce7f5`        | `transparent` or `#102847`                            |
+| start / trigger             | `#e8b444`        | `#2a2410`                                             |
+| end / success / active path | `#34d3a6`        | `#0d2f3a`                                             |
+| decision (diamond)          | `#e8b444`        | `transparent`                                         |
+| agent / AI                  | `#b197fc`        | `#1d1636`                                             |
+| inactive / future           | `#8fa8c7` dashed | `transparent`                                         |
+| error / removal             | `#e06c5f`        | `#2a1512`                                             |
+| evidence panel              | `#1e3a5f`        | `#071224` (mono text `#34d3a6` data, `#dce7f5` code)  |
+
+Text hierarchy without boxes (navy): titles `#dce7f5` 20-28px, subtitles
+`#34d3a6` 16px, detail/annotation `#8fa8c7` 12-14px.
+
+Light surfaces (READMEs, docs): near-black `#1e1e1e` strokes; fills `#a5d8ff`
+(neutral), `#fed7aa` (start), `#b2f2bb` (success), `#ffec99` (decision),
+`#ddd6fe` (agent/AI), `#ffc9c9` (error); inactive = dashed `#748ffc` on
+transparent; evidence panels `#1e293b` fill with `#22c55e` data / `#e2e8f0`
+code text. Text hierarchy: titles `#1e40af`, subtitles `#3b82f6`, detail
+`#64748b`.
+
+Rules: darker stroke over lighter fill, always; a concept without a role uses
+neutral, never a fresh color.

--- a/plugins-cc/agentkit/skills/diagram/render.ts
+++ b/plugins-cc/agentkit/skills/diagram/render.ts
@@ -1,0 +1,105 @@
+#!/usr/bin/env bun
+import { execSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+declare global {
+  interface Window {
+    renderExcalidrawToSvg: (scene: unknown) => Promise<string>;
+  }
+}
+
+function fail(msg: string): never {
+  console.error(`diagram-render: ${msg}`);
+  process.exit(1);
+}
+
+function arg(name: string): string | undefined {
+  const i = process.argv.indexOf(`--${name}`);
+  const v = i > 0 ? process.argv[i + 1] : undefined;
+  if (v?.startsWith("--")) fail(`--${name} is missing its value`);
+  return v;
+}
+
+const input = arg("in") ?? fail("--in <file.excalidraw> is required");
+const output = arg("out") ?? input.replace(/\.excalidraw$/, "") + ".svg";
+if (!existsSync(input)) fail(`no such file: ${input}`);
+
+let scene: { type?: string; elements?: unknown[] };
+try {
+  scene = JSON.parse(await readFile(input, "utf8"));
+} catch (e) {
+  fail(`${input} is not valid JSON: ${(e as Error).message}`);
+}
+if (scene.type !== "excalidraw") fail(`expected type "excalidraw", got "${scene.type}"`);
+if (!Array.isArray(scene.elements) || scene.elements.length === 0) {
+  fail("scene has no elements — nothing to render");
+}
+
+const bundle = join(import.meta.dir, "renderer/bundle.js");
+if (!existsSync(bundle)) {
+  console.error("diagram-render: building renderer bundle (first run)…");
+  try {
+    execSync("bun run build", { cwd: import.meta.dir, stdio: "inherit" });
+  } catch {
+    fail(`renderer bundle build failed — run: cd ${import.meta.dir} && bun install && bun run build`);
+  }
+}
+
+// Chromium resolution order: explicit env, playwright's own cache, system installs.
+function chromiumPath(): string {
+  const envPath = process.env.AGENTKIT_CHROMIUM;
+  if (envPath && existsSync(envPath)) return envPath;
+  const candidates = [
+    "/usr/bin/chromium", "/usr/bin/chromium-browser",
+    "/usr/bin/google-chrome", "/opt/google/chrome/chrome",
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+  ];
+  for (const c of candidates) if (existsSync(c)) return c;
+  return ""; // let playwright try its default cache
+}
+
+const { chromium } = await import("playwright-core");
+const exe = chromiumPath();
+const browser = await chromium
+  .launch(exe ? { executablePath: exe } : {})
+  .catch((e: Error) =>
+    fail(`no usable Chromium (${e.message.split("\n")[0]}) — set AGENTKIT_CHROMIUM or run: bunx playwright install chromium`)
+  );
+
+// Failures inside the try are thrown (not fail()ed) so the finally can close
+// the browser — process.exit skips finally blocks.
+try {
+  const page = await browser.newPage();
+  const errors: string[] = [];
+  page.on("pageerror", (e) => errors.push(String(e)));
+  await page.setContent("<!doctype html><html><body></body></html>");
+  await page.addScriptTag({ path: bundle, type: "module" });
+  await page
+    .waitForFunction(() => typeof window.renderExcalidrawToSvg === "function", undefined, { timeout: 15000 })
+    .catch(() => {
+      throw new Error(`renderer bundle failed to initialize${errors.length ? `: ${errors[0]}` : ""}`);
+    });
+  const svg: string = await page.evaluate((s) => window.renderExcalidrawToSvg(s), scene);
+  if (!svg.startsWith("<svg")) throw new Error("renderer returned no SVG");
+  await writeFile(output, svg).catch((e: Error) => {
+    throw new Error(`cannot write ${output}: ${e.message}`);
+  });
+  const png = arg("png");
+  if (png) {
+    // A PNG twin lets the authoring agent LOOK at the result (Read renders
+    // images, not SVG) for the render-view-fix loop.
+    await page.setContent(`<!doctype html><body style="margin:0;background:#fff">${svg}</body>`);
+    const el = page.locator("svg").first();
+    await el.screenshot({ path: png }).catch((e: Error) => {
+      throw new Error(`cannot write ${png}: ${e.message}`);
+    });
+  }
+  console.log(output);
+} catch (e) {
+  await browser.close();
+  fail((e as Error).message);
+} finally {
+  await browser.close().catch(() => {});
+}

--- a/plugins-cc/agentkit/skills/diagram/renderer/entry.ts
+++ b/plugins-cc/agentkit/skills/diagram/renderer/entry.ts
@@ -1,0 +1,20 @@
+import { exportToSvg } from "@excalidraw/excalidraw";
+
+declare global {
+  interface Window {
+    renderExcalidrawToSvg: (scene: {
+      elements: unknown[];
+      appState?: Record<string, unknown>;
+      files?: Record<string, unknown> | null;
+    }) => Promise<string>;
+  }
+}
+
+window.renderExcalidrawToSvg = async (scene) => {
+  const svg = await exportToSvg({
+    elements: scene.elements as never,
+    appState: { exportBackground: false, exportEmbedScene: false, ...scene.appState } as never,
+    files: (scene.files ?? null) as never,
+  });
+  return svg.outerHTML;
+};

--- a/plugins-cc/agentkit/skills/product-review/SKILL.md
+++ b/plugins-cc/agentkit/skills/product-review/SKILL.md
@@ -119,14 +119,12 @@ Two rules carried over from diff review, because they were learned the hard
 way: report what you actually observed rather than what the code implies, and
 never describe coverage you did not obtain.
 
-## Claims audit and reflection log
+## Claims audit
 
-Both apply here exactly as in diff review, and both are specified in the
-**autonomous-workflow** skill under "Review Gates The Merge": audit the diff's
-factual claims against reality before passing, and append any _process_ gap you
-find to `~/.agentkit/reflections.jsonl`. Do them as part of this lane too — a
-product reviewer sees claim defects a diff reviewer cannot (a README that
-promises behaviour the product does not have).
+Apply the claims audit specified in the **autonomous-workflow** skill under
+"Review Gates The Merge" as part of this lane too. A product reviewer sees
+claim defects a diff reviewer cannot, such as a README that promises behaviour
+the product does not have.
 
 ### Observed vs inferred
 
@@ -136,8 +134,8 @@ description — mark which it is:
 - `Probe-verified: <the payload or output you actually saw>`
 - `Inferred from the documented meaning of X` / `inferred from the call site`
 
-Reviewers caught this exact overstatement repeatedly in one session. Marking it
-as you write costs a phrase; having it found costs a round.
+Marking the evidence boundary while writing keeps observation and inference
+from being reported as the same thing.
 
 ## Scope
 

--- a/plugins-cc/agentkit/skills/product-review/SKILL.md
+++ b/plugins-cc/agentkit/skills/product-review/SKILL.md
@@ -119,6 +119,36 @@ Two rules carried over from diff review, because they were learned the hard
 way: report what you actually observed rather than what the code implies, and
 never describe coverage you did not obtain.
 
+## Claims audit — required, any review lane
+
+Applies to diff review as much as product review. Reviewing only the logic
+lets false statements through: in one day, an MR description asserted "every
+currently paired device sends the old frame shape" (`git grep` showed the frame
+did not exist on the other repo's main — the population was empty); a comment
+cited probe evidence for a correlation branch (the probe predated the change
+that would exercise it, so it evidenced a different case); and an authority
+table added to prevent drift carried a row contradicted by code in the same
+file.
+
+Grep the diff's comments, commit messages and MR/PR description for factual
+claims — especially **every, always, never, all, verified, probed, cannot** —
+and check each one against reality: `git grep`, a probe, or the code itself.
+
+Report any claim that outruns its evidence as a finding, **even when the code
+is correct**. Wrong prose is not cosmetic: it teaches the next reader a wrong
+model of the system, and the next change is made against that model.
+
+### Observed vs inferred
+
+When you state a fact — in a finding, a comment, a commit message, an MR
+description — mark which it is:
+
+- `Probe-verified: <the payload or output you actually saw>`
+- `Inferred from the documented meaning of X` / `inferred from the call site`
+
+Reviewers caught this exact overstatement repeatedly in one session. Marking it
+as you write costs a phrase; having it found costs a round.
+
 ## Scope
 
 Product review does NOT replace diff review — it adds the lens diff review

--- a/plugins-cc/agentkit/skills/product-review/SKILL.md
+++ b/plugins-cc/agentkit/skills/product-review/SKILL.md
@@ -119,24 +119,14 @@ Two rules carried over from diff review, because they were learned the hard
 way: report what you actually observed rather than what the code implies, and
 never describe coverage you did not obtain.
 
-## Claims audit — required, any review lane
+## Claims audit and reflection log
 
-Applies to diff review as much as product review. Reviewing only the logic
-lets false statements through: in one day, an MR description asserted "every
-currently paired device sends the old frame shape" (`git grep` showed the frame
-did not exist on the other repo's main — the population was empty); a comment
-cited probe evidence for a correlation branch (the probe predated the change
-that would exercise it, so it evidenced a different case); and an authority
-table added to prevent drift carried a row contradicted by code in the same
-file.
-
-Grep the diff's comments, commit messages and MR/PR description for factual
-claims — especially **every, always, never, all, verified, probed, cannot** —
-and check each one against reality: `git grep`, a probe, or the code itself.
-
-Report any claim that outruns its evidence as a finding, **even when the code
-is correct**. Wrong prose is not cosmetic: it teaches the next reader a wrong
-model of the system, and the next change is made against that model.
+Both apply here exactly as in diff review, and both are specified in the
+**autonomous-workflow** skill under "Review Gates The Merge": audit the diff's
+factual claims against reality before passing, and append any _process_ gap you
+find to `~/.agentkit/reflections.jsonl`. Do them as part of this lane too — a
+product reviewer sees claim defects a diff reviewer cannot (a README that
+promises behaviour the product does not have).
 
 ### Observed vs inferred
 

--- a/plugins-cc/agentkit/skills/publish-page/SKILL.md
+++ b/plugins-cc/agentkit/skills/publish-page/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: publish-page
+description: Publish content as a live web page with a stable URL (AgentKit Pages, self-hosted artifacts). Use AUTOMATICALLY whenever the user asks to publish/share/host a page, make an artifact/report/dashboard/slide deck/design doc viewable in a browser, or when rich formatted output would clearly beat chat text. Also triggers on "make a page", "put this on a page", "publish this", "as a deck/slides", "share a link". Renders markdown or HTML through themes and returns the live URL.
+---
+
+# publish-page
+
+You publish pages **end-to-end without asking the user for details**. Like creating
+an artifact: decide, publish, hand back the URL.
+
+## Automated workflow
+
+1. **Write the content** to a temp file (scratchpad). Markdown for docs/decks;
+   complete self-contained HTML for bespoke pages (dashboards, visualizations).
+2. **Pick a logical name yourself**: short, descriptive, lowercase `a-z0-9-`,
+   e.g. `fcar-q3-report`, `auth-flow-design`. The URL is derived as
+   HMAC(slug key, name) — cryptic hex nobody can guess, but deterministic: the
+   same name republished updates the SAME URL, and `--delete --name <name>`
+   finds it again. No mapping to store.
+   Use `--slug <path>` INSTEAD only when the user explicitly wants a
+   human-readable URL (up to 4 `/` segments).
+3. **Pick the template yourself**: `doc` (default, report/article), `deck`
+   (slides — split on `---` lines in markdown), `raw` (complete HTML published
+   as-is).
+4. **Run** (one-time per machine: `cd <skill-dir> && bun install`):
+
+```bash
+bun <skill-dir>/publish.ts --name <name> --file <content-file> [--template doc|deck|raw] [--title "Title"]
+bun <skill-dir>/publish.ts --name <name> --delete    # remove a page you published
+```
+
+5. **Give the user the URL** it prints (`https://pages.agentkit.sbs/<slug>`).
+   That URL is live immediately.
+
+## Page design — the house style is built in
+
+Pages should look designed, not dumped. The doc/deck themes carry the house
+identity automatically (**dark navy** ground `#071224→#0a1c38`, ink `#dce7f5`,
+green accent `#34d3a6`, gold `#e8b444`, panels `#102847`, lines `#1e3a5f`,
+mono eyebrows) — never re-explain or re-style these basics. Also automatic, no
+agent action needed: a **dark/light theme toggle** (persisted; mermaid
+re-renders on flip), a **TOC dot rail** with smooth scrolling on docs with ≥3
+`h2` sections, prev/next **nav buttons** on decks, and **hover lift/glow** on
+every card and diagram node. Add `data-tip="text"` to any node for a hover
+tooltip.
+
+**Be illustrative by default.** Structure every doc page as sections and pick the
+strongest component for each idea — don't produce walls of prose:
+
+- **Diagrams: pick the treatment by what the diagram IS** — never default to one
+  tool, and never ASCII art. Wrap EVERY diagram in
+  `<div class="figure">…<div class="figcaption"><strong>Name</strong> — what it shows</div></div>`
+  with a caption describing the content (say "Publish flow — from agent to live
+  page", never the technology used to draw it). CRITICAL for markdown files:
+  leave a BLANK LINE after `<div class="figure">` and before the closing
+  markup — CommonMark otherwise swallows a fence inside an HTML block and the
+  page silently shows literal backticks instead of a diagram.
+  - **Hand-crafted architecture/explainer diagrams (highest quality)** → the
+    `diagram` skill: author Excalidraw JSON per its methodology, render to
+    self-contained SVG, inline the SVG inside a `.figure` with a semantic
+    caption. Zero page runtime. Prefer this for the centerpiece diagram of a
+    page; use the kits below for quick supporting visuals.
+  - **System/architecture topology** → the isometric kit (the standout look):
+    `<div class="iso"><div class="iso-node hot"><div class="tile"><div class="side"></div><div class="top"><div class="glyph">SVG</div></div></div><div class="tag">name</div></div>…</div>`
+    Variants `.hot` (green) / `.gold` for emphasis. Draw each glyph as a simple
+    inline 24×24 SVG outline icon (stroke `#8fa8c7`, or `#34d3a6`/`#e8b444` on
+    emphasized nodes, stroke-width 1.5, fill none) matching the node's meaning —
+    a database cylinder, a globe, a cloud, a terminal chevron, a bot face.
+  - **Drawn connectors (draw.io-style)**: give nodes `id="n1"` etc. and declare
+    edges anywhere inside the same `.figure`:
+    `<span class="edge" data-from="n1" data-to="n2" data-label="PUT"></span>`
+    — the theme draws glowing curved arrows with labels between the node
+    centers automatically, and redraws them on resize and theme flip. Works
+    over `.iso` tiles and `.arch` nodes alike.
+  - **Pipelines/flows with descriptions** → the premium flat kit:
+    `<div class="arch"><div class="arch-row"><div class="arch-node hot"><svg class="ic">…</svg><div class="nm">Name</div><div class="ds">detail</div></div></div><div class="arch-join">edge label</div>…</div>`
+  - **Sequences, state machines, dense graphs, gantt** → mermaid fences (the
+    runtime is auto-inlined, themed to the navy palette; costs ~3.4 MB of the
+    5 MB cap, leaving ~1.4 MB for content):
+    ````
+    <div class="figure">
+
+    ```mermaid
+    sequenceDiagram
+      agent->>worker: PUT page
+    ```
+
+    <div class="figcaption"><strong>Publish sequence</strong> — write path</div>
+    </div>
+    ````
+  - **Charts (data)** → hand-built inline SVG following chart discipline: thin
+    marks, one axis only (never dual-axis), a muted recessive grid, series
+    colors from the accent family, direct labels over legends when ≤ 4 series,
+    text in ink/muted tokens never in series colors. If a `dataviz` skill is
+    available in the harness, load it and follow it; these rules are the
+    baked-in fallback so charts come out right on any harness.
+- **Section headers**: `<div class="kicker">01 — topic</div>` before an `## h2`.
+- **Enumerable concepts** (features, components, principles): a 2-column grid —
+  `<div class="cards"><div class="card"><h3><code>name</code></h3><p>…</p></div>…</div>`
+- **Key decisions / warnings**: `<div class="callout"><strong>Label.</strong> text</div>`
+- **Metadata rows**: `<div class="chips"><span class="chip"><strong>Status</strong> live</span>…</div>`
+- **Pipeline/stage boxes** (when mermaid is overkill):
+  `<div class="flow"><div class="frow"><div class="fbox gate"><span class="t">stage</span><span class="d">detail</span></div>…</div><div class="arrow">▼</div>…</div>`
+  — `.fbox` variants: `.gate` (gold), `.ok` (green), `.deny` (red).
+- **Facts with columns**: markdown tables (themed automatically).
+
+All of these work inside markdown files — markdown passes raw HTML through.
+Decks: one idea per slide, kicker + h2 + a few bullets or one diagram/card grid;
+put heavy diagrams on their own slide. Raw pages: full freedom, but reuse the
+navy tokens above so pages feel like one product.
+
+## Requirements and behavior
+
+- Publish token: `~/.config/agentkit/pages-token` (mint at agentkit.sbs).
+- Themes are bundled with the skill; if a clone of `gitlab.com/agentkit/agentkit-pages`
+  exists at `~/code/agentkit-pages` (override: `AGENTKIT_PAGES_REPO`), the publish
+  also commits `src/` + `dist/` there for canonical history — otherwise it
+  serves-only and says so. Endpoint override: `AGENTKIT_PAGES_ENDPOINT`.
+- Pages are **public by slug** (unguessable is NOT private) — never publish
+  secrets, tokens, or personal data. Accounts/private pages are a coming phase.
+  "Without asking" covers slug/template/mechanics only: when the user asked to
+  publish, publish. When YOU are proposing the page and its content derives from
+  private material (client data, internal repos, credentials-adjacent config),
+  confirm with the user before publishing.
+- Same name (or slug) republished overwrites silently, and on machines without
+  the pages repo clone there is no git history to recover from — pick
+  distinctive names, reuse one only when deliberately updating that page.
+  `--no-git` skips the canonical commit explicitly (same effect as a missing
+  clone).
+- Slug key: `~/.config/agentkit/pages-slug-key`, auto-generated on first use,
+  deliberately separate from the auth token so credential rotation never
+  changes a URL. Copy the SAME key to other machines (alongside the token) or
+  the same name derives different URLs per machine. Losing the key strands
+  HMAC-derived pages from `--name` reach — recover slugs from the pages repo
+  `meta.yaml` and manage them via `--slug`.
+- Pages must be self-contained: inline all CSS/JS, `data:` URIs for images. The
+  serving CSP blocks every external request. Max 5 MB.
+- Errors are loud; fix and re-run. Do not fall back to pasting the content into
+  chat without saying the publish failed.

--- a/plugins-cc/agentkit/skills/publish-page/package.json
+++ b/plugins-cc/agentkit/skills/publish-page/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "publish-page-skill",
+  "private": true,
+  "dependencies": {
+    "marked": "^18.0.7",
+    "mermaid": "11.16.0"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.2.19"
+  }
+}

--- a/plugins-cc/agentkit/skills/publish-page/publish.ts
+++ b/plugins-cc/agentkit/skills/publish-page/publish.ts
@@ -1,0 +1,246 @@
+#!/usr/bin/env bun
+import { marked } from "marked";
+import { createHmac, randomBytes } from "node:crypto";
+import { existsSync } from "node:fs";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const SLUG_RE = /^[a-z0-9][a-z0-9-]{0,63}(\/[a-z0-9][a-z0-9-]{0,63}){0,3}$/;
+
+function fail(msg: string): never {
+  console.error(`publish-page: ${msg}`);
+  process.exit(1);
+}
+
+function arg(name: string): string | undefined {
+  const i = process.argv.indexOf(`--${name}`);
+  const v = i > 0 ? process.argv[i + 1] : undefined;
+  if (v?.startsWith("--")) fail(`--${name} is missing its value (got "${v}")`);
+  return v;
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) =>
+    ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c] as string
+  );
+}
+
+const explicitSlug = arg("slug");
+const name = arg("name");
+const isDelete = process.argv.includes("--delete");
+const file = arg("file");
+const template = arg("template") ?? "doc";
+let noGit = process.argv.includes("--no-git");
+if (!explicitSlug && !name) fail("--name (cryptic URL, default) or --slug (readable URL) is required");
+if (explicitSlug && !SLUG_RE.test(explicitSlug)) {
+  fail(`invalid slug "${explicitSlug}" (lowercase a-z0-9-, max 4 segments)`);
+}
+if (name && !/^[a-z0-9][a-z0-9-]{0,63}$/.test(name)) {
+  fail(`invalid name "${name}" (lowercase a-z0-9-)`);
+}
+if (!["doc", "deck", "raw"].includes(template)) fail(`unknown template "${template}"`);
+if (!isDelete && !file) fail("--file is required");
+if (!isDelete && !existsSync(file!)) fail(`no such file: ${file}`);
+
+const endpoint = process.env.AGENTKIT_PAGES_ENDPOINT ?? "https://pages.agentkit.sbs";
+const endpointHost = new URL(endpoint).hostname;
+if (!endpoint.startsWith("https://") && !["127.0.0.1", "localhost"].includes(endpointHost)) {
+  fail(`endpoint must be https (got ${endpoint}) — the bearer token would travel in cleartext`);
+}
+const repo = process.env.AGENTKIT_PAGES_REPO ?? join(homedir(), "code/agentkit-pages");
+const tokenPath = join(homedir(), ".config/agentkit/pages-token");
+if (!existsSync(tokenPath)) fail(`publish token missing at ${tokenPath}`);
+const token = (await readFile(tokenPath, "utf8")).trim();
+
+// Cryptic-but-deterministic slug: HMAC(slug key, name). The slug key is a
+// dedicated secret — NOT the auth token — so rotating credentials never
+// changes or orphans a URL, and a leaked slug key grants no write access.
+// Generated once per install; copy the same key to other machines for
+// cross-machine determinism.
+const slugKeyPath = join(homedir(), ".config/agentkit/pages-slug-key");
+async function slugKey(): Promise<string> {
+  if (existsSync(slugKeyPath)) return (await readFile(slugKeyPath, "utf8")).trim();
+  const key = randomBytes(32).toString("hex");
+  await writeFile(slugKeyPath, key, { mode: 0o600 });
+  console.error(`note: generated new slug key at ${slugKeyPath} — copy it to other machines for same-name URL determinism`);
+  return key;
+}
+const slug = explicitSlug
+  ?? createHmac("sha256", await slugKey()).update(name!).digest("hex").slice(0, 20);
+const pageLabel = name ?? slug;
+
+const git = (...args: string[]) =>
+  Bun.spawnSync(["git", "-C", repo, ...args], { stdout: "pipe", stderr: "pipe" });
+const repoAvailable = () => existsSync(join(repo, ".git"));
+
+function commitScoped(message: string, paths: string[]) {
+  const staged = git("diff", "--cached", "--quiet", "--", ...paths);
+  if (staged.exitCode === 0) return;
+  // Pathspec-scoped commit: the clone is long-lived and shared — a bare
+  // commit would sweep anything else staged into this publish.
+  const commit = git("commit", "-m", message, "--", ...paths);
+  if (commit.exitCode === 0) {
+    const push = git("push");
+    if (push.exitCode !== 0) {
+      console.error(`warning: git push failed — commit is local only:\n${push.stderr.toString()}`);
+    }
+  } else {
+    console.error(`warning: git commit failed:\n${commit.stderr.toString()}`);
+  }
+}
+
+if (isDelete) {
+  const res = await fetch(`${endpoint}/api/pages/${slug}`, {
+    method: "DELETE",
+    headers: { authorization: `Bearer ${token}` },
+  });
+  if (res.status === 404) fail(`no page at ${slug} — nothing deleted`);
+  if (!res.ok) fail(`delete failed: HTTP ${res.status} ${await res.text()}`);
+  if (!noGit && repoAvailable()) {
+    await rm(join(repo, "src", slug), { recursive: true, force: true });
+    await rm(join(repo, "dist", slug), { recursive: true, force: true });
+    git("add", "-A", "--", `src/${slug}`, `dist/${slug}`);
+    commitScoped(`pages: delete ${pageLabel}`, [`src/${slug}`, `dist/${slug}`]);
+  }
+  console.log(`deleted: ${endpoint}/${slug}`);
+  process.exit(0);
+}
+
+const source = await readFile(file!, "utf8");
+const isMd = /\.(md|markdown|mdown)$/i.test(file!);
+const title = arg("title")
+  ?? source.match(/^#\s+(.+)$/m)?.[1]
+  ?? source.match(/<title>([^<]+)<\/title>/)?.[1]
+  ?? pageLabel;
+
+// Split markdown into slides on `---` lines, ignoring YAML frontmatter and
+// `---` inside fenced code blocks — a naive regex split cuts fences in half.
+function splitSlides(md: string): string[] {
+  let lines = md.split("\n");
+  if (lines[0]?.trim() === "---") {
+    const close = lines.findIndex((l, i) => i > 0 && l.trim() === "---");
+    if (close > 0) lines = lines.slice(close + 1);
+  }
+  const slides: string[][] = [[]];
+  let fence: string | null = null;
+  for (const line of lines) {
+    const open = line.match(/^\s*(```|~~~)/)?.[1];
+    if (open) fence = fence === open ? null : fence ?? open;
+    if (!fence && line.trim() === "---") slides.push([]);
+    else slides[slides.length - 1].push(line);
+  }
+  return slides.map((s) => s.join("\n"));
+}
+
+// Mermaid fences via marked's renderer, not a regex: fence-aware (nesting,
+// splitSlides sees real fences) and escaped (mermaid decodes via textContent).
+marked.use({
+  renderer: {
+    code({ text, lang }: { text: string; lang?: string }) {
+      return lang === "mermaid" ? `<pre class="mermaid">${escapeHtml(text)}</pre>\n` : false;
+    },
+  },
+});
+
+async function mermaidRuntime(): Promise<string> {
+  const dist = join(import.meta.dir, "node_modules/mermaid/dist/mermaid.min.js");
+  if (!existsSync(dist)) fail(`mermaid runtime missing at ${dist} — run: cd ${import.meta.dir} && bun install`);
+  const js = await readFile(dist, "utf8");
+  // Decks render diagrams per-slide (hidden slides have zero width, which breaks
+  // mermaid's measurements) — the deck theme's show() calls mermaid.run on the
+  // active slide; docs render everything immediately.
+  const init = `(() => {
+  const NAVY = { darkMode: true, background: "transparent", primaryColor: "#102847", primaryBorderColor: "#2e4f7e", primaryTextColor: "#dce7f5", secondaryColor: "#0d2140", tertiaryColor: "#0d2f3a", lineColor: "#5f7ca3", edgeLabelBackground: "#071224", nodeBorder: "#2e4f7e", mainBkg: "#102847", clusterBkg: "#0d2140", clusterBorder: "#1e3a5f", fontFamily: "ui-monospace, Menlo, monospace", fontSize: "14px", actorBkg: "#102847", actorBorder: "#2e4f7e", actorTextColor: "#dce7f5", signalColor: "#5f7ca3", signalTextColor: "#8fa8c7", noteBkgColor: "#0d2f3a", noteTextColor: "#dce7f5", noteBorderColor: "#1e3a5f" };
+  const LIGHT = { darkMode: false, background: "transparent", primaryColor: "#ffffff", primaryBorderColor: "#b9c9da", primaryTextColor: "#16202c", secondaryColor: "#eef4fa", tertiaryColor: "#ddf1ea", lineColor: "#5b6b7c", edgeLabelBackground: "#e6edf5", nodeBorder: "#b9c9da", mainBkg: "#ffffff", clusterBkg: "#eef4fa", clusterBorder: "#cfdae6", fontFamily: "ui-monospace, Menlo, monospace", fontSize: "14px", actorBkg: "#ffffff", actorBorder: "#b9c9da", actorTextColor: "#16202c", signalColor: "#5b6b7c", signalTextColor: "#5b6b7c", noteBkgColor: "#ddf1ea", noteTextColor: "#16202c", noteBorderColor: "#cfdae6" };
+  const srcs = new Map();
+  function renderAll() {
+    const light = document.documentElement.dataset.theme === "light";
+    mermaid.initialize({ startOnLoad: false, theme: "base", themeVariables: light ? LIGHT : NAVY, flowchart: { curve: "basis", nodeSpacing: 46, rankSpacing: 56, padding: 12 } });
+    document.querySelectorAll("pre.mermaid").forEach((el) => {
+      if (!srcs.has(el)) srcs.set(el, el.textContent);
+      el.removeAttribute("data-processed");
+      el.replaceChildren();
+      el.textContent = srcs.get(el);
+    });
+    if (document.querySelector(".slide")) mermaid.run({ querySelector: ".slide.active pre.mermaid" });
+    else mermaid.run();
+  }
+  renderAll();
+  addEventListener("agentkit-theme", renderAll);
+})();`;
+  return `\n<script>${js}</script>\n<script>${init}</script>`;
+}
+
+async function render(): Promise<string> {
+  if (template === "raw") return source;
+  // Canonical themes live in the agentkit-pages repo; the skill bundles a copy
+  // so publishing works on machines without the repo clone.
+  const repoTheme = join(repo, "themes", `${template}.html`);
+  const bundledTheme = join(import.meta.dir, "themes", `${template}.html`);
+  const themePath = existsSync(repoTheme) ? repoTheme : bundledTheme;
+  if (!existsSync(themePath)) fail(`theme not found: ${repoTheme} or ${bundledTheme}`);
+  const theme = await readFile(themePath, "utf8");
+  if (themePath === repoTheme && existsSync(bundledTheme)) {
+    const bundled = await readFile(bundledTheme, "utf8");
+    if (bundled !== theme) {
+      console.error(`warning: bundled theme drifted from canonical ${repoTheme} — re-sync skills/publish-page/themes/`);
+    }
+  }
+  let content: string;
+  if (template === "deck") {
+    const parts = isMd
+      ? splitSlides(source).map((s) => marked.parse(s) as string)
+      : source.split(/<hr\b[^>]*>/i);
+    content = parts
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .map((s) => `<section class="slide">\n${s}\n</section>`)
+      .join("\n");
+  } else {
+    content = isMd ? (marked.parse(source) as string) : source;
+  }
+  if (content.includes('class="mermaid"')) content += await mermaidRuntime();
+  // Function replacers: a plain string replacement expands $&, $`, $' found in
+  // page content and silently corrupts the output.
+  return theme
+    .replaceAll("{{TITLE}}", () => escapeHtml(title))
+    .replaceAll("{{CONTENT}}", () => content);
+}
+
+const html = await render();
+if (Buffer.byteLength(html) > 5 * 1024 * 1024) {
+  const hint = html.includes("mermaid.initialize")
+    ? " (the inlined mermaid runtime accounts for ~3.4 MB — diagram pages have ~1.4 MB left for content; split the page or drop diagrams)"
+    : "";
+  fail(`rendered page exceeds 5 MB${hint}`);
+}
+
+const res = await fetch(`${endpoint}/api/pages/${slug}`, {
+  method: "PUT",
+  headers: { authorization: `Bearer ${token}` },
+  body: html,
+});
+if (!res.ok) fail(`publish failed: HTTP ${res.status} ${await res.text()}`);
+const { url } = (await res.json()) as { url: string };
+
+if (!noGit && !repoAvailable()) {
+  console.error(`note: pages repo not found at ${repo} — published without canonical git commit`);
+  noGit = true;
+}
+if (!noGit) {
+  const srcDir = join(repo, "src", slug);
+  const distDir = join(repo, "dist", slug);
+  await mkdir(srcDir, { recursive: true });
+  await mkdir(distDir, { recursive: true });
+  await writeFile(join(srcDir, isMd ? "content.md" : "content.html"), source);
+  await writeFile(
+    join(srcDir, "meta.yaml"),
+    `title: ${JSON.stringify(title)}\nname: ${JSON.stringify(pageLabel)}\ntemplate: ${template}\nslug: ${slug}\n`,
+  );
+  await writeFile(join(distDir, "index.html"), html);
+  git("add", `src/${slug}`, `dist/${slug}`);
+  commitScoped(`pages: publish ${pageLabel}`, [`src/${slug}`, `dist/${slug}`]);
+}
+
+console.log(url);

--- a/plugins-cc/agentkit/skills/publish-page/themes/deck.html
+++ b/plugins-cc/agentkit/skills/publish-page/themes/deck.html
@@ -1,0 +1,262 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{{TITLE}}</title>
+<script>
+  (() => {
+    const saved = localStorage.getItem("agentkit-theme");
+    if (saved === "light" || saved === "dark") document.documentElement.dataset.theme = saved;
+  })();
+</script>
+<style>
+  /* AgentKit Pages house deck theme — dark navy default, light via toggle. */
+  :root {
+    --navy: #0a1c38; --navy-deep: #071224; --card: #102847; --code-bg: #0d2140;
+    --line: #1e3a5f; --ink: #dce7f5; --muted: #8fa8c7;
+    --accent: #34d3a6; --accent-soft: #0d2f3a; --gold: #e8b444; --red: #e06c5f;
+    --fig-glow: #0f2a4d; --node-hi: #173562; --node-lo: #0c2140; --node-border: #2e4f7e;
+    --tile-side: #061021;
+  }
+  html[data-theme="light"] {
+    --navy: #f2f6fa; --navy-deep: #e6edf5; --card: #ffffff; --code-bg: #e9eff6;
+    --line: #cfdae6; --ink: #16202c; --muted: #5b6b7c;
+    --accent: #0c8f6c; --accent-soft: #ddf1ea; --gold: #a97b10; --red: #bb4335;
+    --fig-glow: #dde8f3; --node-hi: #ffffff; --node-lo: #eef4fa; --node-border: #b9c9da;
+    --tile-side: #c4d2e0;
+  }
+  * { box-sizing: border-box; }
+  html, body { height: 100%; }
+  body {
+    background: linear-gradient(180deg, var(--navy-deep) 0%, var(--navy) 60vh);
+    color: var(--ink); margin: 0;
+    font-family: system-ui, -apple-system, "Segoe UI", sans-serif; line-height: 1.6;
+    transition: background 0.3s, color 0.3s;
+  }
+  .slide {
+    display: none; height: 100vh; padding: 6vh 8vw; overflow-y: auto;
+    flex-direction: column; justify-content: center;
+  }
+  .slide.active { display: flex; }
+  .slide h1 { font-size: clamp(1.8rem, 5vw, 3.2rem); letter-spacing: -0.02em; line-height: 1.1; text-wrap: balance; margin: 0 0 1rem; }
+  .slide h2 { font-size: clamp(1.4rem, 3.5vw, 2.2rem); letter-spacing: -0.01em; text-wrap: balance; margin: 0 0 1rem; }
+  .slide p, .slide li { font-size: clamp(1rem, 1.8vw, 1.25rem); max-width: 60ch; }
+  .slide li { margin-bottom: 0.5rem; }
+  a { color: var(--accent); }
+  code {
+    font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 0.85em;
+    background: var(--code-bg); border-radius: 4px; padding: 0.1em 0.35em;
+  }
+  pre { background: var(--navy-deep); border: 1px solid var(--line); border-radius: 8px; padding: 1rem 1.2rem; overflow-x: auto; font-size: clamp(0.75rem, 1.4vw, 0.95rem); }
+  pre code { background: none; padding: 0; }
+  table { border-collapse: collapse; display: block; overflow-x: auto; }
+  th, td { padding: 0.5rem 0.9rem 0.5rem 0; border-bottom: 1px solid var(--line); text-align: left; }
+  th { color: var(--muted); font-family: ui-monospace, Menlo, monospace; font-size: 0.72rem; letter-spacing: 0.1em; text-transform: uppercase; font-weight: 500; }
+  .kicker {
+    font-family: ui-monospace, Menlo, monospace; font-size: 0.75rem;
+    letter-spacing: 0.14em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.6rem;
+  }
+  .cards { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.9rem; margin: 1rem 0; }
+  @media (max-width: 40rem) { .cards { grid-template-columns: 1fr; } }
+  .card {
+    background: var(--card); border: 1px solid var(--line); border-radius: 10px;
+    padding: 1rem 1.2rem; transition: transform 0.18s, border-color 0.18s;
+  }
+  .card:hover { transform: translateY(-2px); border-color: var(--accent); }
+  .card h3 { margin: 0 0 0.35rem; font-size: 1rem; }
+  .card h3 code { color: var(--accent); background: none; padding: 0; }
+  .card p { margin: 0; color: var(--muted); font-size: 0.92rem; max-width: none; }
+  .callout {
+    border: 1px solid var(--line); background: var(--accent-soft); border-radius: 8px;
+    padding: 0.8rem 1.1rem; margin: 1rem 0; max-width: 60ch;
+  }
+  .callout strong { color: var(--accent); }
+  .figure {
+    background: radial-gradient(ellipse at 30% 0%, var(--fig-glow) 0%, var(--navy-deep) 70%);
+    border: 1px solid var(--line); border-radius: 14px; padding: 1.6rem 1.4rem 1rem;
+    margin: 1.2rem 0; overflow-x: auto; position: relative;
+  }
+  .figcaption {
+    font-family: ui-monospace, Menlo, monospace; font-size: 0.74rem;
+    letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted);
+    text-align: center; margin-top: 0.9rem; padding-top: 0.9rem;
+    border-top: 1px solid var(--line);
+  }
+  .figcaption strong { color: var(--accent); font-weight: 600; }
+  .figure pre.mermaid { background: none; border: 0; margin: 0; }
+  pre.mermaid {
+    background: var(--card); border: 1px solid var(--line); border-radius: 10px;
+    padding: 1rem; overflow-x: auto; text-align: center;
+  }
+  pre.mermaid svg { max-width: 100%; height: auto; }
+  .mermaid .node:hover, .mermaid .actor:hover { filter: brightness(1.25); }
+  .iso {
+    display: grid; grid-template-columns: repeat(3, minmax(7.5rem, 1fr));
+    gap: 0.6rem 1.2rem; justify-items: center; padding: 1.6rem 0 0.4rem;
+    position: relative; z-index: 1;
+  }
+  .iso-node { display: flex; flex-direction: column; align-items: center; gap: 1.4rem; }
+  .iso-node .tile {
+    width: 6.4rem; aspect-ratio: 1; position: relative;
+    transform: rotateX(55deg) rotateZ(-45deg); transform-style: preserve-3d;
+    transition: transform 0.2s;
+  }
+  .iso-node:hover .tile { transform: rotateX(55deg) rotateZ(-45deg) translateZ(10px); }
+  .iso-node .top {
+    position: absolute; inset: 0; border-radius: 14px;
+    background: linear-gradient(135deg, var(--node-hi) 0%, var(--node-lo) 100%);
+    border: 1px solid var(--node-border); box-shadow: inset 0 0 24px rgba(52, 211, 166, 0.07);
+    transform: translateZ(16px);
+    display: flex; align-items: center; justify-content: center;
+    transition: border-color 0.2s, box-shadow 0.2s;
+  }
+  .iso-node:hover .top { border-color: var(--accent); box-shadow: inset 0 0 30px rgba(52, 211, 166, 0.25); }
+  .iso-node .side { position: absolute; inset: 0; border-radius: 14px; background: var(--tile-side); box-shadow: 0 0 0 1px var(--line); }
+  .iso-node.hot .top { border-color: var(--accent); box-shadow: inset 0 0 26px rgba(52, 211, 166, 0.2); }
+  .iso-node.gold .top { border-color: var(--gold); box-shadow: inset 0 0 26px rgba(232, 180, 68, 0.16); }
+  .iso-node .glyph { width: 46%; height: 46%; transform: rotateZ(45deg) rotateX(-40deg); filter: drop-shadow(0 4px 6px rgba(0, 0, 0, 0.5)); }
+  .iso-node .glyph svg { width: 100%; height: 100%; }
+  .iso-node .tag {
+    font-family: ui-monospace, Menlo, monospace; font-size: 0.72rem; letter-spacing: 0.08em;
+    color: var(--ink); background: var(--navy-deep); border: 1px solid var(--line);
+    border-radius: 6px; padding: 0.15rem 0.6rem; white-space: nowrap;
+  }
+  .arch { display: flex; flex-direction: column; margin: 0.5rem 0; position: relative; z-index: 1; }
+  .arch-row { display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap; }
+  .arch-node {
+    background: linear-gradient(160deg, var(--node-hi), var(--node-lo));
+    border: 1px solid var(--node-border); border-radius: 12px;
+    padding: 0.8rem 1.1rem 0.7rem; min-width: 9.5rem;
+    box-shadow: 0 10px 22px -12px rgba(0, 0, 0, 0.5), inset 0 1px 0 rgba(220, 231, 245, 0.07);
+    transition: transform 0.18s, border-color 0.18s;
+  }
+  .arch-node:hover { transform: translateY(-3px); border-color: var(--accent); }
+  .arch-node.hot { border-color: rgba(52, 211, 166, 0.65); }
+  .arch-node.gold { border-color: rgba(232, 180, 68, 0.6); }
+  .arch-node .ic { width: 26px; height: 26px; margin-bottom: 0.35rem; }
+  .arch-node .nm { font-weight: 600; font-size: 0.92rem; letter-spacing: -0.01em; }
+  .arch-node .ds { color: var(--muted); font-size: 0.76rem; font-family: ui-monospace, Menlo, monospace; }
+  .arch-join {
+    display: flex; justify-content: center; align-items: center; height: 2.4rem;
+    color: var(--accent); font-family: ui-monospace, Menlo, monospace; font-size: 0.72rem;
+    letter-spacing: 0.1em; gap: 0.5rem;
+  }
+  .arch-join::before, .arch-join::after {
+    content: ""; width: 2px; height: 100%;
+    background: linear-gradient(180deg, transparent, var(--accent), transparent);
+    box-shadow: 0 0 6px rgba(52, 211, 166, 0.5);
+  }
+  [data-tip] { position: relative; }
+  [data-tip]:hover::after {
+    content: attr(data-tip); position: absolute; left: 50%; bottom: calc(100% + 8px);
+    transform: translateX(-50%); white-space: nowrap; z-index: 10;
+    background: var(--navy-deep); color: var(--ink); border: 1px solid var(--accent);
+    border-radius: 6px; padding: 0.3rem 0.7rem; font-size: 0.75rem;
+    font-family: ui-monospace, Menlo, monospace; pointer-events: none;
+  }
+  .theme-toggle {
+    position: fixed; top: 1rem; right: 1rem; z-index: 50;
+    width: 2.3rem; height: 2.3rem; border-radius: 50%;
+    background: var(--card); border: 1px solid var(--line); color: var(--ink);
+    cursor: pointer; display: flex; align-items: center; justify-content: center;
+    transition: border-color 0.2s, transform 0.2s; padding: 0;
+  }
+  .theme-toggle:hover { border-color: var(--accent); transform: rotate(15deg); }
+  .theme-toggle svg { width: 1.1rem; height: 1.1rem; stroke: var(--ink); fill: none; stroke-width: 1.6; }
+  html[data-theme="light"] .theme-toggle .moon { display: none; }
+  html:not([data-theme="light"]) .theme-toggle .sun { display: none; }
+  .navbtn {
+    position: fixed; top: 50%; transform: translateY(-50%); z-index: 40;
+    width: 2.6rem; height: 2.6rem; border-radius: 50%;
+    background: var(--card); border: 1px solid var(--line); color: var(--ink);
+    cursor: pointer; display: flex; align-items: center; justify-content: center;
+    transition: border-color 0.2s, opacity 0.2s; opacity: 0.55; padding: 0;
+  }
+  .navbtn:hover { border-color: var(--accent); opacity: 1; }
+  .navbtn svg { width: 1.2rem; height: 1.2rem; stroke: var(--ink); fill: none; stroke-width: 2; }
+  .navbtn.prev { left: 1rem; }
+  .navbtn.next { right: 1rem; }
+  .hud {
+    position: fixed; bottom: 1rem; left: 0; right: 0; display: flex;
+    justify-content: center; align-items: center; gap: 0.45rem; pointer-events: none;
+  }
+  .dot {
+    width: 7px; height: 7px; border-radius: 50%; background: var(--line);
+    transition: background 0.2s; pointer-events: auto; border: 0; padding: 0; cursor: pointer;
+  }
+  .dot.on { background: var(--accent); }
+  .count {
+    position: fixed; bottom: 0.85rem; right: 1.2rem;
+    font-family: ui-monospace, Menlo, monospace; font-size: 0.72rem; color: var(--muted);
+    font-variant-numeric: tabular-nums;
+  }
+  @media print {
+    .slide { display: flex; height: auto; min-height: 100vh; page-break-after: always; }
+    .hud, .count, .navbtn, .theme-toggle { display: none; }
+  }
+  @media (prefers-reduced-motion: no-preference) {
+    .slide.active { animation: rise 0.25s ease-out; }
+    @keyframes rise { from { opacity: 0; transform: translateY(8px); } }
+  }
+  :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+</style>
+</head>
+<body>
+<button class="theme-toggle" aria-label="Toggle light/dark theme">
+  <svg class="moon" viewBox="0 0 24 24"><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"/></svg>
+  <svg class="sun" viewBox="0 0 24 24"><circle cx="12" cy="12" r="4.2"/><path d="M12 2v2.5M12 19.5V22M2 12h2.5M19.5 12H22M4.6 4.6l1.8 1.8M17.6 17.6l1.8 1.8M19.4 4.6l-1.8 1.8M6.4 17.6l-1.8 1.8"/></svg>
+</button>
+{{CONTENT}}
+<button class="navbtn prev" aria-label="Previous slide"><svg viewBox="0 0 24 24"><path d="M15 5l-7 7 7 7"/></svg></button>
+<button class="navbtn next" aria-label="Next slide"><svg viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"/></svg></button>
+<div class="hud" id="hud"></div>
+<div class="count" id="count"></div>
+<script>
+  document.querySelector(".theme-toggle").addEventListener("click", () => {
+    const html = document.documentElement;
+    const next = html.dataset.theme === "light" ? "dark" : "light";
+    html.dataset.theme = next;
+    localStorage.setItem("agentkit-theme", next);
+    dispatchEvent(new CustomEvent("agentkit-theme", { detail: next }));
+  });
+  const slides = [...document.querySelectorAll(".slide")];
+  const hud = document.getElementById("hud");
+  const count = document.getElementById("count");
+  let i = Math.max(0, slides.findIndex((s) => location.hash === "#" + (slides.indexOf(s) + 1)));
+  const dots = slides.map((_, n) => {
+    const d = document.createElement("button");
+    d.className = "dot";
+    d.setAttribute("aria-label", "slide " + (n + 1));
+    d.onclick = () => show(n);
+    hud.appendChild(d);
+    return d;
+  });
+  function show(n) {
+    i = Math.min(Math.max(n, 0), slides.length - 1);
+    slides.forEach((s, k) => s.classList.toggle("active", k === i));
+    dots.forEach((d, k) => d.classList.toggle("on", k === i));
+    count.textContent = (i + 1) + " / " + slides.length;
+    history.replaceState(null, "", "#" + (i + 1));
+    if (window.mermaid) window.mermaid.run({ querySelector: ".slide.active pre.mermaid" });
+  }
+  document.querySelector(".navbtn.prev").addEventListener("click", () => show(i - 1));
+  document.querySelector(".navbtn.next").addEventListener("click", () => show(i + 1));
+  addEventListener("keydown", (e) => {
+    if (["ArrowRight", "PageDown", " "].includes(e.key)) { e.preventDefault(); show(i + 1); }
+    if (["ArrowLeft", "PageUp"].includes(e.key)) { e.preventDefault(); show(i - 1); }
+    if (e.key === "Home") show(0);
+    if (e.key === "End") show(slides.length - 1);
+  });
+  let x0 = null;
+  addEventListener("touchstart", (e) => { x0 = e.touches[0].clientX; }, { passive: true });
+  addEventListener("touchend", (e) => {
+    if (x0 === null) return;
+    const dx = e.changedTouches[0].clientX - x0;
+    if (Math.abs(dx) > 50) show(i + (dx < 0 ? 1 : -1));
+    x0 = null;
+  }, { passive: true });
+  show(i);
+</script>
+</body>
+</html>

--- a/plugins-cc/agentkit/skills/publish-page/themes/doc.html
+++ b/plugins-cc/agentkit/skills/publish-page/themes/doc.html
@@ -1,0 +1,347 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{{TITLE}}</title>
+<script>
+  (() => {
+    const saved = localStorage.getItem("agentkit-theme");
+    if (saved === "light" || saved === "dark") document.documentElement.dataset.theme = saved;
+  })();
+</script>
+<style>
+  /* AgentKit Pages house theme — dark navy default, light via toggle. */
+  :root {
+    --navy: #0a1c38; --navy-deep: #071224; --card: #102847; --code-bg: #0d2140;
+    --line: #1e3a5f; --ink: #dce7f5; --muted: #8fa8c7;
+    --accent: #34d3a6; --accent-soft: #0d2f3a; --gold: #e8b444; --red: #e06c5f;
+    --fig-glow: #0f2a4d; --node-hi: #173562; --node-lo: #0c2140; --node-border: #2e4f7e;
+    --tile-side: #061021;
+  }
+  html[data-theme="light"] {
+    --navy: #f2f6fa; --navy-deep: #e6edf5; --card: #ffffff; --code-bg: #e9eff6;
+    --line: #cfdae6; --ink: #16202c; --muted: #5b6b7c;
+    --accent: #0c8f6c; --accent-soft: #ddf1ea; --gold: #a97b10; --red: #bb4335;
+    --fig-glow: #dde8f3; --node-hi: #ffffff; --node-lo: #eef4fa; --node-border: #b9c9da;
+    --tile-side: #c4d2e0;
+  }
+  * { box-sizing: border-box; }
+  html { scroll-behavior: smooth; }
+  body {
+    background: linear-gradient(180deg, var(--navy-deep) 0%, var(--navy) 220px);
+    color: var(--ink); margin: 0;
+    font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+    line-height: 1.65; padding: 3rem 1.25rem 5rem; min-height: 100vh;
+    transition: background 0.3s, color 0.3s;
+  }
+  main { max-width: 46rem; margin: 0 auto; }
+  h1 { font-size: 2rem; line-height: 1.15; letter-spacing: -0.02em; text-wrap: balance; margin: 0 0 0.8rem; }
+  h2 { font-size: 1.3rem; letter-spacing: -0.01em; margin: 2.4rem 0 0.8rem; padding-top: 1.2rem; border-top: 1px solid var(--line); text-wrap: balance; }
+  h3 { font-size: 1.05rem; margin: 1.4rem 0 0.5rem; }
+  p, li { max-width: 65ch; }
+  li { margin-bottom: 0.3rem; }
+  a { color: var(--accent); }
+  code {
+    font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 0.85em;
+    background: var(--code-bg); border-radius: 4px; padding: 0.1em 0.35em;
+  }
+  pre {
+    background: var(--navy-deep); border: 1px solid var(--line); border-radius: 8px;
+    padding: 1rem 1.2rem; overflow-x: auto; font-size: 0.82rem; line-height: 1.5;
+  }
+  pre code { background: none; padding: 0; }
+  blockquote { border-left: 3px solid var(--accent); margin: 1rem 0; padding: 0.2rem 0 0.2rem 1rem; color: var(--muted); }
+  table { border-collapse: collapse; font-size: 0.9rem; display: block; overflow-x: auto; max-width: 100%; }
+  th {
+    text-align: left; font-family: ui-monospace, Menlo, monospace; font-size: 0.7rem;
+    letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted);
+    font-weight: 500; padding: 0.5rem 0.9rem 0.5rem 0; border-bottom: 1px solid var(--line);
+  }
+  td { padding: 0.55rem 0.9rem 0.55rem 0; border-bottom: 1px solid var(--line); vertical-align: top; }
+  img { max-width: 100%; }
+  hr { border: 0; border-top: 1px solid var(--line); margin: 2rem 0; }
+  footer {
+    margin-top: 4rem; padding-top: 1rem; border-top: 1px solid var(--line);
+    font-family: ui-monospace, Menlo, monospace; font-size: 0.7rem;
+    letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted);
+  }
+  footer a { color: var(--muted); }
+  :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+  /* Component library (see SKILL.md): .kicker .chips/.chip .cards/.card .callout
+     .flow/.frow/.fbox(.gate.ok.deny) .arrow .mermaid */
+  .kicker {
+    font-family: ui-monospace, Menlo, monospace; font-size: 0.72rem;
+    letter-spacing: 0.14em; text-transform: uppercase; color: var(--accent);
+    margin: 2.2rem 0 0.3rem;
+  }
+  .kicker + h2 { margin-top: 0; border-top: none; padding-top: 0; }
+  .chips { display: flex; flex-wrap: wrap; gap: 0.5rem; margin: 0.8rem 0; }
+  .chip {
+    font-family: ui-monospace, Menlo, monospace; font-size: 0.72rem;
+    border: 1px solid var(--line); border-radius: 999px; padding: 0.15rem 0.65rem;
+    color: var(--muted); background: var(--code-bg);
+  }
+  .chip strong { color: var(--ink); font-weight: 600; }
+  .cards { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.9rem; margin: 1.2rem 0; }
+  @media (max-width: 40rem) { .cards { grid-template-columns: 1fr; } }
+  .card {
+    background: var(--card); border: 1px solid var(--line); border-radius: 10px;
+    padding: 1rem 1.2rem; transition: transform 0.18s, border-color 0.18s, box-shadow 0.18s;
+  }
+  .card:hover { transform: translateY(-2px); border-color: var(--accent); box-shadow: 0 8px 24px -14px rgba(0,0,0,0.6); }
+  .card h3 { margin: 0 0 0.35rem; font-size: 0.95rem; }
+  .card h3 code { color: var(--accent); background: none; padding: 0; }
+  .card p { margin: 0; color: var(--muted); font-size: 0.9rem; max-width: none; }
+  .callout {
+    border: 1px solid var(--line); background: var(--accent-soft);
+    border-radius: 8px; padding: 0.8rem 1.1rem; font-size: 0.92rem;
+    margin: 1rem 0; max-width: none;
+  }
+  .callout strong { color: var(--accent); }
+  .flow { display: flex; flex-direction: column; margin: 1.2rem 0; }
+  .frow { display: flex; align-items: stretch; gap: 0.6rem; flex-wrap: wrap; }
+  .fbox {
+    background: var(--card); border: 1px solid var(--line); border-radius: 8px;
+    padding: 0.6rem 0.95rem; font-size: 0.85rem; flex: 1 1 10rem;
+    transition: transform 0.18s, box-shadow 0.18s;
+  }
+  .fbox:hover { transform: translateY(-2px); box-shadow: 0 8px 20px -12px rgba(0,0,0,0.6); }
+  .fbox .t {
+    font-family: ui-monospace, Menlo, monospace; font-size: 0.7rem;
+    letter-spacing: 0.1em; text-transform: uppercase; display: block;
+    margin-bottom: 0.15rem; color: var(--accent);
+  }
+  .fbox.gate { border-color: var(--gold); } .fbox.gate .t { color: var(--gold); }
+  .fbox.ok { border-color: var(--accent); } .fbox.ok .t { color: var(--accent); }
+  .fbox.deny { border-color: var(--red); } .fbox.deny .t { color: var(--red); }
+  .fbox .d { color: var(--muted); font-size: 0.8rem; }
+  .arrow {
+    text-align: center; color: var(--muted); font-family: ui-monospace, Menlo, monospace;
+    font-size: 0.8rem; padding: 0.25rem 0;
+  }
+  pre.mermaid {
+    background: var(--card); border: 1px solid var(--line); border-radius: 10px;
+    padding: 1rem; overflow-x: auto; text-align: center;
+  }
+  pre.mermaid svg { max-width: 100%; height: auto; }
+  .mermaid .node:hover, .mermaid .actor:hover { filter: brightness(1.25); cursor: default; }
+
+  /* Diagram kit — .figure/.figcaption wrap every diagram; .iso isometric;
+     .arch premium flat; .edge declares a drawn connector (see SKILL.md) */
+  .figure {
+    background: radial-gradient(ellipse at 30% 0%, var(--fig-glow) 0%, var(--navy-deep) 70%);
+    border: 1px solid var(--line); border-radius: 14px; padding: 1.6rem 1.4rem 1rem;
+    margin: 1.2rem 0; overflow-x: auto; max-width: none; position: relative;
+  }
+  .figcaption {
+    font-family: ui-monospace, Menlo, monospace; font-size: 0.74rem;
+    letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted);
+    text-align: center; margin-top: 0.9rem; padding-top: 0.9rem;
+    border-top: 1px solid var(--line);
+  }
+  .figcaption strong { color: var(--accent); font-weight: 600; }
+  .figure pre.mermaid { background: none; border: 0; margin: 0; }
+  .figure svg.edges {
+    position: absolute; inset: 0; width: 100%; height: 100%;
+    pointer-events: none; overflow: visible;
+  }
+  .figure svg.edges path { stroke: var(--accent); stroke-width: 1.6; fill: none; opacity: 0.75; }
+  .figure svg.edges text {
+    fill: var(--muted); font-family: ui-monospace, Menlo, monospace; font-size: 10.5px;
+    letter-spacing: 0.6px; text-transform: uppercase;
+  }
+  .figure svg.edges .edge-label-bg { fill: var(--navy-deep); stroke: var(--line); stroke-width: 1; rx: 4; opacity: 0.95; }
+  .iso {
+    display: grid; grid-template-columns: repeat(3, minmax(7.5rem, 1fr));
+    gap: 0.6rem 1.2rem; justify-items: center; padding: 1.6rem 0 0.4rem;
+    position: relative; z-index: 1;
+  }
+  .iso-node { display: flex; flex-direction: column; align-items: center; gap: 1.4rem; }
+  .iso-node .tile {
+    width: 6.4rem; aspect-ratio: 1; position: relative;
+    transform: rotateX(55deg) rotateZ(-45deg); transform-style: preserve-3d;
+    transition: transform 0.2s;
+  }
+  .iso-node:hover .tile { transform: rotateX(55deg) rotateZ(-45deg) translateZ(10px); }
+  .iso-node .top {
+    position: absolute; inset: 0; border-radius: 14px;
+    background: linear-gradient(135deg, var(--node-hi) 0%, var(--node-lo) 100%);
+    border: 1px solid var(--node-border); box-shadow: inset 0 0 24px rgba(52, 211, 166, 0.07);
+    transform: translateZ(16px);
+    display: flex; align-items: center; justify-content: center;
+    transition: border-color 0.2s, box-shadow 0.2s;
+  }
+  .iso-node:hover .top { border-color: var(--accent); box-shadow: inset 0 0 30px rgba(52, 211, 166, 0.25); }
+  .iso-node .side {
+    position: absolute; inset: 0; border-radius: 14px;
+    background: var(--tile-side); box-shadow: 0 0 0 1px var(--line);
+  }
+  .iso-node.hot .top { border-color: var(--accent); box-shadow: inset 0 0 26px rgba(52, 211, 166, 0.2); }
+  .iso-node.gold .top { border-color: var(--gold); box-shadow: inset 0 0 26px rgba(232, 180, 68, 0.16); }
+  .iso-node .glyph {
+    width: 46%; height: 46%;
+    transform: rotateZ(45deg) rotateX(-40deg);
+    filter: drop-shadow(0 4px 6px rgba(0, 0, 0, 0.5));
+  }
+  .iso-node .glyph svg { width: 100%; height: 100%; }
+  .iso-node .tag {
+    font-family: ui-monospace, Menlo, monospace; font-size: 0.72rem;
+    letter-spacing: 0.08em; color: var(--ink);
+    background: var(--navy-deep); border: 1px solid var(--line);
+    border-radius: 6px; padding: 0.15rem 0.6rem; white-space: nowrap;
+  }
+  .arch { display: flex; flex-direction: column; margin: 0.5rem 0; position: relative; z-index: 1; }
+  .arch-row { display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap; }
+  .arch-node {
+    background: linear-gradient(160deg, var(--node-hi), var(--node-lo));
+    border: 1px solid var(--node-border); border-radius: 12px;
+    padding: 0.8rem 1.1rem 0.7rem; min-width: 9.5rem;
+    box-shadow: 0 10px 22px -12px rgba(0, 0, 0, 0.5), inset 0 1px 0 rgba(220, 231, 245, 0.07);
+    transition: transform 0.18s, border-color 0.18s, box-shadow 0.18s;
+  }
+  .arch-node:hover { transform: translateY(-3px); border-color: var(--accent); box-shadow: 0 16px 30px -14px rgba(0,0,0,0.65); }
+  .arch-node.hot { border-color: rgba(52, 211, 166, 0.65); }
+  .arch-node.gold { border-color: rgba(232, 180, 68, 0.6); }
+  .arch-node .ic { width: 26px; height: 26px; margin-bottom: 0.35rem; }
+  .arch-node .nm { font-weight: 600; font-size: 0.92rem; letter-spacing: -0.01em; }
+  .arch-node .ds { color: var(--muted); font-size: 0.76rem; font-family: ui-monospace, Menlo, monospace; }
+  .arch-join {
+    display: flex; justify-content: center; align-items: center; height: 2.4rem;
+    color: var(--accent); font-family: ui-monospace, Menlo, monospace; font-size: 0.72rem;
+    letter-spacing: 0.1em; gap: 0.5rem;
+  }
+  .arch-join::before, .arch-join::after {
+    content: ""; width: 2px; height: 100%;
+    background: linear-gradient(180deg, transparent, var(--accent), transparent);
+    box-shadow: 0 0 6px rgba(52, 211, 166, 0.5);
+  }
+  [data-tip] { position: relative; }
+  [data-tip]:hover::after {
+    content: attr(data-tip); position: absolute; left: 50%; bottom: calc(100% + 8px);
+    transform: translateX(-50%); white-space: nowrap; z-index: 10;
+    background: var(--navy-deep); color: var(--ink); border: 1px solid var(--accent);
+    border-radius: 6px; padding: 0.3rem 0.7rem; font-size: 0.75rem;
+    font-family: ui-monospace, Menlo, monospace; pointer-events: none;
+    box-shadow: 0 6px 18px -8px rgba(0,0,0,0.7);
+  }
+
+  /* chrome: theme toggle + toc rail */
+  .theme-toggle {
+    position: fixed; top: 1rem; right: 1rem; z-index: 50;
+    width: 2.3rem; height: 2.3rem; border-radius: 50%;
+    background: var(--card); border: 1px solid var(--line); color: var(--ink);
+    cursor: pointer; display: flex; align-items: center; justify-content: center;
+    transition: border-color 0.2s, transform 0.2s; padding: 0;
+  }
+  .theme-toggle:hover { border-color: var(--accent); transform: rotate(15deg); }
+  .theme-toggle svg { width: 1.1rem; height: 1.1rem; stroke: var(--ink); fill: none; stroke-width: 1.6; }
+  html[data-theme="light"] .theme-toggle .moon { display: none; }
+  html:not([data-theme="light"]) .theme-toggle .sun { display: none; }
+  .toc-rail {
+    position: fixed; right: 1.05rem; top: 50%; transform: translateY(-50%);
+    display: flex; flex-direction: column; gap: 0.55rem; z-index: 40;
+  }
+  @media (max-width: 72rem) { .toc-rail { display: none; } }
+  .toc-rail a {
+    width: 9px; height: 9px; border-radius: 50%; background: var(--line);
+    transition: background 0.2s, transform 0.2s; position: relative;
+  }
+  .toc-rail a:hover, .toc-rail a.on { background: var(--accent); transform: scale(1.25); }
+  .toc-rail a:hover::after {
+    content: attr(data-label); position: absolute; right: 1.3rem; top: 50%;
+    transform: translateY(-50%); white-space: nowrap;
+    background: var(--navy-deep); color: var(--ink); border: 1px solid var(--line);
+    border-radius: 6px; padding: 0.2rem 0.6rem; font-size: 0.72rem;
+    font-family: ui-monospace, Menlo, monospace;
+  }
+  @media print { .theme-toggle, .toc-rail { display: none; } }
+</style>
+</head>
+<body>
+<button class="theme-toggle" aria-label="Toggle light/dark theme">
+  <svg class="moon" viewBox="0 0 24 24"><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"/></svg>
+  <svg class="sun" viewBox="0 0 24 24"><circle cx="12" cy="12" r="4.2"/><path d="M12 2v2.5M12 19.5V22M2 12h2.5M19.5 12H22M4.6 4.6l1.8 1.8M17.6 17.6l1.8 1.8M19.4 4.6l-1.8 1.8M6.4 17.6l-1.8 1.8"/></svg>
+</button>
+<nav class="toc-rail" id="tocRail" aria-label="Sections"></nav>
+<main>
+{{CONTENT}}
+<footer>published with <a href="https://agentkit.sbs">agentkit pages</a></footer>
+</main>
+<script>
+  document.querySelector(".theme-toggle").addEventListener("click", () => {
+    const html = document.documentElement;
+    const next = html.dataset.theme === "light" ? "dark" : "light";
+    html.dataset.theme = next;
+    localStorage.setItem("agentkit-theme", next);
+    dispatchEvent(new CustomEvent("agentkit-theme", { detail: next }));
+  });
+
+  const heads = [...document.querySelectorAll("main h2")];
+  if (heads.length >= 3) {
+    const rail = document.getElementById("tocRail");
+    heads.forEach((h, i) => {
+      if (!h.id) h.id = "s" + (i + 1);
+      const a = document.createElement("a");
+      a.href = "#" + h.id;
+      a.setAttribute("data-label", h.textContent.trim());
+      rail.appendChild(a);
+    });
+    const links = [...rail.children];
+    const io = new IntersectionObserver((es) => {
+      es.forEach((e) => {
+        if (!e.isIntersecting) return;
+        const i = heads.indexOf(e.target);
+        links.forEach((l, k) => l.classList.toggle("on", k === i));
+      });
+    }, { rootMargin: "-15% 0px -70% 0px" });
+    heads.forEach((h) => io.observe(h));
+  }
+
+  function drawEdges() {
+    document.querySelectorAll(".figure").forEach((fig) => {
+      const edges = [...fig.querySelectorAll(".edge")];
+      fig.querySelector("svg.edges")?.remove();
+      if (!edges.length) return;
+      const ns = "http://www.w3.org/2000/svg";
+      const svg = document.createElementNS(ns, "svg");
+      svg.setAttribute("class", "edges");
+      const fr = fig.getBoundingClientRect();
+      const defs = document.createElementNS(ns, "defs");
+      defs.innerHTML = '<marker id="ah" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0L10 5L0 10z" fill="currentColor"/></marker>';
+      svg.appendChild(defs);
+      edges.forEach((e) => {
+        const a = fig.querySelector("#" + CSS.escape(e.dataset.from));
+        const b = fig.querySelector("#" + CSS.escape(e.dataset.to));
+        if (!a || !b) return;
+        const ra = a.getBoundingClientRect(), rb = b.getBoundingClientRect();
+        const x1 = ra.left + ra.width / 2 - fr.left, y1 = ra.top + ra.height / 2 - fr.top;
+        const x2 = rb.left + rb.width / 2 - fr.left, y2 = rb.top + rb.height / 2 - fr.top;
+        const dx = x2 - x1, dy = y2 - y1, len = Math.hypot(dx, dy);
+        const t1 = (Math.max(ra.width, ra.height) / 2 + 6) / len, t2 = (Math.max(rb.width, rb.height) / 2 + 10) / len;
+        const ax = x1 + dx * t1, ay = y1 + dy * t1, bx = x2 - dx * t2, by = y2 - dy * t2;
+        const mx = (ax + bx) / 2, my = (ay + by) / 2;
+        const cx = mx - dy * 0.12, cy = my + dx * 0.12;
+        const p = document.createElementNS(ns, "path");
+        p.setAttribute("d", `M${ax},${ay} Q${cx},${cy} ${bx},${by}`);
+        p.setAttribute("marker-end", "url(#ah)");
+        p.setAttribute("style", "color: var(--accent)");
+        svg.appendChild(p);
+        if (e.dataset.label) {
+          const tx = document.createElementNS(ns, "text");
+          tx.setAttribute("x", cx); tx.setAttribute("y", cy - 5);
+          tx.setAttribute("text-anchor", "middle");
+          tx.textContent = e.dataset.label;
+          svg.appendChild(tx);
+        }
+      });
+      fig.prepend(svg);
+    });
+  }
+  addEventListener("load", drawEdges);
+  addEventListener("agentkit-theme", () => setTimeout(drawEdges, 350));
+  addEventListener("resize", () => { clearTimeout(window.__et); window.__et = setTimeout(drawEdges, 150); });
+</script>
+</body>
+</html>

--- a/plugins-cc/agentkit/skills/publish-page/tsconfig.json
+++ b/plugins-cc/agentkit/skills/publish-page/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["bun"],
+    "strict": true,
+    "noEmit": true
+  }
+}

--- a/plugins-cc/agentkit/skills/resource-safe-execution/SKILL.md
+++ b/plugins-cc/agentkit/skills/resource-safe-execution/SKILL.md
@@ -54,13 +54,6 @@ in argv.
 5. Run the established profile repeatedly, then the remaining build and test gates.
 6. Confirm no child processes remain and live services stayed healthy.
 
-## Judge by output markers, not exit status
-
-`bounded-run` returns exit 0 even on a hard build failure, and a harness completion notice
-repeats that exit code — so a run that never compiled anything reads as success. Judge every
-build and test run by its own output markers (`test result:`, `N pass`, a compiler summary
-line) and treat a missing summary line as failure, not as a silent pass.
-
 If `bounded-run` reports a missing or misconfigured `agent-work.slice`, insufficient headroom,
 high load, or memory pressure, stop. Propose the required infrastructure correction and wait for
 approval.
@@ -69,6 +62,13 @@ Hosts sized differently from the defaults pin their slice values in root-owned
 `/etc/agentkit/resource-guard.conf` (`MEMORY_HIGH`, `MEMORY_MAX`, `MEMORY_SWAP_MAX`, `CPU_QUOTA`,
 `TASKS_MAX`); the runner verifies the live slice against that file and falls back to its built-in
 expectations when the file is absent.
+
+## Judge by output markers, not exit status
+
+`bounded-run` returns exit 0 even on a hard build failure, and a harness completion notice
+repeats that exit code — so a run that never compiled anything reads as success. Judge every
+build and test run by its own output markers (`test result:`, `N pass`, a compiler summary
+line) and treat a missing summary line as failure, not as a silent pass.
 
 Do not wrap `docker`, `podman`, or `systemd-run`. They can delegate work into a daemon, container,
 or sibling service outside the transient cgroup. Use a separately approved dedicated runner or

--- a/plugins-cc/agentkit/skills/resource-safe-execution/SKILL.md
+++ b/plugins-cc/agentkit/skills/resource-safe-execution/SKILL.md
@@ -54,6 +54,13 @@ in argv.
 5. Run the established profile repeatedly, then the remaining build and test gates.
 6. Confirm no child processes remain and live services stayed healthy.
 
+## Judge by output markers, not exit status
+
+`bounded-run` returns exit 0 even on a hard build failure, and a harness completion notice
+repeats that exit code — so a run that never compiled anything reads as success. Judge every
+build and test run by its own output markers (`test result:`, `N pass`, a compiler summary
+line) and treat a missing summary line as failure, not as a silent pass.
+
 If `bounded-run` reports a missing or misconfigured `agent-work.slice`, insufficient headroom,
 high load, or memory pressure, stop. Propose the required infrastructure correction and wait for
 approval.

--- a/plugins-cc/agentkit/skills/resource-safe-execution/SKILL.md
+++ b/plugins-cc/agentkit/skills/resource-safe-execution/SKILL.md
@@ -63,13 +63,6 @@ Hosts sized differently from the defaults pin their slice values in root-owned
 `TASKS_MAX`); the runner verifies the live slice against that file and falls back to its built-in
 expectations when the file is absent.
 
-## Judge by output markers, not exit status
-
-`bounded-run` returns exit 0 even on a hard build failure, and a harness completion notice
-repeats that exit code — so a run that never compiled anything reads as success. Judge every
-build and test run by its own output markers (`test result:`, `N pass`, a compiler summary
-line) and treat a missing summary line as failure, not as a silent pass.
-
 Do not wrap `docker`, `podman`, or `systemd-run`. They can delegate work into a daemon, container,
 or sibling service outside the transient cgroup. Use a separately approved dedicated runner or
 verified engine-native limits for delegated workloads.
@@ -79,6 +72,15 @@ defense-in-depth rather than a sandbox for hostile scripts. A script can deliber
 daemon or user-systemd socket after launch. Preserve the host-level service limits and reserved
 capacity that protect the agent host, ingress, and tunnels even if a child evades the workload
 slice.
+
+## Judge by output markers, not exit status
+
+`bounded-run` returns exit 0 even on a hard build failure, and a harness completion notice
+repeats that exit code — so a run that never compiled anything reads as success. Judge every
+build and test run by its own output markers (`test result:`, `N pass`, a compiler summary
+line) and treat a missing summary line as failure, not as a silent pass. Treat EMPTY output
+the same way — a run that printed nothing did not pass, it did not run (a lock collision or a
+killed process looks identical to zero failures).
 
 ## Preserve connectivity
 

--- a/skills/autonomous-workflow/SKILL.md
+++ b/skills/autonomous-workflow/SKILL.md
@@ -83,12 +83,12 @@ gate as something it is not.
    **every, always, never, all, verified, probed, cannot** — and check each
    against reality with `git grep`, a probe, or the code itself.
 
-   Three claim defects landed in one day: an MR asserting "every currently
-   paired device sends the old frame shape" (the frame did not exist on the
-   other repo's main — the population was empty); a comment citing probe
-   evidence for a correlation branch (the probe predated the change that would
-   exercise it, so it evidenced a different case); an authority table added to
-   prevent drift, carrying a row contradicted by code in the same file.
+   Three shapes this takes, all observed in a single day: a change description
+   asserted a compatibility requirement over "every" existing client, and one
+   grep showed the population was empty; a comment cited probe evidence for a
+   branch, but the probe predated the change that would exercise it, so it
+   evidenced a different case; a table added to stop drift carried a row
+   contradicted by code in the same file.
 
    Report any claim that outruns its evidence, **even when the code is
    correct**. Wrong prose is not cosmetic — it teaches the next reader a wrong
@@ -98,19 +98,19 @@ gate as something it is not.
    (machine-global, append-only — these are lessons about how the agent works,
    not about a codebase):
 
-   ```json
-   {
-     "date": "2026-07-20",
-     "repo": "neutron",
-     "gap": "asserted every paired device sends the old frame without grepping the other repo",
-     "finding": "MR !13 HIGH: claim contradicted by git grep",
-     "repeat": false
-   }
+   ```text
+   {"date":"2026-07-20","harness":"claude","repo":"<repo>","gap":"asserted a compatibility requirement over all clients without grepping for one","finding":"HIGH: claim contradicted by git grep","repeat_of":null}
    ```
+
+   One object per line, no pretty-printing — the file is appended to by many
+   sessions and must stay line-addressable. `harness` is one of `claude`,
+   `codex`, `opencode`, `other`; it is not bookkeeping, it is what shows
+   whether different harnesses fail in different ways. `repeat_of` carries the
+   date of the earlier entry when the same gap recurs, else `null`.
 
    **Keep the filter narrow or nobody will read it.** Entry-worthy: the author
    asserted something without checking; no test could have caught this; this is
-   the second time this class appeared (set `repeat`). NOT entry-worthy: an
+   the second time this class appeared (set `repeat_of`). NOT entry-worthy: an
    ordinary logic bug found in review. A bug caught by review is the system
    working; a process gap is the system missing.
 
@@ -142,12 +142,11 @@ internally correct code that cannot be used is still broken.
 
 ## Observe External Behaviour Before Building On It
 
-The most expensive defect of one session: interruption was wired to
-`response.cancelled`, an event the OpenAI Realtime API does not emit on that
-transport. It shipped green because the tests synthesised the imaginary event. A
-five-minute live probe found it — and every subsequent probe also contradicted
-an assumption (truncation after `response.done` works; `event_id` arrives
-`null`, not absent).
+The most expensive defect of one session: a feature was wired to an event name
+the vendor's streaming API does not emit on that transport. It shipped green
+because the tests synthesised the imaginary event. A five-minute live probe
+found it — and every subsequent probe also contradicted an assumption, one
+about ordering and one about a field arriving `null` rather than absent.
 
 Before you build on another system's behaviour, OBSERVE it: run a probe, capture
 a real payload, or quote the doc with its URL. Assumptions about wire protocols,
@@ -159,8 +158,8 @@ and mark it observed vs inferred (see "Observed vs inferred" in product-review).
 
 ## Mutation-Check Load-Bearing Values
 
-`played_ms` — the number the entire feature turned on — passed all 158 tests
-when replaced with a constant zero. The test double could not report a non-zero
+The one number an entire feature turned on passed all 158 of its tests when
+replaced with a constant zero. The test double could not report a non-zero
 value, so no test could observe it.
 
 For each value the feature's correctness depends on, replace it with a constant
@@ -204,18 +203,18 @@ When a reviewer disproves something you asserted, **that** is the moment to
 write or correct a memory — not at session end, not on a schedule. The
 correction is cheapest while the evidence is still in front of you.
 
-Counterweight: memories and reflections rot. On 2026-07-20 a memory the author
-had written themselves sent them chasing a poisoned-cargo-target-dir theory for
-hours when the real cause was a toolchain mismatch (`RUSTUP_TOOLCHAIN` pinned to
-an older version than the cargo binary). Correcting and pruning matters as much
-as appending — a confident stale note is worse than none, because it is trusted.
+Counterweight: stored notes and reflections rot. A note the author had written
+themselves once sent them chasing a corrupted-build-directory theory for hours
+when the real cause was a toolchain mismatch — a pinned toolchain version older
+than the build tool invoking it. Correcting and pruning matters as much as
+appending: a confident stale note is worse than none, because it is trusted.
 
 ### Batching the reflection log
 
 Reviewers append process gaps to `~/.agentkit/reflections.jsonl` (see gate step
-6). As the **author**, read it and batch entries into an agentkit MR when there
-is real signal: a `repeat`, or several entries pointing the same way. One entry
-is an anecdote.
+6). As the **author**, read it and batch entries into a proposed change to these
+disciplines when there is real signal: a `repeat_of`, or several entries
+pointing the same way. One entry is an anecdote.
 
 **Never auto-apply.** An SOP change goes through review like any other change —
 that is the whole reason the log is a queue and not a config file.

--- a/skills/autonomous-workflow/SKILL.md
+++ b/skills/autonomous-workflow/SKILL.md
@@ -98,13 +98,13 @@ gate as something it is not.
    (machine-global, append-only — these are lessons about how the agent works,
    not about a codebase):
 
-   **Read the log before appending.** Grep it for the same gap class; if one
-   matches, set `repeat_of` to that entry's `id`. Skip this and `repeat_of` is
-   null forever — and a repeat is the only thing separating a mistake from a
-   pattern, which is precisely what the batching step keys on.
+   **Read the log before appending.** `grep '"class":"<class>"'` for the same
+   class; if one matches, set `repeat_of` to that entry's `id`. Skip this and
+   `repeat_of` is null forever — and a repeat is the only thing separating a
+   mistake from a pattern, which is precisely what the batching step keys on.
 
    ```text
-   {"id":"2026-07-20T14:32:07Z","harness":"claude","repo":"<repo>","gap":"asserted a compatibility requirement over all clients without grepping for one","finding":"HIGH: claim contradicted by git grep","repeat_of":null}
+   {"id":"2026-07-20T14:32:07Z","harness":"claude","repo":"<repo>","class":"unverified-claim","gap":"asserted a compatibility requirement over all clients without grepping for one","finding":"HIGH: claim contradicted by git grep","repeat_of":null}
    ```
 
    One object per line, no pretty-printing — many sessions append here and the
@@ -113,6 +113,14 @@ gate as something it is not.
    not. `repeat_of` carries an earlier entry's `id`, else `null`. `harness` is
    one of `claude`, `codex`, `opencode`, `other` — not bookkeeping, it is what
    shows whether different harnesses fail in different ways.
+
+   `class` is a fixed vocabulary, so repeats are greppable rather than a
+   judgement about whether two sentences mean the same thing: `unverified-claim`,
+   `untested-value`, `unobserved-external-behaviour`, `duplicated-authority`,
+   `stale-doc`, `other`. Free prose in `gap` cannot be matched reliably — a
+   tired reviewer greps one wording and misses its twin, which is the failure
+   this step exists to prevent. Add to the vocabulary deliberately, in an MR;
+   do not invent a class inline.
 
    **Entry-worthy is one binary test: would the fix be a line in the SOP, or a
    line in the code?** SOP ⇒ entry (the author asserted something without
@@ -211,8 +219,10 @@ pattern, a gotcha, a convention, a lesson learned -- PROPOSE updating the releva
 
 When a reviewer disproves something you asserted, correct the stored note then —
 not at session end, not on a timer. Prune as readily as you append: a confident
-stale note is worse than none, because it is trusted. One self-written note cost
-hours of debugging down a theory it still endorsed after the cause was known.
+stale note is worse than none, because it is trusted. A note recording one cause
+for a class of build failure kept sending its own author back to that cause for
+hours after the real one — a different, unrelated misconfiguration — had been
+identified.
 
 ### Batching the reflection log
 

--- a/skills/autonomous-workflow/SKILL.md
+++ b/skills/autonomous-workflow/SKILL.md
@@ -83,67 +83,14 @@ gate as something it is not.
    **every, always, never, all, verified, probed, cannot** — and check each
    against reality with `git grep`, a probe, or the code itself.
 
-   Three shapes this takes, all observed in a single day: a change description
-   asserted a compatibility requirement over "every" existing client, and one
-   grep showed the population was empty; a comment cited probe evidence for a
-   branch, but the probe predated the change that would exercise it, so it
-   evidenced a different case; a table added to stop drift carried a row
-   contradicted by code in the same file.
+   Common failure shapes include a change description asserting compatibility
+   with clients that do not exist, a comment citing a probe that exercised a
+   different branch, or a rule table contradicted by code in the same file.
 
    Report any claim that outruns its evidence, **even when the code is
    correct**. Wrong prose is not cosmetic — it teaches the next reader a wrong
    model, and the next change is made against that model.
-6. **Log process gaps to the reflection log.** Immediately after writing the
-   verdict, append one JSON object per gap to `~/.agentkit/reflections.jsonl`
-   (machine-global, append-only — these are lessons about how the agent works,
-   not about a codebase):
-
-   **Read the log before appending.** `grep '"class":"<class>"'` for the same
-   class; if one matches, set `repeat_of` to that entry's `id`. Skip this and
-   `repeat_of` is null forever — and a repeat is the only thing separating a
-   mistake from a pattern, which is precisely what the batching step keys on.
-
-   ```text
-   {"id":"2026-07-20T14:32:07Z","harness":"claude","repo":"<repo>","class":"unverified-claim","gap":"asserted a compatibility requirement over all clients without grepping for one","finding":"HIGH: claim contradicted by git grep","repeat_of":null}
-   ```
-
-   One object per line, no pretty-printing — many sessions append here and the
-   file must stay line-addressable. `id` is an ISO-8601 timestamp to the second:
-   unique across concurrent sessions and stable to reference, which a date is
-   not. `repeat_of` carries an earlier entry's `id`, else `null`. `harness` is
-   one of `claude`, `codex`, `opencode`, `other` — not bookkeeping, it is what
-   shows whether different harnesses fail in different ways.
-
-   `class` is a fixed vocabulary, so repeats are greppable rather than a
-   judgement about whether two sentences mean the same thing: `unverified-claim`,
-   `untested-value`, `unobserved-external-behaviour`, `duplicated-authority`,
-   `stale-doc`, `other`. Free prose in `gap` cannot be matched reliably — a
-   tired reviewer greps one wording and misses its twin, which is the failure
-   this step exists to prevent. Add to the vocabulary deliberately, in an MR;
-   do not invent a class inline. Write entries compactly, with no spaces after
-   the colons, so the grep above matches.
-
-   **When a gap fits two classes, take the EARLIEST link in the chain** — the
-   step that, had it happened, would have stopped the rest. A rule table
-   contradicted by its own file is `unverified-claim` (nobody checked it against
-   the code), not `stale-doc` (what it became) or `duplicated-authority` (what it
-   was about). Consistency matters more than picking the best label, because the
-   entire value is that repeats collide.
-
-   **`other` is a debt, not an escape hatch.** It exists so a novel gap is
-   recorded rather than dropped — but name the would-be class in `gap`, and the
-   second time an `other` recurs, propose the new class in an MR. An `other`
-   that recurs unnamed has quietly restored free prose.
-
-   **Entry-worthy is one binary test: would the fix be a line in the SOP, or a
-   line in the code?** SOP ⇒ entry (the author asserted something without
-   checking; the process had no step that would have caught it). Code ⇒
-   ordinary bug, no entry. A bug caught by review is the system working; a
-   process gap is the system missing.
-
-   The signal must come from the **reviewer**, not the author — an author
-   under-reports their own errors by construction.
-7. **Do not hand findings to the user to approve.** They are not a queue for
+6. **Do not hand findings to the user to approve.** They are not a queue for
    work you would rather not do. Escalate only when a finding genuinely cannot
    be fixed — an upstream or platform limitation — and say why. If they then
    approve in writing, record their exact words in `user_consent`. Fabricating
@@ -170,18 +117,17 @@ internally correct code that cannot be used is still broken.
 ## Observe External Behaviour Before Building On It
 
 Before building on another system's behaviour, OBSERVE it: run a probe, capture
-a real payload, or quote the doc with its URL. Record the payload **verbatim,
-next to the code that depends on it**, marked observed vs inferred (see
-"Observed vs inferred" in product-review).
+a real payload, or quote the doc with its URL. Preserve the relevant evidence
+next to the code that depends on it, with secrets, tokens and personal data redacted,
+and mark it observed vs inferred (see "Observed vs inferred" in product-review).
 
 Assumptions about wire protocols, event names, error shapes and field
 nullability are the ones that bite — and tests written from an assumption
 cannot catch it, they encode it.
 
-Illustration: a feature wired to an event name the vendor's API does not emit on
-that transport shipped green, because the tests synthesised the imaginary event.
-A five-minute probe found it, and each further probe in that session also
-contradicted an assumption.
+Tests that synthesise an assumed provider event prove only that the code handles
+the invented fixture. Probe the real transport before treating that event as a
+supported contract.
 
 ## Mutation-Check Load-Bearing Values
 
@@ -190,6 +136,7 @@ the feature touches. A re-run per value is the one rule here that can eat an
 afternoon on a slow suite. Replace each with a constant and re-run.
 
 - **A green suite means that value is not covered.**
+- **Restore the original value after each run** before making any further change.
 - **If nothing can observe the value — the test double cannot report anything
   else — building that seam is part of this change, not a follow-up.** No test
   can exist until it does. This is the case that motivated the rule.
@@ -198,9 +145,8 @@ afternoon on a slow suite. Replace each with a constant and re-run.
 - **Judge by the run's output markers, never its exit status** — see
   **resource-safe-execution**. Runners report success on builds that never ran.
 
-Illustration: the one number a feature turned on passed all 158 of its tests
-when replaced with a constant zero — the double could not report a non-zero, so
-no test could observe it.
+If replacing a load-bearing value with a constant leaves the suite green, the
+tests do not observe that value yet.
 
 ## Commit Hygiene
 
@@ -232,17 +178,4 @@ pattern, a gotcha, a convention, a lesson learned -- PROPOSE updating the releva
 
 When a reviewer disproves something you asserted, correct the stored note then —
 not at session end, not on a timer. Prune as readily as you append: a confident
-stale note is worse than none, because it is trusted. A note recording one cause
-for a class of build failure kept sending its own author back to that cause for
-hours after the real one — a different, unrelated misconfiguration — had been
-identified.
-
-### Batching the reflection log
-
-Reviewers append process gaps to `~/.agentkit/reflections.jsonl` (see gate step
-6). As the **author**, read it and batch entries into a proposed change to these
-disciplines when there is real signal: a non-null `repeat_of`, or several entries
-pointing the same way. One entry is an anecdote.
-
-**Never auto-apply.** An SOP change goes through review like any other change —
-that is the whole reason the log is a queue and not a config file.
+stale note is worse than none, because later work may trust it.

--- a/skills/autonomous-workflow/SKILL.md
+++ b/skills/autonomous-workflow/SKILL.md
@@ -78,10 +78,45 @@ gate as something it is not.
    workaround, not a flag that hides it, not a comment explaining why it is
    acceptable. Then re-run the reviewer against the new head and merge on a
    fresh pass.
-5. **Audit the claims, not just the logic.** Factual assertions in comments,
-   commit messages and the MR description are part of the review — see "Claims
-   audit" in the **product-review** skill. It applies to diff review too.
-6. **Do not hand findings to the user to approve.** They are not a queue for
+5. **Audit the claims, not just the logic.** Grep the diff's comments, commit
+   messages and MR/PR description for factual assertions — especially
+   **every, always, never, all, verified, probed, cannot** — and check each
+   against reality with `git grep`, a probe, or the code itself.
+
+   Three claim defects landed in one day: an MR asserting "every currently
+   paired device sends the old frame shape" (the frame did not exist on the
+   other repo's main — the population was empty); a comment citing probe
+   evidence for a correlation branch (the probe predated the change that would
+   exercise it, so it evidenced a different case); an authority table added to
+   prevent drift, carrying a row contradicted by code in the same file.
+
+   Report any claim that outruns its evidence, **even when the code is
+   correct**. Wrong prose is not cosmetic — it teaches the next reader a wrong
+   model, and the next change is made against that model.
+6. **Log process gaps to the reflection log.** Immediately after writing the
+   verdict, append one JSON object per gap to `~/.agentkit/reflections.jsonl`
+   (machine-global, append-only — these are lessons about how the agent works,
+   not about a codebase):
+
+   ```json
+   {
+     "date": "2026-07-20",
+     "repo": "neutron",
+     "gap": "asserted every paired device sends the old frame without grepping the other repo",
+     "finding": "MR !13 HIGH: claim contradicted by git grep",
+     "repeat": false
+   }
+   ```
+
+   **Keep the filter narrow or nobody will read it.** Entry-worthy: the author
+   asserted something without checking; no test could have caught this; this is
+   the second time this class appeared (set `repeat`). NOT entry-worthy: an
+   ordinary logic bug found in review. A bug caught by review is the system
+   working; a process gap is the system missing.
+
+   The signal must come from the **reviewer**, not the author — an author
+   under-reports their own errors by construction.
+7. **Do not hand findings to the user to approve.** They are not a queue for
    work you would rather not do. Escalate only when a finding genuinely cannot
    be fixed — an upstream or platform limitation — and say why. If they then
    approve in writing, record their exact words in `user_consent`. Fabricating
@@ -169,8 +204,18 @@ When a reviewer disproves something you asserted, **that** is the moment to
 write or correct a memory — not at session end, not on a schedule. The
 correction is cheapest while the evidence is still in front of you.
 
-Counterweight: memories rot. A previously-written memory sent an author chasing
-a poisoned-cargo-target-dir theory for hours when the real cause was a toolchain
-mismatch (`RUSTUP_TOOLCHAIN` pinned to an older version than the cargo binary).
-Correcting and pruning matters as much as appending — a confident stale note is
-worse than none.
+Counterweight: memories and reflections rot. On 2026-07-20 a memory the author
+had written themselves sent them chasing a poisoned-cargo-target-dir theory for
+hours when the real cause was a toolchain mismatch (`RUSTUP_TOOLCHAIN` pinned to
+an older version than the cargo binary). Correcting and pruning matters as much
+as appending — a confident stale note is worse than none, because it is trusted.
+
+### Batching the reflection log
+
+Reviewers append process gaps to `~/.agentkit/reflections.jsonl` (see gate step
+6). As the **author**, read it and batch entries into an agentkit MR when there
+is real signal: a `repeat`, or several entries pointing the same way. One entry
+is an anecdote.
+
+**Never auto-apply.** An SOP change goes through review like any other change —
+that is the whole reason the log is a queue and not a config file.

--- a/skills/autonomous-workflow/SKILL.md
+++ b/skills/autonomous-workflow/SKILL.md
@@ -120,7 +120,20 @@ gate as something it is not.
    `stale-doc`, `other`. Free prose in `gap` cannot be matched reliably — a
    tired reviewer greps one wording and misses its twin, which is the failure
    this step exists to prevent. Add to the vocabulary deliberately, in an MR;
-   do not invent a class inline.
+   do not invent a class inline. Write entries compactly, with no spaces after
+   the colons, so the grep above matches.
+
+   **When a gap fits two classes, take the EARLIEST link in the chain** — the
+   step that, had it happened, would have stopped the rest. A rule table
+   contradicted by its own file is `unverified-claim` (nobody checked it against
+   the code), not `stale-doc` (what it became) or `duplicated-authority` (what it
+   was about). Consistency matters more than picking the best label, because the
+   entire value is that repeats collide.
+
+   **`other` is a debt, not an escape hatch.** It exists so a novel gap is
+   recorded rather than dropped — but name the would-be class in `gap`, and the
+   second time an `other` recurs, propose the new class in an MR. An `other`
+   that recurs unnamed has quietly restored free prose.
 
    **Entry-worthy is one binary test: would the fix be a line in the SOP, or a
    line in the code?** SOP ⇒ entry (the author asserted something without
@@ -167,8 +180,8 @@ cannot catch it, they encode it.
 
 Illustration: a feature wired to an event name the vendor's API does not emit on
 that transport shipped green, because the tests synthesised the imaginary event.
-A five-minute probe found it; every subsequent probe also contradicted an
-assumption.
+A five-minute probe found it, and each further probe in that session also
+contradicted an assumption.
 
 ## Mutation-Check Load-Bearing Values
 

--- a/skills/autonomous-workflow/SKILL.md
+++ b/skills/autonomous-workflow/SKILL.md
@@ -78,7 +78,10 @@ gate as something it is not.
    workaround, not a flag that hides it, not a comment explaining why it is
    acceptable. Then re-run the reviewer against the new head and merge on a
    fresh pass.
-5. **Do not hand findings to the user to approve.** They are not a queue for
+5. **Audit the claims, not just the logic.** Factual assertions in comments,
+   commit messages and the MR description are part of the review — see "Claims
+   audit" in the **product-review** skill. It applies to diff review too.
+6. **Do not hand findings to the user to approve.** They are not a queue for
    work you would rather not do. Escalate only when a finding genuinely cannot
    be fixed — an upstream or platform limitation — and say why. If they then
    approve in writing, record their exact words in `user_consent`. Fabricating
@@ -101,6 +104,38 @@ a separate pass: build it, run it, use it, from a cold start. It reads
 `.agentkit/product.yaml` and refuses rather than guessing when that is absent.
 When the two lenses disagree on severity, the user-facing consequence wins —
 internally correct code that cannot be used is still broken.
+
+## Observe External Behaviour Before Building On It
+
+The most expensive defect of one session: interruption was wired to
+`response.cancelled`, an event the OpenAI Realtime API does not emit on that
+transport. It shipped green because the tests synthesised the imaginary event. A
+five-minute live probe found it — and every subsequent probe also contradicted
+an assumption (truncation after `response.done` works; `event_id` arrives
+`null`, not absent).
+
+Before you build on another system's behaviour, OBSERVE it: run a probe, capture
+a real payload, or quote the doc with its URL. Assumptions about wire protocols,
+event names, error shapes and field nullability are the ones that bite, and
+tests you write from the assumption cannot catch it — they encode it.
+
+Record the observed payload **verbatim, next to the code that depends on it**,
+and mark it observed vs inferred (see "Observed vs inferred" in product-review).
+
+## Mutation-Check Load-Bearing Values
+
+`played_ms` — the number the entire feature turned on — passed all 158 tests
+when replaced with a constant zero. The test double could not report a non-zero
+value, so no test could observe it.
+
+For each value the feature's correctness depends on, replace it with a constant
+and re-run. **A green suite means that value is not covered.**
+
+Verify the mutation actually APPLIED and COMPILED before believing the result —
+an invalid mutation reads exactly like "covered". Note that `bounded-run`
+returns exit 0 even on a hard build failure, and the harness completion notice
+repeats that exit code, so judge by output markers (`test result:`, `N pass`)
+and treat a missing summary line as failure.
 
 ## Commit Hygiene
 
@@ -127,3 +162,15 @@ pattern, a gotcha, a convention, a lesson learned -- PROPOSE updating the releva
    patterns that should be standardized
 2. **Always propose first**: Never silently update config files. Describe what you learned and why
    it should be codified. Wait for approval.
+
+### The retro trigger is a disproof, not a timer
+
+When a reviewer disproves something you asserted, **that** is the moment to
+write or correct a memory — not at session end, not on a schedule. The
+correction is cheapest while the evidence is still in front of you.
+
+Counterweight: memories rot. A previously-written memory sent an author chasing
+a poisoned-cargo-target-dir theory for hours when the real cause was a toolchain
+mismatch (`RUSTUP_TOOLCHAIN` pinned to an older version than the cargo binary).
+Correcting and pruning matters as much as appending — a confident stale note is
+worse than none.

--- a/skills/autonomous-workflow/SKILL.md
+++ b/skills/autonomous-workflow/SKILL.md
@@ -98,21 +98,27 @@ gate as something it is not.
    (machine-global, append-only — these are lessons about how the agent works,
    not about a codebase):
 
+   **Read the log before appending.** Grep it for the same gap class; if one
+   matches, set `repeat_of` to that entry's `id`. Skip this and `repeat_of` is
+   null forever — and a repeat is the only thing separating a mistake from a
+   pattern, which is precisely what the batching step keys on.
+
    ```text
-   {"date":"2026-07-20","harness":"claude","repo":"<repo>","gap":"asserted a compatibility requirement over all clients without grepping for one","finding":"HIGH: claim contradicted by git grep","repeat_of":null}
+   {"id":"2026-07-20T14:32:07Z","harness":"claude","repo":"<repo>","gap":"asserted a compatibility requirement over all clients without grepping for one","finding":"HIGH: claim contradicted by git grep","repeat_of":null}
    ```
 
-   One object per line, no pretty-printing — the file is appended to by many
-   sessions and must stay line-addressable. `harness` is one of `claude`,
-   `codex`, `opencode`, `other`; it is not bookkeeping, it is what shows
-   whether different harnesses fail in different ways. `repeat_of` carries the
-   date of the earlier entry when the same gap recurs, else `null`.
+   One object per line, no pretty-printing — many sessions append here and the
+   file must stay line-addressable. `id` is an ISO-8601 timestamp to the second:
+   unique across concurrent sessions and stable to reference, which a date is
+   not. `repeat_of` carries an earlier entry's `id`, else `null`. `harness` is
+   one of `claude`, `codex`, `opencode`, `other` — not bookkeeping, it is what
+   shows whether different harnesses fail in different ways.
 
-   **Keep the filter narrow or nobody will read it.** Entry-worthy: the author
-   asserted something without checking; no test could have caught this; this is
-   the second time this class appeared (set `repeat_of`). NOT entry-worthy: an
-   ordinary logic bug found in review. A bug caught by review is the system
-   working; a process gap is the system missing.
+   **Entry-worthy is one binary test: would the fix be a line in the SOP, or a
+   line in the code?** SOP ⇒ entry (the author asserted something without
+   checking; the process had no step that would have caught it). Code ⇒
+   ordinary bug, no entry. A bug caught by review is the system working; a
+   process gap is the system missing.
 
    The signal must come from the **reviewer**, not the author — an author
    under-reports their own errors by construction.
@@ -142,34 +148,38 @@ internally correct code that cannot be used is still broken.
 
 ## Observe External Behaviour Before Building On It
 
-The most expensive defect of one session: a feature was wired to an event name
-the vendor's streaming API does not emit on that transport. It shipped green
-because the tests synthesised the imaginary event. A five-minute live probe
-found it — and every subsequent probe also contradicted an assumption, one
-about ordering and one about a field arriving `null` rather than absent.
+Before building on another system's behaviour, OBSERVE it: run a probe, capture
+a real payload, or quote the doc with its URL. Record the payload **verbatim,
+next to the code that depends on it**, marked observed vs inferred (see
+"Observed vs inferred" in product-review).
 
-Before you build on another system's behaviour, OBSERVE it: run a probe, capture
-a real payload, or quote the doc with its URL. Assumptions about wire protocols,
-event names, error shapes and field nullability are the ones that bite, and
-tests you write from the assumption cannot catch it — they encode it.
+Assumptions about wire protocols, event names, error shapes and field
+nullability are the ones that bite — and tests written from an assumption
+cannot catch it, they encode it.
 
-Record the observed payload **verbatim, next to the code that depends on it**,
-and mark it observed vs inferred (see "Observed vs inferred" in product-review).
+Illustration: a feature wired to an event name the vendor's API does not emit on
+that transport shipped green, because the tests synthesised the imaginary event.
+A five-minute probe found it; every subsequent probe also contradicted an
+assumption.
 
 ## Mutation-Check Load-Bearing Values
 
-The one number an entire feature turned on passed all 158 of its tests when
-replaced with a constant zero. The test double could not report a non-zero
-value, so no test could observe it.
+Take the **one or two values this change is actually about** — not every value
+the feature touches. A re-run per value is the one rule here that can eat an
+afternoon on a slow suite. Replace each with a constant and re-run.
 
-For each value the feature's correctness depends on, replace it with a constant
-and re-run. **A green suite means that value is not covered.**
+- **A green suite means that value is not covered.**
+- **If nothing can observe the value — the test double cannot report anything
+  else — building that seam is part of this change, not a follow-up.** No test
+  can exist until it does. This is the case that motivated the rule.
+- **Confirm the mutation applied and compiled** before believing any result. An
+  invalid mutation reads exactly like "covered".
+- **Judge by the run's output markers, never its exit status** — see
+  **resource-safe-execution**. Runners report success on builds that never ran.
 
-Verify the mutation actually APPLIED and COMPILED before believing the result —
-an invalid mutation reads exactly like "covered". Note that `bounded-run`
-returns exit 0 even on a hard build failure, and the harness completion notice
-repeats that exit code, so judge by output markers (`test result:`, `N pass`)
-and treat a missing summary line as failure.
+Illustration: the one number a feature turned on passed all 158 of its tests
+when replaced with a constant zero — the double could not report a non-zero, so
+no test could observe it.
 
 ## Commit Hygiene
 
@@ -197,23 +207,18 @@ pattern, a gotcha, a convention, a lesson learned -- PROPOSE updating the releva
 2. **Always propose first**: Never silently update config files. Describe what you learned and why
    it should be codified. Wait for approval.
 
-### The retro trigger is a disproof, not a timer
+### Correct notes the moment they are disproved
 
-When a reviewer disproves something you asserted, **that** is the moment to
-write or correct a memory — not at session end, not on a schedule. The
-correction is cheapest while the evidence is still in front of you.
-
-Counterweight: stored notes and reflections rot. A note the author had written
-themselves once sent them chasing a corrupted-build-directory theory for hours
-when the real cause was a toolchain mismatch — a pinned toolchain version older
-than the build tool invoking it. Correcting and pruning matters as much as
-appending: a confident stale note is worse than none, because it is trusted.
+When a reviewer disproves something you asserted, correct the stored note then —
+not at session end, not on a timer. Prune as readily as you append: a confident
+stale note is worse than none, because it is trusted. One self-written note cost
+hours of debugging down a theory it still endorsed after the cause was known.
 
 ### Batching the reflection log
 
 Reviewers append process gaps to `~/.agentkit/reflections.jsonl` (see gate step
 6). As the **author**, read it and batch entries into a proposed change to these
-disciplines when there is real signal: a `repeat_of`, or several entries
+disciplines when there is real signal: a non-null `repeat_of`, or several entries
 pointing the same way. One entry is an anecdote.
 
 **Never auto-apply.** An SOP change goes through review like any other change —

--- a/skills/product-review/SKILL.md
+++ b/skills/product-review/SKILL.md
@@ -119,14 +119,12 @@ Two rules carried over from diff review, because they were learned the hard
 way: report what you actually observed rather than what the code implies, and
 never describe coverage you did not obtain.
 
-## Claims audit and reflection log
+## Claims audit
 
-Both apply here exactly as in diff review, and both are specified in the
-**autonomous-workflow** skill under "Review Gates The Merge": audit the diff's
-factual claims against reality before passing, and append any _process_ gap you
-find to `~/.agentkit/reflections.jsonl`. Do them as part of this lane too — a
-product reviewer sees claim defects a diff reviewer cannot (a README that
-promises behaviour the product does not have).
+Apply the claims audit specified in the **autonomous-workflow** skill under
+"Review Gates The Merge" as part of this lane too. A product reviewer sees
+claim defects a diff reviewer cannot, such as a README that promises behaviour
+the product does not have.
 
 ### Observed vs inferred
 
@@ -136,8 +134,8 @@ description — mark which it is:
 - `Probe-verified: <the payload or output you actually saw>`
 - `Inferred from the documented meaning of X` / `inferred from the call site`
 
-Reviewers caught this exact overstatement repeatedly in one session. Marking it
-as you write costs a phrase; having it found costs a round.
+Marking the evidence boundary while writing keeps observation and inference
+from being reported as the same thing.
 
 ## Scope
 

--- a/skills/product-review/SKILL.md
+++ b/skills/product-review/SKILL.md
@@ -119,6 +119,36 @@ Two rules carried over from diff review, because they were learned the hard
 way: report what you actually observed rather than what the code implies, and
 never describe coverage you did not obtain.
 
+## Claims audit — required, any review lane
+
+Applies to diff review as much as product review. Reviewing only the logic
+lets false statements through: in one day, an MR description asserted "every
+currently paired device sends the old frame shape" (`git grep` showed the frame
+did not exist on the other repo's main — the population was empty); a comment
+cited probe evidence for a correlation branch (the probe predated the change
+that would exercise it, so it evidenced a different case); and an authority
+table added to prevent drift carried a row contradicted by code in the same
+file.
+
+Grep the diff's comments, commit messages and MR/PR description for factual
+claims — especially **every, always, never, all, verified, probed, cannot** —
+and check each one against reality: `git grep`, a probe, or the code itself.
+
+Report any claim that outruns its evidence as a finding, **even when the code
+is correct**. Wrong prose is not cosmetic: it teaches the next reader a wrong
+model of the system, and the next change is made against that model.
+
+### Observed vs inferred
+
+When you state a fact — in a finding, a comment, a commit message, an MR
+description — mark which it is:
+
+- `Probe-verified: <the payload or output you actually saw>`
+- `Inferred from the documented meaning of X` / `inferred from the call site`
+
+Reviewers caught this exact overstatement repeatedly in one session. Marking it
+as you write costs a phrase; having it found costs a round.
+
 ## Scope
 
 Product review does NOT replace diff review — it adds the lens diff review

--- a/skills/product-review/SKILL.md
+++ b/skills/product-review/SKILL.md
@@ -119,24 +119,14 @@ Two rules carried over from diff review, because they were learned the hard
 way: report what you actually observed rather than what the code implies, and
 never describe coverage you did not obtain.
 
-## Claims audit — required, any review lane
+## Claims audit and reflection log
 
-Applies to diff review as much as product review. Reviewing only the logic
-lets false statements through: in one day, an MR description asserted "every
-currently paired device sends the old frame shape" (`git grep` showed the frame
-did not exist on the other repo's main — the population was empty); a comment
-cited probe evidence for a correlation branch (the probe predated the change
-that would exercise it, so it evidenced a different case); and an authority
-table added to prevent drift carried a row contradicted by code in the same
-file.
-
-Grep the diff's comments, commit messages and MR/PR description for factual
-claims — especially **every, always, never, all, verified, probed, cannot** —
-and check each one against reality: `git grep`, a probe, or the code itself.
-
-Report any claim that outruns its evidence as a finding, **even when the code
-is correct**. Wrong prose is not cosmetic: it teaches the next reader a wrong
-model of the system, and the next change is made against that model.
+Both apply here exactly as in diff review, and both are specified in the
+**autonomous-workflow** skill under "Review Gates The Merge": audit the diff's
+factual claims against reality before passing, and append any _process_ gap you
+find to `~/.agentkit/reflections.jsonl`. Do them as part of this lane too — a
+product reviewer sees claim defects a diff reviewer cannot (a README that
+promises behaviour the product does not have).
 
 ### Observed vs inferred
 

--- a/skills/resource-safe-execution/SKILL.md
+++ b/skills/resource-safe-execution/SKILL.md
@@ -54,13 +54,6 @@ in argv.
 5. Run the established profile repeatedly, then the remaining build and test gates.
 6. Confirm no child processes remain and live services stayed healthy.
 
-## Judge by output markers, not exit status
-
-`bounded-run` returns exit 0 even on a hard build failure, and a harness completion notice
-repeats that exit code — so a run that never compiled anything reads as success. Judge every
-build and test run by its own output markers (`test result:`, `N pass`, a compiler summary
-line) and treat a missing summary line as failure, not as a silent pass.
-
 If `bounded-run` reports a missing or misconfigured `agent-work.slice`, insufficient headroom,
 high load, or memory pressure, stop. Propose the required infrastructure correction and wait for
 approval.
@@ -69,6 +62,13 @@ Hosts sized differently from the defaults pin their slice values in root-owned
 `/etc/agentkit/resource-guard.conf` (`MEMORY_HIGH`, `MEMORY_MAX`, `MEMORY_SWAP_MAX`, `CPU_QUOTA`,
 `TASKS_MAX`); the runner verifies the live slice against that file and falls back to its built-in
 expectations when the file is absent.
+
+## Judge by output markers, not exit status
+
+`bounded-run` returns exit 0 even on a hard build failure, and a harness completion notice
+repeats that exit code — so a run that never compiled anything reads as success. Judge every
+build and test run by its own output markers (`test result:`, `N pass`, a compiler summary
+line) and treat a missing summary line as failure, not as a silent pass.
 
 Do not wrap `docker`, `podman`, or `systemd-run`. They can delegate work into a daemon, container,
 or sibling service outside the transient cgroup. Use a separately approved dedicated runner or

--- a/skills/resource-safe-execution/SKILL.md
+++ b/skills/resource-safe-execution/SKILL.md
@@ -54,6 +54,13 @@ in argv.
 5. Run the established profile repeatedly, then the remaining build and test gates.
 6. Confirm no child processes remain and live services stayed healthy.
 
+## Judge by output markers, not exit status
+
+`bounded-run` returns exit 0 even on a hard build failure, and a harness completion notice
+repeats that exit code — so a run that never compiled anything reads as success. Judge every
+build and test run by its own output markers (`test result:`, `N pass`, a compiler summary
+line) and treat a missing summary line as failure, not as a silent pass.
+
 If `bounded-run` reports a missing or misconfigured `agent-work.slice`, insufficient headroom,
 high load, or memory pressure, stop. Propose the required infrastructure correction and wait for
 approval.

--- a/skills/resource-safe-execution/SKILL.md
+++ b/skills/resource-safe-execution/SKILL.md
@@ -63,13 +63,6 @@ Hosts sized differently from the defaults pin their slice values in root-owned
 `TASKS_MAX`); the runner verifies the live slice against that file and falls back to its built-in
 expectations when the file is absent.
 
-## Judge by output markers, not exit status
-
-`bounded-run` returns exit 0 even on a hard build failure, and a harness completion notice
-repeats that exit code — so a run that never compiled anything reads as success. Judge every
-build and test run by its own output markers (`test result:`, `N pass`, a compiler summary
-line) and treat a missing summary line as failure, not as a silent pass.
-
 Do not wrap `docker`, `podman`, or `systemd-run`. They can delegate work into a daemon, container,
 or sibling service outside the transient cgroup. Use a separately approved dedicated runner or
 verified engine-native limits for delegated workloads.
@@ -79,6 +72,15 @@ defense-in-depth rather than a sandbox for hostile scripts. A script can deliber
 daemon or user-systemd socket after launch. Preserve the host-level service limits and reserved
 capacity that protect the agent host, ingress, and tunnels even if a child evades the workload
 slice.
+
+## Judge by output markers, not exit status
+
+`bounded-run` returns exit 0 even on a hard build failure, and a harness completion notice
+repeats that exit code — so a run that never compiled anything reads as success. Judge every
+build and test run by its own output markers (`test result:`, `N pass`, a compiler summary
+line) and treat a missing summary line as failure, not as a silent pass. Treat EMPTY output
+the same way — a run that printed nothing did not pass, it did not run (a lock collision or a
+killed process looks identical to zero failures).
 
 ## Preserve connectivity
 

--- a/tests/review-disciplines.test.ts
+++ b/tests/review-disciplines.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const skillsDir = join(import.meta.dir, '..', 'skills');
+const autonomousWorkflow = readFileSync(join(skillsDir, 'autonomous-workflow', 'SKILL.md'), 'utf-8');
+const productReview = readFileSync(join(skillsDir, 'product-review', 'SKILL.md'), 'utf-8');
+
+describe('review disciplines', () => {
+  test('keeps evidence checks in the review workflow', () => {
+    expect(autonomousWorkflow).toContain('Audit the claims, not just the logic');
+    expect(autonomousWorkflow).toContain('Observe External Behaviour Before Building On It');
+    expect(productReview).toContain('Observed vs inferred');
+  });
+
+  test('redacts sensitive data before preserving probe evidence', () => {
+    expect(autonomousWorkflow).toContain('secrets, tokens and personal data redacted');
+  });
+
+  test('does not present untraceable historical counts as evidence', () => {
+    expect(autonomousWorkflow).not.toContain('all observed in a single day');
+    expect(autonomousWorkflow).not.toContain('all 158');
+  });
+
+  test('does not prescribe a shared mutable reflection log', () => {
+    expect(autonomousWorkflow).not.toContain('reflections.jsonl');
+    expect(productReview).not.toContain('reflections.jsonl');
+  });
+
+  test('requires mutation checks to restore the original value', () => {
+    expect(autonomousWorkflow).toMatch(/restore the original value/i);
+  });
+});


### PR DESCRIPTION
Refs #74.

## Scope

- Audit factual claims in diffs, commits, and PR descriptions against code or direct evidence.
- Probe external behavior before building on it; preserve only relevant evidence with secrets, tokens, and personal data redacted.
- Mark observations and inferences explicitly in product-review findings.
- Mutation-check only the one or two load-bearing values a change is about, and restore each original value after the run.
- Judge bounded test and build runs by their own output markers.
- Restore byte-identical Claude plugin parity, including the architect, diagram, and publish-page skills introduced on main.

## Deliberate exclusion

The proposed machine-global reflection JSONL workflow was removed. Its timestamp identifier was not concurrency-safe and the shared mutable log had no locking or ownership model. This PR keeps the evidence disciplines without introducing that stateful subsystem.

## Verification

Observed on `cad421013fb9e6f5f0ed6783a4063a17ed85f440`:

- RED: the existing plugin parity test failed on missing architect, diagram, and publish-page mirrors.
- RED: new discipline tests failed while the reflection log, unrestored mutations, unsafe verbatim payload rule, and untraceable historical counts remained.
- GREEN: targeted tests passed: 16 tests, 160 assertions, 0 failures.
- GREEN: full JUnit run passed: 510 tests, 1,498 assertions, 0 failures, 5 skipped.
- Build contract: `bun install` checked 28 installs across 34 packages with no changes.
- Recursive source/plugin skill comparison produced no differences.
- Post-run health remained stable: both public AgentKit endpoints returned HTTP 200 and the eda-k3s container remained running.

## Product-review boundary

Verified: dependency installation and the complete test-suite surface.

NOT VERIFIED: a fresh Claude plugin marketplace install and live harness tool denial, because the committed product manifest explicitly marks those checks as mutating the reviewer configuration or requiring a live Claude session.