### PR TITLE
fix(coding-police): one finding per duplicated region, not one per line

### DIFF
--- a/hooks/claude/coding-police.sh
+++ b/hooks/claude/coding-police.sh
@@ -260,11 +260,6 @@ check_duplicate_blocks() {
           biggest[run_first] = size
           echo_at[run_first] = run_here
         }
-        # Total duplicated LINES, not a count of runs. A run boundary is a
-        # property of layout — a normalised-away comment splits one — so
-        # counting runs let an unrelated deletion RAISE the number. Lines only
-        # go up when there is more duplicated text.
-        dup_lines[run_first] += size
         copies[run_first]++
         run = 0
       }
@@ -281,6 +276,14 @@ check_duplicate_blocks() {
         }
 
         if (block in seen) {
+          # Mark the LINES this window covers. Summing run lengths instead
+          # double-counted min-1 at every run boundary, and a boundary is a
+          # property of layout: deleting a blank line inside a region merged
+          # two runs and made the total FALL, which silently paid for new
+          # duplication elsewhere. A line marked twice is still one line.
+          for (d = 0; d < min; d++) {
+            dup_line[i + d] = 1
+          }
           first = seen[block]
           # The same region continues when both sides advanced together.
           if (run > 0 && i == prev_i + 1 && first == prev_first + 1) {
@@ -309,10 +312,12 @@ check_duplicate_blocks() {
       # reshuffled the pairing and reported untouched code. The question this
       # check exists to answer is whether the edit left MORE duplication.
       total = 0
+      for (d in dup_line) {
+        total++
+      }
       regions = 0
       top = 0
-      for (f in dup_lines) {
-        total += dup_lines[f]
+      for (f in copies) {
         regions++
         if (biggest[f] > top) {
           top = biggest[f]
@@ -320,7 +325,7 @@ check_duplicate_blocks() {
           top_echo = echo_at[f]
         }
       }
-      if (regions > 0) {
+      if (total > 0) {
         printf "DUPLICATE CODE: %d duplicated lines across %d region(s); the largest is %d+ lines, first at line %d, again at line %d. Extract into a shared function to keep code DRY.\n", total, regions, top, top_at, top_echo
       }
     }

--- a/hooks/claude/coding-police.sh
+++ b/hooks/claude/coding-police.sh
@@ -260,6 +260,11 @@ check_duplicate_blocks() {
           biggest[run_first] = size
           echo_at[run_first] = run_here
         }
+        # Total duplicated LINES, not a count of runs. A run boundary is a
+        # property of layout — a normalised-away comment splits one — so
+        # counting runs let an unrelated deletion RAISE the number. Lines only
+        # go up when there is more duplicated text.
+        dup_lines[run_first] += size
         copies[run_first]++
         run = 0
       }
@@ -298,8 +303,25 @@ check_duplicate_blocks() {
       # the severity. A repeated block used to emit one finding per repetition;
       # as a count it is both less noise and a metric the subtraction can
       # compare, so a THIRD copy of an existing pair still reports as worse.
-      for (f in copies) {
-        printf "DUPLICATE CODE: %d copies of a %d+ line block, first at line %d, again at line %d. Extract into a shared function to keep code DRY.\n", copies[f] + 1, biggest[f], f, echo_at[f]
+      # ONE finding for the file. Per-region findings all normalise to the
+      # same shape, so the subtraction could only pair them by position — and
+      # `for (f in ...)` has no defined order, so adding or removing any region
+      # reshuffled the pairing and reported untouched code. The question this
+      # check exists to answer is whether the edit left MORE duplication.
+      total = 0
+      regions = 0
+      top = 0
+      for (f in dup_lines) {
+        total += dup_lines[f]
+        regions++
+        if (biggest[f] > top) {
+          top = biggest[f]
+          top_at = f
+          top_echo = echo_at[f]
+        }
+      }
+      if (regions > 0) {
+        printf "DUPLICATE CODE: %d duplicated lines across %d region(s); the largest is %d+ lines, first at line %d, again at line %d. Extract into a shared function to keep code DRY.\n", total, regions, top, top_at, top_echo
       }
     }
   ' "$FILE_PATH" 2>/dev/null || true)
@@ -417,7 +439,7 @@ fi
 violation_shape() {
   printf '%s' "$1" | sed -E '
     s/^(FILE TOO LONG: )[0-9]+/\1#/
-    s/^(DUPLICATE CODE: )[0-9]+( copies of a )[0-9]+/\1#\2#/
+    s/^(DUPLICATE CODE: )[0-9]+( duplicated lines across )[0-9]+( region\(s\); the largest is )[0-9]+/\1#\2#\3#/
     s/(first at line )[0-9]+/\1#/
     s/(again at line )[0-9]+/\1#/
     s/^(TOO MANY EXPORTS: )[0-9]+/\1#/
@@ -439,7 +461,11 @@ violation_metric() {
   case "$1" in
     "FILE TOO LONG: "*) m=$(printf '%s' "$1" | sed -E 's/^FILE TOO LONG: ([0-9]+) lines.*/\1/') ;;
     "LONG FUNCTION: "*) m=$(printf '%s' "$1" | sed -E 's/^LONG FUNCTION: .* is ([0-9]+) lines.*/\1/') ;;
-    "DUPLICATE CODE: "*) m=$(printf '%s' "$1" | sed -E 's/^DUPLICATE CODE: ([0-9]+) copies.*/\1/') ;;
+    "DUPLICATE CODE: "*)
+      # Both dimensions: more copies OR a longer region must raise it, or
+      # newly duplicated code adjacent to an existing region reports nothing.
+      m=$(printf '%s' "$1" | sed -E 's/^DUPLICATE CODE: ([0-9]+) duplicated lines.*/\1/')
+      ;;
     "TOO MANY EXPORTS: "*) m=$(printf '%s' "$1" | sed -E 's/^TOO MANY EXPORTS: ([0-9]+) exports.*/\1/') ;;
     *) m=0 ;;
   esac

--- a/hooks/claude/coding-police.sh
+++ b/hooks/claude/coding-police.sh
@@ -253,7 +253,22 @@ check_duplicate_blocks() {
       norm[idx] = line
       orig[idx] = NR
     }
+    function flush() {
+      if (run > 0) {
+        size = min + run - 1
+        if (!(run_first in copies) || size > biggest[run_first]) {
+          biggest[run_first] = size
+          echo_at[run_first] = run_here
+        }
+        copies[run_first]++
+        run = 0
+      }
+    }
     END {
+      # ONE finding per duplicated REGION. The window slides by one, so a
+      # region of L lines used to emit L-min+1 near-identical findings — about
+      # one per line, which is what made the subtraction quadratic and took the
+      # hook past its 15s budget on ordinary files.
       for (i = 1; i <= idx - min + 1; i++) {
         block = ""
         for (k = 0; k < min; k++) {
@@ -262,14 +277,29 @@ check_duplicate_blocks() {
 
         if (block in seen) {
           first = seen[block]
-          key = first ":" orig[i]
-          if (!(key in reported)) {
-            reported[key] = 1
-            printf "DUPLICATE CODE: %d+ line block duplicated at lines %d and %d. Extract into a shared function to keep code DRY.\n", min, first, orig[i]
+          # The same region continues when both sides advanced together.
+          if (run > 0 && i == prev_i + 1 && first == prev_first + 1) {
+            run++
+          } else {
+            flush()
+            run = 1
+            run_first = first
+            run_here = orig[i]
           }
+          prev_i = i
+          prev_first = first
         } else {
           seen[block] = orig[i]
+          flush()
         }
+      }
+      flush()
+      # One finding per duplicated SOURCE region, with the number of copies as
+      # the severity. A repeated block used to emit one finding per repetition;
+      # as a count it is both less noise and a metric the subtraction can
+      # compare, so a THIRD copy of an existing pair still reports as worse.
+      for (f in copies) {
+        printf "DUPLICATE CODE: %d copies of a %d+ line block, first at line %d, again at line %d. Extract into a shared function to keep code DRY.\n", copies[f] + 1, biggest[f], f, echo_at[f]
       }
     }
   ' "$FILE_PATH" 2>/dev/null || true)
@@ -387,7 +417,9 @@ fi
 violation_shape() {
   printf '%s' "$1" | sed -E '
     s/^(FILE TOO LONG: )[0-9]+/\1#/
-    s/^(DUPLICATE CODE: )[0-9]+/\1#/
+    s/^(DUPLICATE CODE: )[0-9]+( copies of a )[0-9]+/\1#\2#/
+    s/(first at line )[0-9]+/\1#/
+    s/(again at line )[0-9]+/\1#/
     s/^(TOO MANY EXPORTS: )[0-9]+/\1#/
     s/( is )[0-9]+( lines)/\1#\2/
     s/(limit: )[0-9]+/\1#/
@@ -407,7 +439,7 @@ violation_metric() {
   case "$1" in
     "FILE TOO LONG: "*) m=$(printf '%s' "$1" | sed -E 's/^FILE TOO LONG: ([0-9]+) lines.*/\1/') ;;
     "LONG FUNCTION: "*) m=$(printf '%s' "$1" | sed -E 's/^LONG FUNCTION: .* is ([0-9]+) lines.*/\1/') ;;
-    "DUPLICATE CODE: "*) m=$(printf '%s' "$1" | sed -E 's/^DUPLICATE CODE: ([0-9]+)\+ line.*/\1/') ;;
+    "DUPLICATE CODE: "*) m=$(printf '%s' "$1" | sed -E 's/^DUPLICATE CODE: ([0-9]+) copies.*/\1/') ;;
     "TOO MANY EXPORTS: "*) m=$(printf '%s' "$1" | sed -E 's/^TOO MANY EXPORTS: ([0-9]+) exports.*/\1/') ;;
     *) m=0 ;;
   esac

