### PR TITLE
fix(resource-police): the guard was silently dead on macOS, then deadlocked

### DIFF
--- a/hooks/claude/resource-police.sh
+++ b/hooks/claude/resource-police.sh
@@ -1,9 +1,64 @@
 #!/bin/bash
 set -euo pipefail
 
-readonly AWK_BIN=/usr/bin/awk
-readonly CAT_BIN=/usr/bin/cat
-readonly JQ_BIN=/usr/bin/jq
+# Absolute paths are deliberate: a hook that inspects a command must not
+# resolve its own tools through a PATH that command could have manipulated.
+# But the locations are NOT the same everywhere — `cat` is /bin/cat on macOS
+# and /usr/bin/cat on most Linux, and jq is wherever it was installed. Probing
+# a short list of known locations keeps the intent while working on both.
+#
+# This mattered: the hardcoded /usr/bin/cat does not exist on macOS, so with
+# `set -e` the hook died on its very first line. Claude Code reported only
+# "non-blocking status code", which reads as noise — so the guard was not
+# merely broken, it was silently OFF while appearing to be installed.
+pick_bin() {
+	local p
+	for p in "$@"; do
+		[[ -x "$p" ]] && {
+			printf '%s' "$p"
+			return 0
+		}
+	done
+	return 1
+}
+
+AWK_BIN=$(pick_bin /usr/bin/awk /bin/awk) || AWK_BIN=""
+CAT_BIN=$(pick_bin /bin/cat /usr/bin/cat) || CAT_BIN=""
+JQ_BIN=$(pick_bin /usr/bin/jq /opt/homebrew/bin/jq /usr/local/bin/jq) || JQ_BIN=""
+readonly AWK_BIN CAT_BIN JQ_BIN
+
+# Missing tools mean this guard cannot run. Say so ONCE, loudly, and allow the
+# command: this is defence-in-depth detection, not a sandbox, so failing closed
+# would wedge every Bash call over a missing utility. What must not happen is
+# failing silently, which is exactly what it did before.
+if [[ -z "$AWK_BIN" || -z "$CAT_BIN" || -z "$JQ_BIN" ]]; then
+	printf 'resource-police: DISABLED — missing %s. Heavy commands are NOT being bounded.\n' \
+		"$([[ -z "$AWK_BIN" ]] && printf 'awk '; [[ -z "$CAT_BIN" ]] && printf 'cat '; [[ -z "$JQ_BIN" ]] && printf 'jq ')" >&2
+	exit 0
+fi
+
+# Stand down where bounding is IMPOSSIBLE, not merely unconfigured.
+#
+# bounded-run contains work in a systemd scope backed by cgroup v2, and dies
+# with 'cgroup v2 is unavailable' without it. macOS has neither cgroups nor
+# systemd, so enforcing here would deny every heavy command and name a remedy
+# that cannot run on this host — a deadlock with no way out except the escape
+# hatch, on every build, test and typecheck.
+#
+# Announced once per session rather than per command: a warning on every Bash
+# call is the kind of noise that trains people to ignore hooks, but silently
+# disabling a guard is how it stays broken for months.
+if [[ ! -r /sys/fs/cgroup/cgroup.controllers ]]; then
+	# Keyed on PPID — the client process, stable across every hook invocation
+	# in one session. $$ is this hook's own pid and changes each time, which
+	# would make "once" mean "always".
+	notice="${TMPDIR:-/tmp}/.agentkit-resource-police-inactive.$PPID"
+	if [[ ! -e "$notice" ]]; then
+		: >"$notice" 2>/dev/null || true
+		printf 'resource-police: INACTIVE on this host — cgroup v2 is unavailable, so bounded-run cannot contain anything. Heavy commands are not being bounded.\n' >&2
+	fi
+	exit 0
+fi
 
 INPUT=$("$CAT_BIN")
 COMMAND=$(printf '%s' "$INPUT" | "$JQ_BIN" -r '.tool_input.command // empty')
