### PR TITLE
docs(coding-discipline): remove the worktree when its branch merges

### DIFF
--- a/instructions/coding-discipline.md
+++ b/instructions/coding-discipline.md
@@ -93,6 +93,25 @@ git branch -vv | awk '/: gone]/ {print $1}' | xargs -r git branch -D
   branch in a squash-merge repo (the follow-up MR will conflict once the first one squashes).
 - At most one feature branch alive per repo at a time, mirroring the mr-police limit.
 
+If the branch had a worktree, **remove the worktree in the same breath as merging it** — a merged
+worktree is a stale checkout of code that no longer exists anywhere else, and they accumulate far
+more quietly than branches do. `git worktree remove` deletes only the checkout; the branch ref
+survives, so this is safe whenever the tree is clean:
+
+```bash
+git worktree list                       # audit BEFORE removing anything
+git -C <worktree> status --porcelain    # must be empty — uncommitted work dies with the checkout
+git worktree remove <worktree>
+git worktree prune
+```
+
+- **Never remove a worktree with a dirty status.** Commit, stash, or leave it and say so — the
+  branch ref will not save uncommitted or untracked files.
+- Audit the whole list, not just the one you just merged. A repo worked by several agents
+  accumulates worktrees from sessions that ended without cleaning up.
+- Worktrees under a harness-managed directory (`.claude/worktrees/`, a scratch dir belonging to
+  another session) are not yours to remove — another agent may be mid-turn inside one.
+
 ## Source
 
 Adapted from Mnimiy's "12-rule CLAUDE.md template"


### PR DESCRIPTION
Branch Hygiene covered deleting the branch after a merge but said nothing about the worktree.

- worktrees accumulate more quietly than branches — a merged one is a stale checkout of code that exists nowhere else
- audit-first recipe; `git worktree remove` deletes only the checkout, so the branch ref survives
- remove only on a clean status — the branch ref does not save uncommitted or untracked files
- leave harness-managed (`.claude/worktrees/`) and other-session worktrees alone; another agent may be mid-turn

Prompted by a live cleanup on `bizfoundry/neutron`: 22 worktrees, 14 of them merged and stale, one carrying 13 uncommitted files that a naive sweep would have destroyed.

Docs only. `bun test`: 468 pass, 5 skip (systemd containment, needs real systemd), 0 fail.