### PR TITLE
feat(comment-police): add the missing Claude Code hook; fix installer drift

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,6 +1,12 @@
 # Agentkit Configuration
 # Copy to: ~/.config/agentkit/config.yaml
 # XDG_CONFIG_HOME is respected if set.
+#
+# comment-police, coding-police and format-police BLOCK an edit (exit 2) when
+# they find a violation — exit 0 would have their output discarded. Turn one or
+# all of them off for a session with:
+#   AGENTKIT_SKIP_HOOKS=coding-police
+#   AGENTKIT_SKIP_HOOKS=all
 
 git-police:
   branch-protection:

--- a/hooks/claude/coding-police.sh
+++ b/hooks/claude/coding-police.sh
@@ -7,9 +7,14 @@ set -euo pipefail
 # Kill switch, matching the AGENTKIT_* convention used by the PreToolUse
 # police. Comma-separated hook names; a blocking hook with no way off is a
 # hook that eventually gets deleted instead of configured.
-case ",${AGENTKIT_SKIP_HOOKS:-}," in
-  *",coding-police,"*|*",all,"*) exit 0 ;;
-esac
+# Trimmed, so "a, b" behaves like "a,b" — version-police already trims, and two
+# readings of one env var is a silent disagreement.
+if [[ -n "${AGENTKIT_SKIP_HOOKS:-}" ]]; then
+  _skip=",$(printf '%s' "$AGENTKIT_SKIP_HOOKS" | tr -d '[:space:]'),"
+  case "$_skip" in
+    *",coding-police,"*|*",all,"*) exit 0 ;;
+  esac
+fi
 
 # ── Configuration ───────────────────────────────────────────────────────────
 AGENTKIT_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/agentkit/config.yaml"
