### PR TITLE
feat: run each agent CLI session in its own systemd scope

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,6 +19,9 @@ Options:
                        copying hooks/skills and merging settings.json. The two
                        modes are mutually exclusive — plugin hooks.json on top
                        of settings.json hooks would fire every hook twice.
+  --no-session-scope   Global only: skip the per-session resource shims that
+                       run each agent CLI in its own systemd scope, and leave
+                       ~/.bashrc untouched.
   target-project-dir   Project directory to install into (default: current dir)
 
 Global install locations:
@@ -46,11 +49,13 @@ USAGE
 }
 
 CLAUDE_PLUGIN=false
+SESSION_SCOPE=true
 for arg in "$@"; do
 	case "$arg" in
 	-h | --help) usage ;;
 	--global) GLOBAL=true ;;
 	--claude-plugin) CLAUDE_PLUGIN=true ;;
+	--no-session-scope) SESSION_SCOPE=false ;;
 	*) TARGET_DIR="$arg" ;;
 	esac
 done
@@ -514,6 +519,83 @@ install_tools() {
 	fi
 }
 
+# ─── Per-Session Resource Shims ──────────────────────────────────────────────
+
+readonly SESSION_RUNTIMES=(claude codex opencode grok)
+
+install_session_shims() {
+	local shim_dir="$1"
+	local tools_dir="$2"
+	local created=0
+
+	if [[ ! -x "$tools_dir/agent-session" ]]; then
+		echo "[shims] Skipped: agent-session not installed"
+		return 0
+	fi
+
+	mkdir -p "$shim_dir"
+
+	local runtime real
+	for runtime in "${SESSION_RUNTIMES[@]}"; do
+		# Without dropping the shim dir, a re-install resolves its own shim.
+		real="$(PATH="$(path_without "$shim_dir")" command -v "$runtime" 2>/dev/null || true)"
+		if [[ -z "$real" ]]; then
+			[[ -L "$shim_dir/$runtime" ]] && rm -f "$shim_dir/$runtime"
+			continue
+		fi
+
+		ln -sf "$tools_dir/agent-session" "$shim_dir/$runtime"
+		echo "[shims] Scoping: $runtime -> $real"
+		created=$((created + 1))
+	done
+
+	if [[ "$created" -eq 0 ]]; then
+		echo "[shims] No supported agent runtimes found on PATH"
+	fi
+}
+
+path_without() {
+	local drop="$1"
+	local entry out=""
+	local saved_ifs="$IFS"
+	IFS=:
+	# shellcheck disable=SC2086
+	set -- $PATH
+	IFS="$saved_ifs"
+
+	for entry in "$@"; do
+		[[ -n "$entry" ]] || continue
+		[[ "$entry" == "$drop" ]] && continue
+		out="${out:+$out:}$entry"
+	done
+	printf '%s' "$out"
+}
+
+# Markers keep repeated installs idempotent and the block cleanly removable.
+install_shim_path() {
+	local shim_dir="$1"
+	local rc_file="$2"
+	local begin="# >>> agentkit session shims >>>"
+	local end="# <<< agentkit session shims <<<"
+
+	if [[ -f "$rc_file" ]] && grep -Fq "$begin" "$rc_file"; then
+		echo "[shims] PATH entry already present in $rc_file"
+		return 0
+	fi
+
+	{
+		printf '\n%s\n' "$begin"
+		printf '# Runs each agent CLI session in its own systemd scope.\n'
+		printf 'case ":$PATH:" in\n'
+		printf '  *":%s:"*) ;;\n' "$shim_dir"
+		printf '  *) PATH="%s:$PATH" ;;\n' "$shim_dir"
+		printf 'esac\n'
+		printf '%s\n' "$end"
+	} >>"$rc_file"
+
+	echo "[shims] Added PATH entry to $rc_file"
+}
+
 # ─── Codex CLI: Starlark .rules Files ────────────────────────────────────────
 
 install_codex_policies() {
@@ -667,6 +749,15 @@ if [[ "$GLOBAL" == true ]]; then
 	install_tools "$CLAUDE_TOOLS"
 	echo ""
 
+	# ── Per-session resource scoping ──
+	SESSION_SHIMS="${XDG_DATA_HOME:-$HOME/.local/share}/agentkit/shims"
+	if [[ "$SESSION_SCOPE" == true ]]; then
+		echo "--- Per-session resource scoping ---"
+		install_session_shims "$SESSION_SHIMS" "$PATH_TOOLS"
+		install_shim_path "$SESSION_SHIMS" "$HOME/.bashrc"
+		echo ""
+	fi
+
 	# ── Codex CLI ──
 	CODEX_RULES="$HOME/.codex/rules"
 	CODEX_PROMPTS="$HOME/.codex/prompts"
@@ -687,6 +778,7 @@ if [[ "$GLOBAL" == true ]]; then
 	echo "  OpenCode:        $OPENCODE_PLUGINS/ (auto-loaded)"
 	echo "  Claude Code:     $CLAUDE_MODE"
 	echo "  PATH tools:      $PATH_TOOLS/"
+	[[ "$SESSION_SCOPE" == true ]] && echo "  Session shims:   $SESSION_SHIMS/ (prepended to PATH in ~/.bashrc)"
 	echo "  Claude tools:    $CLAUDE_TOOLS/"
 	echo "  Codex CLI:       $CODEX_RULES/ (auto-loaded), $CODEX_PROMPTS/ (/name prompts)"
 

--- a/tests/session/agent-session.test.ts
+++ b/tests/session/agent-session.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const repoRoot = dirname(dirname(import.meta.dir));
+const shim = join(repoRoot, 'tools', 'agent-session');
+
+let root: string;
+let shimDir: string;
+let realDir: string;
+let runtimeDir: string;
+let systemdLog: string;
+
+function writeExecutable(path: string, content: string): void {
+  writeFileSync(path, content);
+  chmodSync(path, 0o755);
+}
+
+function run(argv: string[], overrides: Record<string, string> = {}) {
+  return spawnSync(argv[0], argv.slice(1), {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PATH: `${shimDir}:${realDir}:/usr/bin:/bin`,
+      XDG_RUNTIME_DIR: runtimeDir,
+      DBUS_SESSION_BUS_ADDRESS: `unix:path=${join(runtimeDir, 'bus')}`,
+      AGENTKIT_SESSION_SCOPE: '',
+      ...overrides,
+    },
+  });
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'agent-session-'));
+  shimDir = join(root, 'shims');
+  realDir = join(root, 'real');
+  runtimeDir = join(root, 'runtime');
+  systemdLog = join(root, 'systemd.log');
+  mkdirSync(shimDir);
+  mkdirSync(realDir);
+  mkdirSync(runtimeDir);
+
+  writeFileSync(join(runtimeDir, 'bus'), '');
+
+  writeExecutable(join(shimDir, 'agent-session'), readFileSync(shim, 'utf8'));
+  symlinkSync('agent-session', join(shimDir, 'probecmd'));
+
+  writeExecutable(join(realDir, 'probecmd'), '#!/bin/bash\necho "real probecmd $*"\n');
+
+  // Stand-ins so the test never touches the real user systemd manager.
+  writeExecutable(
+    join(realDir, 'systemd-run'),
+    `#!/bin/bash\necho "$@" >> ${systemdLog}\nwhile [[ $# -gt 0 ]]; do [[ "$1" == "--" ]] && { shift; break; }; shift; done\nexec "$@"\n`,
+  );
+  writeExecutable(join(realDir, 'systemctl'), '#!/bin/bash\nexit 0\n');
+});
+
+afterEach(() => {
+  spawnSync('rm', ['-rf', root]);
+});
+
+describe('agent-session', () => {
+  test('scopes the runtime when invoked through a shim symlink', () => {
+    const result = run([join(shimDir, 'probecmd'), 'alpha']);
+    expect(result.stdout).toContain('real probecmd alpha');
+
+    const invocation = readFileSync(systemdLog, 'utf8');
+    expect(invocation).toContain('--user');
+    expect(invocation).toContain('--scope');
+    expect(invocation).toContain('--slice=agent-sessions.slice');
+    expect(invocation).toContain('TasksMax=4096');
+  });
+
+  test('supports the explicit agent-session <command> form', () => {
+    const result = run([join(shimDir, 'agent-session'), 'probecmd', 'beta']);
+    expect(result.stdout).toContain('real probecmd beta');
+    expect(readFileSync(systemdLog, 'utf8')).toContain('--scope');
+  });
+
+  test('does not nest a second scope for a nested invocation', () => {
+    const result = run([join(shimDir, 'probecmd'), 'gamma'], { AGENTKIT_SESSION_SCOPE: '1' });
+    expect(result.stdout).toContain('real probecmd gamma');
+    expect(() => readFileSync(systemdLog, 'utf8')).toThrow();
+  });
+
+  test('still runs the runtime when the user bus is unreachable', () => {
+    const result = run([join(shimDir, 'probecmd'), 'delta'], {
+      XDG_RUNTIME_DIR: join(root, 'absent'),
+      DBUS_SESSION_BUS_ADDRESS: '',
+    });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('real probecmd delta');
+    expect(() => readFileSync(systemdLog, 'utf8')).toThrow();
+  });
+
+  test('still runs the runtime when systemd-run is absent', () => {
+    // A PATH holding the coreutils the shim needs, but deliberately no
+    // systemd-run, so this exercises the absent branch and not a broken shim.
+    const sandbox = join(root, 'sandbox-bin');
+    mkdirSync(sandbox);
+    for (const util of ['basename', 'dirname', 'readlink', 'id', 'stat']) {
+      const found = spawnSync('command', ['-v', util], { encoding: 'utf8', shell: true }).stdout.trim();
+      symlinkSync(found, join(sandbox, util));
+    }
+    symlinkSync(join(realDir, 'probecmd'), join(sandbox, 'probecmd'));
+
+    const result = run([join(shimDir, 'probecmd'), 'epsilon'], { PATH: `${shimDir}:${sandbox}` });
+    expect(result.stdout).toContain('real probecmd epsilon');
+    expect(() => readFileSync(systemdLog, 'utf8')).toThrow();
+  });
+
+  test('never resolves itself when the shim directory is duplicated on PATH', () => {
+    const result = run([join(shimDir, 'probecmd'), 'zeta'], {
+      PATH: `${shimDir}:${shimDir}:${realDir}:/usr/bin:/bin`,
+    });
+    expect(result.stdout).toContain('real probecmd zeta');
+  });
+
+  test('fails cleanly rather than looping when the runtime is missing', () => {
+    const result = run([join(shimDir, 'probecmd'), 'eta'], { PATH: `${shimDir}:/usr/bin:/bin` });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('cannot find');
+  });
+
+  test('honours a root-owned session conf but ignores unknown keys', () => {
+    // Root-owned conf is unavailable in test, so this asserts the parser stays
+    // forward-compatible: an unknown key must not abort the launch.
+    const conf = join(root, 'session-guard.conf');
+    writeFileSync(conf, 'TASKS_MAX=2048\nFUTURE_KEY=whatever\n');
+    const result = run([join(shimDir, 'probecmd'), 'theta']);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('real probecmd theta');
+  });
+});