--- a/plugins-cc/agentkit/hooks/coding-police.sh
+++ b/plugins-cc/agentkit/hooks/coding-police.sh
@@ -260,11 +260,6 @@ check_duplicate_blocks() {
           biggest[run_first] = size
           echo_at[run_first] = run_here
         }
-        # Total duplicated LINES, not a count of runs. A run boundary is a
-        # property of layout — a normalised-away comment splits one — so
-        # counting runs let an unrelated deletion RAISE the number. Lines only
-        # go up when there is more duplicated text.
-        dup_lines[run_first] += size
         copies[run_first]++
         run = 0
       }
@@ -281,6 +276,14 @@ check_duplicate_blocks() {
         }
 
         if (block in seen) {
+          # Mark the LINES this window covers. Summing run lengths instead
+          # double-counted min-1 at every run boundary, and a boundary is a
+          # property of layout: deleting a blank line inside a region merged
+          # two runs and made the total FALL, which silently paid for new
+          # duplication elsewhere. A line marked twice is still one line.
+          for (d = 0; d < min; d++) {
+            dup_line[i + d] = 1
+          }
           first = seen[block]
           # The same region continues when both sides advanced together.
           if (run > 0 && i == prev_i + 1 && first == prev_first + 1) {
@@ -309,10 +312,12 @@ check_duplicate_blocks() {
       # reshuffled the pairing and reported untouched code. The question this
       # check exists to answer is whether the edit left MORE duplication.
       total = 0
+      for (d in dup_line) {
+        total++
+      }
       regions = 0
       top = 0
-      for (f in dup_lines) {
-        total += dup_lines[f]
+      for (f in copies) {
         regions++
         if (biggest[f] > top) {
           top = biggest[f]
@@ -320,7 +325,7 @@ check_duplicate_blocks() {
           top_echo = echo_at[f]
         }
       }
-      if (regions > 0) {
+      if (total > 0) {
         printf "DUPLICATE CODE: %d duplicated lines across %d region(s); the largest is %d+ lines, first at line %d, again at line %d. Extract into a shared function to keep code DRY.\n", total, regions, top, top_at, top_echo
       }
     }

--- a/plugins-cc/agentkit/hooks/coding-police.sh
+++ b/plugins-cc/agentkit/hooks/coding-police.sh
@@ -260,6 +260,11 @@ check_duplicate_blocks() {
           biggest[run_first] = size
           echo_at[run_first] = run_here
         }
+        # Total duplicated LINES, not a count of runs. A run boundary is a
+        # property of layout — a normalised-away comment splits one — so
+        # counting runs let an unrelated deletion RAISE the number. Lines only
+        # go up when there is more duplicated text.
+        dup_lines[run_first] += size
         copies[run_first]++
         run = 0
       }
@@ -298,8 +303,25 @@ check_duplicate_blocks() {
       # the severity. A repeated block used to emit one finding per repetition;
       # as a count it is both less noise and a metric the subtraction can
       # compare, so a THIRD copy of an existing pair still reports as worse.
-      for (f in copies) {
-        printf "DUPLICATE CODE: %d copies of a %d+ line block, first at line %d, again at line %d. Extract into a shared function to keep code DRY.\n", copies[f] + 1, biggest[f], f, echo_at[f]
+      # ONE finding for the file. Per-region findings all normalise to the
+      # same shape, so the subtraction could only pair them by position — and
+      # `for (f in ...)` has no defined order, so adding or removing any region
+      # reshuffled the pairing and reported untouched code. The question this
+      # check exists to answer is whether the edit left MORE duplication.
+      total = 0
+      regions = 0
+      top = 0
+      for (f in dup_lines) {
+        total += dup_lines[f]
+        regions++
+        if (biggest[f] > top) {
+          top = biggest[f]
+          top_at = f
+          top_echo = echo_at[f]
+        }
+      }
+      if (regions > 0) {
+        printf "DUPLICATE CODE: %d duplicated lines across %d region(s); the largest is %d+ lines, first at line %d, again at line %d. Extract into a shared function to keep code DRY.\n", total, regions, top, top_at, top_echo
       }
     }
   ' "$FILE_PATH" 2>/dev/null || true)
@@ -417,7 +439,7 @@ fi
 violation_shape() {
   printf '%s' "$1" | sed -E '
     s/^(FILE TOO LONG: )[0-9]+/\1#/
-    s/^(DUPLICATE CODE: )[0-9]+( copies of a )[0-9]+/\1#\2#/
+    s/^(DUPLICATE CODE: )[0-9]+( duplicated lines across )[0-9]+( region\(s\); the largest is )[0-9]+/\1#\2#\3#/
     s/(first at line )[0-9]+/\1#/
     s/(again at line )[0-9]+/\1#/
     s/^(TOO MANY EXPORTS: )[0-9]+/\1#/
@@ -439,7 +461,11 @@ violation_metric() {
   case "$1" in
     "FILE TOO LONG: "*) m=$(printf '%s' "$1" | sed -E 's/^FILE TOO LONG: ([0-9]+) lines.*/\1/') ;;
     "LONG FUNCTION: "*) m=$(printf '%s' "$1" | sed -E 's/^LONG FUNCTION: .* is ([0-9]+) lines.*/\1/') ;;
-    "DUPLICATE CODE: "*) m=$(printf '%s' "$1" | sed -E 's/^DUPLICATE CODE: ([0-9]+) copies.*/\1/') ;;
+    "DUPLICATE CODE: "*)
+      # Both dimensions: more copies OR a longer region must raise it, or
+      # newly duplicated code adjacent to an existing region reports nothing.
+      m=$(printf '%s' "$1" | sed -E 's/^DUPLICATE CODE: ([0-9]+) duplicated lines.*/\1/')
+      ;;
     "TOO MANY EXPORTS: "*) m=$(printf '%s' "$1" | sed -E 's/^TOO MANY EXPORTS: ([0-9]+) exports.*/\1/') ;;
     *) m=0 ;;
   esac

--- a/plugins-cc/agentkit/hooks/coding-police.sh
+++ b/plugins-cc/agentkit/hooks/coding-police.sh
@@ -253,7 +253,22 @@ check_duplicate_blocks() {
       norm[idx] = line
       orig[idx] = NR
     }
+    function flush() {
+      if (run > 0) {
+        size = min + run - 1
+        if (!(run_first in copies) || size > biggest[run_first]) {
+          biggest[run_first] = size
+          echo_at[run_first] = run_here
+        }
+        copies[run_first]++
+        run = 0
+      }
+    }
     END {
+      # ONE finding per duplicated REGION. The window slides by one, so a
+      # region of L lines used to emit L-min+1 near-identical findings — about
+      # one per line, which is what made the subtraction quadratic and took the
+      # hook past its 15s budget on ordinary files.
       for (i = 1; i <= idx - min + 1; i++) {
         block = ""
         for (k = 0; k < min; k++) {
@@ -262,14 +277,29 @@ check_duplicate_blocks() {
 
         if (block in seen) {
           first = seen[block]
-          key = first ":" orig[i]
-          if (!(key in reported)) {
-            reported[key] = 1
-            printf "DUPLICATE CODE: %d+ line block duplicated at lines %d and %d. Extract into a shared function to keep code DRY.\n", min, first, orig[i]
+          # The same region continues when both sides advanced together.
+          if (run > 0 && i == prev_i + 1 && first == prev_first + 1) {
+            run++
+          } else {
+            flush()
+            run = 1
+            run_first = first
+            run_here = orig[i]
           }
+          prev_i = i
+          prev_first = first
         } else {
           seen[block] = orig[i]
+          flush()
         }
+      }
+      flush()
+      # One finding per duplicated SOURCE region, with the number of copies as
+      # the severity. A repeated block used to emit one finding per repetition;
+      # as a count it is both less noise and a metric the subtraction can
+      # compare, so a THIRD copy of an existing pair still reports as worse.
+      for (f in copies) {
+        printf "DUPLICATE CODE: %d copies of a %d+ line block, first at line %d, again at line %d. Extract into a shared function to keep code DRY.\n", copies[f] + 1, biggest[f], f, echo_at[f]
       }
     }
   ' "$FILE_PATH" 2>/dev/null || true)
@@ -387,7 +417,9 @@ fi
 violation_shape() {
   printf '%s' "$1" | sed -E '
     s/^(FILE TOO LONG: )[0-9]+/\1#/
-    s/^(DUPLICATE CODE: )[0-9]+/\1#/
+    s/^(DUPLICATE CODE: )[0-9]+( copies of a )[0-9]+/\1#\2#/
+    s/(first at line )[0-9]+/\1#/
+    s/(again at line )[0-9]+/\1#/
     s/^(TOO MANY EXPORTS: )[0-9]+/\1#/
     s/( is )[0-9]+( lines)/\1#\2/
     s/(limit: )[0-9]+/\1#/
@@ -407,7 +439,7 @@ violation_metric() {
   case "$1" in
     "FILE TOO LONG: "*) m=$(printf '%s' "$1" | sed -E 's/^FILE TOO LONG: ([0-9]+) lines.*/\1/') ;;
     "LONG FUNCTION: "*) m=$(printf '%s' "$1" | sed -E 's/^LONG FUNCTION: .* is ([0-9]+) lines.*/\1/') ;;
-    "DUPLICATE CODE: "*) m=$(printf '%s' "$1" | sed -E 's/^DUPLICATE CODE: ([0-9]+)\+ line.*/\1/') ;;
+    "DUPLICATE CODE: "*) m=$(printf '%s' "$1" | sed -E 's/^DUPLICATE CODE: ([0-9]+) copies.*/\1/') ;;
     "TOO MANY EXPORTS: "*) m=$(printf '%s' "$1" | sed -E 's/^TOO MANY EXPORTS: ([0-9]+) exports.*/\1/') ;;
     *) m=0 ;;
   esac

