### PR TITLE
feat(git-police): nudge stale-branch cleanup when returning to default

### DIFF
--- a/hooks/claude/git-police.sh
+++ b/hooks/claude/git-police.sh
@@ -81,6 +81,22 @@ deny() {
 	exit 0
 }
 
+# advise: surface a reminder to the agent WITHOUT blocking the command. No
+# permissionDecision is emitted, so the normal permission flow runs and the
+# tool proceeds; `additionalContext` is the only PreToolUse channel Claude
+# Code injects into the model as a system reminder (permissionDecisionReason
+# reaches Claude only on "deny", and stdout on exit 0 is discarded).
+advise() {
+	local msg="$1"
+	jq -n --arg m "$msg" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      additionalContext: $m
+    }
+  }'
+	exit 0
+}
+
 # 1. Block --no-verify (skips pre-commit/commit-msg hooks)
 if echo "$STRIPPED" | grep -qiE '\bgit\b.*--no-verify\b'; then
 	deny "BLOCKED: --no-verify is forbidden. Skipping pre-commit hooks bypasses quality gates (linting, tests, formatting). Fix the issue that's causing the hook to fail instead."
@@ -258,6 +274,46 @@ if echo "$STRIPPED" | grep -qiE '\bgit\b.*(checkout\s+-b|switch\s+-c)\b'; then
 			fi
 		fi
 	done
+fi
+
+# 9. Merge-return branch hygiene (advisory — nudges, never blocks). Rule 7's
+#    hard-deny only fires when NEW work starts (checkout -b / switch -c), so
+#    stale merged branches linger unnoticed between a merge and the next
+#    branch creation. Fire a non-blocking reminder at the OTHER natural
+#    cleanup moment: returning to the default branch (checkout/switch to it,
+#    without -b/-c) or pulling while already on it. Same prune + gone
+#    detection as rule 7; the command is always allowed through.
+GIT_PULL_RE='\bgit([[:space:]]+(-[A-Za-z][^[:space:]]*|--[A-Za-z][A-Za-z0-9-]*(=[^[:space:]]+)?)([[:space:]]+[^-[:space:]][^[:space:]]*)?)*[[:space:]]+pull\b'
+if echo "$STRIPPED" | grep -qiE '\bgit\b.*\b(checkout|switch|pull)\b' \
+	&& ! echo "$STRIPPED" | grep -qiE '(checkout[[:space:]]+-b|switch[[:space:]]+-c)\b'; then
+	DEFAULT_BRANCH=$(tgit symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||' || true)
+	if [[ -z "$DEFAULT_BRANCH" ]]; then
+		for cand in "${PROTECTED_BRANCHES[@]}"; do
+			if tgit show-ref --verify --quiet "refs/heads/${cand}"; then
+				DEFAULT_BRANCH="$cand"
+				break
+			fi
+		done
+	fi
+	RETURN_TO_DEFAULT=false
+	if [[ -n "$DEFAULT_BRANCH" ]]; then
+		# checkout/switch to the default branch (flags allowed between)
+		if echo "$STRIPPED" | grep -qiE "\b(checkout|switch)\b([[:space:]]+-[^[:space:]]+)*[[:space:]]+${DEFAULT_BRANCH}\b"; then
+			RETURN_TO_DEFAULT=true
+		fi
+		# pull while already sitting on the default branch
+		if echo "$STRIPPED" | grep -qiE "$GIT_PULL_RE"; then
+			CURRENT_BRANCH=$(tgit symbolic-ref --short HEAD 2>/dev/null || echo "")
+			[[ "$CURRENT_BRANCH" == "$DEFAULT_BRANCH" ]] && RETURN_TO_DEFAULT=true
+		fi
+	fi
+	if [[ "$RETURN_TO_DEFAULT" == true ]]; then
+		tgit fetch -p --quiet 2>/dev/null || true
+		GONE=$(tgit branch -vv 2>/dev/null | grep ': gone]' | grep -v '^+ ' | awk '{print ($1=="*") ? $2 : $1}' | tr '\n' ' ' || true)
+		if [[ -n "${GONE// /}" ]]; then
+			advise "REMINDER: Stale local branches with deleted upstreams: ${GONE}. These were merged and their remotes deleted; now that you are back on ${DEFAULT_BRANCH}, clean them up: git branch -vv | grep ': gone]' | grep -v '^+ ' | awk '{print (\$1==\"*\")?\$2:\$1}' | xargs -r git branch -D"
+		fi
+	fi
 fi
 
 exit 0

--- a/plugins-cc/agentkit/hooks/git-police.sh
+++ b/plugins-cc/agentkit/hooks/git-police.sh
@@ -81,6 +81,22 @@ deny() {
 	exit 0
 }
 
+# advise: surface a reminder to the agent WITHOUT blocking the command. No
+# permissionDecision is emitted, so the normal permission flow runs and the
+# tool proceeds; `additionalContext` is the only PreToolUse channel Claude
+# Code injects into the model as a system reminder (permissionDecisionReason
+# reaches Claude only on "deny", and stdout on exit 0 is discarded).
+advise() {
+	local msg="$1"
+	jq -n --arg m "$msg" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      additionalContext: $m
+    }
+  }'
+	exit 0
+}
+
 # 1. Block --no-verify (skips pre-commit/commit-msg hooks)
 if echo "$STRIPPED" | grep -qiE '\bgit\b.*--no-verify\b'; then
 	deny "BLOCKED: --no-verify is forbidden. Skipping pre-commit hooks bypasses quality gates (linting, tests, formatting). Fix the issue that's causing the hook to fail instead."