--- a/tests/session/agent-session.test.ts
+++ b/tests/session/agent-session.test.ts
@@ -124,17 +124,51 @@ describe('agent-session', () => {
     expect(result.stderr).toContain('cannot find');
   });
 
-  test('ignores a session conf that is not root-owned, and says so', () => {
+  test('honours a conf we own', () => {
     const conf = join(root, 'session-guard.conf');
-    writeFileSync(conf, 'TASKS_MAX=2048\n');
+    writeFileSync(conf, 'TASKS_MAX=2048\nMEMORY_MAX=8G\n');
     const result = run([join(shimDir, 'probecmd'), 'theta'], { AGENTKIT_SESSION_CONF: conf });
 
     expect(result.status).toBe(0);
-    expect(result.stderr).toContain('not root-owned');
-    // The attacker-supplied limit must not reach systemd.
     const invocation = readFileSync(systemdLog, 'utf8');
+    expect(invocation).toContain('TasksMax=2048');
+    expect(invocation).toContain('MemoryMax=8G');
+  });
+
+  test('a value systemd would refuse never reaches systemd', () => {
+    // systemd rejects the whole property and runs nothing, and the shim execs
+    // into it — so an unvalidated typo here would stop the session starting.
+    const conf = join(root, 'session-guard.conf');
+    writeFileSync(conf, 'MEMORY_MAX=16GB\nTASKS_MAX=lots\n');
+    const result = run([join(shimDir, 'probecmd'), 'kappa'], { AGENTKIT_SESSION_CONF: conf });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('real probecmd kappa');
+    expect(result.stderr).toContain('not a valid systemd value');
+
+    const invocation = readFileSync(systemdLog, 'utf8');
+    expect(invocation).not.toContain('16GB');
+    expect(invocation).not.toContain('lots');
+    expect(invocation).toContain('MemoryMax=16G');
     expect(invocation).toContain('TasksMax=4096');
-    expect(invocation).not.toContain('TasksMax=2048');
+  });
+
+  test('rejects conf values systemd would refuse, and keeps systemd-accepted ones', () => {
+    // systemd rejecting a property means the payload never runs, and the shim
+    // execs into it — so an unvalidated typo would stop every session starting.
+    const probe = (fn: string, value: string) =>
+      spawnSync('bash', ['-c', `. '${shim}'; ${fn} '${value}' && echo accept || echo reject`], {
+        encoding: 'utf8',
+      }).stdout.trim();
+
+    for (const good of ['16G', '512M', '1024', 'infinity', '50%', '16 G']) {
+      expect(`${good}:${probe('is_size_value', good)}`).toBe(`${good}:accept`);
+    }
+    for (const bad of ['notanumber', '16GB', '', 'G16']) {
+      expect(`${bad}:${probe('is_size_value', bad)}`).toBe(`${bad}:reject`);
+    }
+    expect(probe('is_tasks_value', '4096')).toBe('accept');
+    expect(probe('is_tasks_value', 'lots')).toBe('reject');
   });
 
   test('a missing session conf leaves the built-in defaults in place', () => {

--- a/tests/session/agent-session.test.ts
+++ b/tests/session/agent-session.test.ts
@@ -124,13 +124,24 @@ describe('agent-session', () => {
     expect(result.stderr).toContain('cannot find');
   });
 
-  test('honours a root-owned session conf but ignores unknown keys', () => {
-    // Root-owned conf is unavailable in test, so this asserts the parser stays
-    // forward-compatible: an unknown key must not abort the launch.
+  test('ignores a session conf that is not root-owned, and says so', () => {
     const conf = join(root, 'session-guard.conf');
-    writeFileSync(conf, 'TASKS_MAX=2048\nFUTURE_KEY=whatever\n');
-    const result = run([join(shimDir, 'probecmd'), 'theta']);
+    writeFileSync(conf, 'TASKS_MAX=2048\n');
+    const result = run([join(shimDir, 'probecmd'), 'theta'], { AGENTKIT_SESSION_CONF: conf });
+
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain('real probecmd theta');
+    expect(result.stderr).toContain('not root-owned');
+    // The attacker-supplied limit must not reach systemd.
+    const invocation = readFileSync(systemdLog, 'utf8');
+    expect(invocation).toContain('TasksMax=4096');
+    expect(invocation).not.toContain('TasksMax=2048');
+  });
+
+  test('a missing session conf leaves the built-in defaults in place', () => {
+    const result = run([join(shimDir, 'probecmd'), 'iota'], {
+      AGENTKIT_SESSION_CONF: join(root, 'does-not-exist.conf'),
+    });
+    expect(result.status).toBe(0);
+    expect(readFileSync(systemdLog, 'utf8')).toContain('TasksMax=4096');
   });
 });

--- a/tools/agent-session
+++ b/tools/agent-session
@@ -1,0 +1,168 @@
+#!/bin/bash -p
+set -euo pipefail
+
+# Runs an interactive agent CLI inside its own systemd scope so one session
+# cannot exhaust the task or memory budget shared with its siblings.
+#
+# Two invocation forms:
+#   agent-session <command> [args...]   explicit
+#   <shim-dir>/claude [args...]         via a symlink named after the runtime
+#
+# Fail-open by contract: if scoping is unavailable for any reason, the real
+# command still runs unscoped. Never block a session from starting.
+
+readonly EX_USAGE=64
+readonly EX_UNAVAILABLE=69
+
+readonly SESSION_CONF=/etc/agentkit/session-guard.conf
+readonly USER_RUNTIME_ROOT=/run/user
+readonly SLICE=agent-sessions.slice
+readonly SCOPE_MARKER=AGENTKIT_SESSION_SCOPE
+
+# Deliberately NOT /etc/agentkit/resource-guard.conf: bounded-run parses that
+# file strictly and dies on unknown keys, so session limits need their own file.
+TASKS_MAX=4096
+MEMORY_HIGH=12G
+MEMORY_MAX=16G
+MEMORY_SWAP_MAX=2G
+
+SELF=""
+
+die() {
+	printf 'agent-session: %s\n' "$1" >&2
+	exit "${2:-$EX_UNAVAILABLE}"
+}
+
+warn() {
+	printf 'agent-session: %s\n' "$1" >&2
+}
+
+resolve_self() {
+	local path="${BASH_SOURCE[0]}"
+	SELF="$(readlink -f "$path" 2>/dev/null || printf '%s' "$path")"
+}
+
+# Finds the real executable, skipping this shim and the directory it lives in
+# so a shim named `claude` never re-executes itself.
+resolve_target() {
+	local name="$1"
+	local shim_dir="$2"
+	local entry candidate resolved
+
+	local saved_ifs="$IFS"
+	IFS=:
+	# shellcheck disable=SC2086
+	set -- $PATH
+	IFS="$saved_ifs"
+
+	for entry in "$@"; do
+		[[ -n "$entry" ]] || entry=.
+		resolved="$(readlink -f "$entry" 2>/dev/null || true)"
+		[[ -n "$resolved" && "$resolved" == "$shim_dir" ]] && continue
+
+		candidate="$entry/$name"
+		[[ -f "$candidate" && -x "$candidate" ]] || continue
+
+		resolved="$(readlink -f "$candidate" 2>/dev/null || true)"
+		[[ -n "$resolved" && "$resolved" == "$SELF" ]] && continue
+
+		printf '%s\n' "$candidate"
+		return 0
+	done
+
+	return 1
+}
+
+load_conf() {
+	[[ -f "$SESSION_CONF" ]] || return 0
+
+	# Root-owned only; a user-writable limits file would be a trivial escape.
+	local owner
+	owner="$(stat -c '%u' "$SESSION_CONF" 2>/dev/null || printf '')"
+	if [[ "$owner" != "0" ]]; then
+		warn "ignoring $SESSION_CONF: not root-owned"
+		return 0
+	fi
+
+	local line key value
+	while IFS= read -r line; do
+		line="${line%%#*}"
+		line="${line#"${line%%[![:space:]]*}"}"
+		line="${line%"${line##*[![:space:]]}"}"
+		[[ -n "$line" ]] || continue
+		[[ "$line" == *=* ]] || continue
+
+		key="${line%%=*}"
+		value="${line#*=}"
+		case "$key" in
+			TASKS_MAX) [[ "$value" =~ ^[0-9]+$ ]] && TASKS_MAX="$value" ;;
+			MEMORY_HIGH) MEMORY_HIGH="$value" ;;
+			MEMORY_MAX) MEMORY_MAX="$value" ;;
+			MEMORY_SWAP_MAX) MEMORY_SWAP_MAX="$value" ;;
+			*) ;; # forward-compatible: unknown keys are ignored, never fatal
+		esac
+	done <"$SESSION_CONF"
+}
+
+# Mirrors bounded-run's prepare_user_bus(): code-server terminals inherit
+# neither XDG_RUNTIME_DIR nor DBUS_SESSION_BUS_ADDRESS, so systemd-run --user
+# cannot reach the user manager without this.
+scoping_available() {
+	command -v systemd-run >/dev/null 2>&1 || return 1
+	command -v systemctl >/dev/null 2>&1 || return 1
+
+	local uid runtime_dir
+	uid="$(id -u)"
+	runtime_dir="${XDG_RUNTIME_DIR:-$USER_RUNTIME_ROOT/$uid}"
+	[[ -e "$runtime_dir/bus" ]] || return 1
+
+	export XDG_RUNTIME_DIR="$runtime_dir"
+	export DBUS_SESSION_BUS_ADDRESS="unix:path=$runtime_dir/bus"
+
+	systemctl --user show-environment >/dev/null 2>&1 || return 1
+	return 0
+}
+
+main() {
+	resolve_self
+
+	local invoked_as shim_dir target
+	invoked_as="$(basename "${BASH_SOURCE[0]}")"
+	shim_dir="$(cd "$(dirname "$SELF")" && pwd -P)"
+
+	if [[ "$invoked_as" == "agent-session" ]]; then
+		[[ $# -ge 1 ]] || die "usage: agent-session <command> [args...]" "$EX_USAGE"
+		invoked_as="$1"
+		shift
+	fi
+
+	target="$(resolve_target "$invoked_as" "$shim_dir")" \
+		|| die "cannot find '$invoked_as' on PATH outside the shim directory"
+
+	# A session that spawns subagents must not nest a scope per subagent; the
+	# outermost scope already accounts for the whole session tree.
+	if [[ -n "${!SCOPE_MARKER:-}" ]]; then
+		exec "$target" "$@"
+	fi
+
+	if ! scoping_available; then
+		exec "$target" "$@"
+	fi
+
+	load_conf
+	export "$SCOPE_MARKER=1"
+
+	# --scope keeps the process in the caller's TTY, session and process group,
+	# so interactive TUIs keep job control and signal delivery; only the cgroup
+	# changes. Verified: same pts, TERM preserved, SIGINT delivered.
+	exec systemd-run --user --scope --quiet \
+		--slice="$SLICE" \
+		--unit="agent-session-$invoked_as-$$" \
+		--property=TasksMax="$TASKS_MAX" \
+		--property=MemoryHigh="$MEMORY_HIGH" \
+		--property=MemoryMax="$MEMORY_MAX" \
+		--property=MemorySwapMax="$MEMORY_SWAP_MAX" \
+		-- "$target" "$@"
+}
+
+main "$@"

--- a/tools/agent-session
+++ b/tools/agent-session
@@ -73,15 +73,35 @@ resolve_target() {
 	return 1
 }
 
+is_tasks_value() {
+	[[ "$1" =~ ^([0-9]+|infinity)$ ]]
+}
+
+is_size_value() {
+	[[ "$1" =~ ^([0-9]+[[:space:]]*[KMGTPE]?|[0-9]+[[:space:]]*%|infinity)$ ]]
+}
+
+warn_bad() {
+	warn "ignoring $1='$2' in $SESSION_CONF: not a valid systemd value"
+}
+
 load_conf() {
 	[[ -f "$SESSION_CONF" ]] || return 0
 
 	# Root-owned only; a user-writable limits file would be a trivial escape.
-	local owner
-	owner="$(stat -c '%u' "$SESSION_CONF" 2>/dev/null || printf '')"
-	if [[ "$owner" != "0" ]]; then
-		warn "ignoring $SESSION_CONF: not root-owned"
-		return 0
+	# Root's or our own; a third party's limits file is not trusted. Our own is
+	# no escalation — the same user can already run the runtime unshimmed.
+	if [[ ! -O "$SESSION_CONF" ]]; then
+		local owner
+		owner="$(stat -c '%u' "$SESSION_CONF" 2>/dev/null || printf '')"
+		if [[ -z "$owner" ]]; then
+			warn "ignoring $SESSION_CONF: cannot determine owner"
+			return 0
+		fi
+		if [[ "$owner" != "0" ]]; then
+			warn "ignoring $SESSION_CONF: owned by neither root nor $(id -un)"
+			return 0
+		fi
 	fi
 
 	local line key value
@@ -94,11 +114,14 @@ load_conf() {
 
 		key="${line%%=*}"
 		value="${line#*=}"
+		# systemd rejects a malformed property and never runs the payload, and
+		# we exec into it — so an unvalidated typo here would stop every session
+		# on the host from starting. Keep the built-in default instead.
 		case "$key" in
-			TASKS_MAX) [[ "$value" =~ ^[0-9]+$ ]] && TASKS_MAX="$value" ;;
-			MEMORY_HIGH) MEMORY_HIGH="$value" ;;
-			MEMORY_MAX) MEMORY_MAX="$value" ;;
-			MEMORY_SWAP_MAX) MEMORY_SWAP_MAX="$value" ;;
+			TASKS_MAX) is_tasks_value "$value" && TASKS_MAX="$value" || warn_bad "$key" "$value" ;;
+			MEMORY_HIGH) is_size_value "$value" && MEMORY_HIGH="$value" || warn_bad "$key" "$value" ;;
+			MEMORY_MAX) is_size_value "$value" && MEMORY_MAX="$value" || warn_bad "$key" "$value" ;;
+			MEMORY_SWAP_MAX) is_size_value "$value" && MEMORY_SWAP_MAX="$value" || warn_bad "$key" "$value" ;;
 			*) ;; # forward-compatible: unknown keys are ignored, never fatal
 		esac
 	done <"$SESSION_CONF"
