### PR TITLE
fix: derive the user bus in the installer, not just the shim

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -576,12 +576,24 @@ install_session_slice() {
 	SLICE
 	echo "[shims] Aggregate slice: $unit"
 
-	if systemctl --user show-environment > /dev/null 2>&1; then
+	if user_bus_env; then
 		systemctl --user daemon-reload || true
 		echo "[shims] Reloaded user systemd manager"
 	else
 		echo "[shims] User systemd manager unavailable; slice applies at next login"
 	fi
+}
+
+# Terminals spawned by a service manager (code-server, CI) inherit neither of
+# these, so the reload silently deferred to next login — leaving the slice
+# unapplied exactly when it is needed. Same fix agent-session already makes.
+user_bus_env() {
+	local runtime_dir="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+	[[ -e "$runtime_dir/bus" ]] || return 1
+
+	export XDG_RUNTIME_DIR="$runtime_dir"
+	export DBUS_SESSION_BUS_ADDRESS="unix:path=$runtime_dir/bus"
+	systemctl --user show-environment > /dev/null 2>&1
 }
 
 path_without() {

--- a/tests/session/install-session-slice.test.ts
+++ b/tests/session/install-session-slice.test.ts
@@ -74,6 +74,37 @@ describe('aggregate session slice', () => {
     }
   });
 
+  test('finds the user bus when XDG_RUNTIME_DIR is unset', () => {
+    // Terminals spawned by a service manager inherit no XDG_RUNTIME_DIR, so
+    // without this the reload defers to next login and the slice is unapplied.
+    const home = mkdtempSync(join(tmpdir(), 'agentkit-bus-'));
+    try {
+      const runtime = join(home, 'run');
+      const stubBin = join(home, 'stub');
+      mkdirSync(runtime, { recursive: true });
+      mkdirSync(stubBin, { recursive: true });
+      writeFileSync(join(runtime, 'bus'), '');
+      writeFileSync(join(stubBin, 'systemctl'), '#!/bin/bash\nexit 0\n');
+      spawnSync('chmod', ['+x', join(stubBin, 'systemctl')]);
+      spawnSync('chmod', ['+x', join(stubBin, 'id')]);
+
+      const probe = (extra: string) =>
+        spawnSync('bash', [
+          '-c',
+          `source <(sed -n '/^user_bus_env()/,/^}/p' '${installScript}')
+           export XDG_RUNTIME_DIR='${runtime}'
+           ${extra}
+           if user_bus_env; then echo "ok:$DBUS_SESSION_BUS_ADDRESS"; else echo no; fi`,
+        ], { encoding: 'utf-8', env: { ...process.env, PATH: `${stubBin}:${process.env.PATH}` } });
+
+      expect(probe('').stdout.trim()).toBe(`ok:unix:path=${join(runtime, 'bus')}`);
+      // No bus at the derived path must report unavailable, not pretend success.
+      expect(probe(`rm -f '${join(runtime, 'bus')}'`).stdout.trim()).toBe('no');
+    } finally {
+      rmSync(home, { force: true, recursive: true });
+    }
+  });
+
   test('--no-session-scope writes no slice', () => {
     const home = mkdtempSync(join(tmpdir(), 'agentkit-slice-'));
     try {


### PR DESCRIPTION
Follow-on to #101, found by deploying it.

## Symptom

Installing from a code-server terminal:

```
[shims] Aggregate slice: /home/eda/.config/systemd/user/agent-sessions.slice
[shims] User systemd manager unavailable; slice applies at next login
```

The unit was written but never loaded. On a fresh host that leaves the parent slice **uncapped until next login** — exactly the window where an unbounded parent is the problem #101 exists to fix.

## Cause

Terminals spawned by a service manager (code-server, CI runners) inherit neither `XDG_RUNTIME_DIR` nor `DBUS_SESSION_BUS_ADDRESS`, so a bare `systemctl --user` cannot reach the user manager even though it is running and its bus is present at `/run/user/$(id -u)/bus`.

This is the same condition `tools/agent-session` already handles in `scoping_available()`, and that `bounded-run` handles in `prepare_user_bus()`. The installer was the one place that did not.

## Fix

`user_bus_env()` derives the runtime dir, exports both variables, and only then probes the manager. Failure still reports honestly rather than pretending success.

## Verification

Full suite: **491 pass, 5 skip, 0 fail**.

New test drives the function with `XDG_RUNTIME_DIR` pointed at a temp dir and a stubbed `systemctl`: asserts it exports `DBUS_SESSION_BUS_ADDRESS=unix:path=<dir>/bus`, and that removing the bus reports unavailable rather than succeeding.

Mutation-verified: dropping the derivation reds that test (4 pass / 1 fail).