@@ -258,6 +274,46 @@ if echo "$STRIPPED" | grep -qiE '\bgit\b.*(checkout\s+-b|switch\s+-c)\b'; then
 			fi
 		fi
 	done
+fi
+
+# 9. Merge-return branch hygiene (advisory — nudges, never blocks). Rule 7's
+#    hard-deny only fires when NEW work starts (checkout -b / switch -c), so
+#    stale merged branches linger unnoticed between a merge and the next
+#    branch creation. Fire a non-blocking reminder at the OTHER natural
+#    cleanup moment: returning to the default branch (checkout/switch to it,
+#    without -b/-c) or pulling while already on it. Same prune + gone
+#    detection as rule 7; the command is always allowed through.
+GIT_PULL_RE='\bgit([[:space:]]+(-[A-Za-z][^[:space:]]*|--[A-Za-z][A-Za-z0-9-]*(=[^[:space:]]+)?)([[:space:]]+[^-[:space:]][^[:space:]]*)?)*[[:space:]]+pull\b'
+if echo "$STRIPPED" | grep -qiE '\bgit\b.*\b(checkout|switch|pull)\b' \
+	&& ! echo "$STRIPPED" | grep -qiE '(checkout[[:space:]]+-b|switch[[:space:]]+-c)\b'; then
+	DEFAULT_BRANCH=$(tgit symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||' || true)
+	if [[ -z "$DEFAULT_BRANCH" ]]; then
+		for cand in "${PROTECTED_BRANCHES[@]}"; do
+			if tgit show-ref --verify --quiet "refs/heads/${cand}"; then
+				DEFAULT_BRANCH="$cand"
+				break
+			fi
+		done
+	fi
+	RETURN_TO_DEFAULT=false
+	if [[ -n "$DEFAULT_BRANCH" ]]; then
+		# checkout/switch to the default branch (flags allowed between)
+		if echo "$STRIPPED" | grep -qiE "\b(checkout|switch)\b([[:space:]]+-[^[:space:]]+)*[[:space:]]+${DEFAULT_BRANCH}\b"; then
+			RETURN_TO_DEFAULT=true
+		fi
+		# pull while already sitting on the default branch
+		if echo "$STRIPPED" | grep -qiE "$GIT_PULL_RE"; then
+			CURRENT_BRANCH=$(tgit symbolic-ref --short HEAD 2>/dev/null || echo "")
+			[[ "$CURRENT_BRANCH" == "$DEFAULT_BRANCH" ]] && RETURN_TO_DEFAULT=true
+		fi
+	fi
+	if [[ "$RETURN_TO_DEFAULT" == true ]]; then
+		tgit fetch -p --quiet 2>/dev/null || true
+		GONE=$(tgit branch -vv 2>/dev/null | grep ': gone]' | grep -v '^+ ' | awk '{print ($1=="*") ? $2 : $1}' | tr '\n' ' ' || true)
+		if [[ -n "${GONE// /}" ]]; then
+			advise "REMINDER: Stale local branches with deleted upstreams: ${GONE}. These were merged and their remotes deleted; now that you are back on ${DEFAULT_BRANCH}, clean them up: git branch -vv | grep ': gone]' | grep -v '^+ ' | awk '{print (\$1==\"*\")?\$2:\$1}' | xargs -r git branch -D"
+		fi
+	fi
 fi
 
 exit 0

--- a/tests/git-police-hygiene.test.ts
+++ b/tests/git-police-hygiene.test.ts
@@ -180,6 +180,66 @@ describe('git-police push branch resolution (rule 4)', () => {
   });
 });
 