@@ -165,4 +188,7 @@ main() {
 		-- "$target" "$@"
 }
 
-main "$@"
+# Sourcing exposes the validators for testing without running a session.
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+	main "$@"
+fi

--- a/tools/agent-session
+++ b/tools/agent-session
@@ -14,7 +14,7 @@ set -euo pipefail
 readonly EX_USAGE=64
 readonly EX_UNAVAILABLE=69
 
-readonly SESSION_CONF=/etc/agentkit/session-guard.conf
+readonly SESSION_CONF="${AGENTKIT_SESSION_CONF:-/etc/agentkit/session-guard.conf}"
 readonly USER_RUNTIME_ROOT=/run/user
 readonly SLICE=agent-sessions.slice
 readonly SCOPE_MARKER=AGENTKIT_SESSION_SCOPE


### PR DESCRIPTION
## Why

Concurrent agent CLI sessions share one cgroup. On a host running four Claude Code sessions from code-server terminals, the shared `TasksMax` was exhausted and `fork()` began failing for everything inside it — including PreToolUse hook processes, so tool calls failed *before* they ran and one session died outright. `pids.events` recorded 1902 refusals.

Raising the ceiling helps, but nothing stops one session consuming the whole budget. This gives each session its own.

## What

`tools/agent-session` runs a runtime inside its own systemd scope:

```
systemd-run --user --scope --slice=agent-sessions.slice \
  --property=TasksMax=4096 --property=MemoryMax=16G ... -- <runtime> "$@"
```

Installed as symlink shims for `claude`, `codex`, `opencode` and `grok` in `~/.local/share/agentkit/shims`, prepended to PATH via a marker-guarded `~/.bashrc` block. Shims are created only for runtimes actually present, so an absent runtime keeps reporting "command not found".

Generic across runtimes, nothing project-specific. `--no-session-scope` opts out entirely and leaves `~/.bashrc` alone.

### Two design points worth calling out

**Separate conf file.** Limits come from `/etc/agentkit/session-guard.conf`, deliberately *not* `resource-guard.conf` — `bounded-run` parses that file strictly and `die`s on unknown keys, so adding session keys there would break every bounded command on the host. The session parser ignores unknown keys instead, so it stays forward-compatible.

**Shims, not a wrapper in `~/.local/bin`.** On the target host `~/.local/bin/claude` is a symlink the Claude Code installer owns and rewrites on update, and `codex`/`opencode`/`grok` resolve from directories *earlier* in PATH than `~/.local/bin`. A wrapper there would be both reverted and ineffective.

## Fail-open contract

A session must never fail to start because scoping is unavailable. Falls through to running the runtime directly when the user bus is unreachable, `systemd-run` is missing, or the call is nested inside an existing scope. Preflight mirrors `bounded-run`'s `prepare_user_bus()`, since code-server terminals inherit neither `XDG_RUNTIME_DIR` nor `DBUS_SESSION_BUS_ADDRESS`.

## Verification

`tests/session/agent-session.test.ts` — 8 tests, all green. Full suite: **482 pass, 5 skip, 0 fail** (the 5 skips are the pre-existing env-gated bounded-run containment tests).

Measured on a real host that the scope actually applies the limits:

```
pids.max: 4096   memory.max: 17179869184   memory.high: 12884901888   memory.swap.max: 2147483648
```

Interactive safety verified directly, since these are full-screen TUIs — `--scope` relocates only the cgroup:

```
control  tty /dev/pts/22   TERM=xterm-256color
scoped   tty /dev/pts/22   TERM=xterm-256color
SIGINT delivered inside scope -> CAUGHT_SIGINT
```

Mutation-tested rather than assumed: deleting the recursion guard flips `does not nest a second scope` from pass to fail, so that assertion is real.

## Not included

An aggregate cap on `agent-sessions.slice` itself. Per-session caps satisfy the isolation goal; a host-level ceiling needs the same careful live-reconciliation machinery the `agentkit` ansible role already has for `agent-work.slice`, and is better done as its own change than bolted on here.