@@ -137,7 +192,12 @@ parse_launch() {
 }
 
 is_heavy() {
-	local executable="${EXECUTABLE,,}"
+	# `${VAR,,}` is bash 4+. macOS ships bash 3.2 at /bin/bash, which this
+	# script's shebang selects, so that expansion is a hard parse error there —
+	# and with `set -e` it killed the hook mid-run, leaving the guard off. `tr`
+	# is portable and the cost is irrelevant at one call per command.
+	local executable
+	executable=$(printf '%s' "$EXECUTABLE" | LC_ALL=C tr '[:upper:]' '[:lower:]')
 	local first="${ARGS[0]:-}"
 	local second="${ARGS[1]:-}"
 	case "$executable" in

--- a/plugins-cc/agentkit/hooks/resource-police.sh
+++ b/plugins-cc/agentkit/hooks/resource-police.sh
@@ -1,9 +1,64 @@
 #!/bin/bash
 set -euo pipefail
 
-readonly AWK_BIN=/usr/bin/awk
-readonly CAT_BIN=/usr/bin/cat
-readonly JQ_BIN=/usr/bin/jq
+# Absolute paths are deliberate: a hook that inspects a command must not
+# resolve its own tools through a PATH that command could have manipulated.
+# But the locations are NOT the same everywhere — `cat` is /bin/cat on macOS
+# and /usr/bin/cat on most Linux, and jq is wherever it was installed. Probing
+# a short list of known locations keeps the intent while working on both.
+#
+# This mattered: the hardcoded /usr/bin/cat does not exist on macOS, so with
+# `set -e` the hook died on its very first line. Claude Code reported only
+# "non-blocking status code", which reads as noise — so the guard was not
+# merely broken, it was silently OFF while appearing to be installed.
+pick_bin() {
+	local p
+	for p in "$@"; do
+		[[ -x "$p" ]] && {
+			printf '%s' "$p"
+			return 0
+		}
+	done
+	return 1
+}
+
+AWK_BIN=$(pick_bin /usr/bin/awk /bin/awk) || AWK_BIN=""
+CAT_BIN=$(pick_bin /bin/cat /usr/bin/cat) || CAT_BIN=""
+JQ_BIN=$(pick_bin /usr/bin/jq /opt/homebrew/bin/jq /usr/local/bin/jq) || JQ_BIN=""
+readonly AWK_BIN CAT_BIN JQ_BIN
+
+# Missing tools mean this guard cannot run. Say so ONCE, loudly, and allow the
+# command: this is defence-in-depth detection, not a sandbox, so failing closed
+# would wedge every Bash call over a missing utility. What must not happen is
+# failing silently, which is exactly what it did before.
+if [[ -z "$AWK_BIN" || -z "$CAT_BIN" || -z "$JQ_BIN" ]]; then
+	printf 'resource-police: DISABLED — missing %s. Heavy commands are NOT being bounded.\n' \
+		"$([[ -z "$AWK_BIN" ]] && printf 'awk '; [[ -z "$CAT_BIN" ]] && printf 'cat '; [[ -z "$JQ_BIN" ]] && printf 'jq ')" >&2
+	exit 0
+fi
+
+# Stand down where bounding is IMPOSSIBLE, not merely unconfigured.
+#
+# bounded-run contains work in a systemd scope backed by cgroup v2, and dies
+# with 'cgroup v2 is unavailable' without it. macOS has neither cgroups nor
+# systemd, so enforcing here would deny every heavy command and name a remedy
+# that cannot run on this host — a deadlock with no way out except the escape
+# hatch, on every build, test and typecheck.
+#
+# Announced once per session rather than per command: a warning on every Bash
+# call is the kind of noise that trains people to ignore hooks, but silently
+# disabling a guard is how it stays broken for months.
+if [[ ! -r /sys/fs/cgroup/cgroup.controllers ]]; then
+	# Keyed on PPID — the client process, stable across every hook invocation
+	# in one session. $$ is this hook's own pid and changes each time, which
+	# would make "once" mean "always".
+	notice="${TMPDIR:-/tmp}/.agentkit-resource-police-inactive.$PPID"
+	if [[ ! -e "$notice" ]]; then
+		: >"$notice" 2>/dev/null || true
+		printf 'resource-police: INACTIVE on this host — cgroup v2 is unavailable, so bounded-run cannot contain anything. Heavy commands are not being bounded.\n' >&2
+	fi
+	exit 0
+fi
 
 INPUT=$("$CAT_BIN")
 COMMAND=$(printf '%s' "$INPUT" | "$JQ_BIN" -r '.tool_input.command // empty')
@@ -137,7 +192,12 @@ parse_launch() {
 }
 
 is_heavy() {
-	local executable="${EXECUTABLE,,}"
+	# `${VAR,,}` is bash 4+. macOS ships bash 3.2 at /bin/bash, which this
+	# script's shebang selects, so that expansion is a hard parse error there —
+	# and with `set -e` it killed the hook mid-run, leaving the guard off. `tr`
+	# is portable and the cost is irrelevant at one call per command.
+	local executable
+	executable=$(printf '%s' "$EXECUTABLE" | LC_ALL=C tr '[:upper:]' '[:lower:]')
 	local first="${ARGS[0]:-}"
 	local second="${ARGS[1]:-}"
 	case "$executable" in

--- a/plugins-cc/agentkit/tools/bounded-run
+++ b/plugins-cc/agentkit/tools/bounded-run
@@ -280,7 +280,11 @@ build_clean_environment() {
 		CI NO_COLOR FORCE_COLOR SSH_AUTH_SOCK
 	)
 	for name in "${allowed[@]}"; do
-		if [[ -v "$name" ]]; then
+		# `[[ -v VAR ]]` is bash 4.2+; macOS ships bash 3.2, where it is a
+		# parse error ("conditional binary operator expected") that aborts the
+		# runner. `${!name+x}` is the portable set-or-not test and, unlike
+		# `-n "${!name}"`, still passes through variables set to empty.
+		if [[ -n "${!name+x}" ]]; then
 			CLEAN_ENV+=("$name=${!name}")
 		fi
 	done

--- a/tests/resource-police.test.ts
+++ b/tests/resource-police.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import resourcePolice from '../plugins/resource-police';
@@ -9,6 +9,21 @@ import {
   unsupportedResourceCommands,
   untrustedRunnerCommands,
 } from './fixtures/resource-commands';
+
+/**
+ * The shell hook enforces only where bounding is possible.
+ *
+ * `bounded-run` contains work in a systemd scope backed by cgroup v2 and dies
+ * without it, so on a host with neither (macOS, most notably) the hook stands
+ * down rather than denying every heavy command and naming a remedy that cannot
+ * run. These cases assert DENY, so they are Linux-only by construction.
+ *
+ * Skipped, not deleted, and not silently passing: before this guard existed a
+ * macOS checkout reported 64 failures here, which is indistinguishable from a
+ * real regression and trains everyone to ignore the suite.
+ */
+const canBound = existsSync('/sys/fs/cgroup/cgroup.controllers');
+const describeShellHook = canBound ? describe : describe.skip;
 
 const repoRoot = dirname(import.meta.dir);
 const hook = join(repoRoot, 'hooks', 'claude', 'resource-police.sh');
@@ -84,7 +99,7 @@ describe('OpenCode resource-police', () => {
   });
 });
 