+describe('git-police merge-return hygiene (rule 9, advisory)', () => {
+  // Rule 7 hard-denies gone branches only at branch CREATION. Rule 9 fires a
+  // non-blocking reminder at the other cleanup moment: returning to the
+  // default branch (or pulling while on it). Build a squash-merged (gone
+  // upstream) branch, then exercise those return moments.
+  function makeGoneBranch(name: string): void {
+    git(clone, `checkout -q -b ${name}`);
+    git(clone, 'commit --allow-empty -m work');
+    git(clone, `push -q -u origin ${name}`);
+    git(clone, 'checkout -q main');
+    git(clone, `push -q origin --delete ${name}`);
+    git(clone, 'fetch -pq');
+  }
+
+  test('reminds (without blocking) on checkout to default when a gone branch lingers', () => {
+    makeGoneBranch('feat/gone-a');
+    const out = runHook(clone, 'git checkout main');
+    expect(out).toContain('additionalContext'); // the reminder reaches the agent
+    expect(out).toContain('feat/gone-a'); // it names the stale branch
+    expect(out).toContain('xargs -r git branch -D'); // and gives the cleanup command
+    expect(out).not.toContain('"deny"'); // but never blocks the command
+    git(clone, 'branch -D feat/gone-a');
+  });
+
+  test('reminds on git pull while on the default branch', () => {
+    makeGoneBranch('feat/gone-b');
+    const out = runHook(clone, 'git pull');
+    expect(out).toContain('additionalContext');
+    expect(out).toContain('feat/gone-b');
+    expect(out).not.toContain('"deny"');
+    git(clone, 'branch -D feat/gone-b');
+  });
+
+  test('stays silent on checkout to default when no gone branches exist', () => {
+    git(clone, 'checkout -q main');
+    const out = runHook(clone, 'git checkout main');
+    expect(out.trim()).toBe(''); // no advisory, no deny — fully silent
+  });
+
+  test('does not fire when returning to a feature branch (only the default branch)', () => {
+    git(clone, 'checkout -q -b feat/keep');
+    makeGoneBranch('feat/gone-c'); // leaves the clone on main with a gone branch
+    const out = runHook(clone, 'git checkout feat/keep');
+    expect(out).not.toContain('additionalContext');
+    expect(out).not.toContain('feat/gone-c');
+    git(clone, 'checkout -q main');
+    git(clone, 'branch -D feat/gone-c');
+    git(clone, 'branch -D feat/keep');
+  });
+
+  test('branch creation still hard-denies with a gone branch present (rule 7 unchanged)', () => {
+    makeGoneBranch('feat/gone-d');
+    const out = runHook(clone, 'git checkout -b feat/after');
+    expect(out).toContain('"deny"'); // rule 7 still blocks new work
+    expect(out).toContain('feat/gone-d');
+    expect(out).not.toContain('additionalContext'); // deny short-circuits before rule 9
+    git(clone, 'branch -D feat/gone-d');
+  });
+});
+
 describe('git-police push rules require a push subcommand', () => {
   test('allows stash push combined with branch -f in a compound command', () => {
     git(clone, 'checkout -q main');


### PR DESCRIPTION
## Gap

git-police rule 7 hard-denies gone-upstream (squash-merged + remote-deleted) local branches **only at branch creation** (the `-b`/`-c` new-branch forms). Between a merge and the next new branch, stale merged branches linger unnoticed. Real incident: 8 merged `feat/p*` branches' stale tracking refs sat around because no new-branch creation happened.

## Change

Add **rule 9** — a **non-blocking advisory** (nudge, not a deny) at the other natural cleanup moment:

- fires on a `checkout`/`switch` to the **default branch** (not the new-branch form), or a `git pull` while **on** the default branch
- runs `git fetch -p --quiet`, detects `: gone]` branches with the exact existing pipeline (`git branch -vv | grep ': gone]' | grep -v '^+ ' | awk '{print ($1=="*")?$2:$1}'`)
- surfaces the list + the one-line `xargs -r git branch -D` cleanup via PreToolUse `hookSpecificOutput.additionalContext` (the only channel that reaches the model without blocking — `permissionDecisionReason` reaches Claude only on `deny`, exit-0 stdout is discarded)
- **always allows the command through**

Rule 7's hard-deny at branch creation is unchanged — this is a proactive complement, not a replacement.

## Scope

- `hooks/claude/git-police.sh` — new `advise()` helper + rule 9
- `plugins-cc/agentkit/hooks/git-police.sh` — byte-identical mirror (enforced by `agentkit-plugin.test.ts`)
- `tests/git-police-hygiene.test.ts` — 5 new tests

`plugins/git-police.ts` (OpenCode) is intentionally **not** touched: it never implemented rule 7, and OpenCode's `tool.execute.before` has no non-blocking model-context channel (throw = block, return = silent), so the advisory can't be faithfully reproduced there.

## Tests

- full suite: `bun test` -> **421 pass, 5 skip, 0 fail**
- mutation-verified each new assertion catches its regression: break the return-to-default detection -> reminder test fails; make `advise()` emit `deny` -> non-blocking assertion fails; advise when no gone branches -> silent test fails; break pull detection -> pull test fails; neuter the rule-7 deny -> "rule 7 unchanged" test fails