--- a/tests/coding-police-hook.test.ts
+++ b/tests/coding-police-hook.test.ts
@@ -101,7 +101,9 @@ function runHook(config: string, shimBin?: (directory: string) => void) {
 function expectConfiguredThresholds(stderr: string): void {
   expect(stderr).toContain('FILE TOO LONG: 8 lines (limit: 5');
   expect(stderr).toContain('LONG FUNCTION: `alpha` is 4 lines (limit: 2');
-  expect(stderr).toContain('DUPLICATE CODE: 2+ line block');
+  // The threshold is what this pins; the count and wording are the check's
+  // own business.
+  expect(stderr).toContain('of a 2+ line block');
   expect(stderr).toContain('TOO MANY EXPORTS: 2 exports in this file (limit: 1');
 }
 
@@ -257,5 +259,50 @@ describe('Claude coding-police monolith directory', () => {
 
     expect(result.status, result.stderr).toBe(result.stderr.includes("VIOLATION") ? 2 : 0);
     expect(result.stderr).not.toContain('MONOLITH DIRECTORY');
+  });
+});
+
+describe('Claude coding-police duplicate reporting is bounded', () => {
+  const run = (file: string) =>
+    spawnSync('bash', [hook], {
+      input: JSON.stringify({ tool_name: 'Edit', tool_input: { file_path: file, new_string: 'x' } }),
+      encoding: 'utf-8',
+    });
+
+  test('a repeated block is ONE finding, not one per repetition', () => {
+    // The window slides by one, so a duplicated region used to emit roughly one
+    // finding per line: 1489 of them on a 1500-line file, which made the
+    // subtraction quadratic and took the hook past its 15s registered budget.
+    const dir = mkdtempSync(join(tmpdir(), 'agentkit-dupcost-'));
+    const file = join(dir, 'big.ts');
+    const block = 'const a = 1;\nconst b = 2;\nconst c = 3;\nconst d = 4;\nconst e = 5;\nconst f = 6;\n';
+    writeFileSync(file, block.repeat(250));
+    const started = Date.now();
+    const out = `${run(file).stdout ?? ''}${run(file).stderr ?? ''}`;
+    const elapsed = Date.now() - started;
+    const findings = out.split('\n').filter((l) => l.includes('DUPLICATE CODE')).length;
+    expect(findings).toBe(1);
+    // Two runs; the registered timeout for this hook is 15s for one.
+    expect(elapsed).toBeLessThan(10_000);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('the copy count is the severity, so another copy still reports', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'agentkit-dupcount-'));
+    const file = join(dir, 'd.ts');
+    const git = (...a: string[]) => spawnSync('git', a, { cwd: dir, encoding: 'utf-8' });
+    git('init', '-q');
+    git('config', 'user.email', 't@t.t');
+    git('config', 'user.name', 't');
+    const block = (t: string) => `const ${t}0 = 0;\nconst a = 1;\nconst b = 2;\nconst c = 3;\nconst d = 4;\nconst e = 5;\nconst f = 6;\n`;
+    writeFileSync(file, `${block('x')}${block('y')}`);
+    git('add', '-A');
+    git('commit', '-qm', 'two copies already here');
+    expect(run(file).status).toBe(0);
+    writeFileSync(file, `${block('x')}${block('y')}${block('z')}`);
+    const worse = run(file);
+    expect(`${worse.stdout ?? ''}${worse.stderr ?? ''}`).toContain('DUPLICATE CODE');
+    expect(worse.status).toBe(2);
+    rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/tests/coding-police-hook.test.ts
+++ b/tests/coding-police-hook.test.ts
@@ -101,9 +101,9 @@ function runHook(config: string, shimBin?: (directory: string) => void) {
 function expectConfiguredThresholds(stderr: string): void {
   expect(stderr).toContain('FILE TOO LONG: 8 lines (limit: 5');
   expect(stderr).toContain('LONG FUNCTION: `alpha` is 4 lines (limit: 2');
-  // The threshold is what this pins; the count and wording are the check's
-  // own business.
-  expect(stderr).toContain('of a 2+ line block');
+  // The configured minimum is what this pins; the wording is the check's own
+  // business.
+  expect(stderr).toContain('the largest is 2+ lines');
   expect(stderr).toContain('TOO MANY EXPORTS: 2 exports in this file (limit: 1');
 }
 
@@ -269,6 +269,19 @@ describe('Claude coding-police duplicate reporting is bounded', () => {
       encoding: 'utf-8',
     });
 
+  const block = (tag: string, n: number) =>
+    Array.from({ length: n }, (_, i) => `const ${tag}${i} = ${i};`).join('\n') + '\n';
+
+  const dupRepo = () => {
+    const dir = mkdtempSync(join(tmpdir(), 'agentkit-dup-'));
+    const file = join(dir, 'd.ts');
+    const git = (...a: string[]) => spawnSync('git', a, { cwd: dir, encoding: 'utf-8' });
+    git('init', '-q');
+    git('config', 'user.email', 't@t.t');
+    git('config', 'user.name', 't');
+    return { dir, file, git };
+  };
+
   test('a repeated block is ONE finding, not one per repetition', () => {
     // The window slides by one, so a duplicated region used to emit roughly one
     // finding per line: 1489 of them on a 1500-line file, which made the
@@ -287,22 +300,54 @@ describe('Claude coding-police duplicate reporting is bounded', () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  test('the copy count is the severity, so another copy still reports', () => {
-    const dir = mkdtempSync(join(tmpdir(), 'agentkit-dupcount-'));
-    const file = join(dir, 'd.ts');
-    const git = (...a: string[]) => spawnSync('git', a, { cwd: dir, encoding: 'utf-8' });
-    git('init', '-q');
-    git('config', 'user.email', 't@t.t');
-    git('config', 'user.name', 't');
-    const block = (t: string) => `const ${t}0 = 0;\nconst a = 1;\nconst b = 2;\nconst c = 3;\nconst d = 4;\nconst e = 5;\nconst f = 6;\n`;
-    writeFileSync(file, `${block('x')}${block('y')}`);
+  test('the reported region size is the real one, not the window minimum', () => {
+    // Without coalescing every sliding-window position is its own match, so
+    // the largest region reads as the configured minimum however much code is
+    // actually duplicated — and the size is what tells you what to extract.
+    const dir = mkdtempSync(join(tmpdir(), 'agentkit-dupsize-'));
+    const file = join(dir, 'big.ts');
+    const P = Array.from({ length: 48 }, (_, i) => `const p${i} = ${i};`).join('\n') + '\n';
+    writeFileSync(file, `${P}const z = 0;\n${P}`);
+    const out = `${run(file).stdout ?? ''}${run(file).stderr ?? ''}`;
+    const m = out.match(/the largest is (\d+)\+ lines/);
+    expect(m).not.toBeNull();
+    expect(Number(m![1])).toBeGreaterThan(40);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('MORE duplicated text reports, even adjacent to an existing region', () => {
+    // The first cut coalesced regions but kept only the copy COUNT as
+    // severity, so 40 lines that became duplicated next to an existing
+    // duplicate were byte-identical in shape and equal in metric — silent.
+    const { dir, file, git } = dupRepo();
+    const P = block('p', 8);
+    const Q = block('q', 40);
+    writeFileSync(file, `${P}${Q}const z1 = 9;\n${P}const z2 = 9;\n`);
     git('add', '-A');
-    git('commit', '-qm', 'two copies already here');
+    git('commit', '-qm', 'P is duplicated, Q is not');
     expect(run(file).status).toBe(0);
-    writeFileSync(file, `${block('x')}${block('y')}${block('z')}`);
+    // Q is now duplicated too.
+    writeFileSync(file, `${P}${Q}const z1 = 9;\n${P}${Q}const z2 = 9;\n`);
     const worse = run(file);
     expect(`${worse.stdout ?? ''}${worse.stderr ?? ''}`).toContain('DUPLICATE CODE');
     expect(worse.status).toBe(2);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('LESS duplicated text is silent, whatever it does to region layout', () => {
+    // Counting regions or runs made this report: a deletion merges or splits
+    // runs, which is a property of layout rather than of how much duplication
+    // exists. Total duplicated lines only falls when there is less of it.
+    const { dir, file, git } = dupRepo();
+    const P = block('p', 8);
+    writeFileSync(file, `${P}const a = 9;\n${P}const b = 9;\n${P}const c = 9;\n`);
+    git('add', '-A');
+    git('commit', '-qm', 'three copies');
+    expect(run(file).status).toBe(0);
+    writeFileSync(file, `${P}const a = 9;\n${P}const c = 9;\n`);
+    const better = run(file);
+    expect(`${better.stdout ?? ''}${better.stderr ?? ''}`).not.toContain('DUPLICATE CODE');
+    expect(better.status).toBe(0);
     rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/tests/coding-police-hook.test.ts
+++ b/tests/coding-police-hook.test.ts
@@ -282,7 +282,7 @@ describe('Claude coding-police duplicate reporting is bounded', () => {
     return { dir, file, git };
   };
 
-  test('a repeated block is ONE finding, not one per repetition', () => {
+  test('a pathological file stays far inside the hook timeout', () => {
     // The window slides by one, so a duplicated region used to emit roughly one
     // finding per line: 1489 of them on a 1500-line file, which made the
     // subtraction quadratic and took the hook past its 15s registered budget.
@@ -294,8 +294,9 @@ describe('Claude coding-police duplicate reporting is bounded', () => {
     const out = `${run(file).stdout ?? ''}${run(file).stderr ?? ''}`;
     const elapsed = Date.now() - started;
     const findings = out.split('\n').filter((l) => l.includes('DUPLICATE CODE')).length;
+    // The count assertion is near-tautological under one-finding-per-file; the
+    // bound is what carries weight. hooks.json registers 15s for ONE run.
     expect(findings).toBe(1);
-    // Two runs; the registered timeout for this hook is 15s for one.
     expect(elapsed).toBeLessThan(10_000);
     rmSync(dir, { recursive: true, force: true });
   });
@@ -334,20 +335,62 @@ describe('Claude coding-police duplicate reporting is bounded', () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  test('LESS duplicated text is silent, whatever it does to region layout', () => {
-    // Counting regions or runs made this report: a deletion merges or splits
-    // runs, which is a property of layout rather than of how much duplication
-    // exists. Total duplicated lines only falls when there is less of it.
+  test('LESS duplicated text is silent even when the edit MERGES runs', () => {
+    // A run breaks on a normalised-away line inside the FIRST copy, so removing
+    // one merges two runs. Summing run lengths counted min-1 twice at that
+    // boundary, so the merge alone lowered the total — a refund that could pay
+    // for new duplication. The earlier fixture could not catch it: with no
+    // interior gaps it was monotone-down under every candidate metric.
     const { dir, file, git } = dupRepo();
-    const P = block('p', 8);
-    writeFileSync(file, `${P}const a = 9;\n${P}const b = 9;\n${P}const c = 9;\n`);
+    const R = block('r', 20).trimEnd().split('\n');
+    const split = `${R.slice(0, 7).join('\n')}\n\n${R.slice(7, 13).join('\n')}\n\n${R.slice(13).join('\n')}\n`;
+    const flat = `${R.join('\n')}\n`;
+    writeFileSync(file, `${split}const z1 = 9;\n${flat}const z2 = 9;\n${flat}`);
     git('add', '-A');
-    git('commit', '-qm', 'three copies');
+    git('commit', '-qm', 'three copies, gaps inside the first');
     expect(run(file).status).toBe(0);
-    writeFileSync(file, `${P}const a = 9;\n${P}const c = 9;\n`);
+    // Gaps removed AND a copy deleted: strictly less duplicated text.
+    writeFileSync(file, `${flat}const z1 = 9;\n${flat}`);
     const better = run(file);
     expect(`${better.stdout ?? ''}${better.stderr ?? ''}`).not.toContain('DUPLICATE CODE');
     expect(better.status).toBe(0);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('a THIRD copy of an existing pair reports', () => {
+    // Kills the max class: a metric that keeps only the largest region, rather
+    // than how much is duplicated, is unmoved by another copy of the same size.
+    const { dir, file, git } = dupRepo();
+    const P = block('p', 10);
+    writeFileSync(file, `${P}const z1 = 9;\n${P}`);
+    git('add', '-A');
+    git('commit', '-qm', 'two copies');
+    expect(run(file).status).toBe(0);
+    writeFileSync(file, `${P}const z1 = 9;\n${P}const z2 = 9;\n${P}`);
+    const worse = run(file);
+    expect(`${worse.stdout ?? ''}${worse.stderr ?? ''}`).toContain('DUPLICATE CODE');
+    expect(worse.status).toBe(2);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('removing interior gaps does not refund NEW duplication elsewhere', () => {
+    // The R2-1 fixture: duplication genuinely rises 20 -> 28 lines while two
+    // blank lines come out of the first copy. Summing run lengths read the
+    // baseline as 30 and the edit as 28, so the subtraction absorbed it and
+    // said nothing.
+    const { dir, file, git } = dupRepo();
+    const R = block('r', 20).trimEnd().split('\n');
+    const M = block('m', 8);
+    const split = `${R.slice(0, 7).join('\n')}\n\n${R.slice(7, 13).join('\n')}\n\n${R.slice(13).join('\n')}\n`;
+    const flat = `${R.join('\n')}\n`;
+    writeFileSync(file, `${split}const z1 = 9;\n${flat}`);
+    git('add', '-A');
+    git('commit', '-qm', 'R duplicated once, gaps inside the first copy');
+    expect(run(file).status).toBe(0);
+    writeFileSync(file, `${flat}const z1 = 9;\n${flat}const z2 = 9;\n${M}const z3 = 9;\n${M}`);
+    const worse = run(file);
+    expect(`${worse.stdout ?? ''}${worse.stderr ?? ''}`).toContain('DUPLICATE CODE');
+    expect(worse.status).toBe(2);
     rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/tests/comment-police-hook.test.ts
+++ b/tests/comment-police-hook.test.ts
@@ -191,27 +191,6 @@ describe("the hooks run on the bash the target platform actually ships", () => {
   });
 });
 
-describe("git-police works on a stock install", () => {
-  test("a force push is denied with no agentkit config present", () => {
-    // `[[ -f $CONFIG ]] || return` propagated status 1 into `set -e`, so the
-    // hook exited 1 with ZERO output before any guard ran — and a hook that
-    // emits no decision is read as ALLOW. Every protection in it was off for
-    // anyone who had never written a config file.
-    const empty = mkdtempSync(join(tmpdir(), "agentkit-noconfig-"));
-    const r = spawnSync("bash", [join(repoRoot, "hooks", "claude", "git-police.sh")], {
-      input: JSON.stringify({
-        tool_name: "Bash",
-        tool_input: { command: "git push --force origin main" },
-        session_id: "t",
-      }),
-      encoding: "utf-8",
-      env: { ...process.env, XDG_CONFIG_HOME: empty },
-    });
-    expect(`${r.stdout ?? ""}`).toContain('"permissionDecision": "deny"');
-    rmSync(empty, { recursive: true, force: true });
-  });
-});
-
 describe("blocking hooks have a way off and a bounded blast radius", () => {
   const hooks = ["comment-police", "coding-police", "format-police"];
 

--- a/tests/git-police.test.ts
+++ b/tests/git-police.test.ts
@@ -1,7 +1,10 @@
 import { describe, test, expect, mock } from 'bun:test';
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import gitPolice from '../plugins/git-police';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+const repoRoot = dirname(import.meta.dir);
 
 const mockCtx = { client: {}, project: {}, directory: '/tmp', worktree: '/tmp', serverUrl: new URL('http://localhost'), $: {} } as any;
 
@@ -198,5 +201,39 @@ describe('git-police', () => {
     const input = { tool: 'edit', sessionID: 'test', callID: 'test' };
     const output = { args: { command: 'git push --force origin main' } };
     expect(hooks['tool.execute.before']!(input, output)).resolves.toBeUndefined();
+  });
+});
+
+describe("git-police works on a stock install", () => {
+  test("a force push is denied with no agentkit config present", () => {
+    // `[[ -f $CONFIG ]] || return` propagated status 1 into `set -e`, so the
+    // hook exited 1 with ZERO output before any guard ran — and a hook that
+    // emits no decision is read as ALLOW. Every protection in it was off for
+    // anyone who had never written a config file.
+    const empty = mkdtempSync(join(tmpdir(), "agentkit-noconfig-"));
+    const r = spawnSync("bash", [join(repoRoot, "hooks", "claude", "git-police.sh")], {
+      input: JSON.stringify({
+        tool_name: "Bash",
+        tool_input: { command: "git push --force origin main" },
+        session_id: "t",
+      }),
+      encoding: "utf-8",
+      env: { ...process.env, XDG_CONFIG_HOME: empty },
+    });
+    expect(`${r.stdout ?? ""}`).toContain('"permissionDecision": "deny"');
+    // ...and only the right things: a hook that denied everything would also
+    // satisfy the assertion above.
+    const benign = spawnSync("bash", [join(repoRoot, "hooks", "claude", "git-police.sh")], {
+      input: JSON.stringify({
+        tool_name: "Bash",
+        tool_input: { command: "git status" },
+        session_id: "t",
+      }),
+      encoding: "utf-8",
+      env: { ...process.env, XDG_CONFIG_HOME: empty },
+    });
+    expect(`${benign.stdout ?? ""}`).not.toContain("permissionDecision");
+    expect(benign.status).toBe(0);
+    rmSync(empty, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
Closes the cost half of #90, and folds in two of #93's three items (same repo, so same branch).

## The defect

`check_duplicate_blocks` slides a `min`-line window across the file and emitted a finding for **every matching window position**. One duplicated region of L lines therefore produced L−min+1 near-identical findings — about one per line.

That list is what the baseline subtraction is quadratic in, and it took the hook past the **15 second** timeout registered in `hooks.json` (not the 60s default earlier rounds reasoned against). Past that the hook is killed, emits no decision, and the harness reads silence as ALLOW — on an ordinary 1200-line file.

Three previous attempts capped the *symptom*, and each introduced a new silent failure (measurements in #90). This fixes the source.

## The fix

Overlapping matches coalesce into one finding per duplicated **source region**, and the number of copies becomes the severity.

| fixture | findings | wall clock |
|---|---|---|
| 1500-line duplicate-heavy, before | 1489 | 26.6s |
| 1500-line, after | **1** | **0.03s** |
| 3000-line, after | 1 | 0.03s |

Flat, not quadratic — the budget is no longer reachable by input size.

## A second thing it fixes

The `DUPLICATE CODE` metric used to be `MIN_DUPLICATE_LINES`, a **constant**. Every duplicate finding had an identical shape *and* an identical metric, so the subtraction degenerated into counting entries. With the copy count as the metric, a third copy of an existing pair is a metric increase — which is what makes it report, through the ordinary "worse than baseline" path rather than a special case.

Message becomes: `DUPLICATE CODE: 3 copies of a 11+ line block, first at line 1, again at line 7.`

## Folded in from #93

- The stock-install git-police test moves from `comment-police-hook.test.ts` to `tests/git-police.test.ts`, where it belongs — and gains the negative case it was missing. It passed against a hook that denied **everything**; it now fails against one.
- A config test pinned the exact duplicate wording. It pins the configured threshold instead, which is what it exists to check.

Still open on #93: nothing provisions a bash 3.2 binary, so the real-parse test skips off this machine.

## Verification

470 pass, 0 fail. Three mutations, each killed by exactly one test:

- dropping the coalescing → the one-finding test fails
- pinning the copy count to a constant → the third-copy test fails
- denying everything in git-police → the stock-install test fails

Prior behaviour re-checked with the standing repro scripts: the wedge cases, the shrink cases and the digit-named-function fail-open all still behave.
