### PR TITLE
fix: derive shim_dir from the invoked path, not the resolved script

### DIFF
--- a/tests/session/agent-session.test.ts
+++ b/tests/session/agent-session.test.ts
@@ -111,6 +111,32 @@ describe('agent-session', () => {
     expect(() => readFileSync(systemdLog, 'utf8')).toThrow();
   });
 
+  test('resolves the runtime in the deployed topology: shim symlinks into a separate bin dir', () => {
+    // What install.sh actually creates: shims/<runtime> -> <bin>/agent-session,
+    // with the real runtime ALSO in <bin>. Resolving the symlink would make the
+    // shim skip <bin> and never find the runtime.
+    const binDir = join(root, 'bin');
+    const deployedShims = join(root, 'deployed-shims');
+    mkdirSync(binDir);
+    mkdirSync(deployedShims);
+    writeExecutable(join(binDir, 'agent-session'), readFileSync(shim, 'utf8'));
+    writeExecutable(join(binDir, 'probecmd'), '#!/bin/bash\necho "real probecmd $*"\n');
+    symlinkSync(join(binDir, 'agent-session'), join(deployedShims, 'probecmd'));
+    // The systemd stand-ins must travel with binDir, because realDir is kept
+    // OFF PATH so binDir is the only source of probecmd — a second copy there
+    // would mask the skip-the-wrong-dir bug entirely.
+    symlinkSync(join(realDir, 'systemd-run'), join(binDir, 'systemd-run'));
+    symlinkSync(join(realDir, 'systemctl'), join(binDir, 'systemctl'));
+
+    const result = run([join(deployedShims, 'probecmd'), 'deployed'], {
+      PATH: `${deployedShims}:${binDir}:/usr/bin:/bin`,
+    });
+
+    expect(result.stderr).not.toContain('cannot find');
+    expect(result.stdout).toContain('real probecmd deployed');
+    expect(readFileSync(systemdLog, 'utf8')).toContain('--slice=agent-sessions.slice');
+  });
+
   test('never resolves itself when the shim directory is duplicated on PATH', () => {
     const result = run([join(shimDir, 'probecmd'), 'zeta'], {
       PATH: `${shimDir}:${shimDir}:${realDir}:/usr/bin:/bin`,

--- a/tools/agent-session
+++ b/tools/agent-session
@@ -151,7 +151,10 @@ main() {
 
 	local invoked_as shim_dir target
 	invoked_as="$(basename "${BASH_SOURCE[0]}")"
-	shim_dir="$(cd "$(dirname "$SELF")" && pwd -P)"
+	# The directory we were INVOKED through, not the one the script lives in:
+	# a shim is a symlink into ~/.local/bin, and resolving it would make us skip
+	# ~/.local/bin itself — the directory holding the real runtime.
+	shim_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
 	if [[ "$invoked_as" == "agent-session" ]]; then
 		[[ $# -ge 1 ]] || die "usage: agent-session <command> [args...]" "$EX_USAGE"


### PR DESCRIPTION
Regression fix for #98. **#98 shipped a defect that made `claude` unresolvable in any new shell after install.**

## The bug

`install.sh` creates each shim as a symlink:

```
~/.local/share/agentkit/shims/claude -> ~/.local/bin/agent-session
```

`resolve_self()` runs `readlink -f`, which follows that symlink back to `~/.local/bin/agent-session`. `shim_dir` was then derived from the *resolved* path, so it became `~/.local/bin` — and `resolve_target()` skips `shim_dir` when scanning PATH. That is the directory holding the real `claude`, so:

```
$ claude --version
agent-session: cannot find 'claude' on PATH outside the shim directory
```

Fix: derive `shim_dir` from the path we were **invoked through**, not the one the script lives at. `SELF` stays resolved, since it is still the right thing to compare candidates against.

## Why the tests missed it

Every existing test **copied** `agent-session` into the shim directory. The installer **symlinks** it. In the copy layout `readlink -f` is a no-op, so the bug is invisible — the suite agreed with the code because it was not testing the deployed shape.

The new test uses the real layout: shim symlinked into a separate bin dir, with the runtime present **only** in that bin dir. Getting it to discriminate took two corrections of my own:

1. first draft left a second copy of the binary on PATH, which masked the bug entirely
2. removing that also removed the `systemd-run` stub, so the shim fell open and the assertion read a log that was never written

Mutation-verified in both directions — 12 pass with the fix, 11 pass / 1 fail with the bug reintroduced.

## Verification

Full suite: **486 pass, 5 skip, 0 fail**.

Manual reproduction of the deployed topology confirms the resolution:

```
BASH_SOURCE[0]  = /tmp/.../shims/probecmd
SELF (resolved) = /tmp/.../bin/agent-session
dirname invoked = /tmp/.../shims     <- what we now use
dirname SELF    = /tmp/.../bin       <- what we used before, wrongly skipped
```

## Deployment note

The shim PATH block was removed from `~/.bashrc` on the affected host as soon as this was found, so `claude` resolves normally there. It will be re-enabled only after this merges and a reinstall is verified against the real binary.