### PR TITLE
fix(police): the hooks had never run on the bash macOS ships

### DIFF
--- a/hooks/claude/coding-police.sh
+++ b/hooks/claude/coding-police.sh
@@ -109,7 +109,7 @@ case "$FILE_PATH" in
 esac
 
 # Skip paths matching an exclude-patterns entry (e.g. homogeneous routes/migrations dirs)
-for pattern in "${EXCLUDE_PATTERNS[@]}"; do
+for pattern in "${EXCLUDE_PATTERNS[@]+"${EXCLUDE_PATTERNS[@]}"}"; do
   [[ "$FILE_PATH" == *"$pattern"* ]] && exit 0
 done
 
@@ -127,14 +127,23 @@ check_cross_repo_relative_paths() {
   # the repo — a deliberate test fixture, say — is not re-reported on every
   # later edit. Unlike the whole-file checks this is per line, so the baseline
   # is a set of lines rather than a severity: anything not in it is this edit's.
-  local matches committed line body
+  local matches committed line body seen_n committed_n
   matches=$(grep -hE "$CROSS_REPO_RE" "$FILE_PATH" 2>/dev/null || true)
   committed=$(baseline_of | grep -hE "$CROSS_REPO_RE" 2>/dev/null || true)
 
+  # COUNTS, not membership: asking only "is this line committed?" let a second,
+  # byte-identical copy of an offending line be added and reported as nothing.
+  # A duplicated list entry in config is exactly this check's target.
+  seen_n=""
   while IFS= read -r line; do
     [[ -n "$line" ]] || continue
     body=${line#"${line%%[![:space:]]*}"}
-    if [[ -n "$committed" ]] && printf '%s\n' "$committed" | grep -qxF -- "$line"; then
+    committed_n=0
+    if [[ -n "$committed" ]]; then
+      committed_n=$(printf '%s\n' "$committed" | grep -cxF -- "$line" || true)
+    fi
+    seen_n=$(printf '%s\n%s' "$seen_n" "$line")
+    if (( $(printf '%s' "$seen_n" | grep -cxF -- "$line" || true) <= committed_n )); then
       continue
     fi
     VIOLATIONS+=("CROSS-REPO RELATIVE PATH: ${body}. Do not depend on checkout layout across repos; use a published artifact, a vendored/submodule path inside this repo, or runtime configuration.")
@@ -152,9 +161,12 @@ baseline_of() {
   # git answers with the PHYSICAL path; stripping it off a logical FILE_PATH is
   # a no-op that leaves `rel` absolute, finds nothing, and switches the whole
   # subtraction off — the wedge, back, for any checkout under a symlink.
-  abs=$(realpath "$FILE_PATH" 2>/dev/null || printf '%s' "$FILE_PATH")
-  top=$(git -C "$(dirname "$abs")" rev-parse --show-toplevel 2>/dev/null) || return 0
-  top=$(realpath "$top" 2>/dev/null || printf '%s' "$top")
+  # `cd -P` + $PWD are builtins. realpath is not POSIX — busybox and older
+  # macOS lack it — and falling back to the unresolved path silently restores
+  # the very wedge this resolves.
+  abs=$(cd -P -- "$(dirname -- "$FILE_PATH")" 2>/dev/null && printf '%s/%s' "$PWD" "$(basename -- "$FILE_PATH")") || abs=$FILE_PATH
+  top=$(git -C "$(dirname -- "$abs")" rev-parse --show-toplevel 2>/dev/null) || return 0
+  top=$(cd -P -- "$top" 2>/dev/null && printf '%s' "$PWD") || top=$top
   rel=${abs#"$top"/}
   [[ "$rel" == "$abs" ]] && return 0
   git -C "$top" show "HEAD:$rel" 2>/dev/null || true
@@ -341,7 +353,7 @@ check_monolith_directory() {
     esac
 
     excluded=false
-    for pattern in "${EXCLUDE_PATTERNS[@]}"; do
+    for pattern in "${EXCLUDE_PATTERNS[@]+"${EXCLUDE_PATTERNS[@]}"}"; do
       [[ "$entry" == *"$pattern"* ]] && { excluded=true; break; }
     done
     [[ "$excluded" == true ]] && continue
@@ -432,23 +444,17 @@ violation_metric() {
   printf '%s' "$m"
 }
 
-# Which occurrence of `shape` this is. Same-named functions otherwise share a
-# key, and a grown one could match a shrunken namesake's slot and report
-# nothing. No `declare -A`: these run on stock macOS bash 3.2.
-occurrence_of() {
-  local shape=$1 n=1 s
-  shift
-  for s in "$@"; do
-    if [[ "$s" == "$shape" ]]; then
-      n=$((n + 1))
-    fi
-  done
-  printf '%s' "$n"
-}
-
 # The cross-repo check already ran and its findings are NOT whole-file state —
 # they must survive the baseline pass, which resets the array.
 PRE_EXISTING=("${VIOLATIONS[@]+"${VIOLATIONS[@]}"}")
+
+# The subtraction compares every violation against every earlier one, twice.
+# A pathological file emits roughly one violation per line, and at ~1500 the
+# hook ran past the harness's 60s timeout — where it is KILLED, emits no
+# decision, and the harness reads silence as ALLOW. Bound it so no input can
+# do that. Truncation is announced, never silent.
+MAX_SUBTRACT=150
+TRUNCATED=false
 
 BASE_KEYS=()
 BASE_SHAPES=()
@@ -491,8 +497,21 @@ if [[ -n "$BASELINE_FILE" ]]; then
   check_duplicate_blocks
   check_export_count
   for v in "${VIOLATIONS[@]+"${VIOLATIONS[@]}"}"; do
+    if (( ${#BASE_KEYS[@]} >= MAX_SUBTRACT )); then
+      break
+    fi
     base_shape=$(violation_shape "$v")
-    BASE_KEYS+=("$base_shape @$(occurrence_of "$base_shape" "${BASE_SHAPES[@]+"${BASE_SHAPES[@]}"}")")
+    # Counted in-shell. A command substitution here is a FORK PER VIOLATION,
+    # and a duplicate-heavy file emits roughly one violation per line: it took
+    # a 1500-line file past the harness's 60s hook timeout, and a hook that is
+    # killed emits no decision, which reads as ALLOW.
+    base_occ=1
+    for prev in "${BASE_SHAPES[@]+"${BASE_SHAPES[@]}"}"; do
+      if [[ "$prev" == "$base_shape" ]]; then
+        base_occ=$((base_occ + 1))
+      fi
+    done
+    BASE_KEYS+=("$base_shape @$base_occ")
     BASE_SHAPES+=("$base_shape")
     BASE_METRICS+=("$(violation_metric "$v")")
   done
@@ -508,13 +527,24 @@ check_duplicate_blocks
 check_export_count
 check_monolith_directory
 
+if (( ${#VIOLATIONS[@]} > MAX_SUBTRACT )); then
+  TRUNCATED=true
+  VIOLATIONS=("${VIOLATIONS[@]:0:MAX_SUBTRACT}")
+fi
+
 if (( ${#BASE_KEYS[@]} > 0 )); then
   KEPT=()
   CUR_SHAPES=()
   for v in "${VIOLATIONS[@]+"${VIOLATIONS[@]}"}"; do
     shape=$(violation_shape "$v")
     metric=$(violation_metric "$v")
-    key="$shape @$(occurrence_of "$shape" "${CUR_SHAPES[@]+"${CUR_SHAPES[@]}"}")"
+    occ=1
+    for prev in "${CUR_SHAPES[@]+"${CUR_SHAPES[@]}"}"; do
+      if [[ "$prev" == "$shape" ]]; then
+        occ=$((occ + 1))
+      fi
+    done
+    key="$shape @$occ"
     CUR_SHAPES+=("$shape")
     # Silent only where the SAME occurrence was already there and no worse, so
     # an improvement never reports and a regression always does. An occurrence
@@ -531,6 +561,12 @@ if (( ${#BASE_KEYS[@]} > 0 )); then
     fi
   done
   VIOLATIONS=("${KEPT[@]+"${KEPT[@]}"}")
+fi
+
+# Only ever a caveat ON something, never a finding in itself: alone it would
+# block an edit whose file has nothing this edit can fix.
+if [[ "$TRUNCATED" == true && ${#VIOLATIONS[@]} -gt 0 ]]; then
+  VIOLATIONS+=("LIST TRUNCATED: this file produced more than ${MAX_SUBTRACT} findings, so only the first ${MAX_SUBTRACT} were compared against the committed version — others are not shown.")
 fi
 
 VIOLATIONS=("${PRE_EXISTING[@]+"${PRE_EXISTING[@]}"}" "${VIOLATIONS[@]+"${VIOLATIONS[@]}"}")

--- a/hooks/claude/coding-police.sh
+++ b/hooks/claude/coding-police.sh
@@ -118,35 +118,16 @@ done
 VIOLATIONS=()
 
 # ── Check 0: Cross-repo sibling relative paths ─────────────────────────────
-CROSS_REPO_RE='\{\{[[:space:]]*(inventory_dir|playbook_dir|role_path|ansible_parent_role_paths\[[^]]+\])[[:space:]]*\}\}[[:space:]]*/(\.\./){2,}|(^|["'"'"'=[:space:]])(\.\./){2,}(core|eda|fullcircle|dashboard|gitops|infra|ansible-roles)(/|["'"'"'[:space:]]|$)'
-
 check_cross_repo_relative_paths() {
   [[ "$SHOULD_CHECK_PATHS" == true ]] || return 0
 
-  # Matched by CONTENT against the committed file, so a path that is already in
-  # the repo — a deliberate test fixture, say — is not re-reported on every
-  # later edit. Unlike the whole-file checks this is per line, so the baseline
-  # is a set of lines rather than a severity: anything not in it is this edit's.
-  local matches committed line body seen_n committed_n
-  matches=$(grep -hE "$CROSS_REPO_RE" "$FILE_PATH" 2>/dev/null || true)
-  committed=$(baseline_of | grep -hE "$CROSS_REPO_RE" 2>/dev/null || true)
+  local matches
+  matches=$(grep -nE '\{\{[[:space:]]*(inventory_dir|playbook_dir|role_path|ansible_parent_role_paths\[[^]]+\])[[:space:]]*\}\}[[:space:]]*/(\.\./){2,}|(^|["'"'"'=[:space:]])(\.\./){2,}(core|eda|fullcircle|dashboard|gitops|infra|ansible-roles)(/|["'"'"'[:space:]]|$)' "$FILE_PATH" 2>/dev/null || true)
 
-  # COUNTS, not membership: asking only "is this line committed?" let a second,
-  # byte-identical copy of an offending line be added and reported as nothing.
-  # A duplicated list entry in config is exactly this check's target.
-  seen_n=""
   while IFS= read -r line; do
-    [[ -n "$line" ]] || continue
-    body=${line#"${line%%[![:space:]]*}"}
-    committed_n=0
-    if [[ -n "$committed" ]]; then
-      committed_n=$(printf '%s\n' "$committed" | grep -cxF -- "$line" || true)
+    if [[ -n "$line" ]]; then
+      VIOLATIONS+=("CROSS-REPO RELATIVE PATH: ${line}. Do not depend on checkout layout across repos; use a published artifact, a vendored/submodule path inside this repo, or runtime configuration.")
     fi
-    seen_n=$(printf '%s\n%s' "$seen_n" "$line")
-    if (( $(printf '%s' "$seen_n" | grep -cxF -- "$line" || true) <= committed_n )); then
-      continue
-    fi
-    VIOLATIONS+=("CROSS-REPO RELATIVE PATH: ${body}. Do not depend on checkout layout across repos; use a published artifact, a vendored/submodule path inside this repo, or runtime configuration.")
   done <<< "$matches"
 }
 
@@ -157,18 +138,9 @@ check_cross_repo_relative_paths() {
 # that was already too long would otherwise block EVERY later edit to it,
 # unfixably, and Claude Code has no PostToolUse loop guard to stop that.
 baseline_of() {
-  local top rel abs
-  # git answers with the PHYSICAL path; stripping it off a logical FILE_PATH is
-  # a no-op that leaves `rel` absolute, finds nothing, and switches the whole
-  # subtraction off — the wedge, back, for any checkout under a symlink.
-  # `cd -P` + $PWD are builtins. realpath is not POSIX — busybox and older
-  # macOS lack it — and falling back to the unresolved path silently restores
-  # the very wedge this resolves.
-  abs=$(cd -P -- "$(dirname -- "$FILE_PATH")" 2>/dev/null && printf '%s/%s' "$PWD" "$(basename -- "$FILE_PATH")") || abs=$FILE_PATH
-  top=$(git -C "$(dirname -- "$abs")" rev-parse --show-toplevel 2>/dev/null) || return 0
-  top=$(cd -P -- "$top" 2>/dev/null && printf '%s' "$PWD") || top=$top
-  rel=${abs#"$top"/}
-  [[ "$rel" == "$abs" ]] && return 0
+  local top rel
+  top=$(git -C "$(dirname "$FILE_PATH")" rev-parse --show-toplevel 2>/dev/null) || return 0
+  rel=${FILE_PATH#"$top"/}
   git -C "$top" show "HEAD:$rel" 2>/dev/null || true
 }
 
@@ -448,15 +420,6 @@ violation_metric() {
 # they must survive the baseline pass, which resets the array.
 PRE_EXISTING=("${VIOLATIONS[@]+"${VIOLATIONS[@]}"}")
 
-# The subtraction compares every violation against every earlier one, twice.
-# A pathological file emits roughly one violation per line, and at ~1500 the
-# hook ran past the harness's 60s timeout — where it is KILLED, emits no
-# decision, and the harness reads silence as ALLOW. Bound it so no input can
-# do that. Truncation is announced, never silent.
-MAX_SUBTRACT=150
-TRUNCATED=false
-
-BASE_KEYS=()
 BASE_SHAPES=()
 BASE_METRICS=()
 BASELINE_FILE=""
@@ -478,9 +441,6 @@ if [[ -n "$baseline_content" ]]; then
     else
       rm -f "$BASELINE_FILE"
       BASELINE_FILE=""
-      # Leaving it armed runs `rm -f ""` at every exit; a trap command that
-      # fails rewrites a blocking 2 into a non-blocking 1.
-      trap - EXIT
     fi
   fi
 fi
@@ -497,22 +457,7 @@ if [[ -n "$BASELINE_FILE" ]]; then
   check_duplicate_blocks
   check_export_count
   for v in "${VIOLATIONS[@]+"${VIOLATIONS[@]}"}"; do
-    if (( ${#BASE_KEYS[@]} >= MAX_SUBTRACT )); then
-      break
-    fi
-    base_shape=$(violation_shape "$v")
-    # Counted in-shell. A command substitution here is a FORK PER VIOLATION,
-    # and a duplicate-heavy file emits roughly one violation per line: it took
-    # a 1500-line file past the harness's 60s hook timeout, and a hook that is
-    # killed emits no decision, which reads as ALLOW.
-    base_occ=1
-    for prev in "${BASE_SHAPES[@]+"${BASE_SHAPES[@]}"}"; do
-      if [[ "$prev" == "$base_shape" ]]; then
-        base_occ=$((base_occ + 1))
-      fi
-    done
-    BASE_KEYS+=("$base_shape @$base_occ")
-    BASE_SHAPES+=("$base_shape")
+    BASE_SHAPES+=("$(violation_shape "$v")")
     BASE_METRICS+=("$(violation_metric "$v")")
   done
   FILE_PATH="$REAL_FILE_PATH"
@@ -527,46 +472,39 @@ check_duplicate_blocks
 check_export_count
 check_monolith_directory
 
-if (( ${#VIOLATIONS[@]} > MAX_SUBTRACT )); then
-  TRUNCATED=true
-  VIOLATIONS=("${VIOLATIONS[@]:0:MAX_SUBTRACT}")
-fi
-
-if (( ${#BASE_KEYS[@]} > 0 )); then
+if (( ${#BASE_SHAPES[@]} > 0 )); then
   KEPT=()
-  CUR_SHAPES=()
   for v in "${VIOLATIONS[@]+"${VIOLATIONS[@]}"}"; do
     shape=$(violation_shape "$v")
     metric=$(violation_metric "$v")
-    occ=1
-    for prev in "${CUR_SHAPES[@]+"${CUR_SHAPES[@]}"}"; do
-      if [[ "$prev" == "$shape" ]]; then
-        occ=$((occ + 1))
-      fi
-    done
-    key="$shape @$occ"
-    CUR_SHAPES+=("$shape")
-    # Silent only where the SAME occurrence was already there and no worse, so
-    # an improvement never reports and a regression always does. An occurrence
-    # the baseline never had — a third duplicate block — has no key and stays.
-    keep=true
-    for i in "${!BASE_KEYS[@]}"; do
-      if [[ "${BASE_KEYS[$i]}" == "$key" ]] && (( BASE_METRICS[i] >= metric )); then
-        keep=false
+    matched=""
+    # Same severity first, so an unchanged violation claims its own baseline
+    # slot before a shrunken one consumes a bigger neighbour's and leaves the
+    # neighbour looking new.
+    for i in "${!BASE_SHAPES[@]}"; do
+      if [[ "${BASE_SHAPES[$i]}" == "$shape" ]] && (( BASE_METRICS[i] == metric )); then
+        matched=$i
         break
       fi
     done
-    if [[ "$keep" == true ]]; then
+    if [[ -z "$matched" ]]; then
+      # Otherwise any baseline slot that was WORSE absorbs it — an improvement
+      # is silent. A metric above every slot is a real regression and is kept.
+      for i in "${!BASE_SHAPES[@]}"; do
+        if [[ "${BASE_SHAPES[$i]}" == "$shape" ]] && (( BASE_METRICS[i] > metric )); then
+          matched=$i
+          break
+        fi
+      done
+    fi
+    if [[ -n "$matched" ]]; then
+      # Consume it: a THIRD duplicate block when the baseline had two is new.
+      unset 'BASE_SHAPES[matched]' 'BASE_METRICS[matched]'
+    else
       KEPT+=("$v")
     fi
   done
   VIOLATIONS=("${KEPT[@]+"${KEPT[@]}"}")
-fi
-
-# Only ever a caveat ON something, never a finding in itself: alone it would
-# block an edit whose file has nothing this edit can fix.
-if [[ "$TRUNCATED" == true && ${#VIOLATIONS[@]} -gt 0 ]]; then
-  VIOLATIONS+=("LIST TRUNCATED: this file produced more than ${MAX_SUBTRACT} findings, so only the first ${MAX_SUBTRACT} were compared against the committed version — others are not shown.")
 fi
 
 VIOLATIONS=("${PRE_EXISTING[@]+"${PRE_EXISTING[@]}"}" "${VIOLATIONS[@]+"${VIOLATIONS[@]}"}")

--- a/hooks/claude/coding-police.sh
+++ b/hooks/claude/coding-police.sh
@@ -118,16 +118,26 @@ done
 VIOLATIONS=()
 
 # ── Check 0: Cross-repo sibling relative paths ─────────────────────────────
+CROSS_REPO_RE='\{\{[[:space:]]*(inventory_dir|playbook_dir|role_path|ansible_parent_role_paths\[[^]]+\])[[:space:]]*\}\}[[:space:]]*/(\.\./){2,}|(^|["'"'"'=[:space:]])(\.\./){2,}(core|eda|fullcircle|dashboard|gitops|infra|ansible-roles)(/|["'"'"'[:space:]]|$)'
+
 check_cross_repo_relative_paths() {
   [[ "$SHOULD_CHECK_PATHS" == true ]] || return 0
 
-  local matches
-  matches=$(grep -nE '\{\{[[:space:]]*(inventory_dir|playbook_dir|role_path|ansible_parent_role_paths\[[^]]+\])[[:space:]]*\}\}[[:space:]]*/(\.\./){2,}|(^|["'"'"'=[:space:]])(\.\./){2,}(core|eda|fullcircle|dashboard|gitops|infra|ansible-roles)(/|["'"'"'[:space:]]|$)' "$FILE_PATH" 2>/dev/null || true)
+  # Matched by CONTENT against the committed file, so a path that is already in
+  # the repo — a deliberate test fixture, say — is not re-reported on every
+  # later edit. Unlike the whole-file checks this is per line, so the baseline
+  # is a set of lines rather than a severity: anything not in it is this edit's.
+  local matches committed line body
+  matches=$(grep -hE "$CROSS_REPO_RE" "$FILE_PATH" 2>/dev/null || true)
+  committed=$(baseline_of | grep -hE "$CROSS_REPO_RE" 2>/dev/null || true)
 
   while IFS= read -r line; do
-    if [[ -n "$line" ]]; then
-      VIOLATIONS+=("CROSS-REPO RELATIVE PATH: ${line}. Do not depend on checkout layout across repos; use a published artifact, a vendored/submodule path inside this repo, or runtime configuration.")
+    [[ -n "$line" ]] || continue
+    body=${line#"${line%%[![:space:]]*}"}
+    if [[ -n "$committed" ]] && printf '%s\n' "$committed" | grep -qxF -- "$line"; then
+      continue
     fi
+    VIOLATIONS+=("CROSS-REPO RELATIVE PATH: ${body}. Do not depend on checkout layout across repos; use a published artifact, a vendored/submodule path inside this repo, or runtime configuration.")
   done <<< "$matches"
 }
 
@@ -138,9 +148,15 @@ check_cross_repo_relative_paths() {
 # that was already too long would otherwise block EVERY later edit to it,
 # unfixably, and Claude Code has no PostToolUse loop guard to stop that.
 baseline_of() {
-  local top rel
-  top=$(git -C "$(dirname "$FILE_PATH")" rev-parse --show-toplevel 2>/dev/null) || return 0
-  rel=${FILE_PATH#"$top"/}
+  local top rel abs
+  # git answers with the PHYSICAL path; stripping it off a logical FILE_PATH is
+  # a no-op that leaves `rel` absolute, finds nothing, and switches the whole
+  # subtraction off — the wedge, back, for any checkout under a symlink.
+  abs=$(realpath "$FILE_PATH" 2>/dev/null || printf '%s' "$FILE_PATH")
+  top=$(git -C "$(dirname "$abs")" rev-parse --show-toplevel 2>/dev/null) || return 0
+  top=$(realpath "$top" 2>/dev/null || printf '%s' "$top")
+  rel=${abs#"$top"/}
+  [[ "$rel" == "$abs" ]] && return 0
   git -C "$top" show "HEAD:$rel" 2>/dev/null || true
 }
 
@@ -416,10 +432,25 @@ violation_metric() {
   printf '%s' "$m"
 }
 
+# Which occurrence of `shape` this is. Same-named functions otherwise share a
+# key, and a grown one could match a shrunken namesake's slot and report
+# nothing. No `declare -A`: these run on stock macOS bash 3.2.
+occurrence_of() {
+  local shape=$1 n=1 s
+  shift
+  for s in "$@"; do
+    if [[ "$s" == "$shape" ]]; then
+      n=$((n + 1))
+    fi
+  done
+  printf '%s' "$n"
+}
+
 # The cross-repo check already ran and its findings are NOT whole-file state —
 # they must survive the baseline pass, which resets the array.
 PRE_EXISTING=("${VIOLATIONS[@]+"${VIOLATIONS[@]}"}")
 
+BASE_KEYS=()
 BASE_SHAPES=()
 BASE_METRICS=()
 BASELINE_FILE=""
@@ -441,6 +472,9 @@ if [[ -n "$baseline_content" ]]; then
     else
       rm -f "$BASELINE_FILE"
       BASELINE_FILE=""
+      # Leaving it armed runs `rm -f ""` at every exit; a trap command that
+      # fails rewrites a blocking 2 into a non-blocking 1.
+      trap - EXIT
     fi
   fi
 fi
@@ -457,7 +491,9 @@ if [[ -n "$BASELINE_FILE" ]]; then
   check_duplicate_blocks
   check_export_count
   for v in "${VIOLATIONS[@]+"${VIOLATIONS[@]}"}"; do
-    BASE_SHAPES+=("$(violation_shape "$v")")
+    base_shape=$(violation_shape "$v")
+    BASE_KEYS+=("$base_shape @$(occurrence_of "$base_shape" "${BASE_SHAPES[@]+"${BASE_SHAPES[@]}"}")")
+    BASE_SHAPES+=("$base_shape")
     BASE_METRICS+=("$(violation_metric "$v")")
   done
   FILE_PATH="$REAL_FILE_PATH"
@@ -472,35 +508,25 @@ check_duplicate_blocks
 check_export_count
 check_monolith_directory
 
-if (( ${#BASE_SHAPES[@]} > 0 )); then
+if (( ${#BASE_KEYS[@]} > 0 )); then
   KEPT=()
+  CUR_SHAPES=()
   for v in "${VIOLATIONS[@]+"${VIOLATIONS[@]}"}"; do
     shape=$(violation_shape "$v")
     metric=$(violation_metric "$v")
-    matched=""
-    # Same severity first, so an unchanged violation claims its own baseline
-    # slot before a shrunken one consumes a bigger neighbour's and leaves the
-    # neighbour looking new.
-    for i in "${!BASE_SHAPES[@]}"; do
-      if [[ "${BASE_SHAPES[$i]}" == "$shape" ]] && (( BASE_METRICS[i] == metric )); then
-        matched=$i
+    key="$shape @$(occurrence_of "$shape" "${CUR_SHAPES[@]+"${CUR_SHAPES[@]}"}")"
+    CUR_SHAPES+=("$shape")
+    # Silent only where the SAME occurrence was already there and no worse, so
+    # an improvement never reports and a regression always does. An occurrence
+    # the baseline never had — a third duplicate block — has no key and stays.
+    keep=true
+    for i in "${!BASE_KEYS[@]}"; do
+      if [[ "${BASE_KEYS[$i]}" == "$key" ]] && (( BASE_METRICS[i] >= metric )); then
+        keep=false
         break
       fi
     done
-    if [[ -z "$matched" ]]; then
-      # Otherwise any baseline slot that was WORSE absorbs it — an improvement
-      # is silent. A metric above every slot is a real regression and is kept.
-      for i in "${!BASE_SHAPES[@]}"; do
-        if [[ "${BASE_SHAPES[$i]}" == "$shape" ]] && (( BASE_METRICS[i] > metric )); then
-          matched=$i
-          break
-        fi
-      done
-    fi
-    if [[ -n "$matched" ]]; then
-      # Consume it: a THIRD duplicate block when the baseline had two is new.
-      unset 'BASE_SHAPES[matched]' 'BASE_METRICS[matched]'
-    else
+    if [[ "$keep" == true ]]; then
       KEPT+=("$v")
     fi
   done

--- a/hooks/claude/comment-police.sh
+++ b/hooks/claude/comment-police.sh
@@ -84,7 +84,7 @@ esac
 case "$FILE_PATH" in
   *.lock|*.min.*|*.generated.*|*.snap|*.d.ts) exit 0 ;;
 esac
-for pattern in "${EXCLUDE_PATTERNS[@]}"; do
+for pattern in "${EXCLUDE_PATTERNS[@]+"${EXCLUDE_PATTERNS[@]}"}"; do
   [[ "$FILE_PATH" == *"$pattern"* ]] && exit 0
 done
 
@@ -93,8 +93,12 @@ ADDED=$(echo "$INPUT" | jq -r '.tool_input.new_string // .tool_input.content // 
 
 VIOLATIONS=()
 
+# Held in a variable: bash 3.2 cannot parse an unquoted `(` inside [[ =~ ]],
+# and stock macOS still ships 3.2.
+COMMENT_OPENERS='^[[:space:]]*(//|#|--|/\*|\*[^/])'
+
 is_comment_line() {
-  [[ "$1" =~ ^[[:space:]]*(//|#|--|/\*|\*[^/]) ]] || [[ "$1" =~ ^[[:space:]]*\*$ ]]
+  [[ "$1" =~ $COMMENT_OPENERS ]] || [[ "$1" =~ ^[[:space:]]*\*$ ]]
 }
 
 check_blocks_and_ratio() {
@@ -128,7 +132,7 @@ check_forbidden() {
   local hits="" pat
   while IFS= read -r line; do
     is_comment_line "$line" || continue
-    for pat in "${FORGE_PATTERNS[@]}"; do
+    for pat in "${FORGE_PATTERNS[@]+"${FORGE_PATTERNS[@]}"}"; do
       if [[ "$line" =~ $pat ]]; then
         hits+="    ${line#"${line%%[![:space:]]*}"}"$'\n'
         break

--- a/hooks/claude/format-police.sh
+++ b/hooks/claude/format-police.sh
@@ -64,12 +64,12 @@ find_config() {
   done
 }
 
-CONFIG_FLAG=""
+CONFIG_FLAG=()
 LOCAL_CONFIG=$(find_config "$(dirname "$FILE_PATH")")
 if [[ -n "$LOCAL_CONFIG" ]]; then
-  CONFIG_FLAG="--config $LOCAL_CONFIG"
+  CONFIG_FLAG=(--config "$LOCAL_CONFIG")
 elif [[ -n "${DPRINT_DEFAULT_CONFIG:-}" && -f "$DPRINT_DEFAULT_CONFIG" ]]; then
-  CONFIG_FLAG="--config $DPRINT_DEFAULT_CONFIG"
+  CONFIG_FLAG=(--config "$DPRINT_DEFAULT_CONFIG")
 else
   echo "⚠ no dprint.json found — set DPRINT_DEFAULT_CONFIG for a global fallback" >&2
   exit 0
@@ -80,7 +80,7 @@ fi
 ERR_LOG=$(mktemp "${TMPDIR:-/tmp}/dprint-err.XXXXXX")
 trap 'rm -f "$ERR_LOG"' EXIT
 
-if ! "$DPRINT" fmt $CONFIG_FLAG "$FILE_PATH" 2>"$ERR_LOG"; then
+if ! "$DPRINT" fmt "${CONFIG_FLAG[@]}" "$FILE_PATH" 2>"$ERR_LOG"; then
   err=$(cat "$ERR_LOG")
   echo "⚠ dprint fmt failed for $FILE_PATH: $err" >&2
   # ALLOWLIST, not a denylist. Only a failure dprint attributes to THIS file is

--- a/hooks/claude/git-police.sh
+++ b/hooks/claude/git-police.sh
@@ -5,6 +5,10 @@
 # Equivalent to: plugins/git-police.ts (OpenCode)
 set -euo pipefail
 
+# bash 3.2 cannot parse `(` inside [[ =~ ]], and this is a PreToolUse Bash
+# hook: a parse error denies EVERY command, with no way to switch it off.
+RE_YAML_ITEM='^[[:space:]]*-[[:space:]]+(.*)'
+
 PROTECTED_BRANCHES=("main" "master")
 AGENTKIT_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/agentkit/config.yaml"
 
@@ -24,7 +28,7 @@ load_allowed_repos() {
 		if [[ "$in_section" == true && "$line" =~ ^[[:space:]]*allowed-repos: ]]; then
 			continue
 		fi
-		if [[ "$in_section" == true && "$line" =~ ^[[:space:]]*-[[:space:]]+(.*) ]]; then
+		if [[ "$in_section" == true && "$line" =~ $RE_YAML_ITEM ]]; then
 			ALLOWED_REPOS+=("${BASH_REMATCH[1]}")
 		elif [[ "$in_section" == true && ! "$line" =~ ^[[:space:]] ]]; then
 			break

--- a/hooks/claude/git-police.sh
+++ b/hooks/claude/git-police.sh
@@ -62,7 +62,7 @@ tgit() {
 
 if [[ ${#ALLOWED_REPOS[@]} -gt 0 ]]; then
 	REPO_NAME=$(tgit remote get-url origin 2>/dev/null | sed -E 's|.*[:/]([^/]+/[^/]+?)(\.git)?$|\1|' || echo "")
-	for allowed in "${ALLOWED_REPOS[@]}"; do
+	for allowed in "${ALLOWED_REPOS[@]+"${ALLOWED_REPOS[@]}"}"; do
 		if [[ "$REPO_NAME" == *"$allowed"* ]]; then
 			exit 0
 		fi
@@ -131,7 +131,7 @@ PUSH_REMOTE=$(push_remote "$STRIPPED")
 
 # 3. Block pushing directly to protected branches (on origin / implicit upstream)
 if [[ -z "$PUSH_REMOTE" || "$PUSH_REMOTE" == "origin" ]]; then
-	for branch in "${PROTECTED_BRANCHES[@]}"; do
+	for branch in "${PROTECTED_BRANCHES[@]+"${PROTECTED_BRANCHES[@]}"}"; do
 		if echo "$STRIPPED" | grep -qiE "${GIT_PUSH_RE}.*\b${branch}\b"; then
 			deny "BLOCKED: Pushing directly to '${branch}' is forbidden. Create a feature branch and raise a PR instead."
 		fi
@@ -168,7 +168,7 @@ fi
 if [[ -z "$PUSH_REMOTE" || "$PUSH_REMOTE" == "origin" ]] \
 	&& echo "$STRIPPED" | grep -qiE "$GIT_PUSH_RE"; then
 	CURRENT_BRANCH=$(tgit symbolic-ref --short HEAD 2>/dev/null || echo "")
-	for branch in "${PROTECTED_BRANCHES[@]}"; do
+	for branch in "${PROTECTED_BRANCHES[@]+"${PROTECTED_BRANCHES[@]}"}"; do
 		if [[ "$CURRENT_BRANCH" == "$branch" ]]; then
 			deny "BLOCKED: You are on '${branch}'. Pushing from a protected branch is forbidden. Create a feature branch first: git checkout -b feat/your-feature-name"
 		fi
@@ -236,7 +236,7 @@ fi
 # 6. Block direct commits to protected branches
 if echo "$STRIPPED" | grep -qiE "$GIT_COMMIT_RE"; then
 	CURRENT_BRANCH=$(tgit symbolic-ref --short HEAD 2>/dev/null || echo "")
-	for branch in "${PROTECTED_BRANCHES[@]}"; do
+	for branch in "${PROTECTED_BRANCHES[@]+"${PROTECTED_BRANCHES[@]}"}"; do
 		if [[ "$CURRENT_BRANCH" == "$branch" ]]; then
 			deny "BLOCKED: Committing directly to '${branch}' is forbidden. You are on the ${branch} branch. Create a feature branch first: git checkout -b feat/your-feature-name"
 		fi
@@ -263,7 +263,7 @@ if echo "$STRIPPED" | grep -qiE '\bgit\b.*(checkout\s+-b|switch\s+-c)\b'; then
 	CURRENT_BRANCH=$(tgit symbolic-ref --short HEAD 2>/dev/null || echo "")
 	if [[ -n "$CURRENT_BRANCH" && "$STACKING_OK" != "1" ]]; then
 		ON_BASE=false
-		for base in "$DEFAULT_BRANCH" "${PROTECTED_BRANCHES[@]}" dev; do
+		for base in "$DEFAULT_BRANCH" "${PROTECTED_BRANCHES[@]+"${PROTECTED_BRANCHES[@]}"}" dev; do
 			[[ -n "$base" && "$CURRENT_BRANCH" == "$base" ]] && ON_BASE=true
 		done
 		if [[ "$ON_BASE" == false ]]; then
@@ -286,7 +286,7 @@ fi
 # 8. Stale branch protection — warn when creating a branch from a stale base
 if echo "$STRIPPED" | grep -qiE '\bgit\b.*(checkout\s+-b|switch\s+-c)\b'; then
 	CURRENT_BRANCH=$(tgit symbolic-ref --short HEAD 2>/dev/null || echo "")
-	for branch in "${PROTECTED_BRANCHES[@]}"; do
+	for branch in "${PROTECTED_BRANCHES[@]+"${PROTECTED_BRANCHES[@]}"}"; do
 		if [[ "$CURRENT_BRANCH" == "$branch" ]]; then
 			tgit fetch origin "$branch" --quiet 2>/dev/null || true
 			LOCAL_SHA=$(tgit rev-parse "$branch" 2>/dev/null || echo "")
@@ -313,7 +313,7 @@ if echo "$STRIPPED" | grep -qiE '\bgit\b.*\b(checkout|switch|pull)\b' \
 	&& ! echo "$STRIPPED" | grep -qiE '(checkout[[:space:]]+-b|switch[[:space:]]+-c)\b'; then
 	DEFAULT_BRANCH=$(tgit symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||' || true)
 	if [[ -z "$DEFAULT_BRANCH" ]]; then
-		for cand in "${PROTECTED_BRANCHES[@]}"; do
+		for cand in "${PROTECTED_BRANCHES[@]+"${PROTECTED_BRANCHES[@]}"}"; do
 			if tgit show-ref --verify --quiet "refs/heads/${cand}"; then
 				DEFAULT_BRANCH="$cand"
 				break

--- a/hooks/claude/git-police.sh
+++ b/hooks/claude/git-police.sh
@@ -18,7 +18,10 @@ COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 [[ -z "$COMMAND" ]] && exit 0
 
 load_allowed_repos() {
-	[[ -f "$AGENTKIT_CONFIG" ]] || return
+	# `return` alone propagates the failed test's status 1, and this runs as a
+	# plain command under `set -e`: with no config file the hook exited 1 with
+	# NO decision — every guard below it off — which the harness reads as ALLOW.
+	[[ -f "$AGENTKIT_CONFIG" ]] || return 0
 	local in_section=false
 	while IFS= read -r line; do
 		if [[ "$line" =~ ^[[:space:]]*branch-protection: ]]; then

--- a/hooks/claude/resource-police.sh
+++ b/hooks/claude/resource-police.sh
@@ -1,6 +1,28 @@
 #!/bin/bash
 set -euo pipefail
 
+# bash 3.2 — stock on macOS — cannot parse `(` inside [[ =~ ]]. Held in
+# variables, these parse everywhere and BASH_REMATCH still works.
+# A parse error here is fatal: this is a PreToolUse Bash hook, so it would
+# deny EVERY command with the kill switch unreachable.
+RE_BARE_TASK='^(build|check|type-?check|lint)(:[[:alnum:]_-]+)?$'
+RE_BUN_HEAVY='^(add|install|update|test)$'
+RE_CARGO_HEAVY='^(build|check|test|clippy)$'
+RE_DELEGATING='^(ansible|ansible-playbook|doas|mosh|pkexec|run0|ssh|sudo|systemd-run)$'
+RE_DOCKER_READONLY='^(diff|events|history|images|info|inspect|logs|port|ps|stats|top|version)$'
+RE_GO_HEAVY='^(build|test)$'
+RE_KUBECTL_READONLY='^(api-resources|api-versions|auth|cluster-info|describe|explain|get|logs|top|version)$'
+RE_MACHINECTL_READONLY='^(list|show|status)$'
+RE_NPM_HEAVY='^(add|install|i|ci|update|upgrade|test)$'
+RE_ORCHESTRATOR='^(buildah|docker|kubectl|machinectl|nerdctl|podman|service|systemctl)$'
+RE_PODMAN_READONLY='^(containers|images|info|inspect|version)$'
+RE_SCRIPT_TASK='^(build|check|type-?check|lint|test)(:[[:alnum:]_-]+)?$'
+RE_SHELL='^(bash|dash|fish|sh|zsh)$'
+RE_SYSTEMCTL_READONLY='^(cat|get-default|is-active|is-enabled|is-failed|list-|show|status)'
+RE_UV_HEAVY='^(add|sync)$'
+RE_YARN_HEAVY='^(add|install|up|upgrade|test)$'
+
+
 # Absolute paths are deliberate: a hook that inspects a command must not
 # resolve its own tools through a PATH that command could have manipulated.
 # But the locations are NOT the same everywhere — `cat` is /bin/cat on macOS
@@ -202,30 +224,30 @@ is_heavy() {
 	local second="${ARGS[1]:-}"
 	case "$executable" in
 	bun)
-		[[ "$first" =~ ^(add|install|update|test)$ ]] && return 0
-		[[ "$first" == run && "$second" =~ ^(build|check|type-?check|lint|test)(:[[:alnum:]_-]+)?$ ]]
+		[[ "$first" =~ $RE_BUN_HEAVY ]] && return 0
+		[[ "$first" == run && "$second" =~ $RE_SCRIPT_TASK ]]
 		;;
 	bunx | npx)
 		[[ "$first" == tsc && "$second" != --version ]] \
 			|| [[ "$first" == playwright && "$second" == test ]]
 		;;
 	npm | pnpm)
-		[[ "$first" =~ ^(add|install|i|ci|update|upgrade|test)$ ]] && return 0
-		[[ "$first" == run && "$second" =~ ^(build|check|type-?check|lint|test)(:[[:alnum:]_-]+)?$ ]]
+		[[ "$first" =~ $RE_NPM_HEAVY ]] && return 0
+		[[ "$first" == run && "$second" =~ $RE_SCRIPT_TASK ]]
 		;;
 	yarn)
 		[[ -z "$first" ]] && return 0
-		[[ "$first" =~ ^(add|install|up|upgrade|test)$ ]] && return 0
-		[[ "$first" == run && "$second" =~ ^(build|check|type-?check|lint|test)(:[[:alnum:]_-]+)?$ ]] && return 0
-		[[ "$first" =~ ^(build|check|type-?check|lint)(:[[:alnum:]_-]+)?$ ]]
+		[[ "$first" =~ $RE_YARN_HEAVY ]] && return 0
+		[[ "$first" == run && "$second" =~ $RE_SCRIPT_TASK ]] && return 0
+		[[ "$first" =~ $RE_BARE_TASK ]]
 		;;
 	tsc) [[ "$first" != --version ]] ;;
 	playwright) [[ "$first" == test ]] ;;
-	cargo) [[ "$first" =~ ^(build|check|test|clippy)$ ]] ;;
-	go) [[ "$first" =~ ^(build|test)$ ]] ;;
+	cargo) [[ "$first" =~ $RE_CARGO_HEAVY ]] ;;
+	go) [[ "$first" =~ $RE_GO_HEAVY ]] ;;
 	pip | pip3) [[ "$first" == install ]] ;;
 	uv)
-		[[ "$first" =~ ^(add|sync)$ ]] && return 0
+		[[ "$first" =~ $RE_UV_HEAVY ]] && return 0
 		[[ "$first" == pip && "$second" == install ]] && return 0
 		[[ "$first" == run && "$second" == pytest ]]
 		;;
@@ -256,12 +278,12 @@ shell_command_payload() {
 }
 
 is_delegating() {
-	[[ "$EXECUTABLE" =~ ^(ansible|ansible-playbook|doas|mosh|pkexec|run0|ssh|sudo|systemd-run)$ ]] && return 0
-	if [[ "$EXECUTABLE" =~ ^(buildah|docker|kubectl|machinectl|nerdctl|podman|service|systemctl)$ ]]; then
+	[[ "$EXECUTABLE" =~ $RE_DELEGATING ]] && return 0
+	if [[ "$EXECUTABLE" =~ $RE_ORCHESTRATOR ]]; then
 		is_read_only_diagnostic && return 1
 		return 0
 	fi
-	if [[ "$EXECUTABLE" =~ ^(bash|dash|fish|sh|zsh)$ ]]; then
+	if [[ "$EXECUTABLE" =~ $RE_SHELL ]]; then
 		shell_command_payload && return 0
 	fi
 	return 1
@@ -279,11 +301,11 @@ is_read_only_diagnostic() {
 		break
 	done
 	case "$EXECUTABLE" in
-	systemctl) [[ "$first" =~ ^(cat|get-default|is-active|is-enabled|is-failed|list-|show|status) ]] ;;
-	kubectl) [[ "$first" =~ ^(api-resources|api-versions|auth|cluster-info|describe|explain|get|logs|top|version)$ ]] ;;
-	docker | nerdctl | podman) [[ "$first" =~ ^(diff|events|history|images|info|inspect|logs|port|ps|stats|top|version)$ ]] ;;
-	buildah) [[ "$first" =~ ^(containers|images|info|inspect|version)$ ]] ;;
-	machinectl) [[ "$first" =~ ^(list|show|status)$ ]] ;;
+	systemctl) [[ "$first" =~ $RE_SYSTEMCTL_READONLY ]] ;;
+	kubectl) [[ "$first" =~ $RE_KUBECTL_READONLY ]] ;;
+	docker | nerdctl | podman) [[ "$first" =~ $RE_DOCKER_READONLY ]] ;;
+	buildah) [[ "$first" =~ $RE_PODMAN_READONLY ]] ;;
+	machinectl) [[ "$first" =~ $RE_MACHINECTL_READONLY ]] ;;
 	service) [[ "$second" == status ]] ;;
 	*) return 1 ;;
 	esac
@@ -355,7 +377,7 @@ analyze_command() {
 			fi
 			continue
 		fi
-		if [[ "$EXECUTABLE" =~ ^(bash|dash|fish|sh|zsh)$ ]] && shell_command_payload; then
+		if [[ "$EXECUTABLE" =~ $RE_SHELL ]] && shell_command_payload; then
 			analyze_command "$PAYLOAD" $((depth + 1))
 			continue
 		fi

--- a/hooks/claude/resource-police.sh
+++ b/hooks/claude/resource-police.sh
@@ -269,7 +269,7 @@ is_delegating() {
 
 is_read_only_diagnostic() {
 	local first='' second='' argument
-	for argument in "${ARGS[@]}"; do
+	for argument in "${ARGS[@]+"${ARGS[@]}"}"; do
 		[[ "$argument" == -* ]] && continue
 		if [[ -z "$first" ]]; then
 			first="$argument"

--- a/hooks/claude/resource-police.sh
+++ b/hooks/claude/resource-police.sh
@@ -15,7 +15,7 @@ RE_KUBECTL_READONLY='^(api-resources|api-versions|auth|cluster-info|describe|exp
 RE_MACHINECTL_READONLY='^(list|show|status)$'
 RE_NPM_HEAVY='^(add|install|i|ci|update|upgrade|test)$'
 RE_ORCHESTRATOR='^(buildah|docker|kubectl|machinectl|nerdctl|podman|service|systemctl)$'
-RE_PODMAN_READONLY='^(containers|images|info|inspect|version)$'
+RE_BUILDAH_READONLY='^(containers|images|info|inspect|version)$'
 RE_SCRIPT_TASK='^(build|check|type-?check|lint|test)(:[[:alnum:]_-]+)?$'
 RE_SHELL='^(bash|dash|fish|sh|zsh)$'
 RE_SYSTEMCTL_READONLY='^(cat|get-default|is-active|is-enabled|is-failed|list-|show|status)'
@@ -304,7 +304,7 @@ is_read_only_diagnostic() {
 	systemctl) [[ "$first" =~ $RE_SYSTEMCTL_READONLY ]] ;;
 	kubectl) [[ "$first" =~ $RE_KUBECTL_READONLY ]] ;;
 	docker | nerdctl | podman) [[ "$first" =~ $RE_DOCKER_READONLY ]] ;;
-	buildah) [[ "$first" =~ $RE_PODMAN_READONLY ]] ;;
+	buildah) [[ "$first" =~ $RE_BUILDAH_READONLY ]] ;;
 	machinectl) [[ "$first" =~ $RE_MACHINECTL_READONLY ]] ;;
 	service) [[ "$second" == status ]] ;;
 	*) return 1 ;;

--- a/plugins-cc/agentkit/hooks/coding-police.sh
+++ b/plugins-cc/agentkit/hooks/coding-police.sh
@@ -109,7 +109,7 @@ case "$FILE_PATH" in
 esac
 
 # Skip paths matching an exclude-patterns entry (e.g. homogeneous routes/migrations dirs)
-for pattern in "${EXCLUDE_PATTERNS[@]}"; do
+for pattern in "${EXCLUDE_PATTERNS[@]+"${EXCLUDE_PATTERNS[@]}"}"; do
   [[ "$FILE_PATH" == *"$pattern"* ]] && exit 0
 done
 
@@ -127,14 +127,23 @@ check_cross_repo_relative_paths() {
   # the repo — a deliberate test fixture, say — is not re-reported on every
   # later edit. Unlike the whole-file checks this is per line, so the baseline
   # is a set of lines rather than a severity: anything not in it is this edit's.
-  local matches committed line body
+  local matches committed line body seen_n committed_n
   matches=$(grep -hE "$CROSS_REPO_RE" "$FILE_PATH" 2>/dev/null || true)
   committed=$(baseline_of | grep -hE "$CROSS_REPO_RE" 2>/dev/null || true)
 
+  # COUNTS, not membership: asking only "is this line committed?" let a second,
+  # byte-identical copy of an offending line be added and reported as nothing.
+  # A duplicated list entry in config is exactly this check's target.
+  seen_n=""
   while IFS= read -r line; do
     [[ -n "$line" ]] || continue
     body=${line#"${line%%[![:space:]]*}"}
-    if [[ -n "$committed" ]] && printf '%s\n' "$committed" | grep -qxF -- "$line"; then
+    committed_n=0
+    if [[ -n "$committed" ]]; then
+      committed_n=$(printf '%s\n' "$committed" | grep -cxF -- "$line" || true)
+    fi
+    seen_n=$(printf '%s\n%s' "$seen_n" "$line")
+    if (( $(printf '%s' "$seen_n" | grep -cxF -- "$line" || true) <= committed_n )); then
       continue
     fi
     VIOLATIONS+=("CROSS-REPO RELATIVE PATH: ${body}. Do not depend on checkout layout across repos; use a published artifact, a vendored/submodule path inside this repo, or runtime configuration.")
@@ -152,9 +161,12 @@ baseline_of() {
   # git answers with the PHYSICAL path; stripping it off a logical FILE_PATH is
   # a no-op that leaves `rel` absolute, finds nothing, and switches the whole
   # subtraction off — the wedge, back, for any checkout under a symlink.
-  abs=$(realpath "$FILE_PATH" 2>/dev/null || printf '%s' "$FILE_PATH")
-  top=$(git -C "$(dirname "$abs")" rev-parse --show-toplevel 2>/dev/null) || return 0
-  top=$(realpath "$top" 2>/dev/null || printf '%s' "$top")
+  # `cd -P` + $PWD are builtins. realpath is not POSIX — busybox and older
+  # macOS lack it — and falling back to the unresolved path silently restores
+  # the very wedge this resolves.
+  abs=$(cd -P -- "$(dirname -- "$FILE_PATH")" 2>/dev/null && printf '%s/%s' "$PWD" "$(basename -- "$FILE_PATH")") || abs=$FILE_PATH
+  top=$(git -C "$(dirname -- "$abs")" rev-parse --show-toplevel 2>/dev/null) || return 0
+  top=$(cd -P -- "$top" 2>/dev/null && printf '%s' "$PWD") || top=$top
   rel=${abs#"$top"/}
   [[ "$rel" == "$abs" ]] && return 0
   git -C "$top" show "HEAD:$rel" 2>/dev/null || true
@@ -341,7 +353,7 @@ check_monolith_directory() {
     esac
 
     excluded=false
-    for pattern in "${EXCLUDE_PATTERNS[@]}"; do
+    for pattern in "${EXCLUDE_PATTERNS[@]+"${EXCLUDE_PATTERNS[@]}"}"; do
       [[ "$entry" == *"$pattern"* ]] && { excluded=true; break; }
     done
     [[ "$excluded" == true ]] && continue
@@ -432,23 +444,17 @@ violation_metric() {
   printf '%s' "$m"
 }
 
-# Which occurrence of `shape` this is. Same-named functions otherwise share a
-# key, and a grown one could match a shrunken namesake's slot and report
-# nothing. No `declare -A`: these run on stock macOS bash 3.2.
-occurrence_of() {
-  local shape=$1 n=1 s
-  shift
-  for s in "$@"; do
-    if [[ "$s" == "$shape" ]]; then
-      n=$((n + 1))
-    fi
-  done
-  printf '%s' "$n"
-}
-
 # The cross-repo check already ran and its findings are NOT whole-file state —
 # they must survive the baseline pass, which resets the array.
 PRE_EXISTING=("${VIOLATIONS[@]+"${VIOLATIONS[@]}"}")
+
+# The subtraction compares every violation against every earlier one, twice.
+# A pathological file emits roughly one violation per line, and at ~1500 the
+# hook ran past the harness's 60s timeout — where it is KILLED, emits no
+# decision, and the harness reads silence as ALLOW. Bound it so no input can
+# do that. Truncation is announced, never silent.
+MAX_SUBTRACT=150
+TRUNCATED=false
 
 BASE_KEYS=()
 BASE_SHAPES=()
@@ -491,8 +497,21 @@ if [[ -n "$BASELINE_FILE" ]]; then
   check_duplicate_blocks
   check_export_count
   for v in "${VIOLATIONS[@]+"${VIOLATIONS[@]}"}"; do
+    if (( ${#BASE_KEYS[@]} >= MAX_SUBTRACT )); then
+      break
+    fi
     base_shape=$(violation_shape "$v")
-    BASE_KEYS+=("$base_shape @$(occurrence_of "$base_shape" "${BASE_SHAPES[@]+"${BASE_SHAPES[@]}"}")")
+    # Counted in-shell. A command substitution here is a FORK PER VIOLATION,
+    # and a duplicate-heavy file emits roughly one violation per line: it took
+    # a 1500-line file past the harness's 60s hook timeout, and a hook that is
+    # killed emits no decision, which reads as ALLOW.
+    base_occ=1
+    for prev in "${BASE_SHAPES[@]+"${BASE_SHAPES[@]}"}"; do
+      if [[ "$prev" == "$base_shape" ]]; then
+        base_occ=$((base_occ + 1))
+      fi
+    done
+    BASE_KEYS+=("$base_shape @$base_occ")
     BASE_SHAPES+=("$base_shape")
     BASE_METRICS+=("$(violation_metric "$v")")
   done
@@ -508,13 +527,24 @@ check_duplicate_blocks
 check_export_count
 check_monolith_directory
 
+if (( ${#VIOLATIONS[@]} > MAX_SUBTRACT )); then
+  TRUNCATED=true
+  VIOLATIONS=("${VIOLATIONS[@]:0:MAX_SUBTRACT}")
+fi
+
 if (( ${#BASE_KEYS[@]} > 0 )); then
   KEPT=()
   CUR_SHAPES=()
   for v in "${VIOLATIONS[@]+"${VIOLATIONS[@]}"}"; do
     shape=$(violation_shape "$v")
     metric=$(violation_metric "$v")
-    key="$shape @$(occurrence_of "$shape" "${CUR_SHAPES[@]+"${CUR_SHAPES[@]}"}")"
+    occ=1
+    for prev in "${CUR_SHAPES[@]+"${CUR_SHAPES[@]}"}"; do
+      if [[ "$prev" == "$shape" ]]; then
+        occ=$((occ + 1))
+      fi
+    done
+    key="$shape @$occ"
     CUR_SHAPES+=("$shape")
     # Silent only where the SAME occurrence was already there and no worse, so
     # an improvement never reports and a regression always does. An occurrence
@@ -531,6 +561,12 @@ if (( ${#BASE_KEYS[@]} > 0 )); then
     fi
   done
   VIOLATIONS=("${KEPT[@]+"${KEPT[@]}"}")
+fi
+
+# Only ever a caveat ON something, never a finding in itself: alone it would
+# block an edit whose file has nothing this edit can fix.
+if [[ "$TRUNCATED" == true && ${#VIOLATIONS[@]} -gt 0 ]]; then
+  VIOLATIONS+=("LIST TRUNCATED: this file produced more than ${MAX_SUBTRACT} findings, so only the first ${MAX_SUBTRACT} were compared against the committed version — others are not shown.")
 fi
 
 VIOLATIONS=("${PRE_EXISTING[@]+"${PRE_EXISTING[@]}"}" "${VIOLATIONS[@]+"${VIOLATIONS[@]}"}")

--- a/plugins-cc/agentkit/hooks/coding-police.sh
+++ b/plugins-cc/agentkit/hooks/coding-police.sh
@@ -118,35 +118,16 @@ done
 VIOLATIONS=()
 
 # ── Check 0: Cross-repo sibling relative paths ─────────────────────────────
-CROSS_REPO_RE='\{\{[[:space:]]*(inventory_dir|playbook_dir|role_path|ansible_parent_role_paths\[[^]]+\])[[:space:]]*\}\}[[:space:]]*/(\.\./){2,}|(^|["'"'"'=[:space:]])(\.\./){2,}(core|eda|fullcircle|dashboard|gitops|infra|ansible-roles)(/|["'"'"'[:space:]]|$)'
-
 check_cross_repo_relative_paths() {
   [[ "$SHOULD_CHECK_PATHS" == true ]] || return 0
 
-  # Matched by CONTENT against the committed file, so a path that is already in
-  # the repo — a deliberate test fixture, say — is not re-reported on every
-  # later edit. Unlike the whole-file checks this is per line, so the baseline
-  # is a set of lines rather than a severity: anything not in it is this edit's.
-  local matches committed line body seen_n committed_n
-  matches=$(grep -hE "$CROSS_REPO_RE" "$FILE_PATH" 2>/dev/null || true)
-  committed=$(baseline_of | grep -hE "$CROSS_REPO_RE" 2>/dev/null || true)
+  local matches
+  matches=$(grep -nE '\{\{[[:space:]]*(inventory_dir|playbook_dir|role_path|ansible_parent_role_paths\[[^]]+\])[[:space:]]*\}\}[[:space:]]*/(\.\./){2,}|(^|["'"'"'=[:space:]])(\.\./){2,}(core|eda|fullcircle|dashboard|gitops|infra|ansible-roles)(/|["'"'"'[:space:]]|$)' "$FILE_PATH" 2>/dev/null || true)
 
-  # COUNTS, not membership: asking only "is this line committed?" let a second,
-  # byte-identical copy of an offending line be added and reported as nothing.
-  # A duplicated list entry in config is exactly this check's target.
-  seen_n=""
   while IFS= read -r line; do
-    [[ -n "$line" ]] || continue
-    body=${line#"${line%%[![:space:]]*}"}
-    committed_n=0
-    if [[ -n "$committed" ]]; then
-      committed_n=$(printf '%s\n' "$committed" | grep -cxF -- "$line" || true)
+    if [[ -n "$line" ]]; then
+      VIOLATIONS+=("CROSS-REPO RELATIVE PATH: ${line}. Do not depend on checkout layout across repos; use a published artifact, a vendored/submodule path inside this repo, or runtime configuration.")
     fi
-    seen_n=$(printf '%s\n%s' "$seen_n" "$line")
-    if (( $(printf '%s' "$seen_n" | grep -cxF -- "$line" || true) <= committed_n )); then
-      continue
-    fi
-    VIOLATIONS+=("CROSS-REPO RELATIVE PATH: ${body}. Do not depend on checkout layout across repos; use a published artifact, a vendored/submodule path inside this repo, or runtime configuration.")
   done <<< "$matches"
 }
 
@@ -157,18 +138,9 @@ check_cross_repo_relative_paths() {
 # that was already too long would otherwise block EVERY later edit to it,
 # unfixably, and Claude Code has no PostToolUse loop guard to stop that.
 baseline_of() {
-  local top rel abs
-  # git answers with the PHYSICAL path; stripping it off a logical FILE_PATH is
-  # a no-op that leaves `rel` absolute, finds nothing, and switches the whole
-  # subtraction off — the wedge, back, for any checkout under a symlink.
-  # `cd -P` + $PWD are builtins. realpath is not POSIX — busybox and older
-  # macOS lack it — and falling back to the unresolved path silently restores
-  # the very wedge this resolves.
-  abs=$(cd -P -- "$(dirname -- "$FILE_PATH")" 2>/dev/null && printf '%s/%s' "$PWD" "$(basename -- "$FILE_PATH")") || abs=$FILE_PATH
-  top=$(git -C "$(dirname -- "$abs")" rev-parse --show-toplevel 2>/dev/null) || return 0
-  top=$(cd -P -- "$top" 2>/dev/null && printf '%s' "$PWD") || top=$top
-  rel=${abs#"$top"/}
-  [[ "$rel" == "$abs" ]] && return 0
+  local top rel
+  top=$(git -C "$(dirname "$FILE_PATH")" rev-parse --show-toplevel 2>/dev/null) || return 0
+  rel=${FILE_PATH#"$top"/}
   git -C "$top" show "HEAD:$rel" 2>/dev/null || true
 }
 
@@ -448,15 +420,6 @@ violation_metric() {
 # they must survive the baseline pass, which resets the array.
 PRE_EXISTING=("${VIOLATIONS[@]+"${VIOLATIONS[@]}"}")
 
-# The subtraction compares every violation against every earlier one, twice.
-# A pathological file emits roughly one violation per line, and at ~1500 the
-# hook ran past the harness's 60s timeout — where it is KILLED, emits no
-# decision, and the harness reads silence as ALLOW. Bound it so no input can
-# do that. Truncation is announced, never silent.
-MAX_SUBTRACT=150
-TRUNCATED=false
-
-BASE_KEYS=()
 BASE_SHAPES=()
 BASE_METRICS=()
 BASELINE_FILE=""
@@ -478,9 +441,6 @@ if [[ -n "$baseline_content" ]]; then
     else
       rm -f "$BASELINE_FILE"
       BASELINE_FILE=""
-      # Leaving it armed runs `rm -f ""` at every exit; a trap command that
-      # fails rewrites a blocking 2 into a non-blocking 1.
-      trap - EXIT
     fi
   fi
 fi
@@ -497,22 +457,7 @@ if [[ -n "$BASELINE_FILE" ]]; then
   check_duplicate_blocks
   check_export_count
   for v in "${VIOLATIONS[@]+"${VIOLATIONS[@]}"}"; do
-    if (( ${#BASE_KEYS[@]} >= MAX_SUBTRACT )); then
-      break
-    fi
-    base_shape=$(violation_shape "$v")
-    # Counted in-shell. A command substitution here is a FORK PER VIOLATION,
-    # and a duplicate-heavy file emits roughly one violation per line: it took
-    # a 1500-line file past the harness's 60s hook timeout, and a hook that is
-    # killed emits no decision, which reads as ALLOW.
-    base_occ=1
-    for prev in "${BASE_SHAPES[@]+"${BASE_SHAPES[@]}"}"; do
-      if [[ "$prev" == "$base_shape" ]]; then
-        base_occ=$((base_occ + 1))
-      fi
-    done
-    BASE_KEYS+=("$base_shape @$base_occ")
-    BASE_SHAPES+=("$base_shape")
+    BASE_SHAPES+=("$(violation_shape "$v")")
     BASE_METRICS+=("$(violation_metric "$v")")
   done
   FILE_PATH="$REAL_FILE_PATH"
@@ -527,46 +472,39 @@ check_duplicate_blocks
 check_export_count
 check_monolith_directory
 
-if (( ${#VIOLATIONS[@]} > MAX_SUBTRACT )); then
-  TRUNCATED=true
-  VIOLATIONS=("${VIOLATIONS[@]:0:MAX_SUBTRACT}")
-fi
-
-if (( ${#BASE_KEYS[@]} > 0 )); then
+if (( ${#BASE_SHAPES[@]} > 0 )); then
   KEPT=()
-  CUR_SHAPES=()
   for v in "${VIOLATIONS[@]+"${VIOLATIONS[@]}"}"; do
     shape=$(violation_shape "$v")
     metric=$(violation_metric "$v")
-    occ=1
-    for prev in "${CUR_SHAPES[@]+"${CUR_SHAPES[@]}"}"; do
-      if [[ "$prev" == "$shape" ]]; then
-        occ=$((occ + 1))
-      fi
-    done
-    key="$shape @$occ"
-    CUR_SHAPES+=("$shape")
-    # Silent only where the SAME occurrence was already there and no worse, so
-    # an improvement never reports and a regression always does. An occurrence
-    # the baseline never had — a third duplicate block — has no key and stays.
-    keep=true
-    for i in "${!BASE_KEYS[@]}"; do
-      if [[ "${BASE_KEYS[$i]}" == "$key" ]] && (( BASE_METRICS[i] >= metric )); then
-        keep=false
+    matched=""
+    # Same severity first, so an unchanged violation claims its own baseline
+    # slot before a shrunken one consumes a bigger neighbour's and leaves the
+    # neighbour looking new.
+    for i in "${!BASE_SHAPES[@]}"; do
+      if [[ "${BASE_SHAPES[$i]}" == "$shape" ]] && (( BASE_METRICS[i] == metric )); then
+        matched=$i
         break
       fi
     done
-    if [[ "$keep" == true ]]; then
+    if [[ -z "$matched" ]]; then
+      # Otherwise any baseline slot that was WORSE absorbs it — an improvement
+      # is silent. A metric above every slot is a real regression and is kept.
+      for i in "${!BASE_SHAPES[@]}"; do
+        if [[ "${BASE_SHAPES[$i]}" == "$shape" ]] && (( BASE_METRICS[i] > metric )); then
+          matched=$i
+          break
+        fi
+      done
+    fi
+    if [[ -n "$matched" ]]; then
+      # Consume it: a THIRD duplicate block when the baseline had two is new.
+      unset 'BASE_SHAPES[matched]' 'BASE_METRICS[matched]'
+    else
       KEPT+=("$v")
     fi
   done
   VIOLATIONS=("${KEPT[@]+"${KEPT[@]}"}")
-fi
-
-# Only ever a caveat ON something, never a finding in itself: alone it would
-# block an edit whose file has nothing this edit can fix.
-if [[ "$TRUNCATED" == true && ${#VIOLATIONS[@]} -gt 0 ]]; then
-  VIOLATIONS+=("LIST TRUNCATED: this file produced more than ${MAX_SUBTRACT} findings, so only the first ${MAX_SUBTRACT} were compared against the committed version — others are not shown.")
 fi
 
 VIOLATIONS=("${PRE_EXISTING[@]+"${PRE_EXISTING[@]}"}" "${VIOLATIONS[@]+"${VIOLATIONS[@]}"}")

--- a/plugins-cc/agentkit/hooks/coding-police.sh
+++ b/plugins-cc/agentkit/hooks/coding-police.sh
@@ -118,16 +118,26 @@ done
 VIOLATIONS=()
 
 # ── Check 0: Cross-repo sibling relative paths ─────────────────────────────
+CROSS_REPO_RE='\{\{[[:space:]]*(inventory_dir|playbook_dir|role_path|ansible_parent_role_paths\[[^]]+\])[[:space:]]*\}\}[[:space:]]*/(\.\./){2,}|(^|["'"'"'=[:space:]])(\.\./){2,}(core|eda|fullcircle|dashboard|gitops|infra|ansible-roles)(/|["'"'"'[:space:]]|$)'
+
 check_cross_repo_relative_paths() {
   [[ "$SHOULD_CHECK_PATHS" == true ]] || return 0
 
-  local matches
-  matches=$(grep -nE '\{\{[[:space:]]*(inventory_dir|playbook_dir|role_path|ansible_parent_role_paths\[[^]]+\])[[:space:]]*\}\}[[:space:]]*/(\.\./){2,}|(^|["'"'"'=[:space:]])(\.\./){2,}(core|eda|fullcircle|dashboard|gitops|infra|ansible-roles)(/|["'"'"'[:space:]]|$)' "$FILE_PATH" 2>/dev/null || true)
+  # Matched by CONTENT against the committed file, so a path that is already in
+  # the repo — a deliberate test fixture, say — is not re-reported on every
+  # later edit. Unlike the whole-file checks this is per line, so the baseline
+  # is a set of lines rather than a severity: anything not in it is this edit's.
+  local matches committed line body
+  matches=$(grep -hE "$CROSS_REPO_RE" "$FILE_PATH" 2>/dev/null || true)
+  committed=$(baseline_of | grep -hE "$CROSS_REPO_RE" 2>/dev/null || true)
 
   while IFS= read -r line; do
-    if [[ -n "$line" ]]; then
-      VIOLATIONS+=("CROSS-REPO RELATIVE PATH: ${line}. Do not depend on checkout layout across repos; use a published artifact, a vendored/submodule path inside this repo, or runtime configuration.")
+    [[ -n "$line" ]] || continue
+    body=${line#"${line%%[![:space:]]*}"}
+    if [[ -n "$committed" ]] && printf '%s\n' "$committed" | grep -qxF -- "$line"; then
+      continue
     fi
+    VIOLATIONS+=("CROSS-REPO RELATIVE PATH: ${body}. Do not depend on checkout layout across repos; use a published artifact, a vendored/submodule path inside this repo, or runtime configuration.")
   done <<< "$matches"
 }
 
@@ -138,9 +148,15 @@ check_cross_repo_relative_paths() {
 # that was already too long would otherwise block EVERY later edit to it,
 # unfixably, and Claude Code has no PostToolUse loop guard to stop that.
 baseline_of() {
-  local top rel
-  top=$(git -C "$(dirname "$FILE_PATH")" rev-parse --show-toplevel 2>/dev/null) || return 0
-  rel=${FILE_PATH#"$top"/}
+  local top rel abs
+  # git answers with the PHYSICAL path; stripping it off a logical FILE_PATH is
+  # a no-op that leaves `rel` absolute, finds nothing, and switches the whole
+  # subtraction off — the wedge, back, for any checkout under a symlink.
+  abs=$(realpath "$FILE_PATH" 2>/dev/null || printf '%s' "$FILE_PATH")
+  top=$(git -C "$(dirname "$abs")" rev-parse --show-toplevel 2>/dev/null) || return 0
+  top=$(realpath "$top" 2>/dev/null || printf '%s' "$top")
+  rel=${abs#"$top"/}
+  [[ "$rel" == "$abs" ]] && return 0
   git -C "$top" show "HEAD:$rel" 2>/dev/null || true
 }
 
@@ -416,10 +432,25 @@ violation_metric() {
   printf '%s' "$m"
 }
 
+# Which occurrence of `shape` this is. Same-named functions otherwise share a
+# key, and a grown one could match a shrunken namesake's slot and report
+# nothing. No `declare -A`: these run on stock macOS bash 3.2.
+occurrence_of() {
+  local shape=$1 n=1 s
+  shift
+  for s in "$@"; do
+    if [[ "$s" == "$shape" ]]; then
+      n=$((n + 1))
+    fi
+  done
+  printf '%s' "$n"
+}
+
 # The cross-repo check already ran and its findings are NOT whole-file state —
 # they must survive the baseline pass, which resets the array.
 PRE_EXISTING=("${VIOLATIONS[@]+"${VIOLATIONS[@]}"}")
 
+BASE_KEYS=()
 BASE_SHAPES=()
 BASE_METRICS=()
 BASELINE_FILE=""
@@ -441,6 +472,9 @@ if [[ -n "$baseline_content" ]]; then
     else
       rm -f "$BASELINE_FILE"
       BASELINE_FILE=""
+      # Leaving it armed runs `rm -f ""` at every exit; a trap command that
+      # fails rewrites a blocking 2 into a non-blocking 1.
+      trap - EXIT
     fi
   fi
 fi
@@ -457,7 +491,9 @@ if [[ -n "$BASELINE_FILE" ]]; then
   check_duplicate_blocks
   check_export_count
   for v in "${VIOLATIONS[@]+"${VIOLATIONS[@]}"}"; do
-    BASE_SHAPES+=("$(violation_shape "$v")")
+    base_shape=$(violation_shape "$v")
+    BASE_KEYS+=("$base_shape @$(occurrence_of "$base_shape" "${BASE_SHAPES[@]+"${BASE_SHAPES[@]}"}")")
+    BASE_SHAPES+=("$base_shape")
     BASE_METRICS+=("$(violation_metric "$v")")
   done
   FILE_PATH="$REAL_FILE_PATH"
@@ -472,35 +508,25 @@ check_duplicate_blocks
 check_export_count
 check_monolith_directory
 
-if (( ${#BASE_SHAPES[@]} > 0 )); then
+if (( ${#BASE_KEYS[@]} > 0 )); then
   KEPT=()
+  CUR_SHAPES=()
   for v in "${VIOLATIONS[@]+"${VIOLATIONS[@]}"}"; do
     shape=$(violation_shape "$v")
     metric=$(violation_metric "$v")
-    matched=""
-    # Same severity first, so an unchanged violation claims its own baseline
-    # slot before a shrunken one consumes a bigger neighbour's and leaves the
-    # neighbour looking new.
-    for i in "${!BASE_SHAPES[@]}"; do
-      if [[ "${BASE_SHAPES[$i]}" == "$shape" ]] && (( BASE_METRICS[i] == metric )); then
-        matched=$i
+    key="$shape @$(occurrence_of "$shape" "${CUR_SHAPES[@]+"${CUR_SHAPES[@]}"}")"
+    CUR_SHAPES+=("$shape")
+    # Silent only where the SAME occurrence was already there and no worse, so
+    # an improvement never reports and a regression always does. An occurrence
+    # the baseline never had — a third duplicate block — has no key and stays.
+    keep=true
+    for i in "${!BASE_KEYS[@]}"; do
+      if [[ "${BASE_KEYS[$i]}" == "$key" ]] && (( BASE_METRICS[i] >= metric )); then
+        keep=false
         break
       fi
     done
-    if [[ -z "$matched" ]]; then
-      # Otherwise any baseline slot that was WORSE absorbs it — an improvement
-      # is silent. A metric above every slot is a real regression and is kept.
-      for i in "${!BASE_SHAPES[@]}"; do
-        if [[ "${BASE_SHAPES[$i]}" == "$shape" ]] && (( BASE_METRICS[i] > metric )); then
-          matched=$i
-          break
-        fi
-      done
-    fi
-    if [[ -n "$matched" ]]; then
-      # Consume it: a THIRD duplicate block when the baseline had two is new.
-      unset 'BASE_SHAPES[matched]' 'BASE_METRICS[matched]'
-    else
+    if [[ "$keep" == true ]]; then
       KEPT+=("$v")
     fi
   done

--- a/plugins-cc/agentkit/hooks/comment-police.sh
+++ b/plugins-cc/agentkit/hooks/comment-police.sh
@@ -84,7 +84,7 @@ esac
 case "$FILE_PATH" in
   *.lock|*.min.*|*.generated.*|*.snap|*.d.ts) exit 0 ;;
 esac
-for pattern in "${EXCLUDE_PATTERNS[@]}"; do
+for pattern in "${EXCLUDE_PATTERNS[@]+"${EXCLUDE_PATTERNS[@]}"}"; do
   [[ "$FILE_PATH" == *"$pattern"* ]] && exit 0
 done
 
@@ -93,8 +93,12 @@ ADDED=$(echo "$INPUT" | jq -r '.tool_input.new_string // .tool_input.content // 
 
 VIOLATIONS=()
 
+# Held in a variable: bash 3.2 cannot parse an unquoted `(` inside [[ =~ ]],
+# and stock macOS still ships 3.2.
+COMMENT_OPENERS='^[[:space:]]*(//|#|--|/\*|\*[^/])'
+
 is_comment_line() {
-  [[ "$1" =~ ^[[:space:]]*(//|#|--|/\*|\*[^/]) ]] || [[ "$1" =~ ^[[:space:]]*\*$ ]]
+  [[ "$1" =~ $COMMENT_OPENERS ]] || [[ "$1" =~ ^[[:space:]]*\*$ ]]
 }
 
 check_blocks_and_ratio() {
@@ -128,7 +132,7 @@ check_forbidden() {
   local hits="" pat
   while IFS= read -r line; do
     is_comment_line "$line" || continue
-    for pat in "${FORGE_PATTERNS[@]}"; do
+    for pat in "${FORGE_PATTERNS[@]+"${FORGE_PATTERNS[@]}"}"; do
       if [[ "$line" =~ $pat ]]; then
         hits+="    ${line#"${line%%[![:space:]]*}"}"$'\n'
         break

--- a/plugins-cc/agentkit/hooks/format-police.sh
+++ b/plugins-cc/agentkit/hooks/format-police.sh
@@ -64,12 +64,12 @@ find_config() {
   done
 }
 
-CONFIG_FLAG=""
+CONFIG_FLAG=()
 LOCAL_CONFIG=$(find_config "$(dirname "$FILE_PATH")")
 if [[ -n "$LOCAL_CONFIG" ]]; then
-  CONFIG_FLAG="--config $LOCAL_CONFIG"
+  CONFIG_FLAG=(--config "$LOCAL_CONFIG")
 elif [[ -n "${DPRINT_DEFAULT_CONFIG:-}" && -f "$DPRINT_DEFAULT_CONFIG" ]]; then
-  CONFIG_FLAG="--config $DPRINT_DEFAULT_CONFIG"
+  CONFIG_FLAG=(--config "$DPRINT_DEFAULT_CONFIG")
 else
   echo "⚠ no dprint.json found — set DPRINT_DEFAULT_CONFIG for a global fallback" >&2
   exit 0
@@ -80,7 +80,7 @@ fi
 ERR_LOG=$(mktemp "${TMPDIR:-/tmp}/dprint-err.XXXXXX")
 trap 'rm -f "$ERR_LOG"' EXIT
 
-if ! "$DPRINT" fmt $CONFIG_FLAG "$FILE_PATH" 2>"$ERR_LOG"; then
+if ! "$DPRINT" fmt "${CONFIG_FLAG[@]}" "$FILE_PATH" 2>"$ERR_LOG"; then
   err=$(cat "$ERR_LOG")
   echo "⚠ dprint fmt failed for $FILE_PATH: $err" >&2
   # ALLOWLIST, not a denylist. Only a failure dprint attributes to THIS file is

--- a/plugins-cc/agentkit/hooks/git-police.sh
+++ b/plugins-cc/agentkit/hooks/git-police.sh
@@ -5,6 +5,10 @@
 # Equivalent to: plugins/git-police.ts (OpenCode)
 set -euo pipefail
 
+# bash 3.2 cannot parse `(` inside [[ =~ ]], and this is a PreToolUse Bash
+# hook: a parse error denies EVERY command, with no way to switch it off.
+RE_YAML_ITEM='^[[:space:]]*-[[:space:]]+(.*)'
+
 PROTECTED_BRANCHES=("main" "master")
 AGENTKIT_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/agentkit/config.yaml"
 
@@ -24,7 +28,7 @@ load_allowed_repos() {
 		if [[ "$in_section" == true && "$line" =~ ^[[:space:]]*allowed-repos: ]]; then
 			continue
 		fi
-		if [[ "$in_section" == true && "$line" =~ ^[[:space:]]*-[[:space:]]+(.*) ]]; then
+		if [[ "$in_section" == true && "$line" =~ $RE_YAML_ITEM ]]; then
 			ALLOWED_REPOS+=("${BASH_REMATCH[1]}")
 		elif [[ "$in_section" == true && ! "$line" =~ ^[[:space:]] ]]; then
 			break

--- a/plugins-cc/agentkit/hooks/git-police.sh
+++ b/plugins-cc/agentkit/hooks/git-police.sh
@@ -62,7 +62,7 @@ tgit() {
 
 if [[ ${#ALLOWED_REPOS[@]} -gt 0 ]]; then
 	REPO_NAME=$(tgit remote get-url origin 2>/dev/null | sed -E 's|.*[:/]([^/]+/[^/]+?)(\.git)?$|\1|' || echo "")
-	for allowed in "${ALLOWED_REPOS[@]}"; do
+	for allowed in "${ALLOWED_REPOS[@]+"${ALLOWED_REPOS[@]}"}"; do
 		if [[ "$REPO_NAME" == *"$allowed"* ]]; then
 			exit 0
 		fi
@@ -131,7 +131,7 @@ PUSH_REMOTE=$(push_remote "$STRIPPED")
 
 # 3. Block pushing directly to protected branches (on origin / implicit upstream)
 if [[ -z "$PUSH_REMOTE" || "$PUSH_REMOTE" == "origin" ]]; then
-	for branch in "${PROTECTED_BRANCHES[@]}"; do
+	for branch in "${PROTECTED_BRANCHES[@]+"${PROTECTED_BRANCHES[@]}"}"; do
 		if echo "$STRIPPED" | grep -qiE "${GIT_PUSH_RE}.*\b${branch}\b"; then
 			deny "BLOCKED: Pushing directly to '${branch}' is forbidden. Create a feature branch and raise a PR instead."
 		fi
@@ -168,7 +168,7 @@ fi
 if [[ -z "$PUSH_REMOTE" || "$PUSH_REMOTE" == "origin" ]] \
 	&& echo "$STRIPPED" | grep -qiE "$GIT_PUSH_RE"; then
 	CURRENT_BRANCH=$(tgit symbolic-ref --short HEAD 2>/dev/null || echo "")
-	for branch in "${PROTECTED_BRANCHES[@]}"; do
+	for branch in "${PROTECTED_BRANCHES[@]+"${PROTECTED_BRANCHES[@]}"}"; do
 		if [[ "$CURRENT_BRANCH" == "$branch" ]]; then
 			deny "BLOCKED: You are on '${branch}'. Pushing from a protected branch is forbidden. Create a feature branch first: git checkout -b feat/your-feature-name"
 		fi
@@ -236,7 +236,7 @@ fi
 # 6. Block direct commits to protected branches
 if echo "$STRIPPED" | grep -qiE "$GIT_COMMIT_RE"; then
 	CURRENT_BRANCH=$(tgit symbolic-ref --short HEAD 2>/dev/null || echo "")
-	for branch in "${PROTECTED_BRANCHES[@]}"; do
+	for branch in "${PROTECTED_BRANCHES[@]+"${PROTECTED_BRANCHES[@]}"}"; do
 		if [[ "$CURRENT_BRANCH" == "$branch" ]]; then
 			deny "BLOCKED: Committing directly to '${branch}' is forbidden. You are on the ${branch} branch. Create a feature branch first: git checkout -b feat/your-feature-name"
 		fi
@@ -263,7 +263,7 @@ if echo "$STRIPPED" | grep -qiE '\bgit\b.*(checkout\s+-b|switch\s+-c)\b'; then
 	CURRENT_BRANCH=$(tgit symbolic-ref --short HEAD 2>/dev/null || echo "")
 	if [[ -n "$CURRENT_BRANCH" && "$STACKING_OK" != "1" ]]; then
 		ON_BASE=false
-		for base in "$DEFAULT_BRANCH" "${PROTECTED_BRANCHES[@]}" dev; do
+		for base in "$DEFAULT_BRANCH" "${PROTECTED_BRANCHES[@]+"${PROTECTED_BRANCHES[@]}"}" dev; do
 			[[ -n "$base" && "$CURRENT_BRANCH" == "$base" ]] && ON_BASE=true
 		done
 		if [[ "$ON_BASE" == false ]]; then
@@ -286,7 +286,7 @@ fi
 # 8. Stale branch protection — warn when creating a branch from a stale base
 if echo "$STRIPPED" | grep -qiE '\bgit\b.*(checkout\s+-b|switch\s+-c)\b'; then
 	CURRENT_BRANCH=$(tgit symbolic-ref --short HEAD 2>/dev/null || echo "")
-	for branch in "${PROTECTED_BRANCHES[@]}"; do
+	for branch in "${PROTECTED_BRANCHES[@]+"${PROTECTED_BRANCHES[@]}"}"; do
 		if [[ "$CURRENT_BRANCH" == "$branch" ]]; then
 			tgit fetch origin "$branch" --quiet 2>/dev/null || true
 			LOCAL_SHA=$(tgit rev-parse "$branch" 2>/dev/null || echo "")
@@ -313,7 +313,7 @@ if echo "$STRIPPED" | grep -qiE '\bgit\b.*\b(checkout|switch|pull)\b' \
 	&& ! echo "$STRIPPED" | grep -qiE '(checkout[[:space:]]+-b|switch[[:space:]]+-c)\b'; then
 	DEFAULT_BRANCH=$(tgit symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||' || true)
 	if [[ -z "$DEFAULT_BRANCH" ]]; then
-		for cand in "${PROTECTED_BRANCHES[@]}"; do
+		for cand in "${PROTECTED_BRANCHES[@]+"${PROTECTED_BRANCHES[@]}"}"; do
 			if tgit show-ref --verify --quiet "refs/heads/${cand}"; then
 				DEFAULT_BRANCH="$cand"
 				break

--- a/plugins-cc/agentkit/hooks/git-police.sh
+++ b/plugins-cc/agentkit/hooks/git-police.sh
@@ -18,7 +18,10 @@ COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 [[ -z "$COMMAND" ]] && exit 0
 
 load_allowed_repos() {
-	[[ -f "$AGENTKIT_CONFIG" ]] || return
+	# `return` alone propagates the failed test's status 1, and this runs as a
+	# plain command under `set -e`: with no config file the hook exited 1 with
+	# NO decision — every guard below it off — which the harness reads as ALLOW.
+	[[ -f "$AGENTKIT_CONFIG" ]] || return 0
 	local in_section=false
 	while IFS= read -r line; do
 		if [[ "$line" =~ ^[[:space:]]*branch-protection: ]]; then

--- a/plugins-cc/agentkit/hooks/resource-police.sh
+++ b/plugins-cc/agentkit/hooks/resource-police.sh
@@ -1,6 +1,28 @@
 #!/bin/bash
 set -euo pipefail
 
+# bash 3.2 — stock on macOS — cannot parse `(` inside [[ =~ ]]. Held in
+# variables, these parse everywhere and BASH_REMATCH still works.
+# A parse error here is fatal: this is a PreToolUse Bash hook, so it would
+# deny EVERY command with the kill switch unreachable.
+RE_BARE_TASK='^(build|check|type-?check|lint)(:[[:alnum:]_-]+)?$'
+RE_BUN_HEAVY='^(add|install|update|test)$'
+RE_CARGO_HEAVY='^(build|check|test|clippy)$'
+RE_DELEGATING='^(ansible|ansible-playbook|doas|mosh|pkexec|run0|ssh|sudo|systemd-run)$'
+RE_DOCKER_READONLY='^(diff|events|history|images|info|inspect|logs|port|ps|stats|top|version)$'
+RE_GO_HEAVY='^(build|test)$'
+RE_KUBECTL_READONLY='^(api-resources|api-versions|auth|cluster-info|describe|explain|get|logs|top|version)$'
+RE_MACHINECTL_READONLY='^(list|show|status)$'
+RE_NPM_HEAVY='^(add|install|i|ci|update|upgrade|test)$'
+RE_ORCHESTRATOR='^(buildah|docker|kubectl|machinectl|nerdctl|podman|service|systemctl)$'
+RE_PODMAN_READONLY='^(containers|images|info|inspect|version)$'
+RE_SCRIPT_TASK='^(build|check|type-?check|lint|test)(:[[:alnum:]_-]+)?$'
+RE_SHELL='^(bash|dash|fish|sh|zsh)$'
+RE_SYSTEMCTL_READONLY='^(cat|get-default|is-active|is-enabled|is-failed|list-|show|status)'
+RE_UV_HEAVY='^(add|sync)$'
+RE_YARN_HEAVY='^(add|install|up|upgrade|test)$'
+
+
 # Absolute paths are deliberate: a hook that inspects a command must not
 # resolve its own tools through a PATH that command could have manipulated.
 # But the locations are NOT the same everywhere — `cat` is /bin/cat on macOS
@@ -202,30 +224,30 @@ is_heavy() {
 	local second="${ARGS[1]:-}"
 	case "$executable" in
 	bun)
-		[[ "$first" =~ ^(add|install|update|test)$ ]] && return 0
-		[[ "$first" == run && "$second" =~ ^(build|check|type-?check|lint|test)(:[[:alnum:]_-]+)?$ ]]
+		[[ "$first" =~ $RE_BUN_HEAVY ]] && return 0
+		[[ "$first" == run && "$second" =~ $RE_SCRIPT_TASK ]]
 		;;
 	bunx | npx)
 		[[ "$first" == tsc && "$second" != --version ]] \
 			|| [[ "$first" == playwright && "$second" == test ]]
 		;;
 	npm | pnpm)
-		[[ "$first" =~ ^(add|install|i|ci|update|upgrade|test)$ ]] && return 0
-		[[ "$first" == run && "$second" =~ ^(build|check|type-?check|lint|test)(:[[:alnum:]_-]+)?$ ]]
+		[[ "$first" =~ $RE_NPM_HEAVY ]] && return 0
+		[[ "$first" == run && "$second" =~ $RE_SCRIPT_TASK ]]
 		;;
 	yarn)
 		[[ -z "$first" ]] && return 0
-		[[ "$first" =~ ^(add|install|up|upgrade|test)$ ]] && return 0
-		[[ "$first" == run && "$second" =~ ^(build|check|type-?check|lint|test)(:[[:alnum:]_-]+)?$ ]] && return 0
-		[[ "$first" =~ ^(build|check|type-?check|lint)(:[[:alnum:]_-]+)?$ ]]
+		[[ "$first" =~ $RE_YARN_HEAVY ]] && return 0
+		[[ "$first" == run && "$second" =~ $RE_SCRIPT_TASK ]] && return 0
+		[[ "$first" =~ $RE_BARE_TASK ]]
 		;;
 	tsc) [[ "$first" != --version ]] ;;
 	playwright) [[ "$first" == test ]] ;;
-	cargo) [[ "$first" =~ ^(build|check|test|clippy)$ ]] ;;
-	go) [[ "$first" =~ ^(build|test)$ ]] ;;
+	cargo) [[ "$first" =~ $RE_CARGO_HEAVY ]] ;;
+	go) [[ "$first" =~ $RE_GO_HEAVY ]] ;;
 	pip | pip3) [[ "$first" == install ]] ;;
 	uv)
-		[[ "$first" =~ ^(add|sync)$ ]] && return 0
+		[[ "$first" =~ $RE_UV_HEAVY ]] && return 0
 		[[ "$first" == pip && "$second" == install ]] && return 0
 		[[ "$first" == run && "$second" == pytest ]]
 		;;
@@ -256,12 +278,12 @@ shell_command_payload() {
 }
 
 is_delegating() {
-	[[ "$EXECUTABLE" =~ ^(ansible|ansible-playbook|doas|mosh|pkexec|run0|ssh|sudo|systemd-run)$ ]] && return 0
-	if [[ "$EXECUTABLE" =~ ^(buildah|docker|kubectl|machinectl|nerdctl|podman|service|systemctl)$ ]]; then
+	[[ "$EXECUTABLE" =~ $RE_DELEGATING ]] && return 0
+	if [[ "$EXECUTABLE" =~ $RE_ORCHESTRATOR ]]; then
 		is_read_only_diagnostic && return 1
 		return 0
 	fi
-	if [[ "$EXECUTABLE" =~ ^(bash|dash|fish|sh|zsh)$ ]]; then
+	if [[ "$EXECUTABLE" =~ $RE_SHELL ]]; then
 		shell_command_payload && return 0
 	fi
 	return 1
@@ -279,11 +301,11 @@ is_read_only_diagnostic() {
 		break
 	done
 	case "$EXECUTABLE" in
-	systemctl) [[ "$first" =~ ^(cat|get-default|is-active|is-enabled|is-failed|list-|show|status) ]] ;;
-	kubectl) [[ "$first" =~ ^(api-resources|api-versions|auth|cluster-info|describe|explain|get|logs|top|version)$ ]] ;;
-	docker | nerdctl | podman) [[ "$first" =~ ^(diff|events|history|images|info|inspect|logs|port|ps|stats|top|version)$ ]] ;;
-	buildah) [[ "$first" =~ ^(containers|images|info|inspect|version)$ ]] ;;
-	machinectl) [[ "$first" =~ ^(list|show|status)$ ]] ;;
+	systemctl) [[ "$first" =~ $RE_SYSTEMCTL_READONLY ]] ;;
+	kubectl) [[ "$first" =~ $RE_KUBECTL_READONLY ]] ;;
+	docker | nerdctl | podman) [[ "$first" =~ $RE_DOCKER_READONLY ]] ;;
+	buildah) [[ "$first" =~ $RE_PODMAN_READONLY ]] ;;
+	machinectl) [[ "$first" =~ $RE_MACHINECTL_READONLY ]] ;;
 	service) [[ "$second" == status ]] ;;
 	*) return 1 ;;
 	esac
@@ -355,7 +377,7 @@ analyze_command() {
 			fi
 			continue
 		fi
-		if [[ "$EXECUTABLE" =~ ^(bash|dash|fish|sh|zsh)$ ]] && shell_command_payload; then
+		if [[ "$EXECUTABLE" =~ $RE_SHELL ]] && shell_command_payload; then
 			analyze_command "$PAYLOAD" $((depth + 1))
 			continue
 		fi

--- a/plugins-cc/agentkit/hooks/resource-police.sh
+++ b/plugins-cc/agentkit/hooks/resource-police.sh
@@ -269,7 +269,7 @@ is_delegating() {
 
 is_read_only_diagnostic() {
 	local first='' second='' argument
-	for argument in "${ARGS[@]}"; do
+	for argument in "${ARGS[@]+"${ARGS[@]}"}"; do
 		[[ "$argument" == -* ]] && continue
 		if [[ -z "$first" ]]; then
 			first="$argument"

--- a/plugins-cc/agentkit/hooks/resource-police.sh
+++ b/plugins-cc/agentkit/hooks/resource-police.sh
@@ -15,7 +15,7 @@ RE_KUBECTL_READONLY='^(api-resources|api-versions|auth|cluster-info|describe|exp
 RE_MACHINECTL_READONLY='^(list|show|status)$'
 RE_NPM_HEAVY='^(add|install|i|ci|update|upgrade|test)$'
 RE_ORCHESTRATOR='^(buildah|docker|kubectl|machinectl|nerdctl|podman|service|systemctl)$'
-RE_PODMAN_READONLY='^(containers|images|info|inspect|version)$'
+RE_BUILDAH_READONLY='^(containers|images|info|inspect|version)$'
 RE_SCRIPT_TASK='^(build|check|type-?check|lint|test)(:[[:alnum:]_-]+)?$'
 RE_SHELL='^(bash|dash|fish|sh|zsh)$'
 RE_SYSTEMCTL_READONLY='^(cat|get-default|is-active|is-enabled|is-failed|list-|show|status)'
@@ -304,7 +304,7 @@ is_read_only_diagnostic() {
 	systemctl) [[ "$first" =~ $RE_SYSTEMCTL_READONLY ]] ;;
 	kubectl) [[ "$first" =~ $RE_KUBECTL_READONLY ]] ;;
 	docker | nerdctl | podman) [[ "$first" =~ $RE_DOCKER_READONLY ]] ;;
-	buildah) [[ "$first" =~ $RE_PODMAN_READONLY ]] ;;
+	buildah) [[ "$first" =~ $RE_BUILDAH_READONLY ]] ;;
 	machinectl) [[ "$first" =~ $RE_MACHINECTL_READONLY ]] ;;
 	service) [[ "$second" == status ]] ;;
 	*) return 1 ;;

--- a/tests/comment-police-hook.test.ts
+++ b/tests/comment-police-hook.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import { dirname, join } from 'node:path';
 import { spawnSync } from 'node:child_process';
-import { chmodSync, mkdtempSync, readdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 
 const repoRoot = dirname(import.meta.dir);
@@ -133,11 +133,11 @@ describe('police hooks reach the model', () => {
 });
 
 describe("the hooks run on the bash the target platform actually ships", () => {
-  // stock macOS is bash 3.2, where `"${arr[@]}"` on an EMPTY array is an
-  // unbound-variable error under `set -u`: the hook dies, emits no decision,
-  // and the harness reads silence as ALLOW. bash did not fix it until 4.4.
-  // Verified against a real 3.2.0 build; pinned here statically so CI does not
-  // need one.
+  // stock macOS is bash 3.2. Two constructs die there and both are fatal:
+  // `"${arr[@]}"` on an EMPTY array is an unbound-variable error under `set -u`
+  // (not fixed until bash 4.4), and `(` inside [[ =~ ]] is a PARSE error. For a
+  // PreToolUse Bash hook a parse error denies EVERY command, and the kill
+  // switch is unreachable because the script never starts.
   const hookDir = join(repoRoot, "hooks", "claude");
   const shells = readdirSync(hookDir).filter((f) => f.endsWith(".sh"));
 
@@ -146,13 +146,11 @@ describe("the hooks run on the bash the target platform actually ships", () => {
     const exempt = new Set(["CONFIG_FLAG"]);
     const offenders: string[] = [];
     for (const name of shells) {
-      const body = readFileSync(join(hookDir, name), "utf-8");
-      body.split("\n").forEach((line, i) => {
+      readFileSync(join(hookDir, name), "utf-8").split("\n").forEach((line, i) => {
         for (const m of line.matchAll(/"\$\{([A-Z_]+)\[@\]\}"/g)) {
-          const arr = m[1];
-          if (exempt.has(arr)) continue;
-          if (line.includes(`\${${arr}[@]+`)) continue;
-          offenders.push(`${name}:${i + 1} ${arr}`);
+          if (exempt.has(m[1])) continue;
+          if (line.includes(`\${${m[1]}[@]+`)) continue;
+          offenders.push(`${name}:${i + 1} ${m[1]}`);
         }
       });
     }
@@ -160,17 +158,13 @@ describe("the hooks run on the bash the target platform actually ships", () => {
   });
 
   test("no [[ =~ ]] pattern contains an unquoted group", () => {
-    // bash 3.2 cannot parse `(` inside a conditional regex; the pattern has to
-    // live in a variable. A syntax error here is another silent non-decision.
     const offenders: string[] = [];
-    for (const name of ["coding-police.sh", "comment-police.sh", "format-police.sh"]) {
-      const body = readFileSync(join(hookDir, name), "utf-8");
-      body.split("\n").forEach((line, i) => {
+    for (const name of shells) {
+      readFileSync(join(hookDir, name), "utf-8").split("\n").forEach((line, i) => {
         const at = line.indexOf("=~");
         if (at < 0) return;
-        // Everything up to the closing ]] is the pattern. A character class can
-        // contain ], so stopping at the first ] misses the group entirely —
-        // which is exactly how this assertion first failed to fail.
+        // A character class can contain ], so stopping at the first ] misses
+        // the group entirely — which is how this assertion first failed to fail.
         const end = line.lastIndexOf("]]");
         const pattern = end > at ? line.slice(at + 2, end) : line.slice(at + 2);
         if (/(^|[^\\])\(/.test(pattern)) offenders.push(`${name}:${i + 1}`);
@@ -349,18 +343,15 @@ describe("coding-police reports what the EDIT did, not what the file already was
     git("config", "user.name", "t");
     return { dir, file, git };
   }
-  // Bodies are unique PER FUNCTION: identical bodies make every fixture with
-  // two long functions emit ~n duplicate-block violations too, which is both
-  // slow and not what these tests are about.
   const longFn = (name: string, n: number) =>
     `export function ${name}() {\n${
-      Array.from({ length: n }, (_, i) => `  const ${name}_v${i} = ${i};`).join("\n")
+      Array.from({ length: n }, (_, i) => `  const v${i} = ${i};`).join("\n")
     }\n}\n`;
   const dupBlock = (tag: string) =>
     `// dup ${tag}\nconst a = 1;\nconst b = 2;\nconst c = 3;\nconst d = 4;\nconst e = 5;\n`;
 
-  // Assembled at runtime: spelled out, this file would trip the very check
-  // these tests exercise, on every later edit.
+  // Assembled at runtime: spelled out, this file trips the very check these
+  // tests exercise, on every later edit to it.
   const up = "../";
   const crossRepo = `${up}${up}core/roles`;
 
@@ -488,119 +479,17 @@ describe("coding-police reports what the EDIT did, not what the file already was
     rmSync(dir, { recursive: true, force: true });
   });
 
-  test("two functions sharing a name are tracked separately", () => {
-    // Without an occurrence ordinal they share one key, so a grown function
-    // matched its shrunken namesake's slot and the edit reported nothing.
-    const { dir, file, git } = legacyRepo();
-    writeFileSync(file, `${longFn("parse", 105)}${longFn("parse", 200)}`);
-    git("add", "-A");
-    git("commit", "-qm", "two over-cap functions with the same name");
-    expect(run(file).status).toBe(0);
-    writeFileSync(file, `${longFn("parse", 180)}${longFn("parse", 110)}`);
-    const r = run(file);
-    // longFn wraps the body in a signature and a closing brace.
-    expect(r.out).toContain("is 182 lines");
-    expect(r.out).not.toContain("is 112 lines");
-    expect(r.status).toBe(2);
-    rmSync(dir, { recursive: true, force: true });
-  }, 30_000);
-
-  test("the baseline resolves through a symlinked checkout", () => {
-    // git reports the physical path; stripping it off a logical one left `rel`
-    // absolute, so `git show` found nothing and the subtraction switched off
-    // entirely — the wedge, for anyone whose checkout sits under a symlink.
-    const { dir, file, git } = legacyRepo();
-    const lines = (n: number) =>
-      Array.from({ length: n }, (_, i) => `const x${i} = ${i};`).join("\n") + "\n";
-    writeFileSync(file, lines(1200));
-    git("add", "-A");
-    git("commit", "-qm", "already over the cap");
-    const link = `${dir}-link`;
-    symlinkSync(dir, link);
-    const viaLink = join(link, "legacy.ts");
-    const untouched = run(viaLink);
-    expect(untouched.out).not.toContain("FILE TOO LONG");
-    expect(untouched.status).toBe(0);
-    // The subtraction must still be live through the symlink, not just quiet.
-    writeFileSync(file, lines(1400));
-    expect(run(viaLink).status).toBe(2);
-    rmSync(link, { force: true });
-    rmSync(dir, { recursive: true, force: true });
-  });
-
-  test("a SECOND copy of an already-committed cross-repo line is still reported", () => {
-    // Membership answers "is this line committed?", which let a byte-identical
-    // duplicate be added and reported as nothing — a new dependency on
-    // checkout layout, silently. A duplicated list entry is the realistic case.
-    const { dir, git } = legacyRepo();
-    const file = join(dir, "list.yaml");
-    writeFileSync(file, `- "${crossRepo}"\n`);
-    git("add", "-A");
-    git("commit", "-qm", "one offending entry, already in the repo");
-    writeFileSync(file, `- "${crossRepo}"\n- "${crossRepo}"\n`);
-    const added = run(file);
-    expect(added.out).toContain("CROSS-REPO RELATIVE PATH");
-    expect(added.status).toBe(2);
-    // Back to the committed count: quiet again.
-    writeFileSync(file, `- "${crossRepo}"\n`);
-    expect(run(file).status).toBe(0);
-    rmSync(dir, { recursive: true, force: true });
-  });
-
-  test("a pathological file is bounded, and the bound never blocks on its own", () => {
-    // The subtraction is quadratic in violations. A duplicate-heavy file emits
-    // roughly one per line and took the hook past the harness's 60s timeout —
-    // where it is killed, says nothing, and silence reads as ALLOW.
-    const { dir, file, git } = legacyRepo();
-    const block = "const a = 1;\nconst b = 2;\nconst c = 3;\nconst d = 4;\nconst e = 5;\nconst f = 6;\n";
-    writeFileSync(file, block.repeat(300));
-    git("add", "-A");
-    git("commit", "-qm", "1800 lines of repeated blocks");
-    const started = Date.now();
-    const untouched = run(file);
-    expect(Date.now() - started).toBeLessThan(20_000);
-    // Nothing this edit did: the truncation caveat must not block by itself.
-    expect(untouched.status).toBe(0);
-    expect(untouched.out).not.toContain("LIST TRUNCATED");
-    // A real regression still blocks, and says the list is partial.
-    writeFileSync(file, block.repeat(300) + "export const z = 1;\n".repeat(40));
-    const worse = run(file);
-    expect(worse.status).toBe(2);
-    expect(worse.out).toContain("LIST TRUNCATED");
-    rmSync(dir, { recursive: true, force: true });
-    // Two runs over an 1800-line fixture; the assertion above is the real
-    // bound, this only stops bun's 5s default from making it flaky.
-  }, 30_000);
-
-  test("cross-repo relative paths survive the baseline pass on a tracked file", () => {
+  test("cross-repo relative paths survive the baseline pass", () => {
     // The subtraction reset the violations array, silently disabling this
-    // check on every TRACKED file — exactly the files it targets. A path this
-    // edit ADDS must still be reported there.
-    const { dir, git } = legacyRepo();
-    const file = join(dir, "conf.ts");
-    writeFileSync(file, "export const ok = 1;\n");
-    git("add", "-A");
-    git("commit", "-qm", "tracked");
-    writeFileSync(file, `export const ok = 1;\nexport const p = "${crossRepo}";\n`);
-    const r = run(file);
-    expect(r.out).toContain("CROSS-REPO RELATIVE PATH");
-    expect(r.status).toBe(2);
-    rmSync(dir, { recursive: true, force: true });
-  });
-
-  test("a cross-repo path that is already committed does not re-report forever", () => {
-    // Per line, not per file: this check has no severity to compare, so an
-    // already-committed fixture would otherwise block every later edit to the
-    // file that contains it — the same wedge, by a different door.
+    // check on every TRACKED file — exactly the files it targets.
     const { dir, git } = legacyRepo();
     const file = join(dir, "conf.ts");
     writeFileSync(file, `export const p = "${crossRepo}";\n`);
     git("add", "-A");
-    git("commit", "-qm", "the offending path is already in the repo");
-    writeFileSync(file, `export const p = "${crossRepo}";\nexport const added = 2;\n`);
+    git("commit", "-qm", "tracked");
     const r = run(file);
-    expect(r.out).not.toContain("CROSS-REPO RELATIVE PATH");
-    expect(r.status).toBe(0);
+    expect(r.out).toContain("CROSS-REPO RELATIVE PATH");
+    expect(r.status).toBe(2);
     rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/tests/comment-police-hook.test.ts
+++ b/tests/comment-police-hook.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import { dirname, join } from 'node:path';
 import { spawnSync } from 'node:child_process';
-import { chmodSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 
 const repoRoot = dirname(import.meta.dir);
@@ -141,6 +141,23 @@ describe("the hooks run on the bash the target platform actually ships", () => {
   const hookDir = join(repoRoot, "hooks", "claude");
   const shells = readdirSync(hookDir).filter((f) => f.endsWith(".sh"));
 
+  // The real check, when a 3.2 is available: it subsumes both spelling proxies
+  // below, which pin how the rules are WRITTEN rather than that they hold.
+  const bash32 = [
+    process.env.AGENTKIT_BASH32,
+    "/usr/local/bin/bash-3.2",
+    join(tmpdir(), "bash-3.2", "bash"),
+  ].find((p) => p && existsSync(p));
+
+  test.skipIf(!bash32)("every hook parses under real bash 3.2", () => {
+    const offenders: string[] = [];
+    for (const name of shells) {
+      const r = spawnSync(bash32!, ["-n", join(hookDir, name)], { encoding: "utf-8" });
+      if (r.status !== 0) offenders.push(`${name}: ${(r.stderr ?? "").split("\n")[0]}`);
+    }
+    expect(offenders).toEqual([]);
+  });
+
   test("every possibly-empty array expansion uses the +expansion guard", () => {
     // CONFIG_FLAG is exempt: every branch assigns two elements or exits first.
     const exempt = new Set(["CONFIG_FLAG"]);
@@ -171,6 +188,27 @@ describe("the hooks run on the bash the target platform actually ships", () => {
       });
     }
     expect(offenders).toEqual([]);
+  });
+});
+
+describe("git-police works on a stock install", () => {
+  test("a force push is denied with no agentkit config present", () => {
+    // `[[ -f $CONFIG ]] || return` propagated status 1 into `set -e`, so the
+    // hook exited 1 with ZERO output before any guard ran — and a hook that
+    // emits no decision is read as ALLOW. Every protection in it was off for
+    // anyone who had never written a config file.
+    const empty = mkdtempSync(join(tmpdir(), "agentkit-noconfig-"));
+    const r = spawnSync("bash", [join(repoRoot, "hooks", "claude", "git-police.sh")], {
+      input: JSON.stringify({
+        tool_name: "Bash",
+        tool_input: { command: "git push --force origin main" },
+        session_id: "t",
+      }),
+      encoding: "utf-8",
+      env: { ...process.env, XDG_CONFIG_HOME: empty },
+    });
+    expect(`${r.stdout ?? ""}`).toContain('"permissionDecision": "deny"');
+    rmSync(empty, { recursive: true, force: true });
   });
 });
 

--- a/tests/comment-police-hook.test.ts
+++ b/tests/comment-police-hook.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import { dirname, join } from 'node:path';
 import { spawnSync } from 'node:child_process';
-import { chmodSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdtempSync, readdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 
 const repoRoot = dirname(import.meta.dir);
@@ -129,6 +129,54 @@ describe('police hooks reach the model', () => {
       const b = readFileSync(join(repoRoot, 'plugins-cc', 'agentkit', 'hooks', name), 'utf-8');
       expect(b).toBe(a);
     }
+  });
+});
+
+describe("the hooks run on the bash the target platform actually ships", () => {
+  // stock macOS is bash 3.2, where `"${arr[@]}"` on an EMPTY array is an
+  // unbound-variable error under `set -u`: the hook dies, emits no decision,
+  // and the harness reads silence as ALLOW. bash did not fix it until 4.4.
+  // Verified against a real 3.2.0 build; pinned here statically so CI does not
+  // need one.
+  const hookDir = join(repoRoot, "hooks", "claude");
+  const shells = readdirSync(hookDir).filter((f) => f.endsWith(".sh"));
+
+  test("every possibly-empty array expansion uses the +expansion guard", () => {
+    // CONFIG_FLAG is exempt: every branch assigns two elements or exits first.
+    const exempt = new Set(["CONFIG_FLAG"]);
+    const offenders: string[] = [];
+    for (const name of shells) {
+      const body = readFileSync(join(hookDir, name), "utf-8");
+      body.split("\n").forEach((line, i) => {
+        for (const m of line.matchAll(/"\$\{([A-Z_]+)\[@\]\}"/g)) {
+          const arr = m[1];
+          if (exempt.has(arr)) continue;
+          if (line.includes(`\${${arr}[@]+`)) continue;
+          offenders.push(`${name}:${i + 1} ${arr}`);
+        }
+      });
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  test("no [[ =~ ]] pattern contains an unquoted group", () => {
+    // bash 3.2 cannot parse `(` inside a conditional regex; the pattern has to
+    // live in a variable. A syntax error here is another silent non-decision.
+    const offenders: string[] = [];
+    for (const name of ["coding-police.sh", "comment-police.sh", "format-police.sh"]) {
+      const body = readFileSync(join(hookDir, name), "utf-8");
+      body.split("\n").forEach((line, i) => {
+        const at = line.indexOf("=~");
+        if (at < 0) return;
+        // Everything up to the closing ]] is the pattern. A character class can
+        // contain ], so stopping at the first ] misses the group entirely —
+        // which is exactly how this assertion first failed to fail.
+        const end = line.lastIndexOf("]]");
+        const pattern = end > at ? line.slice(at + 2, end) : line.slice(at + 2);
+        if (/(^|[^\\])\(/.test(pattern)) offenders.push(`${name}:${i + 1}`);
+      });
+    }
+    expect(offenders).toEqual([]);
   });
 });
 
@@ -301,9 +349,12 @@ describe("coding-police reports what the EDIT did, not what the file already was
     git("config", "user.name", "t");
     return { dir, file, git };
   }
+  // Bodies are unique PER FUNCTION: identical bodies make every fixture with
+  // two long functions emit ~n duplicate-block violations too, which is both
+  // slow and not what these tests are about.
   const longFn = (name: string, n: number) =>
     `export function ${name}() {\n${
-      Array.from({ length: n }, (_, i) => `  const v${i} = ${i};`).join("\n")
+      Array.from({ length: n }, (_, i) => `  const ${name}_v${i} = ${i};`).join("\n")
     }\n}\n`;
   const dupBlock = (tag: string) =>
     `// dup ${tag}\nconst a = 1;\nconst b = 2;\nconst c = 3;\nconst d = 4;\nconst e = 5;\n`;
@@ -452,7 +503,7 @@ describe("coding-police reports what the EDIT did, not what the file already was
     expect(r.out).not.toContain("is 112 lines");
     expect(r.status).toBe(2);
     rmSync(dir, { recursive: true, force: true });
-  });
+  }, 30_000);
 
   test("the baseline resolves through a symlinked checkout", () => {
     // git reports the physical path; stripping it off a logical one left `rel`
@@ -476,6 +527,50 @@ describe("coding-police reports what the EDIT did, not what the file already was
     rmSync(link, { force: true });
     rmSync(dir, { recursive: true, force: true });
   });
+
+  test("a SECOND copy of an already-committed cross-repo line is still reported", () => {
+    // Membership answers "is this line committed?", which let a byte-identical
+    // duplicate be added and reported as nothing — a new dependency on
+    // checkout layout, silently. A duplicated list entry is the realistic case.
+    const { dir, git } = legacyRepo();
+    const file = join(dir, "list.yaml");
+    writeFileSync(file, `- "${crossRepo}"\n`);
+    git("add", "-A");
+    git("commit", "-qm", "one offending entry, already in the repo");
+    writeFileSync(file, `- "${crossRepo}"\n- "${crossRepo}"\n`);
+    const added = run(file);
+    expect(added.out).toContain("CROSS-REPO RELATIVE PATH");
+    expect(added.status).toBe(2);
+    // Back to the committed count: quiet again.
+    writeFileSync(file, `- "${crossRepo}"\n`);
+    expect(run(file).status).toBe(0);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("a pathological file is bounded, and the bound never blocks on its own", () => {
+    // The subtraction is quadratic in violations. A duplicate-heavy file emits
+    // roughly one per line and took the hook past the harness's 60s timeout —
+    // where it is killed, says nothing, and silence reads as ALLOW.
+    const { dir, file, git } = legacyRepo();
+    const block = "const a = 1;\nconst b = 2;\nconst c = 3;\nconst d = 4;\nconst e = 5;\nconst f = 6;\n";
+    writeFileSync(file, block.repeat(300));
+    git("add", "-A");
+    git("commit", "-qm", "1800 lines of repeated blocks");
+    const started = Date.now();
+    const untouched = run(file);
+    expect(Date.now() - started).toBeLessThan(20_000);
+    // Nothing this edit did: the truncation caveat must not block by itself.
+    expect(untouched.status).toBe(0);
+    expect(untouched.out).not.toContain("LIST TRUNCATED");
+    // A real regression still blocks, and says the list is partial.
+    writeFileSync(file, block.repeat(300) + "export const z = 1;\n".repeat(40));
+    const worse = run(file);
+    expect(worse.status).toBe(2);
+    expect(worse.out).toContain("LIST TRUNCATED");
+    rmSync(dir, { recursive: true, force: true });
+    // Two runs over an 1800-line fixture; the assertion above is the real
+    // bound, this only stops bun's 5s default from making it flaky.
+  }, 30_000);
 
   test("cross-repo relative paths survive the baseline pass on a tracked file", () => {
     // The subtraction reset the violations array, silently disabling this

--- a/tests/comment-police-hook.test.ts
+++ b/tests/comment-police-hook.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import { dirname, join } from 'node:path';
 import { spawnSync } from 'node:child_process';
-import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 
 const repoRoot = dirname(import.meta.dir);
@@ -308,6 +308,11 @@ describe("coding-police reports what the EDIT did, not what the file already was
   const dupBlock = (tag: string) =>
     `// dup ${tag}\nconst a = 1;\nconst b = 2;\nconst c = 3;\nconst d = 4;\nconst e = 5;\n`;
 
+  // Assembled at runtime: spelled out, this file would trip the very check
+  // these tests exercise, on every later edit.
+  const up = "../";
+  const crossRepo = `${up}${up}core/roles`;
+
   const run = (file: string) => {
     const r = spawnSync("bash", [join(repoRoot, "hooks", "claude", "coding-police.sh")], {
       input: JSON.stringify({ tool_name: "Edit", tool_input: { file_path: file, new_string: "x" } }),
@@ -432,17 +437,75 @@ describe("coding-police reports what the EDIT did, not what the file already was
     rmSync(dir, { recursive: true, force: true });
   });
 
-  test("cross-repo relative paths survive the baseline pass", () => {
+  test("two functions sharing a name are tracked separately", () => {
+    // Without an occurrence ordinal they share one key, so a grown function
+    // matched its shrunken namesake's slot and the edit reported nothing.
+    const { dir, file, git } = legacyRepo();
+    writeFileSync(file, `${longFn("parse", 105)}${longFn("parse", 200)}`);
+    git("add", "-A");
+    git("commit", "-qm", "two over-cap functions with the same name");
+    expect(run(file).status).toBe(0);
+    writeFileSync(file, `${longFn("parse", 180)}${longFn("parse", 110)}`);
+    const r = run(file);
+    // longFn wraps the body in a signature and a closing brace.
+    expect(r.out).toContain("is 182 lines");
+    expect(r.out).not.toContain("is 112 lines");
+    expect(r.status).toBe(2);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("the baseline resolves through a symlinked checkout", () => {
+    // git reports the physical path; stripping it off a logical one left `rel`
+    // absolute, so `git show` found nothing and the subtraction switched off
+    // entirely — the wedge, for anyone whose checkout sits under a symlink.
+    const { dir, file, git } = legacyRepo();
+    const lines = (n: number) =>
+      Array.from({ length: n }, (_, i) => `const x${i} = ${i};`).join("\n") + "\n";
+    writeFileSync(file, lines(1200));
+    git("add", "-A");
+    git("commit", "-qm", "already over the cap");
+    const link = `${dir}-link`;
+    symlinkSync(dir, link);
+    const viaLink = join(link, "legacy.ts");
+    const untouched = run(viaLink);
+    expect(untouched.out).not.toContain("FILE TOO LONG");
+    expect(untouched.status).toBe(0);
+    // The subtraction must still be live through the symlink, not just quiet.
+    writeFileSync(file, lines(1400));
+    expect(run(viaLink).status).toBe(2);
+    rmSync(link, { force: true });
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("cross-repo relative paths survive the baseline pass on a tracked file", () => {
     // The subtraction reset the violations array, silently disabling this
-    // check on every TRACKED file — exactly the files it targets.
+    // check on every TRACKED file — exactly the files it targets. A path this
+    // edit ADDS must still be reported there.
     const { dir, git } = legacyRepo();
     const file = join(dir, "conf.ts");
-    writeFileSync(file, 'export const p = "../../core/roles";\n');
+    writeFileSync(file, "export const ok = 1;\n");
     git("add", "-A");
     git("commit", "-qm", "tracked");
+    writeFileSync(file, `export const ok = 1;\nexport const p = "${crossRepo}";\n`);
     const r = run(file);
     expect(r.out).toContain("CROSS-REPO RELATIVE PATH");
     expect(r.status).toBe(2);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("a cross-repo path that is already committed does not re-report forever", () => {
+    // Per line, not per file: this check has no severity to compare, so an
+    // already-committed fixture would otherwise block every later edit to the
+    // file that contains it — the same wedge, by a different door.
+    const { dir, git } = legacyRepo();
+    const file = join(dir, "conf.ts");
+    writeFileSync(file, `export const p = "${crossRepo}";\n`);
+    git("add", "-A");
+    git("commit", "-qm", "the offending path is already in the repo");
+    writeFileSync(file, `export const p = "${crossRepo}";\nexport const added = 2;\n`);
+    const r = run(file);
+    expect(r.out).not.toContain("CROSS-REPO RELATIVE PATH");
+    expect(r.status).toBe(0);
     rmSync(dir, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
**Scope was cut this round.** It began as the #88 subtraction fixes; review measured that each of those introduced a new fail-open of the class it was fixing, so they are reverted to `main` and preserved in a follow-up. What ships here is the part verified end to end on the target platform.

## The bug

On stock macOS **bash 3.2**, two constructs are fatal, and both were present across the hook set:

| construct | effect | hooks |
|---|---|---|
| `"${arr[@]}"` on an EMPTY array under `set -u` | unbound-variable error, exit 1, **no decision** — which reads as ALLOW | coding-police, comment-police |
| `(` inside `[[ =~ ]]` | **PARSE** error — the script never starts | git-police, resource-police |

The second is the severe one. Both are **PreToolUse `Bash`** hooks, so on that platform they denied *every* Bash command — and since the script never started, `AGENTKIT_SKIP_HOOKS` was unreachable. An unfixable wedge on the primary target.

Neither was hypothetical: `/bin/bash` on the Mac in this fleet is `3.2.57`.

## Verification

Against a real GNU **bash 3.2.0** build, not by reasoning:

- all ten hooks parse (`bash-3.2.0 -n`);
- 3.2 and 5.2 return **identical decisions** across nine probes covering both the deny paths (force push, the verify-skipping flag, `cargo build`, `docker system prune`, `sudo systemctl`, `bun install`) and the allow paths (`ls`, `kubectl get pods`).

Two static assertions pin both rules so CI needs no 3.2 binary. Both are mutation-tested — un-guarding an array fails the first; inlining one regex group fails the second. The second assertion had to be fixed after it first failed to fail: its own regex stopped at the `]` inside a character class.

Also here: `CONFIG_FLAG` becomes an array so a dprint config path containing a space cannot word-split; and this test file's own cross-repo fixture is assembled at runtime, because spelled out it tripped the check on every edit to the file.

457 pass.

## What was dropped, and why

The ordinal, `MAX_SUBTRACT`, the cross-repo occurrence counting and the `realpath` change are reverted. Measured, each was a new silent failure:

- the cap discarded a genuinely new violation **and** suppressed its own truncation caveat in the same case — exit 0, no output, where the identical edit on an unpadded file exits 2;
- the cap truncated the two passes independently, so deleting 100 long functions from a legacy file (a strict improvement) was answered with **89** pre-existing findings and exit 2, where `main` is quiet;
- the cross-repo counter was unbounded and forked two greps per offending line: **76.8s at 4000 lines**, reintroducing the very 60s-timeout fail-open the cap existed to remove.

Main's known limits beat three new silent failures. Tracked with the measurements in the follow-up issue.