-describe('Claude resource-police', () => {
+describeShellHook('Claude resource-police', () => {
   for (const command of blockedResourceCommands) {
     test(`blocks unbounded command: ${command}`, () => {
       const output = runHook(command);
@@ -129,7 +144,7 @@ describe('Claude resource-police', () => {
   });
 });
 
-describe('Codex resource policy', () => {
+describeShellHook('Codex resource policy', () => {
   test('forbids direct heavy command prefixes without interactive prompts', () => {
     const contents = readFileSync(policy, 'utf-8');
     expect(contents).not.toContain('decision = "prompt"');

--- a/tools/bounded-run
+++ b/tools/bounded-run
@@ -280,7 +280,11 @@ build_clean_environment() {
 		CI NO_COLOR FORCE_COLOR SSH_AUTH_SOCK
 	)
 	for name in "${allowed[@]}"; do
-		if [[ -v "$name" ]]; then
+		# `[[ -v VAR ]]` is bash 4.2+; macOS ships bash 3.2, where it is a
+		# parse error ("conditional binary operator expected") that aborts the
+		# runner. `${!name+x}` is the portable set-or-not test and, unlike
+		# `-n "${!name}"`, still passes through variables set to empty.
+		if [[ -n "${!name+x}" ]]; then
 			CLEAN_ENV+=("$name=${!name}")
 		fi
 	done


### PR DESCRIPTION
Reported as a recurring `PreToolUse hook error / non-blocking status code`, which reads as noise. It was not noise — **the hook exited on its first line and never ran**, so every heavy command went unbounded while the guard appeared to be installed.

Four defects, each hidden behind the one before it:

| # | Defect | Effect |
|---|---|---|
| 1 | `/usr/bin/cat` does not exist on macOS (it is `/bin/cat`) | with `set -e`, the hook died on line 8 — guard silently OFF |
| 2 | `${EXECUTABLE,,}` is bash 4+; macOS ships bash 3.2 | aborted mid-run once it got that far |
| 3 | `[[ -v "$name" ]]` in `bounded-run` is bash 4.2+ | `conditional binary operator expected` — the runner itself would not start |
| 4 | `bounded-run` requires **cgroup v2 + systemd**, which macOS does not have | with 1–3 fixed the hook *worked*, and denied every build/test/typecheck while naming a remedy that **cannot run** — a deadlock |

### The shape of the fix

Binaries are probed across known **absolute** locations — still absolute, because a hook that inspects a command must not resolve its own tools through a PATH that command could have manipulated. A genuinely missing tool now says so and allows, rather than dying mutely.

The hook **stands down where bounding is impossible**, not merely unconfigured, and says so **once per session**:

- Not silently — silence is how this stayed broken.
- Not per-command — a warning on every Bash call trains people to ignore hooks.
- **Linux behaviour is unchanged**: the check is conditional on `/sys/fs/cgroup/cgroup.controllers` being readable.

### Tests

The resource-police cases assert DENY, so they are Linux-only by construction and now **skip** on hosts that cannot bound. They were not passing before — a macOS checkout reported **64 failures in that file alone**, indistinguishable from a real regression.

Full suite on macOS: **89 failures before, 23 after**. The remaining 23 are other Linux-only suites (`bounded-run argument contract`, `coding-police` GNU grep) with the same root cause, left for a separate change.

Both copies of each file (`hooks/claude/` and `plugins-cc/agentkit/`) are updated and remain byte-identical.