### PR TITLE
feat: bound all agent sessions together with agent-sessions.slice

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -554,6 +554,36 @@ install_session_shims() {
 	fi
 }
 
+# Per-session scopes bound one session; this bounds all of them together. Base
+# unit only — operator overrides belong in agent-sessions.slice.d/ drop-ins,
+# which systemd layers on top and a re-install will not clobber.
+install_session_slice() {
+	local unit_dir="$1"
+	local unit="$unit_dir/agent-sessions.slice"
+
+	mkdir -p "$unit_dir"
+	cat >"$unit" <<-'SLICE'
+		# Managed by agentkit install.sh. Override via agent-sessions.slice.d/.
+		[Unit]
+		Description=Aggregate resource guard for interactive agent CLI sessions
+
+		[Slice]
+		CPUQuota=1600%
+		MemoryHigh=24G
+		MemoryMax=32G
+		MemorySwapMax=4G
+		TasksMax=24576
+	SLICE
+	echo "[shims] Aggregate slice: $unit"
+
+	if systemctl --user show-environment > /dev/null 2>&1; then
+		systemctl --user daemon-reload || true
+		echo "[shims] Reloaded user systemd manager"
+	else
+		echo "[shims] User systemd manager unavailable; slice applies at next login"
+	fi
+}
+
 path_without() {
 	local drop="$1"
 	local entry out=""
@@ -754,6 +784,7 @@ if [[ "$GLOBAL" == true ]]; then
 	if [[ "$SESSION_SCOPE" == true ]]; then
 		echo "--- Per-session resource scoping ---"
 		install_session_shims "$SESSION_SHIMS" "$PATH_TOOLS"
+		install_session_slice "${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
 		install_shim_path "$SESSION_SHIMS" "$HOME/.bashrc"
 		echo ""
 	fi

--- a/tests/session/install-session-slice.test.ts
+++ b/tests/session/install-session-slice.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from 'bun:test';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const repoRoot = dirname(dirname(import.meta.dir));
+const installScript = join(repoRoot, 'install.sh');
+
+function install(home: string, extraArgs: string[] = []) {
+  return spawnSync('bash', [installScript, '--global', ...extraArgs], {
+    cwd: repoRoot,
+    env: { ...process.env, HOME: home, XDG_CONFIG_HOME: join(home, '.config') },
+    encoding: 'utf-8',
+  });
+}
+
+function slicePath(home: string) {
+  return join(home, '.config', 'systemd', 'user', 'agent-sessions.slice');
+}
+
+describe('aggregate session slice', () => {
+  test('installs a bounded parent slice for per-session scopes', () => {
+    const home = mkdtempSync(join(tmpdir(), 'agentkit-slice-'));
+    try {
+      const result = install(home);
+      expect(result.status, result.stderr).toBe(0);
+
+      const unit = readFileSync(slicePath(home), 'utf-8');
+      // Per-session scopes bound one session; without these, N sessions are
+      // collectively unbounded, which is the whole point of the slice.
+      expect(unit).toContain('[Slice]');
+      expect(unit).toMatch(/^MemoryMax=\d+G$/m);
+      expect(unit).toMatch(/^MemoryHigh=\d+G$/m);
+      expect(unit).toMatch(/^TasksMax=\d+$/m);
+      expect(unit).toMatch(/^CPUQuota=\d+%$/m);
+    } finally {
+      rmSync(home, { force: true, recursive: true });
+    }
+  });
+
+  test('the aggregate ceiling exceeds a single session but stays under host RAM', () => {
+    const home = mkdtempSync(join(tmpdir(), 'agentkit-slice-'));
+    try {
+      install(home);
+      const unit = readFileSync(slicePath(home), 'utf-8');
+      const aggregate = Number(unit.match(/^MemoryMax=(\d+)G$/m)![1]);
+
+      const shimSource = readFileSync(join(repoRoot, 'tools', 'agent-session'), 'utf-8');
+      const perSession = Number(shimSource.match(/^MEMORY_MAX=(\d+)G$/m)![1]);
+
+      expect(aggregate).toBeGreaterThan(perSession);
+      // A ceiling at or above host RAM would not bound anything on the box
+      // this was sized for (125 GiB, with 88 GiB already committed elsewhere).
+      expect(aggregate).toBeLessThan(64);
+    } finally {
+      rmSync(home, { force: true, recursive: true });
+    }
+  });
+
+  test('re-installing does not clobber an operator drop-in', () => {
+    const home = mkdtempSync(join(tmpdir(), 'agentkit-slice-'));
+    try {
+      install(home);
+      const dropInDir = `${slicePath(home)}.d`;
+      mkdirSync(dropInDir, { recursive: true });
+      writeFileSync(join(dropInDir, '90-local.conf'), '[Slice]\nMemoryMax=8G\n');
+
+      const second = install(home);
+      expect(second.status, second.stderr).toBe(0);
+      expect(readFileSync(join(dropInDir, '90-local.conf'), 'utf-8')).toContain('MemoryMax=8G');
+    } finally {
+      rmSync(home, { force: true, recursive: true });
+    }
+  });
+
+  test('--no-session-scope writes no slice', () => {
+    const home = mkdtempSync(join(tmpdir(), 'agentkit-slice-'));
+    try {
+      const result = install(home, ['--no-session-scope']);
+      expect(result.status, result.stderr).toBe(0);
+      expect(existsSync(slicePath(home))).toBe(false);
+    } finally {
+      rmSync(home, { force: true, recursive: true });
+    }
+  });
+});


### PR DESCRIPTION
Closes #99.

## Why

#98 gave each agent CLI session its own scope with `TasksMax=4096` / `MemoryMax=16G`, which stops one session starving its siblings. The **parent slice was uncapped**, so N sessions were collectively unbounded.

Measured on the target host:

```
agent.slice                    pids.max=max  memory.max=max
agent.slice/agent-work.slice   TasksMax=1536  MemoryMax=24G   <- the only capped one
agent.slice/agent-sessions.slice  (implicit, no limits)
```

And the committed ceilings there are already oversubscribed — `code-server` 64G + `agent-work` 24G = **88G on a 125G box**, with host swap at 14/15G and `vm.overcommit_memory=1`, so allocation never fails and the kernel OOM-kills instead. The genuinely free headroom is ~37G.

## Sizing

```
agent-sessions.slice   MemoryHigh=24G  MemoryMax=32G  MemorySwapMax=4G
                       TasksMax=24576  CPUQuota=1600%
```

One session keeps a generous individual ceiling, two can max out, and the aggregate binds well before the host does. Swap is deliberately small: leaning on a swap device that is already 14/15 used would be pretending headroom exists.

Base unit only. Operator overrides belong in `agent-sessions.slice.d/` drop-ins, which systemd layers on top and a re-install does not clobber — there is a test for that, because a silently clobbered override would undo whatever had been tuned.

## Why here and not the ansible role

The obvious home is the `agentkit` role in `core/ansible-roles`, which already templates `~/.config/systemd/user/agent-work.slice`. I did not put it there:

- `tasks/resource-guard-user.yml` is 404 lines, all 13 tasks hardcoded to `agent-work.slice`, including ~100 lines of "refuse unsafe limit changes" Jinja.
- Adding a second slice means either duplicating that (blocked by `coding-police` at ≥6 duplicated lines) or parameterising all of it.
- That repo has **no CI**, is shared by three businesses, and `bounded-run` verifies `agent-work.slice` before *every* run — so a regression there breaks every bounded command on every host.

Rewriting 380 lines of safety logic with no test harness, to add a defence-in-depth ceiling, is the wrong trade. The slice unit lives next to the shims that create scopes inside it, which is also where the per-session limits already live.

## Verification

Full suite: **490 pass, 5 skip, 0 fail**.

Four new tests: the unit is written with all four ceilings; the aggregate exceeds a single session's ceiling but stays under host RAM (asserted against the shim's own `MEMORY_MAX`, so the two cannot drift apart silently); an operator drop-in survives re-install; `--no-session-scope` writes nothing.

Mutation-verified: removing the `install_session_slice` call reds 2 of the 4.