### PR TITLE
fix(git-police): don't flag worktree-active gone branches as stale

### DIFF
--- a/hooks/claude/git-police.sh
+++ b/hooks/claude/git-police.sh
@@ -230,9 +230,15 @@ if echo "$STRIPPED" | grep -qiE '\bgit\b.*(checkout\s+-b|switch\s+-c)\b'; then
 		fi
 	fi
 	tgit fetch -p --quiet 2>/dev/null || true
-	GONE=$(tgit branch -vv 2>/dev/null | grep ': gone]' | awk '{print $1}' | tr '\n' ' ' || true)
+	# `git branch -vv` prefixes a branch checked out in ANOTHER worktree with
+	# `+` and the current branch with `*`, so a bare `$1` prints that marker
+	# instead of the branch name — and worse, flags a branch that's actively
+	# checked out elsewhere (normal under a worktree-per-branch workflow) as
+	# stale clutter. Exclude `+` lines (active elsewhere, not deletable here)
+	# and take $2 when the current-branch `*` marker is present.
+	GONE=$(tgit branch -vv 2>/dev/null | grep ': gone]' | grep -v '^+ ' | awk '{print ($1=="*") ? $2 : $1}' | tr '\n' ' ' || true)
 	if [[ -n "${GONE// /}" ]]; then
-		deny "BLOCKED: Stale local branches with deleted upstreams: ${GONE}. Clean up before starting new work: git branch -vv | awk '/: gone]/ {print \$1}' | xargs -r git branch -D"
+		deny "BLOCKED: Stale local branches with deleted upstreams: ${GONE}. Clean up before starting new work: git branch -vv | grep ': gone]' | grep -v '^+ ' | awk '{print (\$1=="*")?\$2:\$1}' | xargs -r git branch -D"
 	fi
 fi
 

--- a/plugins-cc/agentkit/hooks/git-police.sh
+++ b/plugins-cc/agentkit/hooks/git-police.sh
@@ -230,9 +230,15 @@ if echo "$STRIPPED" | grep -qiE '\bgit\b.*(checkout\s+-b|switch\s+-c)\b'; then
 		fi
 	fi
 	tgit fetch -p --quiet 2>/dev/null || true
-	GONE=$(tgit branch -vv 2>/dev/null | grep ': gone]' | awk '{print $1}' | tr '\n' ' ' || true)
+	# `git branch -vv` prefixes a branch checked out in ANOTHER worktree with
+	# `+` and the current branch with `*`, so a bare `$1` prints that marker
+	# instead of the branch name — and worse, flags a branch that's actively
+	# checked out elsewhere (normal under a worktree-per-branch workflow) as
+	# stale clutter. Exclude `+` lines (active elsewhere, not deletable here)
+	# and take $2 when the current-branch `*` marker is present.
+	GONE=$(tgit branch -vv 2>/dev/null | grep ': gone]' | grep -v '^+ ' | awk '{print ($1=="*") ? $2 : $1}' | tr '\n' ' ' || true)
 	if [[ -n "${GONE// /}" ]]; then
-		deny "BLOCKED: Stale local branches with deleted upstreams: ${GONE}. Clean up before starting new work: git branch -vv | awk '/: gone]/ {print \$1}' | xargs -r git branch -D"
+		deny "BLOCKED: Stale local branches with deleted upstreams: ${GONE}. Clean up before starting new work: git branch -vv | grep ': gone]' | grep -v '^+ ' | awk '{print (\$1=="*")?\$2:\$1}' | xargs -r git branch -D"
 	fi
 fi
 

--- a/tests/git-police-hygiene.test.ts
+++ b/tests/git-police-hygiene.test.ts
@@ -83,6 +83,29 @@ describe('git-police branch hygiene (rule 7)', () => {
     git(clone, 'branch -D feat/merged-away');
     expect(runHook(clone, 'git checkout -b feat/next')).not.toContain('feat/merged-away');
   });
+
+  test('a gone-upstream branch checked out in another worktree is NOT flagged as stale', () => {
+    // Under a worktree-per-branch workflow this is the normal state, not clutter:
+    // the branch is active elsewhere (git branch -vv prefixes it with `+`) and
+    // cannot be deleted from here. It must not block new branch creation.
+    git(clone, 'checkout -q -b feat/in-worktree');
+    git(clone, 'commit --allow-empty -m work');
+    git(clone, 'push -q -u origin feat/in-worktree');
+    git(clone, 'checkout -q main');
+    const wt = join(root, 'wt-active');
+    git(clone, `worktree add -q ${wt} feat/in-worktree`);
+    git(clone, 'push -q origin --delete feat/in-worktree');
+    git(clone, 'fetch -pq');
+
+    // git branch -vv now shows `+ feat/in-worktree ... : gone]`. Pre-fix this
+    // emitted `+` as a bogus stale-branch name and blocked; it must allow now.
+    const out = runHook(clone, 'git checkout -b feat/next');
+    expect(out).not.toContain('feat/in-worktree');
+    expect(out).not.toContain('Stale local branches');
+
+    git(clone, `worktree remove --force ${wt}`);
+    git(clone, 'branch -D feat/in-worktree');
+  });
 });
 
 describe('git-police branch creation resolves the targeted repo (rules 6-7)', () => {


### PR DESCRIPTION
`git branch -vv` prefixes a branch checked out in **another worktree** with `+` and the current branch with `*`, so the stale-branch detector's `awk '{print $1}'` printed the *marker* instead of the branch name — and, worse, flagged branches actively checked out elsewhere as stale clutter. Under a worktree-per-branch workflow (the normal state when multiple agents/sessions share a clone) this blocked new branch creation repo-wide.

**Fix:** `grep -v '^+ '` excludes branches active in another worktree (not deletable from here, not clutter), and `($1=="*")?$2:$1` extracts the real branch name when the current-branch marker is present. Applied to both hook copies (`hooks/claude/` + `plugins-cc/agentkit/hooks/`). Touches **only** stale-branch detection — no change to no-verify / force-push / protected-branch / AI-attribution enforcement.

**Test:** new hygiene case puts a gone-upstream branch in a separate worktree and asserts the hook doesn't flag it. Mutation-verified — reverting to the buggy `awk '{print $1}'` reds the new test. Full git-police suite 60/60.

Found live: a running session's git-police blocked all branch creation because worktree-active branches were misread as stale. Requested by the operator to land properly rather than as a live-file patch.