@@ -146,13 +151,8 @@ worsened() {
 }
 
 check_file_length() {
-  local line_count was
+  local line_count
   line_count=$(wc -l < "$FILE_PATH")
-  was=$(baseline_of | wc -l)
-  # Already over before this edit and not made worse: not this edit's business.
-  if (( was > MAX_FILE_LINES )) && ! worsened "$line_count" "$was"; then
-    return 0
-  fi
   if (( line_count > MAX_FILE_LINES )); then
     local excess=$(( line_count - MAX_FILE_LINES ))
     VIOLATIONS+=("FILE TOO LONG: ${line_count} lines (limit: ${MAX_FILE_LINES}, over by ${excess}). Split this file into smaller modules grouped by functionality. Identify logical boundaries (types, helpers, handlers, constants) and extract them.")
@@ -367,11 +367,60 @@ if [[ "$IS_CODE_FILE" != true ]]; then
   exit 0
 fi
 
+# Whole-file checks measure state this edit may not have caused. Run them once
+# against the committed baseline and once against the working file, then report
+# only what got WORSE — otherwise a legacy file with a long function or a
+# duplicated block nags after every unrelated edit, forever, and there is no
+# PostToolUse loop guard to stop it.
+#
+# Keyed by violation LABEL with the largest number seen for that label: line
+# numbers shift, counts and sizes are what "worse" means.
+worst_by_label() {
+  local v label n
+  for v in "$@"; do
+    label=${v%%:*}
+    n=$(printf '%s' "$v" | grep -oE '[0-9]+' | sort -rn | head -1)
+    printf '%s\t%s\n' "$label" "${n:-0}"
+  done | awk -F'\t' '{ if ($2+0 > m[$1]) m[$1]=$2+0 } END { for (k in m) printf "%s\t%s\n", k, m[k] }'
+}
+
+BASELINE_WORST=""
+BASELINE_FILE=""
+baseline_content=$(baseline_of)
+if [[ -n "$baseline_content" ]]; then
+  BASELINE_FILE=$(mktemp "${TMPDIR:-/tmp}/coding-police-base.XXXXXX.${FILE_PATH##*.}")
+  printf '%s\n' "$baseline_content" > "$BASELINE_FILE"
+  REAL_FILE_PATH="$FILE_PATH"
+  FILE_PATH="$BASELINE_FILE"
+  VIOLATIONS=()
+  check_file_length
+  check_function_lengths
+  check_duplicate_blocks
+  check_export_count
+  BASELINE_WORST=$(worst_by_label "${VIOLATIONS[@]+"${VIOLATIONS[@]}"}")
+  FILE_PATH="$REAL_FILE_PATH"
+  rm -f "$BASELINE_FILE"
+  VIOLATIONS=()
+fi
+
 check_file_length
 check_function_lengths
 check_duplicate_blocks
 check_export_count
 check_monolith_directory
+
+if [[ -n "$BASELINE_WORST" ]]; then
+  KEPT=()
+  for v in "${VIOLATIONS[@]+"${VIOLATIONS[@]}"}"; do
+    label=${v%%:*}
+    n=$(printf '%s' "$v" | grep -oE '[0-9]+' | sort -rn | head -1); n=${n:-0}
+    was=$(printf '%s' "$BASELINE_WORST" | awk -F'\t' -v l="$label" '$1==l { print $2 }')
+    # Present at HEAD and no worse now: not this edit's doing.
+    if [[ -n "$was" ]] && (( n <= was )); then continue; fi
+    KEPT+=("$v")
+  done
+  VIOLATIONS=("${KEPT[@]+"${KEPT[@]}"}")
+fi
 
 # ── Output violations ──────────────────────────────────────────────────────
 if (( ${#VIOLATIONS[@]} > 0 )); then

--- a/hooks/claude/coding-police.sh
+++ b/hooks/claude/coding-police.sh
@@ -373,13 +373,30 @@ fi
 # them reported untouched legacy code and hid genuinely new violations. Blanking
 # them compares the SHAPE and the identifier; counting occurrences means a
 # second duplicate block, or a second over-long function, still surfaces.
-# Blank EVERY number for the shape, and carry the severity separately. Keeping
-# sizes in the shape made the compare symmetric: a metric that moved in either
-# direction stopped matching, so DELETING 100 lines from an over-limit file
-# reported it as new — punishing the model for the cleanup the rule asks for.
-# The shape answers "same violation?"; the metric answers "worse?".
+# Blank the numeric FIELDS for the shape, and carry the severity separately.
+# Keeping sizes in the shape made the compare symmetric: a metric that moved in
+# either direction stopped matching, so DELETING 100 lines from an over-limit
+# file reported it as new — punishing the model for the cleanup the rule asks
+# for. The shape answers "same violation?"; the metric answers "worse?".
+#
+# Field by field, never a blanket s/[0-9]+/#/g: that also rewrote the backticked
+# identifier, so `handleV1Request` and `handleV2Request` collapsed into ONE
+# shape and the worse-slot pass below handed a real regression the other
+# function's slot — reporting nothing at all. Silence is the fail-open
+# direction. Directory paths and quoted source lines have the same hazard.
 violation_shape() {
-  printf '%s' "$1" | sed -E 's/[0-9]+/#/g'
+  printf '%s' "$1" | sed -E '
+    s/^(FILE TOO LONG: )[0-9]+/\1#/
+    s/^(DUPLICATE CODE: )[0-9]+/\1#/
+    s/^(TOO MANY EXPORTS: )[0-9]+/\1#/
+    s/( is )[0-9]+( lines)/\1#\2/
+    s/(limit: )[0-9]+/\1#/
+    s/(cap: )[0-9]+/\1#/
+    s/(over by )[0-9]+/\1#/
+    s/(already has )[0-9]+/\1#/
+    s/(at lines? )[0-9]+/\1#/g
+    s/( and )[0-9]+/\1#/g
+  '
 }
 
 # The severity number, chosen per message TYPE. Never "the largest number in
@@ -405,6 +422,7 @@ PRE_EXISTING=("${VIOLATIONS[@]+"${VIOLATIONS[@]}"}")
 
 BASE_SHAPES=()
 BASE_METRICS=()
+BASELINE_FILE=""
 baseline_content=$(baseline_of)
 if [[ -n "$baseline_content" ]]; then
   # mktemp needs the X's LAST (BSD accepts no suffix), but the baseline file is
@@ -412,11 +430,24 @@ if [[ -n "$baseline_content" ]]; then
   # the extension, so an extensionless temp file silently skipped that check and
   # left every over-cap file blocking its own edits forever. Rename it back.
   BASELINE_FILE=$(mktemp "${TMPDIR:-/tmp}/coding-police-base-XXXXXX")
+  # Under `set -e` a failure here would kill the hook between mktemp and rm:
+  # it would leak the file and, worse, emit no decision at all — which the
+  # harness reads as ALLOW. Degrade to "no baseline" instead of dying.
+  trap 'rm -f "$BASELINE_FILE"' EXIT
   baseline_ext="${FILE_PATH##*.}"
   if [[ "$baseline_ext" != "$FILE_PATH" ]]; then
-    mv "$BASELINE_FILE" "$BASELINE_FILE.$baseline_ext"
-    BASELINE_FILE="$BASELINE_FILE.$baseline_ext"
+    if mv -f -- "$BASELINE_FILE" "$BASELINE_FILE.$baseline_ext"; then
+      BASELINE_FILE="$BASELINE_FILE.$baseline_ext"
+    else
+      rm -f "$BASELINE_FILE"
+      BASELINE_FILE=""
+    fi
   fi
+fi
+
+# Empty when there is no committed baseline, or the rename failed and the
+# baseline was abandoned. Both mean "measure nothing" — never "die".
+if [[ -n "$BASELINE_FILE" ]]; then
   printf '%s\n' "$baseline_content" > "$BASELINE_FILE"
   REAL_FILE_PATH="$FILE_PATH"
   FILE_PATH="$BASELINE_FILE"
@@ -431,6 +462,7 @@ if [[ -n "$baseline_content" ]]; then
   done
   FILE_PATH="$REAL_FILE_PATH"
   rm -f "$BASELINE_FILE"
+  trap - EXIT
 fi
 
 VIOLATIONS=()

--- a/hooks/claude/coding-police.sh
+++ b/hooks/claude/coding-police.sh
@@ -362,6 +362,9 @@ if (( ${#VIOLATIONS[@]} > 0 )); then
     echo ""
     echo "Fix these violations before proceeding."
   } >&2
+  # Exit 2 is what delivers this. Claude Code discards a PostToolUse
+  # hook's stderr at exit 0, so the check ran and nobody heard it.
+  exit 2
 fi
 
 exit 0

--- a/hooks/claude/coding-police.sh
+++ b/hooks/claude/coding-police.sh
@@ -373,11 +373,30 @@ fi
 # them reported untouched legacy code and hid genuinely new violations. Blanking
 # them compares the SHAPE and the identifier; counting occurrences means a
 # second duplicate block, or a second over-long function, still surfaces.
-# Blank only POSITIONS (line numbers), never sizes or counts — those are the
-# severity. "1200 lines" vs "1400 lines" must differ; "starts at line 201" vs
-# "line 211" must not.
+# Blank EVERY number for the shape, and carry the severity separately. Keeping
+# sizes in the shape made the compare symmetric: a metric that moved in either
+# direction stopped matching, so DELETING 100 lines from an over-limit file
+# reported it as new — punishing the model for the cleanup the rule asks for.
+# The shape answers "same violation?"; the metric answers "worse?".
 violation_shape() {
-  printf '%s' "$1" | sed -E 's/(at lines? )[0-9]+/\1#/g; s/(and )[0-9]+/\1#/g'
+  printf '%s' "$1" | sed -E 's/[0-9]+/#/g'
+}
+
+# The severity number, chosen per message TYPE. Never "the largest number in
+# the line" — that picked up `starts at line 201` and inverted the comparison
+# on any file long enough for a line number to exceed a length.
+violation_metric() {
+  local m
+  case "$1" in
+    "FILE TOO LONG: "*) m=$(printf '%s' "$1" | sed -E 's/^FILE TOO LONG: ([0-9]+) lines.*/\1/') ;;
+    "LONG FUNCTION: "*) m=$(printf '%s' "$1" | sed -E 's/^LONG FUNCTION: .* is ([0-9]+) lines.*/\1/') ;;
+    "DUPLICATE CODE: "*) m=$(printf '%s' "$1" | sed -E 's/^DUPLICATE CODE: ([0-9]+)\+ line.*/\1/') ;;
+    "TOO MANY EXPORTS: "*) m=$(printf '%s' "$1" | sed -E 's/^TOO MANY EXPORTS: ([0-9]+) exports.*/\1/') ;;
+    *) m=0 ;;
+  esac
+  # A sed that did not match returns the whole line; that must not reach $(( )).
+  [[ "$m" =~ ^[0-9]+$ ]] || m=0
+  printf '%s' "$m"
 }
 
 # The cross-repo check already ran and its findings are NOT whole-file state —
@@ -385,9 +404,19 @@ violation_shape() {
 PRE_EXISTING=("${VIOLATIONS[@]+"${VIOLATIONS[@]}"}")
 
 BASE_SHAPES=()
+BASE_METRICS=()
 baseline_content=$(baseline_of)
 if [[ -n "$baseline_content" ]]; then
+  # mktemp needs the X's LAST (BSD accepts no suffix), but the baseline file is
+  # then measured as if it were the real one — and check_export_count gates on
+  # the extension, so an extensionless temp file silently skipped that check and
+  # left every over-cap file blocking its own edits forever. Rename it back.
   BASELINE_FILE=$(mktemp "${TMPDIR:-/tmp}/coding-police-base-XXXXXX")
+  baseline_ext="${FILE_PATH##*.}"
+  if [[ "$baseline_ext" != "$FILE_PATH" ]]; then
+    mv "$BASELINE_FILE" "$BASELINE_FILE.$baseline_ext"
+    BASELINE_FILE="$BASELINE_FILE.$baseline_ext"
+  fi
   printf '%s\n' "$baseline_content" > "$BASELINE_FILE"
   REAL_FILE_PATH="$FILE_PATH"
   FILE_PATH="$BASELINE_FILE"
@@ -398,6 +427,7 @@ if [[ -n "$baseline_content" ]]; then
   check_export_count
   for v in "${VIOLATIONS[@]+"${VIOLATIONS[@]}"}"; do
     BASE_SHAPES+=("$(violation_shape "$v")")
+    BASE_METRICS+=("$(violation_metric "$v")")
   done
   FILE_PATH="$REAL_FILE_PATH"
   rm -f "$BASELINE_FILE"
@@ -414,16 +444,33 @@ if (( ${#BASE_SHAPES[@]} > 0 )); then
   KEPT=()
   for v in "${VIOLATIONS[@]+"${VIOLATIONS[@]}"}"; do
     shape=$(violation_shape "$v")
-    matched=false
+    metric=$(violation_metric "$v")
+    matched=""
+    # Same severity first, so an unchanged violation claims its own baseline
+    # slot before a shrunken one consumes a bigger neighbour's and leaves the
+    # neighbour looking new.
     for i in "${!BASE_SHAPES[@]}"; do
-      if [[ "${BASE_SHAPES[$i]}" == "$shape" ]]; then
-        # Consume it: a THIRD duplicate block when the baseline had two is new.
-        unset 'BASE_SHAPES[i]'
-        matched=true
+      if [[ "${BASE_SHAPES[$i]}" == "$shape" ]] && (( BASE_METRICS[i] == metric )); then
+        matched=$i
         break
       fi
     done
-    [[ "$matched" == true ]] || KEPT+=("$v")
+    if [[ -z "$matched" ]]; then
+      # Otherwise any baseline slot that was WORSE absorbs it — an improvement
+      # is silent. A metric above every slot is a real regression and is kept.
+      for i in "${!BASE_SHAPES[@]}"; do
+        if [[ "${BASE_SHAPES[$i]}" == "$shape" ]] && (( BASE_METRICS[i] > metric )); then
+          matched=$i
+          break
+        fi
+      done
+    fi
+    if [[ -n "$matched" ]]; then
+      # Consume it: a THIRD duplicate block when the baseline had two is new.
+      unset 'BASE_SHAPES[matched]' 'BASE_METRICS[matched]'
+    else
+      KEPT+=("$v")
+    fi
   done
   VIOLATIONS=("${KEPT[@]+"${KEPT[@]}"}")
 fi

--- a/hooks/claude/coding-police.sh
+++ b/hooks/claude/coding-police.sh
@@ -144,11 +144,6 @@ baseline_of() {
   git -C "$top" show "HEAD:$rel" 2>/dev/null || true
 }
 
-# Whether this edit made `metric` worse than it already was at HEAD.
-worsened() {
-  local now="$1" was="$2"
-  (( now > was ))
-}
 
 check_file_length() {
   local line_count
@@ -369,26 +364,30 @@ fi
 
 # Whole-file checks measure state this edit may not have caused. Run them once
 # against the committed baseline and once against the working file, then report
-# only what got WORSE — otherwise a legacy file with a long function or a
+# only what is NEW — otherwise a legacy file with a long function or a
 # duplicated block nags after every unrelated edit, forever, and there is no
 # PostToolUse loop guard to stop it.
 #
-# Keyed by violation LABEL with the largest number seen for that label: line
-# numbers shift, counts and sizes are what "worse" means.
-worst_by_label() {
-  local v label n
-  for v in "$@"; do
-    label=${v%%:*}
-    n=$(printf '%s' "$v" | grep -oE '[0-9]+' | sort -rn | head -1)
-    printf '%s\t%s\n' "$label" "${n:-0}"
-  done | awk -F'\t' '{ if ($2+0 > m[$1]) m[$1]=$2+0 } END { for (k in m) printf "%s\t%s\n", k, m[k] }'
+# Compared as a MULTISET of violations with every number blanked. Numbers are
+# line offsets and sizes that shift when unrelated lines move, so matching on
+# them reported untouched legacy code and hid genuinely new violations. Blanking
+# them compares the SHAPE and the identifier; counting occurrences means a
+# second duplicate block, or a second over-long function, still surfaces.
+# Blank only POSITIONS (line numbers), never sizes or counts — those are the
+# severity. "1200 lines" vs "1400 lines" must differ; "starts at line 201" vs
+# "line 211" must not.
+violation_shape() {
+  printf '%s' "$1" | sed -E 's/(at lines? )[0-9]+/\1#/g; s/(and )[0-9]+/\1#/g'
 }
 
-BASELINE_WORST=""
-BASELINE_FILE=""
+# The cross-repo check already ran and its findings are NOT whole-file state —
+# they must survive the baseline pass, which resets the array.
+PRE_EXISTING=("${VIOLATIONS[@]+"${VIOLATIONS[@]}"}")
+
+BASE_SHAPES=()
 baseline_content=$(baseline_of)
 if [[ -n "$baseline_content" ]]; then
-  BASELINE_FILE=$(mktemp "${TMPDIR:-/tmp}/coding-police-base.XXXXXX.${FILE_PATH##*.}")
+  BASELINE_FILE=$(mktemp "${TMPDIR:-/tmp}/coding-police-base-XXXXXX")
   printf '%s\n' "$baseline_content" > "$BASELINE_FILE"
   REAL_FILE_PATH="$FILE_PATH"
   FILE_PATH="$BASELINE_FILE"
@@ -397,30 +396,39 @@ if [[ -n "$baseline_content" ]]; then
   check_function_lengths
   check_duplicate_blocks
   check_export_count
-  BASELINE_WORST=$(worst_by_label "${VIOLATIONS[@]+"${VIOLATIONS[@]}"}")
+  for v in "${VIOLATIONS[@]+"${VIOLATIONS[@]}"}"; do
+    BASE_SHAPES+=("$(violation_shape "$v")")
+  done
   FILE_PATH="$REAL_FILE_PATH"
   rm -f "$BASELINE_FILE"
-  VIOLATIONS=()
 fi
 
+VIOLATIONS=()
 check_file_length
 check_function_lengths
 check_duplicate_blocks
 check_export_count
 check_monolith_directory
 
-if [[ -n "$BASELINE_WORST" ]]; then
+if (( ${#BASE_SHAPES[@]} > 0 )); then
   KEPT=()
   for v in "${VIOLATIONS[@]+"${VIOLATIONS[@]}"}"; do
-    label=${v%%:*}
-    n=$(printf '%s' "$v" | grep -oE '[0-9]+' | sort -rn | head -1); n=${n:-0}
-    was=$(printf '%s' "$BASELINE_WORST" | awk -F'\t' -v l="$label" '$1==l { print $2 }')
-    # Present at HEAD and no worse now: not this edit's doing.
-    if [[ -n "$was" ]] && (( n <= was )); then continue; fi
-    KEPT+=("$v")
+    shape=$(violation_shape "$v")
+    matched=false
+    for i in "${!BASE_SHAPES[@]}"; do
+      if [[ "${BASE_SHAPES[$i]}" == "$shape" ]]; then
+        # Consume it: a THIRD duplicate block when the baseline had two is new.
+        unset 'BASE_SHAPES[i]'
+        matched=true
+        break
+      fi
+    done
+    [[ "$matched" == true ]] || KEPT+=("$v")
   done
   VIOLATIONS=("${KEPT[@]+"${KEPT[@]}"}")
 fi
+
+VIOLATIONS=("${PRE_EXISTING[@]+"${PRE_EXISTING[@]}"}" "${VIOLATIONS[@]+"${VIOLATIONS[@]}"}")
 
 # ── Output violations ──────────────────────────────────────────────────────
 if (( ${#VIOLATIONS[@]} > 0 )); then

--- a/hooks/claude/coding-police.sh
+++ b/hooks/claude/coding-police.sh
@@ -4,6 +4,13 @@
 # Equivalent to: plugins/coding-police.ts (OpenCode)
 set -euo pipefail
 
+# Kill switch, matching the AGENTKIT_* convention used by the PreToolUse
+# police. Comma-separated hook names; a blocking hook with no way off is a
+# hook that eventually gets deleted instead of configured.
+case ",${AGENTKIT_SKIP_HOOKS:-}," in
+  *",coding-police,"*|*",all,"*) exit 0 ;;
+esac
+
 # ── Configuration ───────────────────────────────────────────────────────────
 AGENTKIT_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/agentkit/config.yaml"
 
@@ -120,9 +127,32 @@ check_cross_repo_relative_paths() {
 }
 
 # ── Check 1: File length ───────────────────────────────────────────────────
+
+# The committed version of FILE_PATH, or empty when it is new / not in git.
+# Whole-file checks measure state the current edit may not have caused; a file
+# that was already too long would otherwise block EVERY later edit to it,
+# unfixably, and Claude Code has no PostToolUse loop guard to stop that.
+baseline_of() {
+  local top rel
+  top=$(git -C "$(dirname "$FILE_PATH")" rev-parse --show-toplevel 2>/dev/null) || return 0
+  rel=${FILE_PATH#"$top"/}
+  git -C "$top" show "HEAD:$rel" 2>/dev/null || true
+}
+
+# Whether this edit made `metric` worse than it already was at HEAD.
+worsened() {
+  local now="$1" was="$2"
+  (( now > was ))
+}
+
 check_file_length() {
-  local line_count
+  local line_count was
   line_count=$(wc -l < "$FILE_PATH")
+  was=$(baseline_of | wc -l)
+  # Already over before this edit and not made worse: not this edit's business.
+  if (( was > MAX_FILE_LINES )) && ! worsened "$line_count" "$was"; then
+    return 0
+  fi
   if (( line_count > MAX_FILE_LINES )); then
     local excess=$(( line_count - MAX_FILE_LINES ))
     VIOLATIONS+=("FILE TOO LONG: ${line_count} lines (limit: ${MAX_FILE_LINES}, over by ${excess}). Split this file into smaller modules grouped by functionality. Identify logical boundaries (types, helpers, handlers, constants) and extract them.")
@@ -332,6 +362,7 @@ if [[ "$IS_CODE_FILE" != true ]]; then
       echo ""
       echo "Fix these violations before proceeding."
     } >&2
+    exit 2
   fi
   exit 0
 fi

--- a/hooks/claude/comment-police.sh
+++ b/hooks/claude/comment-police.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# comment-police.sh — Claude Code PostToolUse hook (matcher: Edit|Write)
+# Claude-side counterpart of plugins/comment-police.ts; both read the
+# `comment-police:` section of the agentkit config, so the keys must match.
+#
+# Checks ADDED lines only — a file's pre-existing comments are not the business
+# of whoever touched one line of it.
+set -euo pipefail
+
+AGENTKIT_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/agentkit/config.yaml"
+
+MAX_BLOCK_LINES=6
+MAX_COMMENT_RATIO_PCT=30
+EXCLUDE_PATTERNS=()
+
+# Forge references rot: a comment lives as long as the repo, but issues and
+# merge requests live in the forge, so a clone or a migration leaves the pointer
+# dangling exactly when someone needs the reasoning.
+FORGE_PATTERNS=(
+  '[#!][0-9]{1,6}([^0-9a-zA-Z_]|$)'
+  '(issue|ticket|PR|MR|merge request|pull request)[[:space:]]*[#!]?[0-9]+'
+  '(gitlab|github)\.com/[^[:space:]]*/(issues|merge_requests|pull)/'
+  '(commit|sha)[[:space:]]+[0-9a-f]{7,40}'
+  '[Pp]lan-?[[:space:]]?[0-9]+'
+  'as part of (this|the) (PR|MR|fix)'
+  'see (issue|ticket|PR|MR)'
+)
+
+load_config() {
+  [[ -f "$AGENTKIT_CONFIG" ]] || return 0
+  local key value
+  while IFS='=' read -r key value; do
+    case "$key" in
+      max-block-lines) MAX_BLOCK_LINES="$value" ;;
+      max-comment-ratio) MAX_COMMENT_RATIO_PCT=$(awk -v r="$value" 'BEGIN{printf "%d", r*100}') ;;
+      exclude-pattern) EXCLUDE_PATTERNS+=("$value") ;;
+    esac
+  done < <(awk '
+    /^[^[:space:]#]/ { in_section = ($0 ~ /^comment-police:/); in_excludes = 0; next }
+    in_section {
+      line = $0
+      sub(/^[[:space:]]+/, "", line)
+      if (in_excludes) {
+        if (line ~ /^-[[:space:]]*.+$/) { v = line; sub(/^-[[:space:]]*/, "", v); print "exclude-pattern=" v; next }
+        in_excludes = 0
+      }
+      if (line ~ /^exclude-patterns:[[:space:]]*$/) { in_excludes = 1; next }
+      if (line !~ /^(max-block-lines:[[:space:]]*[0-9]+|max-comment-ratio:[[:space:]]*[0-9.]+)([[:space:]]*#.*)?$/) next
+      k = line; sub(/:.*/, "", k)
+      sub(/^[^:]*:[[:space:]]*/, "", line); sub(/[[:space:]#].*$/, "", line)
+      print k "=" line
+    }
+  ' "$AGENTKIT_CONFIG")
+}
+load_config
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+INPUT=$(cat)
+case "$(echo "$INPUT" | jq -r '.tool_name // empty')" in
+  Edit|Write|edit|write) ;;
+  *) exit 0 ;;
+esac
+
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.filePath // empty')
+[[ -z "$FILE_PATH" ]] && exit 0
+
+case "$FILE_PATH" in
+  *.ts|*.tsx|*.js|*.jsx|*.py|*.rb|*.go|*.rs|*.java|*.kt|*.cs|*.cpp|*.c|*.h|*.hpp|*.swift|*.scala|*.vue|*.svelte|*.sh|*.bash) ;;
+  *) exit 0 ;;
+esac
+case "$FILE_PATH" in
+  *.lock|*.min.*|*.generated.*|*.snap|*.d.ts) exit 0 ;;
+esac
+for pattern in "${EXCLUDE_PATTERNS[@]}"; do
+  [[ "$FILE_PATH" == *"$pattern"* ]] && exit 0
+done
+
+ADDED=$(echo "$INPUT" | jq -r '.tool_input.new_string // .tool_input.content // empty')
+[[ -z "$ADDED" ]] && exit 0
+
+VIOLATIONS=()
+
+is_comment_line() {
+  [[ "$1" =~ ^[[:space:]]*(//|#|--|/\*|\*[^/]) ]] || [[ "$1" =~ ^[[:space:]]*\*$ ]]
+}
+
+check_blocks_and_ratio() {
+  local run=0 worst=0 first="" comments=0 total=0
+  while IFS= read -r line; do
+    [[ -z "${line//[[:space:]]/}" ]] && continue
+    total=$(( total + 1 ))
+    if is_comment_line "$line"; then
+      comments=$(( comments + 1 ))
+      (( run == 0 )) && first="$(echo "$line" | sed 's/^[[:space:]]*//' | cut -c1-60)"
+      run=$(( run + 1 ))
+      (( run > worst )) && worst=$run
+    else
+      run=0
+    fi
+  done <<< "$ADDED"
+
+  if (( worst > MAX_BLOCK_LINES )); then
+    VIOLATIONS+=("COMMENT BLOCK TOO LONG: ${worst} consecutive comment lines (limit: ${MAX_BLOCK_LINES}), starting \"${first}...\". A comment earns its place by explaining non-obvious WHY. Restating what the code does, narrating history, or enumerating cases the code already enumerates is not that.")
+  fi
+
+  if (( total >= 10 )); then
+    local pct=$(( comments * 100 / total ))
+    if (( pct > MAX_COMMENT_RATIO_PCT )); then
+      VIOLATIONS+=("TOO MANY COMMENTS: ${pct}% of the added lines are comments (limit: ${MAX_COMMENT_RATIO_PCT}%). If you are explaining the code, fix the code instead — rename, extract a helper, restructure.")
+    fi
+  fi
+}
+
+check_forbidden() {
+  local hits="" pat
+  while IFS= read -r line; do
+    is_comment_line "$line" || continue
+    for pat in "${FORGE_PATTERNS[@]}"; do
+      if [[ "$line" =~ $pat ]]; then
+        hits+="    ${line#"${line%%[![:space:]]*}"}"$'\n'
+        break
+      fi
+    done
+  done <<< "$ADDED"
+  [[ -z "$hits" ]] && return 0
+  VIOLATIONS+=("FORGE REFERENCE IN A COMMENT:
+${hits}  Issues, merge requests and commit shas live in the forge, not the repo — a clone or a forge migration leaves the pointer dangling and the reasoning unreachable. State the reason in the comment itself; put traceability in the commit message; record durable decisions in an in-repo design doc.")
+}
+
+check_blocks_and_ratio
+check_forbidden
+
+if (( ${#VIOLATIONS[@]} > 0 )); then
+  {
+    echo ""
+    echo "COMMENT DISCIPLINE VIOLATION (comment-police)"
+    echo "=================================================="
+    for i in "${!VIOLATIONS[@]}"; do
+      echo "$(( i + 1 )). ${VIOLATIONS[$i]}"
+      echo ""
+    done
+    echo "REQUIRED ACTIONS:"
+    echo "- Default to no comment; add one only for non-obvious WHY."
+    echo "- Keep blocks to ${MAX_BLOCK_LINES} lines or fewer."
+    echo "- No issue/MR/PR numbers, commit shas, plan numbers, or forge URLs in source."
+    echo "- Traceability goes in the commit message; durable decisions in an in-repo doc."
+    echo ""
+    echo "Fix these before proceeding."
+  } >&2
+fi
+
+exit 0

--- a/hooks/claude/comment-police.sh
+++ b/hooks/claude/comment-police.sh
@@ -10,9 +10,14 @@ set -euo pipefail
 # Kill switch, matching the AGENTKIT_* convention used by the PreToolUse
 # police. Comma-separated hook names; a blocking hook with no way off is a
 # hook that eventually gets deleted instead of configured.
-case ",${AGENTKIT_SKIP_HOOKS:-}," in
-  *",comment-police,"*|*",all,"*) exit 0 ;;
-esac
+# Trimmed, so "a, b" behaves like "a,b" — version-police already trims, and two
+# readings of one env var is a silent disagreement.
+if [[ -n "${AGENTKIT_SKIP_HOOKS:-}" ]]; then
+  _skip=",$(printf '%s' "$AGENTKIT_SKIP_HOOKS" | tr -d '[:space:]'),"
+  case "$_skip" in
+    *",comment-police,"*|*",all,"*) exit 0 ;;
+  esac
+fi
 
 AGENTKIT_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/agentkit/config.yaml"
 

--- a/hooks/claude/comment-police.sh
+++ b/hooks/claude/comment-police.sh
@@ -7,6 +7,13 @@
 # of whoever touched one line of it.
 set -euo pipefail
 
+# Kill switch, matching the AGENTKIT_* convention used by the PreToolUse
+# police. Comma-separated hook names; a blocking hook with no way off is a
+# hook that eventually gets deleted instead of configured.
+case ",${AGENTKIT_SKIP_HOOKS:-}," in
+  *",comment-police,"*|*",all,"*) exit 0 ;;
+esac
+
 AGENTKIT_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/agentkit/config.yaml"
 
 MAX_BLOCK_LINES=6

--- a/hooks/claude/comment-police.sh
+++ b/hooks/claude/comment-police.sh
@@ -148,6 +148,9 @@ if (( ${#VIOLATIONS[@]} > 0 )); then
     echo ""
     echo "Fix these before proceeding."
   } >&2
+  # Exit 2 is what delivers this. Claude Code discards a PostToolUse
+  # hook's stderr at exit 0, so the check ran and nobody heard it.
+  exit 2
 fi
 
 exit 0

--- a/hooks/claude/format-police.sh
+++ b/hooks/claude/format-police.sh
@@ -83,17 +83,17 @@ trap 'rm -f "$ERR_LOG"' EXIT
 if ! "$DPRINT" fmt $CONFIG_FLAG "$FILE_PATH" 2>"$ERR_LOG"; then
   err=$(cat "$ERR_LOG")
   echo "⚠ dprint fmt failed for $FILE_PATH: $err" >&2
-  # Exit 2 ONLY when the failure is attributable to the edited file, i.e. the
-  # model can act on it. dprint fetches wasm plugins over the network, so a
-  # config typo or an offline machine would otherwise turn EVERY edit to any
-  # formattable file into an error nobody can fix — the exact blast-radius
-  # problem this hook set out to bound.
+  # ALLOWLIST, not a denylist. Only a failure dprint attributes to THIS file is
+  # something the model can act on; everything else — an unresolvable plugin, a
+  # scoped `includes` that excludes this extension, no network — is
+  # infrastructure, and blocking on it turns every edit into an error nobody
+  # can fix. Denylisting was tried and was unsound: dprint echoes the path into
+  # the message, so a pattern like *config* silently swallowed real errors in
+  # any file under a config/ directory.
   case "$err" in
-    *"Error resolving plugin"*|*"plugin"*"404"*|*"error sending request"*|*"os error"*|\
-    *"No such file or directory"*|*"Had 0 plugins"*|*"config"*)
-      exit 0 ;;
+    *"Error formatting $FILE_PATH"*) exit 2 ;;
   esac
-  exit 2
+  exit 0
 fi
 
 exit 0

--- a/hooks/claude/format-police.sh
+++ b/hooks/claude/format-police.sh
@@ -4,6 +4,13 @@
 # Equivalent to: plugins/format-police.ts (OpenCode)
 set -euo pipefail
 
+# Kill switch, matching the AGENTKIT_* convention used by the PreToolUse
+# police. Comma-separated hook names; a blocking hook with no way off is a
+# hook that eventually gets deleted instead of configured.
+case ",${AGENTKIT_SKIP_HOOKS:-}," in
+  *",format-police,"*|*",all,"*) exit 0 ;;
+esac
+
 INPUT=$(cat)
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
 

--- a/hooks/claude/format-police.sh
+++ b/hooks/claude/format-police.sh
@@ -66,6 +66,8 @@ fi
 # Format the file — warn on failure instead of silently swallowing
 if ! "$DPRINT" fmt $CONFIG_FLAG "$FILE_PATH" 2>/tmp/dprint-err.log; then
   echo "⚠ dprint fmt failed for $FILE_PATH: $(cat /tmp/dprint-err.log)" >&2
+  # Exit 2: a formatting failure that nobody hears lands unformatted code.
+  exit 2
 fi
 
 exit 0

--- a/hooks/claude/format-police.sh
+++ b/hooks/claude/format-police.sh
@@ -7,9 +7,14 @@ set -euo pipefail
 # Kill switch, matching the AGENTKIT_* convention used by the PreToolUse
 # police. Comma-separated hook names; a blocking hook with no way off is a
 # hook that eventually gets deleted instead of configured.
-case ",${AGENTKIT_SKIP_HOOKS:-}," in
-  *",format-police,"*|*",all,"*) exit 0 ;;
-esac
+# Trimmed, so "a, b" behaves like "a,b" — version-police already trims, and two
+# readings of one env var is a silent disagreement.
+if [[ -n "${AGENTKIT_SKIP_HOOKS:-}" ]]; then
+  _skip=",$(printf '%s' "$AGENTKIT_SKIP_HOOKS" | tr -d '[:space:]'),"
+  case "$_skip" in
+    *",format-police,"*|*",all,"*) exit 0 ;;
+  esac
+fi
 
 INPUT=$(cat)
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
@@ -70,10 +75,24 @@ else
   exit 0
 fi
 
-# Format the file — warn on failure instead of silently swallowing
-if ! "$DPRINT" fmt $CONFIG_FLAG "$FILE_PATH" 2>/tmp/dprint-err.log; then
-  echo "⚠ dprint fmt failed for $FILE_PATH: $(cat /tmp/dprint-err.log)" >&2
-  # Exit 2: a formatting failure that nobody hears lands unformatted code.
+# Per-invocation temp file: a fixed /tmp path races concurrent sessions and is
+# a symlink target.
+ERR_LOG=$(mktemp "${TMPDIR:-/tmp}/dprint-err.XXXXXX")
+trap 'rm -f "$ERR_LOG"' EXIT
+
+if ! "$DPRINT" fmt $CONFIG_FLAG "$FILE_PATH" 2>"$ERR_LOG"; then
+  err=$(cat "$ERR_LOG")
+  echo "⚠ dprint fmt failed for $FILE_PATH: $err" >&2
+  # Exit 2 ONLY when the failure is attributable to the edited file, i.e. the
+  # model can act on it. dprint fetches wasm plugins over the network, so a
+  # config typo or an offline machine would otherwise turn EVERY edit to any
+  # formattable file into an error nobody can fix — the exact blast-radius
+  # problem this hook set out to bound.
+  case "$err" in
+    *"Error resolving plugin"*|*"plugin"*"404"*|*"error sending request"*|*"os error"*|\
+    *"No such file or directory"*|*"Had 0 plugins"*|*"config"*)
+      exit 0 ;;
+  esac
   exit 2
 fi
 

--- a/hooks/claude/git-police.sh
+++ b/hooks/claude/git-police.sh
@@ -139,6 +139,31 @@ if [[ -z "$PUSH_REMOTE" || "$PUSH_REMOTE" == "origin" ]]; then
 fi
 
 # 4. Block push when the targeted repo is on a protected branch (even without
+
+# 5. Block creating a branch in a clone that other worktrees share. Another
+#    agent may be working in it, and checkout swaps the tree under them.
+SHARED_BRANCH_OK="${AGENTKIT_ALLOW_SHARED_BRANCH:-}"
+# Also honoured inline, since a prefix never reaches this hook's environment.
+if echo "$COMMAND" | grep -qE '(^|[[:space:];&|])AGENTKIT_ALLOW_SHARED_BRANCH=1'; then
+	SHARED_BRANCH_OK=1
+fi
+if [[ "$SHARED_BRANCH_OK" != "1" ]] \
+	&& echo "$STRIPPED" | grep -qiE '\bgit([[:space:]]+-[A-Za-z][^[:space:]]*([[:space:]]+[^-[:space:]][^[:space:]]*)?)*[[:space:]]+(checkout[[:space:]]+(-b|-B)|switch[[:space:]]+(-c|-C))\b'; then
+	GIT_DIR_PATH=$(tgit rev-parse --git-dir 2>/dev/null || echo "")
+	COMMON_DIR_PATH=$(tgit rev-parse --git-common-dir 2>/dev/null || echo "")
+	# Equal ⇒ this IS the main clone; differing ⇒ already inside a worktree.
+	if [[ -n "$GIT_DIR_PATH" && "$GIT_DIR_PATH" == "$COMMON_DIR_PATH" ]]; then
+		WORKTREE_COUNT=$(tgit worktree list 2>/dev/null | wc -l | tr -d ' ')
+		if [[ "${WORKTREE_COUNT:-0}" -gt 1 ]]; then
+			REPO_BASE=$(basename "$(tgit rev-parse --show-toplevel 2>/dev/null || echo repo)")
+			deny "BLOCKED: creating a branch in a shared clone. This checkout has ${WORKTREE_COUNT} worktrees, so another agent may be working in it and a checkout swaps the tree under them. Create a worktree instead:
+
+  git worktree add ../${REPO_BASE}-wt/<name> -b <branch> origin/<default>
+
+Intentional (nobody else is in this clone): prefix with AGENTKIT_ALLOW_SHARED_BRANCH=1."
+		fi
+	fi
+fi
 #    branch name in command) — same origin scoping as rule 3.
 if [[ -z "$PUSH_REMOTE" || "$PUSH_REMOTE" == "origin" ]] \
 	&& echo "$STRIPPED" | grep -qiE "$GIT_PUSH_RE"; then

--- a/hooks/claude/settings.json
+++ b/hooks/claude/settings.json
@@ -68,6 +68,12 @@
             "command": "$HOME/.claude/hooks/coding-police.sh",
             "timeout": 15,
             "statusMessage": "coding-police: checking coding standards..."
+          },
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/comment-police.sh",
+            "timeout": 15,
+            "statusMessage": "comment-police: checking comment discipline..."
           }
         ]
       }

--- a/install.sh
+++ b/install.sh
@@ -446,74 +446,23 @@ merge_claude_settings() {
 		return
 	fi
 
-	# Build the hooks JSON using the actual installed hook paths
+	# Derived from the canonical wiring, never a second copy of it. A duplicate
+	# list here silently drifts: review-police was wired in settings.json for
+	# months and never installed, so the merge gate was inert on every machine
+	# that used this installer.
+	local canonical="$REPO_DIR/hooks/claude/settings.json"
+	if [[ ! -f "$canonical" ]]; then
+		echo "[claude] ERROR: missing $canonical — cannot wire hooks." >&2
+		return 1
+	fi
 	local hooks_json
-	hooks_json=$(jq -n \
-		--arg git_police "$hooks_dir/git-police.sh" \
-		--arg kubectl_police "$hooks_dir/kubectl-police.sh" \
-		--arg pkg_police "$hooks_dir/pkg-police.sh" \
-		--arg resource_police "$hooks_dir/resource-police.sh" \
-		--arg mr_police "$hooks_dir/mr-police.sh" \
-		--arg format_police "$hooks_dir/format-police.sh" \
-		--arg coding_police "$hooks_dir/coding-police.sh" \
-		'{
-      hooks: {
-        PreToolUse: [
-          {
-            matcher: "Bash",
-            hooks: [
-              {
-                type: "command",
-                command: $git_police,
-                timeout: 10,
-                statusMessage: "git-police: checking safety rules..."
-              },
-              {
-                type: "command",
-                command: $kubectl_police,
-                timeout: 10,
-                statusMessage: "kubectl-police: checking Kargo safety..."
-              },
-              {
-                type: "command",
-                command: $pkg_police,
-                timeout: 10,
-                statusMessage: "pkg-police: enforcing bun..."
-              },
-              {
-                type: "command",
-                command: $resource_police,
-                timeout: 10,
-                statusMessage: "resource-police: requiring bounded execution..."
-              },
-              {
-                type: "command",
-                command: $mr_police,
-                timeout: 15,
-                statusMessage: "mr-police: checking for unmerged MRs..."
-              }
-            ]
-          }
-        ],
-        PostToolUse: [
-          {
-            matcher: "Edit|Write",
-            hooks: [
-              {
-                type: "command",
-                command: $format_police,
-                timeout: 15
-              },
-              {
-                type: "command",
-                command: $coding_police,
-                timeout: 15
-              }
-            ]
-          }
-        ]
-      }
-    }')
+	hooks_json=$(jq --arg dir "$hooks_dir" '
+    {hooks: (.hooks | with_entries(
+      .value |= map(.hooks |= map(
+        .command |= sub("^\\$HOME/\\.claude/hooks"; $dir)
+      ))
+    ))}
+  ' "$canonical")
 
 	if [[ -f "$settings_file" ]]; then
 		# Merge: existing settings + our hooks (our hooks win on conflict)

--- a/plugins-cc/agentkit/hooks/coding-police.sh
+++ b/plugins-cc/agentkit/hooks/coding-police.sh
@@ -7,9 +7,14 @@ set -euo pipefail
 # Kill switch, matching the AGENTKIT_* convention used by the PreToolUse
 # police. Comma-separated hook names; a blocking hook with no way off is a
 # hook that eventually gets deleted instead of configured.
-case ",${AGENTKIT_SKIP_HOOKS:-}," in
-  *",coding-police,"*|*",all,"*) exit 0 ;;
-esac
+# Trimmed, so "a, b" behaves like "a,b" — version-police already trims, and two
+# readings of one env var is a silent disagreement.
+if [[ -n "${AGENTKIT_SKIP_HOOKS:-}" ]]; then
+  _skip=",$(printf '%s' "$AGENTKIT_SKIP_HOOKS" | tr -d '[:space:]'),"
+  case "$_skip" in
+    *",coding-police,"*|*",all,"*) exit 0 ;;
+  esac
+fi
 
 # ── Configuration ───────────────────────────────────────────────────────────
 AGENTKIT_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/agentkit/config.yaml"
@@ -146,13 +151,8 @@ worsened() {
 }
 
 check_file_length() {
-  local line_count was
+  local line_count
   line_count=$(wc -l < "$FILE_PATH")
-  was=$(baseline_of | wc -l)
-  # Already over before this edit and not made worse: not this edit's business.
-  if (( was > MAX_FILE_LINES )) && ! worsened "$line_count" "$was"; then
-    return 0
-  fi
   if (( line_count > MAX_FILE_LINES )); then
     local excess=$(( line_count - MAX_FILE_LINES ))
     VIOLATIONS+=("FILE TOO LONG: ${line_count} lines (limit: ${MAX_FILE_LINES}, over by ${excess}). Split this file into smaller modules grouped by functionality. Identify logical boundaries (types, helpers, handlers, constants) and extract them.")
@@ -367,11 +367,60 @@ if [[ "$IS_CODE_FILE" != true ]]; then
   exit 0
 fi
 
+# Whole-file checks measure state this edit may not have caused. Run them once
+# against the committed baseline and once against the working file, then report
+# only what got WORSE — otherwise a legacy file with a long function or a
+# duplicated block nags after every unrelated edit, forever, and there is no
+# PostToolUse loop guard to stop it.
+#
+# Keyed by violation LABEL with the largest number seen for that label: line
+# numbers shift, counts and sizes are what "worse" means.
+worst_by_label() {
+  local v label n
+  for v in "$@"; do
+    label=${v%%:*}
+    n=$(printf '%s' "$v" | grep -oE '[0-9]+' | sort -rn | head -1)
+    printf '%s\t%s\n' "$label" "${n:-0}"
+  done | awk -F'\t' '{ if ($2+0 > m[$1]) m[$1]=$2+0 } END { for (k in m) printf "%s\t%s\n", k, m[k] }'
+}
+
+BASELINE_WORST=""
+BASELINE_FILE=""
+baseline_content=$(baseline_of)
+if [[ -n "$baseline_content" ]]; then
+  BASELINE_FILE=$(mktemp "${TMPDIR:-/tmp}/coding-police-base.XXXXXX.${FILE_PATH##*.}")
+  printf '%s\n' "$baseline_content" > "$BASELINE_FILE"
+  REAL_FILE_PATH="$FILE_PATH"
+  FILE_PATH="$BASELINE_FILE"
+  VIOLATIONS=()
+  check_file_length
+  check_function_lengths
+  check_duplicate_blocks
+  check_export_count
+  BASELINE_WORST=$(worst_by_label "${VIOLATIONS[@]+"${VIOLATIONS[@]}"}")
+  FILE_PATH="$REAL_FILE_PATH"
+  rm -f "$BASELINE_FILE"
+  VIOLATIONS=()
+fi
+
 check_file_length
 check_function_lengths
 check_duplicate_blocks
 check_export_count
 check_monolith_directory
+
+if [[ -n "$BASELINE_WORST" ]]; then
+  KEPT=()
+  for v in "${VIOLATIONS[@]+"${VIOLATIONS[@]}"}"; do
+    label=${v%%:*}
+    n=$(printf '%s' "$v" | grep -oE '[0-9]+' | sort -rn | head -1); n=${n:-0}
+    was=$(printf '%s' "$BASELINE_WORST" | awk -F'\t' -v l="$label" '$1==l { print $2 }')
+    # Present at HEAD and no worse now: not this edit's doing.
+    if [[ -n "$was" ]] && (( n <= was )); then continue; fi
+    KEPT+=("$v")
+  done
+  VIOLATIONS=("${KEPT[@]+"${KEPT[@]}"}")
+fi
 
 # ── Output violations ──────────────────────────────────────────────────────
 if (( ${#VIOLATIONS[@]} > 0 )); then

--- a/plugins-cc/agentkit/hooks/coding-police.sh
+++ b/plugins-cc/agentkit/hooks/coding-police.sh
@@ -373,13 +373,30 @@ fi
 # them reported untouched legacy code and hid genuinely new violations. Blanking
 # them compares the SHAPE and the identifier; counting occurrences means a
 # second duplicate block, or a second over-long function, still surfaces.
-# Blank EVERY number for the shape, and carry the severity separately. Keeping
-# sizes in the shape made the compare symmetric: a metric that moved in either
-# direction stopped matching, so DELETING 100 lines from an over-limit file
-# reported it as new — punishing the model for the cleanup the rule asks for.
-# The shape answers "same violation?"; the metric answers "worse?".
+# Blank the numeric FIELDS for the shape, and carry the severity separately.
+# Keeping sizes in the shape made the compare symmetric: a metric that moved in
+# either direction stopped matching, so DELETING 100 lines from an over-limit
+# file reported it as new — punishing the model for the cleanup the rule asks
+# for. The shape answers "same violation?"; the metric answers "worse?".
+#
+# Field by field, never a blanket s/[0-9]+/#/g: that also rewrote the backticked
+# identifier, so `handleV1Request` and `handleV2Request` collapsed into ONE
+# shape and the worse-slot pass below handed a real regression the other
+# function's slot — reporting nothing at all. Silence is the fail-open
+# direction. Directory paths and quoted source lines have the same hazard.
 violation_shape() {
-  printf '%s' "$1" | sed -E 's/[0-9]+/#/g'
+  printf '%s' "$1" | sed -E '
+    s/^(FILE TOO LONG: )[0-9]+/\1#/
+    s/^(DUPLICATE CODE: )[0-9]+/\1#/
+    s/^(TOO MANY EXPORTS: )[0-9]+/\1#/
+    s/( is )[0-9]+( lines)/\1#\2/
+    s/(limit: )[0-9]+/\1#/
+    s/(cap: )[0-9]+/\1#/
+    s/(over by )[0-9]+/\1#/
+    s/(already has )[0-9]+/\1#/
+    s/(at lines? )[0-9]+/\1#/g
+    s/( and )[0-9]+/\1#/g
+  '
 }
 
 # The severity number, chosen per message TYPE. Never "the largest number in
@@ -405,6 +422,7 @@ PRE_EXISTING=("${VIOLATIONS[@]+"${VIOLATIONS[@]}"}")
 
 BASE_SHAPES=()
 BASE_METRICS=()
+BASELINE_FILE=""
 baseline_content=$(baseline_of)
 if [[ -n "$baseline_content" ]]; then
   # mktemp needs the X's LAST (BSD accepts no suffix), but the baseline file is
@@ -412,11 +430,24 @@ if [[ -n "$baseline_content" ]]; then
   # the extension, so an extensionless temp file silently skipped that check and
   # left every over-cap file blocking its own edits forever. Rename it back.
   BASELINE_FILE=$(mktemp "${TMPDIR:-/tmp}/coding-police-base-XXXXXX")
+  # Under `set -e` a failure here would kill the hook between mktemp and rm:
+  # it would leak the file and, worse, emit no decision at all — which the
+  # harness reads as ALLOW. Degrade to "no baseline" instead of dying.
+  trap 'rm -f "$BASELINE_FILE"' EXIT
   baseline_ext="${FILE_PATH##*.}"
   if [[ "$baseline_ext" != "$FILE_PATH" ]]; then
-    mv "$BASELINE_FILE" "$BASELINE_FILE.$baseline_ext"
-    BASELINE_FILE="$BASELINE_FILE.$baseline_ext"
+    if mv -f -- "$BASELINE_FILE" "$BASELINE_FILE.$baseline_ext"; then
+      BASELINE_FILE="$BASELINE_FILE.$baseline_ext"
+    else
+      rm -f "$BASELINE_FILE"
+      BASELINE_FILE=""
+    fi
   fi
+fi
+
+# Empty when there is no committed baseline, or the rename failed and the
+# baseline was abandoned. Both mean "measure nothing" — never "die".
+if [[ -n "$BASELINE_FILE" ]]; then
   printf '%s\n' "$baseline_content" > "$BASELINE_FILE"
   REAL_FILE_PATH="$FILE_PATH"
   FILE_PATH="$BASELINE_FILE"
@@ -431,6 +462,7 @@ if [[ -n "$baseline_content" ]]; then
   done
   FILE_PATH="$REAL_FILE_PATH"
   rm -f "$BASELINE_FILE"
+  trap - EXIT
 fi
 
 VIOLATIONS=()

--- a/plugins-cc/agentkit/hooks/coding-police.sh
+++ b/plugins-cc/agentkit/hooks/coding-police.sh
@@ -362,6 +362,9 @@ if (( ${#VIOLATIONS[@]} > 0 )); then
     echo ""
     echo "Fix these violations before proceeding."
   } >&2
+  # Exit 2 is what delivers this. Claude Code discards a PostToolUse
+  # hook's stderr at exit 0, so the check ran and nobody heard it.
+  exit 2
 fi
 
 exit 0

--- a/plugins-cc/agentkit/hooks/coding-police.sh
+++ b/plugins-cc/agentkit/hooks/coding-police.sh
@@ -373,11 +373,30 @@ fi
 # them reported untouched legacy code and hid genuinely new violations. Blanking
 # them compares the SHAPE and the identifier; counting occurrences means a
 # second duplicate block, or a second over-long function, still surfaces.
-# Blank only POSITIONS (line numbers), never sizes or counts — those are the
-# severity. "1200 lines" vs "1400 lines" must differ; "starts at line 201" vs
-# "line 211" must not.
+# Blank EVERY number for the shape, and carry the severity separately. Keeping
+# sizes in the shape made the compare symmetric: a metric that moved in either
+# direction stopped matching, so DELETING 100 lines from an over-limit file
+# reported it as new — punishing the model for the cleanup the rule asks for.
+# The shape answers "same violation?"; the metric answers "worse?".
 violation_shape() {
-  printf '%s' "$1" | sed -E 's/(at lines? )[0-9]+/\1#/g; s/(and )[0-9]+/\1#/g'
+  printf '%s' "$1" | sed -E 's/[0-9]+/#/g'
+}
+
+# The severity number, chosen per message TYPE. Never "the largest number in
+# the line" — that picked up `starts at line 201` and inverted the comparison
+# on any file long enough for a line number to exceed a length.
+violation_metric() {
+  local m
+  case "$1" in
+    "FILE TOO LONG: "*) m=$(printf '%s' "$1" | sed -E 's/^FILE TOO LONG: ([0-9]+) lines.*/\1/') ;;
+    "LONG FUNCTION: "*) m=$(printf '%s' "$1" | sed -E 's/^LONG FUNCTION: .* is ([0-9]+) lines.*/\1/') ;;
+    "DUPLICATE CODE: "*) m=$(printf '%s' "$1" | sed -E 's/^DUPLICATE CODE: ([0-9]+)\+ line.*/\1/') ;;
+    "TOO MANY EXPORTS: "*) m=$(printf '%s' "$1" | sed -E 's/^TOO MANY EXPORTS: ([0-9]+) exports.*/\1/') ;;
+    *) m=0 ;;
+  esac
+  # A sed that did not match returns the whole line; that must not reach $(( )).
+  [[ "$m" =~ ^[0-9]+$ ]] || m=0
+  printf '%s' "$m"
 }
 
 # The cross-repo check already ran and its findings are NOT whole-file state —
@@ -385,9 +404,19 @@ violation_shape() {
 PRE_EXISTING=("${VIOLATIONS[@]+"${VIOLATIONS[@]}"}")
 
 BASE_SHAPES=()
+BASE_METRICS=()
 baseline_content=$(baseline_of)
 if [[ -n "$baseline_content" ]]; then
+  # mktemp needs the X's LAST (BSD accepts no suffix), but the baseline file is
+  # then measured as if it were the real one — and check_export_count gates on
+  # the extension, so an extensionless temp file silently skipped that check and
+  # left every over-cap file blocking its own edits forever. Rename it back.
   BASELINE_FILE=$(mktemp "${TMPDIR:-/tmp}/coding-police-base-XXXXXX")
+  baseline_ext="${FILE_PATH##*.}"
+  if [[ "$baseline_ext" != "$FILE_PATH" ]]; then
+    mv "$BASELINE_FILE" "$BASELINE_FILE.$baseline_ext"
+    BASELINE_FILE="$BASELINE_FILE.$baseline_ext"
+  fi
   printf '%s\n' "$baseline_content" > "$BASELINE_FILE"
   REAL_FILE_PATH="$FILE_PATH"
   FILE_PATH="$BASELINE_FILE"
@@ -398,6 +427,7 @@ if [[ -n "$baseline_content" ]]; then
   check_export_count
   for v in "${VIOLATIONS[@]+"${VIOLATIONS[@]}"}"; do
     BASE_SHAPES+=("$(violation_shape "$v")")
+    BASE_METRICS+=("$(violation_metric "$v")")
   done
   FILE_PATH="$REAL_FILE_PATH"
   rm -f "$BASELINE_FILE"
@@ -414,16 +444,33 @@ if (( ${#BASE_SHAPES[@]} > 0 )); then
   KEPT=()
   for v in "${VIOLATIONS[@]+"${VIOLATIONS[@]}"}"; do
     shape=$(violation_shape "$v")
-    matched=false
+    metric=$(violation_metric "$v")
+    matched=""
+    # Same severity first, so an unchanged violation claims its own baseline
+    # slot before a shrunken one consumes a bigger neighbour's and leaves the
+    # neighbour looking new.
     for i in "${!BASE_SHAPES[@]}"; do
-      if [[ "${BASE_SHAPES[$i]}" == "$shape" ]]; then
-        # Consume it: a THIRD duplicate block when the baseline had two is new.
-        unset 'BASE_SHAPES[i]'
-        matched=true
+      if [[ "${BASE_SHAPES[$i]}" == "$shape" ]] && (( BASE_METRICS[i] == metric )); then
+        matched=$i
         break
       fi
     done
-    [[ "$matched" == true ]] || KEPT+=("$v")
+    if [[ -z "$matched" ]]; then
+      # Otherwise any baseline slot that was WORSE absorbs it — an improvement
+      # is silent. A metric above every slot is a real regression and is kept.
+      for i in "${!BASE_SHAPES[@]}"; do
+        if [[ "${BASE_SHAPES[$i]}" == "$shape" ]] && (( BASE_METRICS[i] > metric )); then
+          matched=$i
+          break
+        fi
+      done
+    fi
+    if [[ -n "$matched" ]]; then
+      # Consume it: a THIRD duplicate block when the baseline had two is new.
+      unset 'BASE_SHAPES[matched]' 'BASE_METRICS[matched]'
+    else
+      KEPT+=("$v")
+    fi
   done
   VIOLATIONS=("${KEPT[@]+"${KEPT[@]}"}")
 fi

--- a/plugins-cc/agentkit/hooks/coding-police.sh
+++ b/plugins-cc/agentkit/hooks/coding-police.sh
@@ -144,11 +144,6 @@ baseline_of() {
   git -C "$top" show "HEAD:$rel" 2>/dev/null || true
 }
 
-# Whether this edit made `metric` worse than it already was at HEAD.
-worsened() {
-  local now="$1" was="$2"
-  (( now > was ))
-}
 
 check_file_length() {
   local line_count
@@ -369,26 +364,30 @@ fi
 
 # Whole-file checks measure state this edit may not have caused. Run them once
 # against the committed baseline and once against the working file, then report
-# only what got WORSE — otherwise a legacy file with a long function or a
+# only what is NEW — otherwise a legacy file with a long function or a
 # duplicated block nags after every unrelated edit, forever, and there is no
 # PostToolUse loop guard to stop it.
 #
-# Keyed by violation LABEL with the largest number seen for that label: line
-# numbers shift, counts and sizes are what "worse" means.
-worst_by_label() {
-  local v label n
-  for v in "$@"; do
-    label=${v%%:*}
-    n=$(printf '%s' "$v" | grep -oE '[0-9]+' | sort -rn | head -1)
-    printf '%s\t%s\n' "$label" "${n:-0}"
-  done | awk -F'\t' '{ if ($2+0 > m[$1]) m[$1]=$2+0 } END { for (k in m) printf "%s\t%s\n", k, m[k] }'
+# Compared as a MULTISET of violations with every number blanked. Numbers are
+# line offsets and sizes that shift when unrelated lines move, so matching on
+# them reported untouched legacy code and hid genuinely new violations. Blanking
+# them compares the SHAPE and the identifier; counting occurrences means a
+# second duplicate block, or a second over-long function, still surfaces.
+# Blank only POSITIONS (line numbers), never sizes or counts — those are the
+# severity. "1200 lines" vs "1400 lines" must differ; "starts at line 201" vs
+# "line 211" must not.
+violation_shape() {
+  printf '%s' "$1" | sed -E 's/(at lines? )[0-9]+/\1#/g; s/(and )[0-9]+/\1#/g'
 }
 
-BASELINE_WORST=""
-BASELINE_FILE=""
+# The cross-repo check already ran and its findings are NOT whole-file state —
+# they must survive the baseline pass, which resets the array.
+PRE_EXISTING=("${VIOLATIONS[@]+"${VIOLATIONS[@]}"}")
+
+BASE_SHAPES=()
 baseline_content=$(baseline_of)
 if [[ -n "$baseline_content" ]]; then
-  BASELINE_FILE=$(mktemp "${TMPDIR:-/tmp}/coding-police-base.XXXXXX.${FILE_PATH##*.}")
+  BASELINE_FILE=$(mktemp "${TMPDIR:-/tmp}/coding-police-base-XXXXXX")
   printf '%s\n' "$baseline_content" > "$BASELINE_FILE"
   REAL_FILE_PATH="$FILE_PATH"
   FILE_PATH="$BASELINE_FILE"
@@ -397,30 +396,39 @@ if [[ -n "$baseline_content" ]]; then
   check_function_lengths
   check_duplicate_blocks
   check_export_count
-  BASELINE_WORST=$(worst_by_label "${VIOLATIONS[@]+"${VIOLATIONS[@]}"}")
+  for v in "${VIOLATIONS[@]+"${VIOLATIONS[@]}"}"; do
+    BASE_SHAPES+=("$(violation_shape "$v")")
+  done
   FILE_PATH="$REAL_FILE_PATH"
   rm -f "$BASELINE_FILE"
-  VIOLATIONS=()
 fi
 
+VIOLATIONS=()
 check_file_length
 check_function_lengths
 check_duplicate_blocks
 check_export_count
 check_monolith_directory
 
-if [[ -n "$BASELINE_WORST" ]]; then
+if (( ${#BASE_SHAPES[@]} > 0 )); then
   KEPT=()
   for v in "${VIOLATIONS[@]+"${VIOLATIONS[@]}"}"; do
-    label=${v%%:*}
-    n=$(printf '%s' "$v" | grep -oE '[0-9]+' | sort -rn | head -1); n=${n:-0}
-    was=$(printf '%s' "$BASELINE_WORST" | awk -F'\t' -v l="$label" '$1==l { print $2 }')
-    # Present at HEAD and no worse now: not this edit's doing.
-    if [[ -n "$was" ]] && (( n <= was )); then continue; fi
-    KEPT+=("$v")
+    shape=$(violation_shape "$v")
+    matched=false
+    for i in "${!BASE_SHAPES[@]}"; do
+      if [[ "${BASE_SHAPES[$i]}" == "$shape" ]]; then
+        # Consume it: a THIRD duplicate block when the baseline had two is new.
+        unset 'BASE_SHAPES[i]'
+        matched=true
+        break
+      fi
+    done
+    [[ "$matched" == true ]] || KEPT+=("$v")
   done
   VIOLATIONS=("${KEPT[@]+"${KEPT[@]}"}")
 fi
+
+VIOLATIONS=("${PRE_EXISTING[@]+"${PRE_EXISTING[@]}"}" "${VIOLATIONS[@]+"${VIOLATIONS[@]}"}")
 
 # ── Output violations ──────────────────────────────────────────────────────
 if (( ${#VIOLATIONS[@]} > 0 )); then

--- a/plugins-cc/agentkit/hooks/coding-police.sh
+++ b/plugins-cc/agentkit/hooks/coding-police.sh
@@ -4,6 +4,13 @@
 # Equivalent to: plugins/coding-police.ts (OpenCode)
 set -euo pipefail
 
+# Kill switch, matching the AGENTKIT_* convention used by the PreToolUse
+# police. Comma-separated hook names; a blocking hook with no way off is a
+# hook that eventually gets deleted instead of configured.
+case ",${AGENTKIT_SKIP_HOOKS:-}," in
+  *",coding-police,"*|*",all,"*) exit 0 ;;
+esac
+
 # ── Configuration ───────────────────────────────────────────────────────────
 AGENTKIT_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/agentkit/config.yaml"
 
@@ -120,9 +127,32 @@ check_cross_repo_relative_paths() {
 }
 
 # ── Check 1: File length ───────────────────────────────────────────────────
+
+# The committed version of FILE_PATH, or empty when it is new / not in git.
+# Whole-file checks measure state the current edit may not have caused; a file
+# that was already too long would otherwise block EVERY later edit to it,
+# unfixably, and Claude Code has no PostToolUse loop guard to stop that.
+baseline_of() {
+  local top rel
+  top=$(git -C "$(dirname "$FILE_PATH")" rev-parse --show-toplevel 2>/dev/null) || return 0
+  rel=${FILE_PATH#"$top"/}
+  git -C "$top" show "HEAD:$rel" 2>/dev/null || true
+}
+
+# Whether this edit made `metric` worse than it already was at HEAD.
+worsened() {
+  local now="$1" was="$2"
+  (( now > was ))
+}
+
 check_file_length() {
-  local line_count
+  local line_count was
   line_count=$(wc -l < "$FILE_PATH")
+  was=$(baseline_of | wc -l)
+  # Already over before this edit and not made worse: not this edit's business.
+  if (( was > MAX_FILE_LINES )) && ! worsened "$line_count" "$was"; then
+    return 0
+  fi
   if (( line_count > MAX_FILE_LINES )); then
     local excess=$(( line_count - MAX_FILE_LINES ))
     VIOLATIONS+=("FILE TOO LONG: ${line_count} lines (limit: ${MAX_FILE_LINES}, over by ${excess}). Split this file into smaller modules grouped by functionality. Identify logical boundaries (types, helpers, handlers, constants) and extract them.")
@@ -332,6 +362,7 @@ if [[ "$IS_CODE_FILE" != true ]]; then
       echo ""
       echo "Fix these violations before proceeding."
     } >&2
+    exit 2
   fi
   exit 0
 fi

--- a/plugins-cc/agentkit/hooks/comment-police.sh
+++ b/plugins-cc/agentkit/hooks/comment-police.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# comment-police.sh — Claude Code PostToolUse hook (matcher: Edit|Write)
+# Claude-side counterpart of plugins/comment-police.ts; both read the
+# `comment-police:` section of the agentkit config, so the keys must match.
+#
+# Checks ADDED lines only — a file's pre-existing comments are not the business
+# of whoever touched one line of it.
+set -euo pipefail
+
+AGENTKIT_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/agentkit/config.yaml"
+
+MAX_BLOCK_LINES=6
+MAX_COMMENT_RATIO_PCT=30
+EXCLUDE_PATTERNS=()
+
+# Forge references rot: a comment lives as long as the repo, but issues and
+# merge requests live in the forge, so a clone or a migration leaves the pointer
+# dangling exactly when someone needs the reasoning.
+FORGE_PATTERNS=(
+  '[#!][0-9]{1,6}([^0-9a-zA-Z_]|$)'
+  '(issue|ticket|PR|MR|merge request|pull request)[[:space:]]*[#!]?[0-9]+'
+  '(gitlab|github)\.com/[^[:space:]]*/(issues|merge_requests|pull)/'
+  '(commit|sha)[[:space:]]+[0-9a-f]{7,40}'
+  '[Pp]lan-?[[:space:]]?[0-9]+'
+  'as part of (this|the) (PR|MR|fix)'
+  'see (issue|ticket|PR|MR)'
+)
+
+load_config() {
+  [[ -f "$AGENTKIT_CONFIG" ]] || return 0
+  local key value
+  while IFS='=' read -r key value; do
+    case "$key" in
+      max-block-lines) MAX_BLOCK_LINES="$value" ;;
+      max-comment-ratio) MAX_COMMENT_RATIO_PCT=$(awk -v r="$value" 'BEGIN{printf "%d", r*100}') ;;
+      exclude-pattern) EXCLUDE_PATTERNS+=("$value") ;;
+    esac
+  done < <(awk '
+    /^[^[:space:]#]/ { in_section = ($0 ~ /^comment-police:/); in_excludes = 0; next }
+    in_section {
+      line = $0
+      sub(/^[[:space:]]+/, "", line)
+      if (in_excludes) {
+        if (line ~ /^-[[:space:]]*.+$/) { v = line; sub(/^-[[:space:]]*/, "", v); print "exclude-pattern=" v; next }
+        in_excludes = 0
+      }
+      if (line ~ /^exclude-patterns:[[:space:]]*$/) { in_excludes = 1; next }
+      if (line !~ /^(max-block-lines:[[:space:]]*[0-9]+|max-comment-ratio:[[:space:]]*[0-9.]+)([[:space:]]*#.*)?$/) next
+      k = line; sub(/:.*/, "", k)
+      sub(/^[^:]*:[[:space:]]*/, "", line); sub(/[[:space:]#].*$/, "", line)
+      print k "=" line
+    }
+  ' "$AGENTKIT_CONFIG")
+}
+load_config
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+INPUT=$(cat)
+case "$(echo "$INPUT" | jq -r '.tool_name // empty')" in
+  Edit|Write|edit|write) ;;
+  *) exit 0 ;;
+esac
+
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.filePath // empty')
+[[ -z "$FILE_PATH" ]] && exit 0
+
+case "$FILE_PATH" in
+  *.ts|*.tsx|*.js|*.jsx|*.py|*.rb|*.go|*.rs|*.java|*.kt|*.cs|*.cpp|*.c|*.h|*.hpp|*.swift|*.scala|*.vue|*.svelte|*.sh|*.bash) ;;
+  *) exit 0 ;;
+esac
+case "$FILE_PATH" in
+  *.lock|*.min.*|*.generated.*|*.snap|*.d.ts) exit 0 ;;
+esac
+for pattern in "${EXCLUDE_PATTERNS[@]}"; do
+  [[ "$FILE_PATH" == *"$pattern"* ]] && exit 0
+done
+
+ADDED=$(echo "$INPUT" | jq -r '.tool_input.new_string // .tool_input.content // empty')
+[[ -z "$ADDED" ]] && exit 0
+
+VIOLATIONS=()
+
+is_comment_line() {
+  [[ "$1" =~ ^[[:space:]]*(//|#|--|/\*|\*[^/]) ]] || [[ "$1" =~ ^[[:space:]]*\*$ ]]
+}
+
+check_blocks_and_ratio() {
+  local run=0 worst=0 first="" comments=0 total=0
+  while IFS= read -r line; do
+    [[ -z "${line//[[:space:]]/}" ]] && continue
+    total=$(( total + 1 ))
+    if is_comment_line "$line"; then
+      comments=$(( comments + 1 ))
+      (( run == 0 )) && first="$(echo "$line" | sed 's/^[[:space:]]*//' | cut -c1-60)"
+      run=$(( run + 1 ))
+      (( run > worst )) && worst=$run
+    else
+      run=0
+    fi
+  done <<< "$ADDED"
+
+  if (( worst > MAX_BLOCK_LINES )); then
+    VIOLATIONS+=("COMMENT BLOCK TOO LONG: ${worst} consecutive comment lines (limit: ${MAX_BLOCK_LINES}), starting \"${first}...\". A comment earns its place by explaining non-obvious WHY. Restating what the code does, narrating history, or enumerating cases the code already enumerates is not that.")
+  fi
+
+  if (( total >= 10 )); then
+    local pct=$(( comments * 100 / total ))
+    if (( pct > MAX_COMMENT_RATIO_PCT )); then
+      VIOLATIONS+=("TOO MANY COMMENTS: ${pct}% of the added lines are comments (limit: ${MAX_COMMENT_RATIO_PCT}%). If you are explaining the code, fix the code instead — rename, extract a helper, restructure.")
+    fi
+  fi
+}
+
+check_forbidden() {
+  local hits="" pat
+  while IFS= read -r line; do
+    is_comment_line "$line" || continue
+    for pat in "${FORGE_PATTERNS[@]}"; do
+      if [[ "$line" =~ $pat ]]; then
+        hits+="    ${line#"${line%%[![:space:]]*}"}"$'\n'
+        break
+      fi
+    done
+  done <<< "$ADDED"
+  [[ -z "$hits" ]] && return 0
+  VIOLATIONS+=("FORGE REFERENCE IN A COMMENT:
+${hits}  Issues, merge requests and commit shas live in the forge, not the repo — a clone or a forge migration leaves the pointer dangling and the reasoning unreachable. State the reason in the comment itself; put traceability in the commit message; record durable decisions in an in-repo design doc.")
+}
+
+check_blocks_and_ratio
+check_forbidden
+
+if (( ${#VIOLATIONS[@]} > 0 )); then
+  {
+    echo ""
+    echo "COMMENT DISCIPLINE VIOLATION (comment-police)"
+    echo "=================================================="
+    for i in "${!VIOLATIONS[@]}"; do
+      echo "$(( i + 1 )). ${VIOLATIONS[$i]}"
+      echo ""
+    done
+    echo "REQUIRED ACTIONS:"
+    echo "- Default to no comment; add one only for non-obvious WHY."
+    echo "- Keep blocks to ${MAX_BLOCK_LINES} lines or fewer."
+    echo "- No issue/MR/PR numbers, commit shas, plan numbers, or forge URLs in source."
+    echo "- Traceability goes in the commit message; durable decisions in an in-repo doc."
+    echo ""
+    echo "Fix these before proceeding."
+  } >&2
+fi
+
+exit 0

--- a/plugins-cc/agentkit/hooks/comment-police.sh
+++ b/plugins-cc/agentkit/hooks/comment-police.sh
@@ -10,9 +10,14 @@ set -euo pipefail
 # Kill switch, matching the AGENTKIT_* convention used by the PreToolUse
 # police. Comma-separated hook names; a blocking hook with no way off is a
 # hook that eventually gets deleted instead of configured.
-case ",${AGENTKIT_SKIP_HOOKS:-}," in
-  *",comment-police,"*|*",all,"*) exit 0 ;;
-esac
+# Trimmed, so "a, b" behaves like "a,b" — version-police already trims, and two
+# readings of one env var is a silent disagreement.
+if [[ -n "${AGENTKIT_SKIP_HOOKS:-}" ]]; then
+  _skip=",$(printf '%s' "$AGENTKIT_SKIP_HOOKS" | tr -d '[:space:]'),"
+  case "$_skip" in
+    *",comment-police,"*|*",all,"*) exit 0 ;;
+  esac
+fi
 
 AGENTKIT_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/agentkit/config.yaml"
 

--- a/plugins-cc/agentkit/hooks/comment-police.sh
+++ b/plugins-cc/agentkit/hooks/comment-police.sh
@@ -7,6 +7,13 @@
 # of whoever touched one line of it.
 set -euo pipefail
 
+# Kill switch, matching the AGENTKIT_* convention used by the PreToolUse
+# police. Comma-separated hook names; a blocking hook with no way off is a
+# hook that eventually gets deleted instead of configured.
+case ",${AGENTKIT_SKIP_HOOKS:-}," in
+  *",comment-police,"*|*",all,"*) exit 0 ;;
+esac
+
 AGENTKIT_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/agentkit/config.yaml"
 
 MAX_BLOCK_LINES=6

--- a/plugins-cc/agentkit/hooks/comment-police.sh
+++ b/plugins-cc/agentkit/hooks/comment-police.sh
@@ -148,6 +148,9 @@ if (( ${#VIOLATIONS[@]} > 0 )); then
     echo ""
     echo "Fix these before proceeding."
   } >&2
+  # Exit 2 is what delivers this. Claude Code discards a PostToolUse
+  # hook's stderr at exit 0, so the check ran and nobody heard it.
+  exit 2
 fi
 
 exit 0

--- a/plugins-cc/agentkit/hooks/format-police.sh
+++ b/plugins-cc/agentkit/hooks/format-police.sh
@@ -83,17 +83,17 @@ trap 'rm -f "$ERR_LOG"' EXIT
 if ! "$DPRINT" fmt $CONFIG_FLAG "$FILE_PATH" 2>"$ERR_LOG"; then
   err=$(cat "$ERR_LOG")
   echo "⚠ dprint fmt failed for $FILE_PATH: $err" >&2
-  # Exit 2 ONLY when the failure is attributable to the edited file, i.e. the
-  # model can act on it. dprint fetches wasm plugins over the network, so a
-  # config typo or an offline machine would otherwise turn EVERY edit to any
-  # formattable file into an error nobody can fix — the exact blast-radius
-  # problem this hook set out to bound.
+  # ALLOWLIST, not a denylist. Only a failure dprint attributes to THIS file is
+  # something the model can act on; everything else — an unresolvable plugin, a
+  # scoped `includes` that excludes this extension, no network — is
+  # infrastructure, and blocking on it turns every edit into an error nobody
+  # can fix. Denylisting was tried and was unsound: dprint echoes the path into
+  # the message, so a pattern like *config* silently swallowed real errors in
+  # any file under a config/ directory.
   case "$err" in
-    *"Error resolving plugin"*|*"plugin"*"404"*|*"error sending request"*|*"os error"*|\
-    *"No such file or directory"*|*"Had 0 plugins"*|*"config"*)
-      exit 0 ;;
+    *"Error formatting $FILE_PATH"*) exit 2 ;;
   esac
-  exit 2
+  exit 0
 fi
 
 exit 0

--- a/plugins-cc/agentkit/hooks/format-police.sh
+++ b/plugins-cc/agentkit/hooks/format-police.sh
@@ -4,6 +4,13 @@
 # Equivalent to: plugins/format-police.ts (OpenCode)
 set -euo pipefail
 
+# Kill switch, matching the AGENTKIT_* convention used by the PreToolUse
+# police. Comma-separated hook names; a blocking hook with no way off is a
+# hook that eventually gets deleted instead of configured.
+case ",${AGENTKIT_SKIP_HOOKS:-}," in
+  *",format-police,"*|*",all,"*) exit 0 ;;
+esac
+
 INPUT=$(cat)
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
 

--- a/plugins-cc/agentkit/hooks/format-police.sh
+++ b/plugins-cc/agentkit/hooks/format-police.sh
@@ -66,6 +66,8 @@ fi
 # Format the file — warn on failure instead of silently swallowing
 if ! "$DPRINT" fmt $CONFIG_FLAG "$FILE_PATH" 2>/tmp/dprint-err.log; then
   echo "⚠ dprint fmt failed for $FILE_PATH: $(cat /tmp/dprint-err.log)" >&2
+  # Exit 2: a formatting failure that nobody hears lands unformatted code.
+  exit 2
 fi
 
 exit 0

--- a/plugins-cc/agentkit/hooks/format-police.sh
+++ b/plugins-cc/agentkit/hooks/format-police.sh
@@ -7,9 +7,14 @@ set -euo pipefail
 # Kill switch, matching the AGENTKIT_* convention used by the PreToolUse
 # police. Comma-separated hook names; a blocking hook with no way off is a
 # hook that eventually gets deleted instead of configured.
-case ",${AGENTKIT_SKIP_HOOKS:-}," in
-  *",format-police,"*|*",all,"*) exit 0 ;;
-esac
+# Trimmed, so "a, b" behaves like "a,b" — version-police already trims, and two
+# readings of one env var is a silent disagreement.
+if [[ -n "${AGENTKIT_SKIP_HOOKS:-}" ]]; then
+  _skip=",$(printf '%s' "$AGENTKIT_SKIP_HOOKS" | tr -d '[:space:]'),"
+  case "$_skip" in
+    *",format-police,"*|*",all,"*) exit 0 ;;
+  esac
+fi
 
 INPUT=$(cat)
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
@@ -70,10 +75,24 @@ else
   exit 0
 fi
 
-# Format the file — warn on failure instead of silently swallowing
-if ! "$DPRINT" fmt $CONFIG_FLAG "$FILE_PATH" 2>/tmp/dprint-err.log; then
-  echo "⚠ dprint fmt failed for $FILE_PATH: $(cat /tmp/dprint-err.log)" >&2
-  # Exit 2: a formatting failure that nobody hears lands unformatted code.
+# Per-invocation temp file: a fixed /tmp path races concurrent sessions and is
+# a symlink target.
+ERR_LOG=$(mktemp "${TMPDIR:-/tmp}/dprint-err.XXXXXX")
+trap 'rm -f "$ERR_LOG"' EXIT
+
+if ! "$DPRINT" fmt $CONFIG_FLAG "$FILE_PATH" 2>"$ERR_LOG"; then
+  err=$(cat "$ERR_LOG")
+  echo "⚠ dprint fmt failed for $FILE_PATH: $err" >&2
+  # Exit 2 ONLY when the failure is attributable to the edited file, i.e. the
+  # model can act on it. dprint fetches wasm plugins over the network, so a
+  # config typo or an offline machine would otherwise turn EVERY edit to any
+  # formattable file into an error nobody can fix — the exact blast-radius
+  # problem this hook set out to bound.
+  case "$err" in
+    *"Error resolving plugin"*|*"plugin"*"404"*|*"error sending request"*|*"os error"*|\
+    *"No such file or directory"*|*"Had 0 plugins"*|*"config"*)
+      exit 0 ;;
+  esac
   exit 2
 fi
 

--- a/plugins-cc/agentkit/hooks/git-police.sh
+++ b/plugins-cc/agentkit/hooks/git-police.sh
@@ -139,6 +139,31 @@ if [[ -z "$PUSH_REMOTE" || "$PUSH_REMOTE" == "origin" ]]; then
 fi
 
 # 4. Block push when the targeted repo is on a protected branch (even without
+
+# 5. Block creating a branch in a clone that other worktrees share. Another
+#    agent may be working in it, and checkout swaps the tree under them.
+SHARED_BRANCH_OK="${AGENTKIT_ALLOW_SHARED_BRANCH:-}"
+# Also honoured inline, since a prefix never reaches this hook's environment.
+if echo "$COMMAND" | grep -qE '(^|[[:space:];&|])AGENTKIT_ALLOW_SHARED_BRANCH=1'; then
+	SHARED_BRANCH_OK=1
+fi
+if [[ "$SHARED_BRANCH_OK" != "1" ]] \
+	&& echo "$STRIPPED" | grep -qiE '\bgit([[:space:]]+-[A-Za-z][^[:space:]]*([[:space:]]+[^-[:space:]][^[:space:]]*)?)*[[:space:]]+(checkout[[:space:]]+(-b|-B)|switch[[:space:]]+(-c|-C))\b'; then
+	GIT_DIR_PATH=$(tgit rev-parse --git-dir 2>/dev/null || echo "")
+	COMMON_DIR_PATH=$(tgit rev-parse --git-common-dir 2>/dev/null || echo "")
+	# Equal ⇒ this IS the main clone; differing ⇒ already inside a worktree.
+	if [[ -n "$GIT_DIR_PATH" && "$GIT_DIR_PATH" == "$COMMON_DIR_PATH" ]]; then
+		WORKTREE_COUNT=$(tgit worktree list 2>/dev/null | wc -l | tr -d ' ')
+		if [[ "${WORKTREE_COUNT:-0}" -gt 1 ]]; then
+			REPO_BASE=$(basename "$(tgit rev-parse --show-toplevel 2>/dev/null || echo repo)")
+			deny "BLOCKED: creating a branch in a shared clone. This checkout has ${WORKTREE_COUNT} worktrees, so another agent may be working in it and a checkout swaps the tree under them. Create a worktree instead:
+
+  git worktree add ../${REPO_BASE}-wt/<name> -b <branch> origin/<default>
+
+Intentional (nobody else is in this clone): prefix with AGENTKIT_ALLOW_SHARED_BRANCH=1."
+		fi
+	fi
+fi
 #    branch name in command) — same origin scoping as rule 3.
 if [[ -z "$PUSH_REMOTE" || "$PUSH_REMOTE" == "origin" ]] \
 	&& echo "$STRIPPED" | grep -qiE "$GIT_PUSH_RE"; then

--- a/plugins-cc/agentkit/hooks/hooks.json
+++ b/plugins-cc/agentkit/hooks/hooks.json
@@ -68,6 +68,12 @@
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/coding-police.sh",
             "timeout": 15,
             "statusMessage": "coding-police: checking coding standards..."
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/comment-police.sh",
+            "timeout": 15,
+            "statusMessage": "comment-police: checking comment discipline..."
           }
         ]
       }

--- a/plugins/comment-police.ts
+++ b/plugins/comment-police.ts
@@ -27,6 +27,11 @@ const DEFAULTS: CommentPoliceConfig = {
     'added (when|for) (we|the)',
     'as part of (this|the) (PR|MR|fix)',
     'see (issue|ticket|PR|MR)',
+    // Bare refs rot the same way spelled-out ones do, and are what agents
+    // reach for: a hash or bang glued to a number, often after a repo slug.
+    '[#!]\\d{1,6}(\\D|$)',
+    '(gitlab|github)\\.com/\\S*/(issues|merge_requests|pull)/',
+    '(commit|sha)\\s+[0-9a-f]{7,40}',
   ],
   excludePatterns: [],
 };

--- a/rules/coding-standards.md
+++ b/rules/coding-standards.md
@@ -35,3 +35,16 @@ Enforce these standards proactively to ensure the codebase remains modular, DRY,
 - Plan your file structure **before** writing large amounts of code.
 - If you realize a feature requires 1000+ lines, create the directory structure and multiple files from the start.
 - Do not wait for the "Coding Police" plugin to warn you — modularity should be built-in.
+
+## Worktrees, not branches, in a shared clone
+
+Assume another agent is working in any clone you did not just create. Creating a
+branch there swaps the working tree under them mid-edit. Use a worktree:
+
+```sh
+git worktree add ../<repo>-wt/<name> -b <branch> origin/<default>
+```
+
+`git-police` refuses branch creation in a clone that has other worktrees.
+Override with `AGENTKIT_ALLOW_SHARED_BRANCH=1` only when you know nobody else
+is in it.

--- a/rules/comment-discipline.md
+++ b/rules/comment-discipline.md
@@ -10,6 +10,7 @@ Default to writing **no comments**. Add one only when the WHY is non-obvious and
 
 - **Multi-paragraph rationale blocks** above functions, jobs, steps. The PR description / commit message is where rationale lives.
 - **References to the current PR / task / commit / plan**: `closes #N`, `Plan-15 slice 2`, `for the v0.14.0 flow`, `added when we did X`. These rot the moment the surrounding code changes.
+- **Any forge reference at all**, including bare ones agents reach for reflexively: `(#170)`, `some-repo!31`, a GitLab/GitHub issue or MR URL, a commit sha. The durability argument is the whole point: a comment lives as long as the repo, but issues and merge requests live in the **forge**. Clone the repo elsewhere, or migrate forges, and the pointer dangles — the reasoning is unreachable exactly when someone needs it. Three homes are durable and travel with the code: the comment itself (state the reason, don't link to it), the commit message (traceability), and an in-repo design doc (decisions worth keeping). A merge request is none of them.
 - **WHAT-narration**: comments that re-state what the code clearly does (`# call API`, `// loop over items`, `# release jobs run after binaries succeed`).
 - **Tutorial-style top-of-file headers** longer than ~10 lines describing how to use the file. README / docs are the right home.
 - **Documenting default values** that are visible two lines below.

--- a/tests/agentkit-plugin.test.ts
+++ b/tests/agentkit-plugin.test.ts
@@ -25,7 +25,7 @@ const PRE_TOOL_USE_HOOKS = [
   'resource-police.sh',
   'review-police.sh',
 ];
-const POST_TOOL_USE_HOOKS = ['format-police.sh', 'coding-police.sh'];
+const POST_TOOL_USE_HOOKS = ['format-police.sh', 'coding-police.sh', 'comment-police.sh'];
 const ALL_POLICE_HOOKS = [...PRE_TOOL_USE_HOOKS, ...POST_TOOL_USE_HOOKS];
 
 function readJson(...parts: string[]): any {

--- a/tests/coding-police-hook.test.ts
+++ b/tests/coding-police-hook.test.ts
@@ -109,14 +109,14 @@ describe('Claude coding-police configuration', () => {
   test('loads every threshold before a following YAML section', () => {
     const result = runHook(`coding-police:\n${settings}git-police:\n  enabled: true\n`);
 
-    expect(result.status, result.stderr).toBe(0);
+    expect(result.status, result.stderr).toBe(result.stderr.includes("VIOLATION") ? 2 : 0);
     expectConfiguredThresholds(result.stderr);
   });
 
   test('loads every threshold when coding-police is the final YAML section', () => {
     const result = runHook(`git-police:\n  enabled: true\ncoding-police:\n${settings}`);
 
-    expect(result.status, result.stderr).toBe(0);
+    expect(result.status, result.stderr).toBe(result.stderr.includes("VIOLATION") ? 2 : 0);
     expectConfiguredThresholds(result.stderr);
   });
 
@@ -125,7 +125,7 @@ describe('Claude coding-police configuration', () => {
       `coding-police:\n${settings}notes: |\n  max-file-lines: 1\n`,
     );
 
-    expect(result.status, result.stderr).toBe(0);
+    expect(result.status, result.stderr).toBe(result.stderr.includes("VIOLATION") ? 2 : 0);
     expectConfiguredThresholds(result.stderr);
     expect(result.stderr).not.toContain('FILE TOO LONG: 8 lines (limit: 1');
   });
@@ -160,7 +160,7 @@ exec /usr/bin/head "$@"
       );
     });
 
-    expect(result.status, result.stderr).toBe(0);
+    expect(result.status, result.stderr).toBe(result.stderr.includes("VIOLATION") ? 2 : 0);
     expect(result.stderr).not.toContain('unsupported -P');
     expect(result.stderr).not.toContain('unsupported \\s');
     expect(result.stderr).not.toContain('illegal line count');
@@ -185,7 +185,7 @@ describe('Claude coding-police monolith directory', () => {
     const result = runHookOnFile('coding-police:\n  max-dir-files: 15\n', root, target);
     rmSync(root, { force: true, recursive: true });
 
-    expect(result.status, result.stderr).toBe(0);
+    expect(result.status, result.stderr).toBe(result.stderr.includes("VIOLATION") ? 2 : 0);
     expect(result.stderr).toContain('MONOLITH DIRECTORY');
     expect(result.stderr).toContain('15 source files');
     expect(result.stderr).toContain('cap: 15');
@@ -203,7 +203,7 @@ describe('Claude coding-police monolith directory', () => {
     const result = runHookOnFile('coding-police:\n  max-dir-files: 15\n', root, target);
     rmSync(root, { force: true, recursive: true });
 
-    expect(result.status, result.stderr).toBe(0);
+    expect(result.status, result.stderr).toBe(result.stderr.includes("VIOLATION") ? 2 : 0);
     expect(result.stderr).not.toContain('MONOLITH DIRECTORY');
   });
 
@@ -219,7 +219,7 @@ describe('Claude coding-police monolith directory', () => {
     const result = runHookOnFile('coding-police:\n  max-dir-files: 0\n', root, target);
     rmSync(root, { force: true, recursive: true });
 
-    expect(result.status, result.stderr).toBe(0);
+    expect(result.status, result.stderr).toBe(result.stderr.includes("VIOLATION") ? 2 : 0);
     expect(result.stderr).not.toContain('MONOLITH DIRECTORY');
   });
 
@@ -239,7 +239,7 @@ describe('Claude coding-police monolith directory', () => {
     );
     rmSync(root, { force: true, recursive: true });
 
-    expect(result.status, result.stderr).toBe(0);
+    expect(result.status, result.stderr).toBe(result.stderr.includes("VIOLATION") ? 2 : 0);
     expect(result.stderr).not.toContain('MONOLITH DIRECTORY');
   });
 
@@ -255,7 +255,7 @@ describe('Claude coding-police monolith directory', () => {
     const result = runHookOnFile('coding-police:\n  max-dir-files: 15\n', root, target);
     rmSync(root, { force: true, recursive: true });
 
-    expect(result.status, result.stderr).toBe(0);
+    expect(result.status, result.stderr).toBe(result.stderr.includes("VIOLATION") ? 2 : 0);
     expect(result.stderr).not.toContain('MONOLITH DIRECTORY');
   });
 });

--- a/tests/comment-police-hook.test.ts
+++ b/tests/comment-police-hook.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'bun:test';
+import { dirname, join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const repoRoot = dirname(import.meta.dir);
+const hook = join(repoRoot, 'hooks', 'claude', 'comment-police.sh');
+const pluginHook = join(repoRoot, 'plugins-cc', 'agentkit', 'hooks', 'comment-police.sh');
+
+function run(added: string, filePath = '/tmp/subject.ts', hookPath = hook): string {
+  const payload = JSON.stringify({
+    tool_name: 'Edit',
+    tool_input: { file_path: filePath, new_string: added },
+  });
+  const result = spawnSync('bash', [hookPath], { input: payload, encoding: 'utf-8' });
+  expect(result.status).toBe(0);
+  return `${result.stdout ?? ''}${result.stderr ?? ''}`;
+}
+
+const flagged = (out: string) => out.includes('COMMENT DISCIPLINE VIOLATION');
+
+describe('comment-police hook', () => {
+  test('a forge reference is rejected in every form an agent actually writes', () => {
+    const forms = [
+      '// Drain window (#170): the backend has nothing left to cancel',
+      '// Pairs with some-repo!31 for the daemon side',
+      '// see https://gitlab.com/org/repo/-/merge_requests/466',
+      '// behaviour reverted in commit a09d020b',
+      '// Two-screens principle (plan 024)',
+      '// as part of this MR the gate moved',
+    ];
+    for (const form of forms) {
+      const out = run(`${form}\nconst a = 1;\n`);
+      expect(flagged(out)).toBe(true);
+      expect(out).toContain('FORGE REFERENCE');
+    }
+  });
+
+  test('the reason a comment states itself is kept', () => {
+    const out = run('// Head, not tail: the sentence worth speaking announces the call.\nconst a = 1;\n');
+    expect(flagged(out)).toBe(false);
+  });
+
+  test('block length is bounded, and the boundary is not off by one', () => {
+    const six = Array.from({ length: 6 }, (_, i) => `// line ${i}`).join('\n');
+    const seven = Array.from({ length: 7 }, (_, i) => `// line ${i}`).join('\n');
+    expect(flagged(run(`${six}\nconst a = 1;\n`))).toBe(false);
+    const out = run(`${seven}\nconst a = 1;\n`);
+    expect(flagged(out)).toBe(true);
+    expect(out).toContain('COMMENT BLOCK TOO LONG');
+  });
+
+  test('a comment-heavy edit is flagged on ratio even with short blocks', () => {
+    const body = Array.from({ length: 8 }, (_, i) => `// note ${i}\nconst v${i} = ${i};`).join('\n');
+    const out = run(`${body}\n`);
+    expect(flagged(out)).toBe(true);
+    expect(out).toContain('TOO MANY COMMENTS');
+  });
+
+  test('a shebang is not a forge reference', () => {
+    expect(flagged(run('#!/usr/bin/env bash\nset -euo pipefail\n', '/tmp/subject.sh'))).toBe(false);
+  });
+
+  test('prose files are left alone', () => {
+    const many = Array.from({ length: 9 }, (_, i) => `# heading ${i}`).join('\n');
+    expect(flagged(run(many, '/tmp/subject.md'))).toBe(false);
+  });
+
+  test('a ref inside code rather than a comment is not the hook\'s business', () => {
+    expect(flagged(run('const url = "https://gitlab.com/org/repo/-/issues/12";\n'))).toBe(false);
+  });
+
+  test('the plugin copy behaves identically to the claude copy', () => {
+    const sample = '// Drain window (#170): nothing to cancel\nconst a = 1;\n';
+    expect(flagged(run(sample, '/tmp/subject.ts', pluginHook))).toBe(true);
+    expect(flagged(run('// A single honest reason.\nconst a = 1;\n', '/tmp/subject.ts', pluginHook))).toBe(false);
+  });
+});

--- a/tests/comment-police-hook.test.ts
+++ b/tests/comment-police-hook.test.ts
@@ -413,6 +413,25 @@ describe("coding-police reports what the EDIT did, not what the file already was
     rmSync(dir, { recursive: true, force: true });
   });
 
+  test("functions whose names differ only in digits keep distinct shapes", () => {
+    // Blanking every number to compare shapes also rewrote the backticked
+    // identifier, so `step1` and `step2` became one shape — and the
+    // worse-was-already-there pass then handed a real regression the OTHER
+    // function's slot and reported nothing at all. Silence is the fail-open
+    // direction, so this is the case that matters most.
+    const { dir, file, git } = legacyRepo();
+    writeFileSync(file, `${longFn("step2", 120)}${longFn("step1", 250)}`);
+    git("add", "-A");
+    git("commit", "-qm", "two over-cap functions, digit-suffixed names");
+    // One edit: step2 doubles (a real regression) while step1 shrinks.
+    writeFileSync(file, `${longFn("step2", 242)}${longFn("step1", 112)}`);
+    const r = run(file);
+    expect(r.out).toContain("`step2`");
+    expect(r.out).not.toContain("`step1`");
+    expect(r.status).toBe(2);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
   test("cross-repo relative paths survive the baseline pass", () => {
     // The subtraction reset the violations array, silently disabling this
     // check on every TRACKED file — exactly the files it targets.

--- a/tests/comment-police-hook.test.ts
+++ b/tests/comment-police-hook.test.ts
@@ -357,6 +357,62 @@ describe("coding-police reports what the EDIT did, not what the file already was
     rmSync(dir, { recursive: true, force: true });
   });
 
+  test("the export check runs against the baseline too, so an over-cap file stays quiet", () => {
+    // The baseline was written to an extensionless temp file, and
+    // check_export_count returns early on anything that is not .ts/.tsx/.js/.jsx.
+    // So TOO MANY EXPORTS never entered the baseline, could never be subtracted,
+    // and every edit to an over-cap file was blocked by a count it did not change.
+    const { dir, file, git } = legacyRepo();
+    const exports = (n: number) =>
+      Array.from({ length: n }, (_, i) => `export const e${i} = ${i};`).join("\n") + "\n";
+    writeFileSync(file, exports(20));
+    git("add", "-A");
+    git("commit", "-qm", "already over the export cap");
+    const unchanged = run(file);
+    expect(unchanged.out).not.toContain("TOO MANY EXPORTS");
+    expect(unchanged.status).toBe(0);
+    // One more export IS this edit's doing.
+    writeFileSync(file, exports(21));
+    const worse = run(file);
+    expect(worse.out).toContain("TOO MANY EXPORTS");
+    expect(worse.status).toBe(2);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("shrinking a violation that is still over the limit is silent, not 'different'", () => {
+    // Comparing shapes for equality is symmetric: it reported an improvement as
+    // a new violation, blocking the exact cleanup the rule asks for. Severity
+    // must be compared as a NUMBER, and only upward.
+    const { dir, file, git } = legacyRepo();
+    const lines = (n: number) =>
+      Array.from({ length: n }, (_, i) => `const x${i} = ${i};`).join("\n") + "\n";
+    writeFileSync(file, lines(1200));
+    git("add", "-A");
+    git("commit", "-qm", "over the length cap");
+    writeFileSync(file, lines(1100));
+    const shrunk = run(file);
+    expect(shrunk.out).not.toContain("FILE TOO LONG");
+    expect(shrunk.status).toBe(0);
+    // A single line the other way is a regression and must still block.
+    writeFileSync(file, lines(1201));
+    const grown = run(file);
+    expect(grown.out).toContain("FILE TOO LONG");
+    expect(grown.status).toBe(2);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("a legacy long function shortened but still over the limit is silent", () => {
+    const { dir, file, git } = legacyRepo();
+    writeFileSync(file, longFn("legacy", 130));
+    git("add", "-A");
+    git("commit", "-qm", "legacy");
+    writeFileSync(file, longFn("legacy", 115));
+    const r = run(file);
+    expect(r.out).not.toContain("LONG FUNCTION");
+    expect(r.status).toBe(0);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
   test("cross-repo relative paths survive the baseline pass", () => {
     // The subtraction reset the violations array, silently disabling this
     // check on every TRACKED file — exactly the files it targets.

--- a/tests/comment-police-hook.test.ts
+++ b/tests/comment-police-hook.test.ts
@@ -215,26 +215,48 @@ describe("blocking hooks have a way off and a bounded blast radius", () => {
     rmSync(subject, { force: true });
   });
 
-  test("format-police does NOT block on a broken formatter install", () => {
-    // dprint fetches wasm plugins over the network. An offline machine or one
-    // bad config key must not turn every edit into an error nobody can fix.
-    const dir = mkdtempSync(join(tmpdir(), "agentkit-fmtinfra-"));
-    const bin = join(dir, "dprint");
-    writeFileSync(bin, "#!/usr/bin/env bash\necho 'Error resolving plugin https://x/y.wasm: 404 Not Found' >&2\nexit 1\n");
-    chmodSync(bin, 0o755);
-    writeFileSync(join(dir, "dprint.json"), "{}");
-    writeFileSync(join(dir, "clean.ts"), "const a = 1;\n");
+  test("format-police does NOT block on infrastructure failures", () => {
+    // dprint fetches wasm plugins over the network, and a repo's `includes`
+    // may not cover this extension at all. Neither is something the model can
+    // act on, so neither may block. agentkit's OWN dprint.json omits .ts —
+    // blocking on that would have made this repo un-editable.
+    const cases = [
+      "Error resolving plugin https://x/y.wasm: 404 Not Found",
+      "No files found to format with the specified plugins",
+      "error sending request for url (https://plugins.dprint.dev/x.wasm)",
+    ];
+    for (const stderr of cases) {
+      const dir = mkdtempSync(join(tmpdir(), "agentkit-fmtinfra-"));
+      const bin = join(dir, "dprint");
+      writeFileSync(bin, `#!/usr/bin/env bash\necho ${JSON.stringify(stderr)} >&2\nexit 1\n`);
+      chmodSync(bin, 0o755);
+      writeFileSync(join(dir, "dprint.json"), "{}");
+      const file = join(dir, "clean.ts");
+      writeFileSync(file, "const a = 1;\n");
+      const r = spawnSync("bash", [join(repoRoot, "hooks", "claude", "format-police.sh")], {
+        input: JSON.stringify({ tool_name: "Edit", tool_input: { file_path: file, new_string: "x" } }),
+        encoding: "utf-8",
+        env: { ...process.env, PATH: `${dir}:${process.env.PATH ?? ""}` },
+        cwd: dir,
+      });
+      expect(r.status, stderr).toBe(0);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a real edit to a .ts file in THIS repo does not error", () => {
+    // The regression that would have shipped: agentkit's dprint.json covers
+    // md/json/toml/yaml only, so dprint reports "no files found" for every .ts
+    // — and blocking on that makes the repo un-editable.
     const r = spawnSync("bash", [join(repoRoot, "hooks", "claude", "format-police.sh")], {
       input: JSON.stringify({
         tool_name: "Edit",
-        tool_input: { file_path: join(dir, "clean.ts"), new_string: "x" },
+        tool_input: { file_path: join(repoRoot, "plugins", "comment-police.ts"), new_string: "x" },
       }),
       encoding: "utf-8",
-      env: { ...process.env, PATH: `${dir}:${process.env.PATH ?? ""}` },
-      cwd: dir,
+      cwd: repoRoot,
     });
-    expect(r.status).toBe(0);
-    rmSync(dir, { recursive: true, force: true });
+    expect(r.status, `${r.stdout ?? ""}${r.stderr ?? ""}`).toBe(0);
   });
 
   test("format-police exits 2 when dprint actually fails", () => {
@@ -245,7 +267,11 @@ describe("blocking hooks have a way off and a bounded blast radius", () => {
     const dir = mkdtempSync(join(tmpdir(), "agentkit-fmt-"));
     const file = join(dir, "broken.ts");
     const bin = join(dir, "dprint");
-    writeFileSync(bin, "#!/usr/bin/env bash\necho 'syntax error' >&2\nexit 1\n");
+    // dprint's own attributable wording — the allowlisted signal.
+    writeFileSync(
+      bin,
+      `#!/usr/bin/env bash\necho "Error formatting $4: Unexpected token" >&2\nexit 1\n`,
+    );
     chmodSync(bin, 0o755);
     writeFileSync(join(dir, "dprint.json"), "{}");
     writeFileSync(file, "const = = =;\n");
@@ -256,6 +282,91 @@ describe("blocking hooks have a way off and a bounded blast radius", () => {
       cwd: dir,
     });
     expect(`${r.stderr ?? ""}`).toContain("dprint fmt failed");
+    expect(r.status).toBe(2);
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe("coding-police reports what the EDIT did, not what the file already was", () => {
+  // The subtraction pass had no coverage: narrowing it back to file-length
+  // only — reintroducing the bug it was written for — passed the whole suite.
+  function legacyRepo(): { dir: string; file: string; git: (...a: string[]) => void; } {
+    const dir = mkdtempSync(join(tmpdir(), "agentkit-sub-"));
+    const file = join(dir, "legacy.ts");
+    const git = (...a: string[]) => {
+      spawnSync("git", a, { cwd: dir, encoding: "utf-8" });
+    };
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    return { dir, file, git };
+  }
+  const longFn = (name: string, n: number) =>
+    `export function ${name}() {\n${
+      Array.from({ length: n }, (_, i) => `  const v${i} = ${i};`).join("\n")
+    }\n}\n`;
+  const dupBlock = (tag: string) =>
+    `// dup ${tag}\nconst a = 1;\nconst b = 2;\nconst c = 3;\nconst d = 4;\nconst e = 5;\n`;
+
+  const run = (file: string) => {
+    const r = spawnSync("bash", [join(repoRoot, "hooks", "claude", "coding-police.sh")], {
+      input: JSON.stringify({ tool_name: "Edit", tool_input: { file_path: file, new_string: "x" } }),
+      encoding: "utf-8",
+    });
+    return { out: `${r.stdout ?? ""}${r.stderr ?? ""}`, status: r.status };
+  };
+
+  test("a legacy long function is not re-reported when unrelated lines shift it", () => {
+    const { dir, file, git } = legacyRepo();
+    writeFileSync(file, longFn("legacy", 130));
+    git("add", "-A");
+    git("commit", "-qm", "legacy");
+    // Prepend unrelated lines: the function moves down but is untouched.
+    writeFileSync(file, `const x0 = 0;\nconst x1 = 1;\n${longFn("legacy", 130)}`);
+    const r = run(file);
+    expect(r.out).not.toContain("LONG FUNCTION");
+    expect(r.status).toBe(0);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("a NEW long function IS reported even though one already existed", () => {
+    // The failure mode of comparing a single max number: the new violation's
+    // metric was lower than the legacy one's, so it vanished.
+    const { dir, file, git } = legacyRepo();
+    writeFileSync(file, longFn("legacy", 130));
+    git("add", "-A");
+    git("commit", "-qm", "legacy");
+    writeFileSync(file, `${longFn("fresh", 112)}${longFn("legacy", 130)}`);
+    const r = run(file);
+    expect(r.out).toContain("`fresh`");
+    expect(r.out).not.toContain("`legacy`");
+    expect(r.status).toBe(2);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("an ADDITIONAL duplicate block is reported; the pre-existing ones are not", () => {
+    const { dir, file, git } = legacyRepo();
+    writeFileSync(file, `${dupBlock("one")}${dupBlock("two")}`);
+    git("add", "-A");
+    git("commit", "-qm", "legacy dups");
+    const r0 = run(file);
+    expect(r0.out).not.toContain("DUPLICATE CODE");
+    writeFileSync(file, `${dupBlock("one")}${dupBlock("two")}${dupBlock("three")}`);
+    const r1 = run(file);
+    expect(r1.out).toContain("DUPLICATE CODE");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("cross-repo relative paths survive the baseline pass", () => {
+    // The subtraction reset the violations array, silently disabling this
+    // check on every TRACKED file — exactly the files it targets.
+    const { dir, git } = legacyRepo();
+    const file = join(dir, "conf.ts");
+    writeFileSync(file, 'export const p = "../../core/roles";\n');
+    git("add", "-A");
+    git("commit", "-qm", "tracked");
+    const r = run(file);
+    expect(r.out).toContain("CROSS-REPO RELATIVE PATH");
     expect(r.status).toBe(2);
     rmSync(dir, { recursive: true, force: true });
   });

--- a/tests/comment-police-hook.test.ts
+++ b/tests/comment-police-hook.test.ts
@@ -195,6 +195,48 @@ describe("blocking hooks have a way off and a bounded blast radius", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
+  test("AGENTKIT_SKIP_HOOKS tolerates spaces, matching version-police", () => {
+    const subject = join(tmpdir(), `agentkit-skipws-${process.pid}.ts`);
+    const bad = `${"// filler comment line\n".repeat(8)}const a = 1;\n`;
+    writeFileSync(subject, bad);
+    const payload = JSON.stringify({
+      tool_name: "Edit",
+      tool_input: { file_path: subject, new_string: bad },
+    });
+    const hook = join(repoRoot, "hooks", "claude", "comment-police.sh");
+    for (const value of [" all ", "coding-police, comment-police", "\tall"]) {
+      const r = spawnSync("bash", [hook], {
+        input: payload,
+        encoding: "utf-8",
+        env: { ...process.env, AGENTKIT_SKIP_HOOKS: value },
+      });
+      expect(r.status, `AGENTKIT_SKIP_HOOKS=${JSON.stringify(value)}`).toBe(0);
+    }
+    rmSync(subject, { force: true });
+  });
+
+  test("format-police does NOT block on a broken formatter install", () => {
+    // dprint fetches wasm plugins over the network. An offline machine or one
+    // bad config key must not turn every edit into an error nobody can fix.
+    const dir = mkdtempSync(join(tmpdir(), "agentkit-fmtinfra-"));
+    const bin = join(dir, "dprint");
+    writeFileSync(bin, "#!/usr/bin/env bash\necho 'Error resolving plugin https://x/y.wasm: 404 Not Found' >&2\nexit 1\n");
+    chmodSync(bin, 0o755);
+    writeFileSync(join(dir, "dprint.json"), "{}");
+    writeFileSync(join(dir, "clean.ts"), "const a = 1;\n");
+    const r = spawnSync("bash", [join(repoRoot, "hooks", "claude", "format-police.sh")], {
+      input: JSON.stringify({
+        tool_name: "Edit",
+        tool_input: { file_path: join(dir, "clean.ts"), new_string: "x" },
+      }),
+      encoding: "utf-8",
+      env: { ...process.env, PATH: `${dir}:${process.env.PATH ?? ""}` },
+      cwd: dir,
+    });
+    expect(r.status).toBe(0);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
   test("format-police exits 2 when dprint actually fails", () => {
     // The surviving mutant: nothing tested format-police's exit at all.
     // A stub dprint that always fails makes this deterministic — asserting

--- a/tests/comment-police-hook.test.ts
+++ b/tests/comment-police-hook.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import { dirname, join } from 'node:path';
 import { spawnSync } from 'node:child_process';
-import { readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 
 const repoRoot = dirname(import.meta.dir);
@@ -129,5 +129,92 @@ describe('police hooks reach the model', () => {
       const b = readFileSync(join(repoRoot, 'plugins-cc', 'agentkit', 'hooks', name), 'utf-8');
       expect(b).toBe(a);
     }
+  });
+});
+
+describe("blocking hooks have a way off and a bounded blast radius", () => {
+  const hooks = ["comment-police", "coding-police", "format-police"];
+
+  test("AGENTKIT_SKIP_HOOKS disables them", () => {
+    // A blocking hook with no kill switch is one that gets deleted rather
+    // than configured — and there is no PostToolUse loop guard to fall back on.
+    const subject = join(tmpdir(), `agentkit-skip-${process.pid}.ts`);
+    writeFileSync(subject, `${"// filler comment line\n".repeat(8)}const a = 1;\n`);
+    const payload = JSON.stringify({
+      tool_name: "Edit",
+      tool_input: { file_path: subject, new_string: `${"// filler comment line\n".repeat(8)}const a = 1;\n` },
+    });
+    for (const h of hooks) {
+      const hook = join(repoRoot, "hooks", "claude", `${h}.sh`);
+      for (const value of ["all", h]) {
+        const r = spawnSync("bash", [hook], {
+          input: payload,
+          encoding: "utf-8",
+          env: { ...process.env, AGENTKIT_SKIP_HOOKS: value },
+        });
+        expect(r.status, `${h} with AGENTKIT_SKIP_HOOKS=${value}`).toBe(0);
+      }
+    }
+    rmSync(subject, { force: true });
+  });
+
+  test("a file that was ALREADY too long does not block every later edit", () => {
+    // The wedge: coding-police measures whole-file state, so without this an
+    // unrelated one-line edit to a big legacy file is unfixably blocked.
+    const dir = mkdtempSync(join(tmpdir(), "agentkit-baseline-"));
+    const file = join(dir, "big.ts");
+    const git = (...a: string[]) => spawnSync("git", a, { cwd: dir, encoding: "utf-8" });
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    // Distinct lines: a repeated line would trip the duplicate-code check
+    // instead, and this test is about the LENGTH check alone.
+    const lines = (n: number) =>
+      Array.from({ length: n }, (_, i) => `const x${i} = ${i};`).join("\n") + "\n";
+    writeFileSync(file, lines(1200));
+    git("add", "-A");
+    git("commit", "-qm", "big file already exists");
+
+    // Unchanged size: still over the limit, but not this edit's doing.
+    writeFileSync(file, lines(1200));
+    const r = spawnSync("bash", [join(repoRoot, "hooks", "claude", "coding-police.sh")], {
+      input: JSON.stringify({ tool_name: "Edit", tool_input: { file_path: file, new_string: "const x = 1;\n" } }),
+      encoding: "utf-8",
+    });
+    expect(`${r.stdout ?? ""}${r.stderr ?? ""}`).not.toContain("FILE TOO LONG");
+    expect(r.status).toBe(0);
+
+    // Growing it further IS this edit's doing, and must block.
+    writeFileSync(file, lines(1400));
+    const worse = spawnSync("bash", [join(repoRoot, "hooks", "claude", "coding-police.sh")], {
+      input: JSON.stringify({ tool_name: "Edit", tool_input: { file_path: file, new_string: "const x = 1;\n" } }),
+      encoding: "utf-8",
+    });
+    expect(`${worse.stdout ?? ""}${worse.stderr ?? ""}`).toContain("FILE TOO LONG");
+    expect(worse.status).toBe(2);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("format-police exits 2 when dprint actually fails", () => {
+    // The surviving mutant: nothing tested format-police's exit at all.
+    // A stub dprint that always fails makes this deterministic — asserting
+    // "0 or 2" would pass whatever the hook did, which is the weakness this
+    // whole review round was about.
+    const dir = mkdtempSync(join(tmpdir(), "agentkit-fmt-"));
+    const file = join(dir, "broken.ts");
+    const bin = join(dir, "dprint");
+    writeFileSync(bin, "#!/usr/bin/env bash\necho 'syntax error' >&2\nexit 1\n");
+    chmodSync(bin, 0o755);
+    writeFileSync(join(dir, "dprint.json"), "{}");
+    writeFileSync(file, "const = = =;\n");
+    const r = spawnSync("bash", [join(repoRoot, "hooks", "claude", "format-police.sh")], {
+      input: JSON.stringify({ tool_name: "Edit", tool_input: { file_path: file, new_string: "x" } }),
+      encoding: "utf-8",
+      env: { ...process.env, PATH: `${dir}:${process.env.PATH ?? ""}` },
+      cwd: dir,
+    });
+    expect(`${r.stderr ?? ""}`).toContain("dprint fmt failed");
+    expect(r.status).toBe(2);
+    rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/tests/comment-police-hook.test.ts
+++ b/tests/comment-police-hook.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from 'bun:test';
 import { dirname, join } from 'node:path';
 import { spawnSync } from 'node:child_process';
+import { readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 
 const repoRoot = dirname(import.meta.dir);
 const hook = join(repoRoot, 'hooks', 'claude', 'comment-police.sh');
@@ -12,8 +14,12 @@ function run(added: string, filePath = '/tmp/subject.ts', hookPath = hook): stri
     tool_input: { file_path: filePath, new_string: added },
   });
   const result = spawnSync('bash', [hookPath], { input: payload, encoding: 'utf-8' });
-  expect(result.status).toBe(0);
-  return `${result.stdout ?? ''}${result.stderr ?? ''}`;
+  const out = `${result.stdout ?? ''}${result.stderr ?? ''}`;
+  // Delivery is half the contract: Claude Code discards a PostToolUse hook's
+  // stderr at exit 0, so a violation reported at 0 is one nobody hears. This
+  // helper previously asserted 0 unconditionally, which pinned that bug.
+  expect(result.status).toBe(out.includes('VIOLATION') ? 2 : 0);
+  return out;
 }
 
 const flagged = (out: string) => out.includes('COMMENT DISCIPLINE VIOLATION');
@@ -73,5 +79,55 @@ describe('comment-police hook', () => {
     const sample = '// Drain window (#170): nothing to cancel\nconst a = 1;\n';
     expect(flagged(run(sample, '/tmp/subject.ts', pluginHook))).toBe(true);
     expect(flagged(run('// A single honest reason.\nconst a = 1;\n', '/tmp/subject.ts', pluginHook))).toBe(false);
+  });
+});
+
+describe('police hooks reach the model', () => {
+  // coding-police measures the file ON DISK; comment-police reads the added
+  // string. Both need a real path, so each case writes its own subject.
+  const cases = [
+    { name: 'comment-police', hook: join(repoRoot, 'hooks', 'claude', 'comment-police.sh'),
+      bad: `${'// filler comment line\n'.repeat(8)}const a = 1;\n` },
+    { name: 'coding-police', hook: join(repoRoot, 'hooks', 'claude', 'coding-police.sh'),
+      bad: 'const x = 1;\n'.repeat(1200) },
+  ];
+  const subject = join(tmpdir(), `agentkit-police-${process.pid}.ts`);
+
+  // A PostToolUse hook that reports a violation at exit 0 has its stderr
+  // discarded — it runs, finds the problem, and the model never learns of it.
+  for (const c of cases) {
+    test(`${c.name} exits 2 on a violation, so its stderr is delivered`, () => {
+      writeFileSync(subject, c.bad);
+      const payload = JSON.stringify({
+        tool_name: 'Edit',
+        tool_input: { file_path: subject, new_string: c.bad },
+      });
+      const r = spawnSync('bash', [c.hook], { input: payload, encoding: 'utf-8' });
+      rmSync(subject, { force: true });
+      expect(`${r.stdout ?? ''}${r.stderr ?? ''}`).toContain('VIOLATION');
+      expect(r.status).toBe(2);
+    });
+
+    test(`${c.name} stays silent and exits 0 on a clean edit`, () => {
+      const clean = 'const a = 1;\nconst b = 2;\n';
+      writeFileSync(subject, clean);
+      const payload = JSON.stringify({
+        tool_name: 'Edit',
+        tool_input: { file_path: subject, new_string: clean },
+      });
+      const r = spawnSync('bash', [c.hook], { input: payload, encoding: 'utf-8' });
+      rmSync(subject, { force: true });
+      expect(r.status).toBe(0);
+    });
+  }
+
+  test('the packaged plugin copy matches the canonical hook byte for byte', () => {
+    // Two copies ship; a fix applied to one and not the other is a hook that
+    // behaves differently depending on how agentkit was installed.
+    for (const name of ['comment-police.sh', 'coding-police.sh', 'format-police.sh']) {
+      const a = readFileSync(join(repoRoot, 'hooks', 'claude', name), 'utf-8');
+      const b = readFileSync(join(repoRoot, 'plugins-cc', 'agentkit', 'hooks', name), 'utf-8');
+      expect(b).toBe(a);
+    }
   });
 });

--- a/tests/git-police-hygiene.test.ts
+++ b/tests/git-police-hygiene.test.ts
@@ -258,3 +258,48 @@ describe('git-police push rules require a push subcommand', () => {
     expect(out).toContain('Force push');
   });
 });
+
+describe('shared-clone branch guard', () => {
+  let solo: string;
+  let shared: string;
+  let linked: string;
+
+  beforeAll(() => {
+    solo = join(root, 'solo');
+    shared = join(root, 'shared');
+    linked = join(root, 'shared-wt', 'feat');
+    execSync(`git clone ${origin} ${solo}`, { stdio: 'pipe' });
+    execSync(`git clone ${origin} ${shared}`, { stdio: 'pipe' });
+    git(shared, `worktree add ${linked} -b wt/existing`);
+  });
+
+  test('a clone with no worktrees is left alone', () => {
+    expect(runHook(solo, 'git checkout -b feat/x')).not.toContain('shared clone');
+  });
+
+  test('creating a branch in a clone others share is refused', () => {
+    const out = runHook(shared, 'git checkout -b feat/x');
+    expect(out).toContain('shared clone');
+    expect(out).toContain('git worktree add');
+    expect(runHook(shared, 'git switch -c feat/x')).toContain('shared clone');
+  });
+
+  test('inside a worktree it is allowed — that is the point', () => {
+    expect(runHook(linked, 'git checkout -b feat/y')).not.toContain('shared clone');
+  });
+
+  test('the escape hatch works inline, where a prefix cannot reach the hook env', () => {
+    expect(runHook(shared, 'AGENTKIT_ALLOW_SHARED_BRANCH=1 git checkout -b feat/x'))
+      .not.toContain('shared clone');
+  });
+
+  test('switching to an existing branch, and creating a worktree, are untouched', () => {
+    expect(runHook(shared, 'git checkout main')).not.toContain('shared clone');
+    expect(runHook(shared, 'git worktree add ../x -b feat/z')).not.toContain('shared clone');
+  });
+
+  test('the words appearing in a commit message are not a branch creation', () => {
+    expect(runHook(shared, "git commit -m 'git checkout -b is blocked'"))
+      .not.toContain('shared clone');
+  });
+});

--- a/tests/install-hooks.test.ts
+++ b/tests/install-hooks.test.ts
@@ -38,25 +38,36 @@ describe('Claude Code hook wiring', () => {
         readFileSync(join(claudeDir, 'settings.json'), 'utf-8'),
       );
 
-      const preToolUse = settings.hooks.PreToolUse;
-      expect(preToolUse).toHaveLength(1);
-      expect(preToolUse[0].matcher).toBe('Bash');
-      expect(commandNames(preToolUse[0].hooks).sort()).toEqual(
-        [
-          'git-police.sh',
-          'kubectl-police.sh',
-          'mr-police.sh',
-          'pkg-police.sh',
-          'resource-police.sh',
-        ].sort(),
+      // The installed wiring must equal the canonical file, not a second copy
+      // maintained by hand — the drift between them left review-police shipped
+      // but never wired, so the merge gate was inert wherever this installer ran.
+      const canonical = JSON.parse(
+        readFileSync(join(repoRoot, 'hooks', 'claude', 'settings.json'), 'utf-8'),
       );
+      for (const event of Object.keys(canonical.hooks)) {
+        const want = canonical.hooks[event];
+        const got = settings.hooks[event];
+        expect(got, `${event} missing from installed settings`).toBeDefined();
+        expect(got).toHaveLength(want.length);
+        want.forEach((group: any, i: number) => {
+          expect(got[i].matcher).toEqual(group.matcher);
+          expect(commandNames(got[i].hooks)).toEqual(commandNames(group.hooks));
+        });
+      }
 
-      const postToolUse = settings.hooks.PostToolUse;
-      expect(postToolUse).toHaveLength(1);
-      expect(postToolUse[0].matcher).toBe('Edit|Write');
-      expect(commandNames(postToolUse[0].hooks).sort()).toEqual(
-        ['coding-police.sh', 'format-police.sh'].sort(),
-      );
+      // Every command must point at the installed hooks dir, never the token.
+      for (const groups of Object.values<any>(settings.hooks)) {
+        for (const group of groups) {
+          for (const entry of group.hooks) {
+            expect(entry.command).not.toContain('$HOME');
+            expect(entry.command).toStartWith(join(claudeDir, 'hooks'));
+          }
+        }
+      }
+
+      // Named explicitly so deleting one from the canonical file fails here.
+      expect(commandNames(settings.hooks.PreToolUse[0].hooks)).toContain('review-police.sh');
+      expect(commandNames(settings.hooks.PostToolUse[0].hooks)).toContain('comment-police.sh');
     } finally {
       rmSync(home, { force: true, recursive: true });
     }


### PR DESCRIPTION
## comment-police had no Claude Code hook

The rule (`rules/comment-discipline.md`) and the OpenCode plugin (`plugins/comment-police.ts`) both existed. Claude Code had **no hook at all**, so agents running under it were entirely unenforced — which is how long comment blocks and issue/MR references kept landing in source.

- new `hooks/claude/comment-police.sh` (+ the plugin-runtime copy), reading the same `comment-police:` config keys as the OpenCode plugin
- checks **added lines only**, so touching a file does not inherit blame for its existing comments
- extends the forbidden set in **both** runtimes to the bare forms agents actually write — a hash or bang glued to a number, forge URLs, commit shas. The previous patterns only matched spelled-out ones like `closes #N`, so they missed the common case.

Rationale recorded in the rule: a comment lives as long as the repo, but issues and merge requests live in the forge. Clone elsewhere or migrate forges and the pointer dangles — the reasoning is unreachable exactly when it is needed.

## The installer had drifted from the canonical wiring

Found while installing the above. `install.sh` kept a **second, hand-maintained copy** of the hook wiring in jq rather than reading `hooks/claude/settings.json`. Consequences on any machine installed with it:

| hook | in settings.json | installed |
|---|---|---|
| review-police (Bash) | yes | **no** |
| review-police (MCP merge matcher) | yes | **no** |
| comment-police | yes (new) | **no** |

So the merge gate shipped as a file nobody called. `tests/install-hooks.test.ts` asserted the drifted shape (`PreToolUse` length 1), locking the bug in; it now compares installed wiring against the canonical file and names both hooks explicitly.

## Verification

- 435 tests pass, 0 fail
- new `tests/comment-police-hook.test.ts`: 8 cases incl. shebang, prose files, refs in code vs comments, block-length boundary, and parity between the two hook copies
- mutation-tested: hook disarmed to `exit 0` → 3 fail; forge check removed → 1 fail; block limit raised to 99 → 1 fail
- installed locally and verified `review-police` and `comment-police` are now wired, with the existing non-agentkit hooks preserved by the merge