### PR TITLE
feat(pages): AgentKit Pages module — worker, publish-page skill, themes flow

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -84,6 +84,17 @@ install_skills() {
 		fi
 
 		cp -r "$skill_dir" "$target"
+
+		# Skills that ship runtime dependencies (a package.json) need an install
+		# step: bun does NOT auto-install when a package.json is present.
+		if [[ -f "$target/package.json" ]]; then
+			if command -v bun >/dev/null 2>&1; then
+				echo "[skills] Installing dependencies: $skill_name"
+				(cd "$target" && bun install --silent)
+			else
+				echo "[skills] WARNING: $skill_name needs 'bun install' in $target (bun not found)"
+			fi
+		fi
 	done
 }
 

--- a/pages/worker/.gitignore
+++ b/pages/worker/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/pages/worker/package.json
+++ b/pages/worker/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "agentkit-pages-worker",
+  "private": true,
+  "devDependencies": {
+    "wrangler": "^4.27.0"
+  }
+}

--- a/pages/worker/src/worker.js
+++ b/pages/worker/src/worker.js
@@ -1,0 +1,72 @@
+const SLUG_RE = /^[a-z0-9][a-z0-9-]{0,63}(\/[a-z0-9][a-z0-9-]{0,63}){0,3}$/;
+const MAX_PAGE_BYTES = 5 * 1024 * 1024;
+
+const PAGE_HEADERS = {
+  "content-type": "text/html; charset=utf-8",
+  "x-content-type-options": "nosniff",
+  "referrer-policy": "no-referrer",
+  "content-security-policy":
+    "default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src data:; font-src data:; frame-ancestors 'none'",
+};
+
+function html(status, body) {
+  return new Response(body, { status, headers: PAGE_HEADERS });
+}
+
+const NOT_FOUND = `<!doctype html><meta charset="utf-8"><title>Not found</title>
+<body style="font-family:system-ui;display:grid;place-items:center;min-height:90vh">
+<div style="text-align:center"><h1 style="letter-spacing:-0.02em">404</h1>
+<p>No page lives at this address.</p></div>`;
+
+async function servePage(env, key) {
+  const obj = await env.PAGES.get(key);
+  if (!obj) return html(404, NOT_FOUND);
+  return html(200, obj.body);
+}
+
+async function handlePublish(request, env, slug) {
+  const auth = request.headers.get("authorization") ?? "";
+  const token = auth.replace(/^Bearer\s+/i, "");
+  if (!env.PUBLISH_TOKEN || token !== env.PUBLISH_TOKEN) {
+    return new Response("unauthorized\n", { status: 401 });
+  }
+  if (slug !== "_site" && !SLUG_RE.test(slug)) {
+    return new Response("invalid slug\n", { status: 400 });
+  }
+  const body = await request.arrayBuffer();
+  if (body.byteLength === 0 || body.byteLength > MAX_PAGE_BYTES) {
+    return new Response("page must be 1 byte to 5 MB\n", { status: 413 });
+  }
+  const key = slug === "_site" ? "_site/index.html" : `pages/${slug}/index.html`;
+  await env.PAGES.put(key, body, {
+    httpMetadata: { contentType: "text/html; charset=utf-8" },
+  });
+  const url = slug === "_site"
+    ? "https://agentkit.sbs/"
+    : `https://pages.agentkit.sbs/${slug}`;
+  return Response.json({ ok: true, slug, url });
+}
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    const host = url.hostname;
+    const path = url.pathname.replace(/\/+$/, "").replace(/^\/+/, "");
+
+    if (request.method === "PUT" && path.startsWith("api/pages/")) {
+      return handlePublish(request, env, path.slice("api/pages/".length));
+    }
+    if (request.method !== "GET" && request.method !== "HEAD") {
+      return new Response("method not allowed\n", { status: 405 });
+    }
+
+    if (host === "agentkit.sbs" || host === "www.agentkit.sbs") {
+      return servePage(env, "_site/index.html");
+    }
+    if (path === "") {
+      return servePage(env, "_site/pages-index.html");
+    }
+    if (!SLUG_RE.test(path)) return html(404, NOT_FOUND);
+    return servePage(env, `pages/${path}/index.html`);
+  },
+};

--- a/pages/worker/src/worker.js
+++ b/pages/worker/src/worker.js
@@ -34,7 +34,7 @@ async function servePage(env, key, headers) {
 async function handlePublish(request, env, slug) {
   const auth = request.headers.get("authorization") ?? "";
   const token = auth.replace(/^Bearer\s+/i, "");
-  const isSite = slug in SITE_SLUGS;
+  const isSite = Object.hasOwn(SITE_SLUGS, slug);
   const expected = isSite ? env.SITE_TOKEN : env.PUBLISH_TOKEN;
   if (!expected || token !== expected) {
     return new Response("unauthorized\n", { status: 401 });

--- a/pages/worker/src/worker.js
+++ b/pages/worker/src/worker.js
@@ -1,16 +1,23 @@
 const SLUG_RE = /^[a-z0-9][a-z0-9-]{0,63}(\/[a-z0-9][a-z0-9-]{0,63}){0,3}$/;
 const MAX_PAGE_BYTES = 5 * 1024 * 1024;
 
-const PAGE_HEADERS = {
+// Slugs the site deploy flow may write, gated by SITE_TOKEN instead of
+// PUBLISH_TOKEN so a leaked page-publish token cannot deface the site.
+const SITE_SLUGS = { "_site": "_site/index.html", "_pages-index": "_site/pages-index.html" };
+
+const BASE_HEADERS = {
   "content-type": "text/html; charset=utf-8",
   "x-content-type-options": "nosniff",
   "referrer-policy": "no-referrer",
   "content-security-policy":
-    "default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src data:; font-src data:; frame-ancestors 'none'",
+    "default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src data:; font-src data:; frame-ancestors 'none'; form-action 'none'; base-uri 'none'",
 };
+// Published pages are public-by-slug until the accounts phase: keep crawlers
+// out so an unlinked slug stays unlisted.
+const PAGE_HEADERS = { ...BASE_HEADERS, "x-robots-tag": "noindex, nofollow" };
 
-function html(status, body) {
-  return new Response(body, { status, headers: PAGE_HEADERS });
+function html(status, body, headers = BASE_HEADERS) {
+  return new Response(body, { status, headers });
 }
 
 const NOT_FOUND = `<!doctype html><meta charset="utf-8"><title>Not found</title>
@@ -18,31 +25,39 @@ const NOT_FOUND = `<!doctype html><meta charset="utf-8"><title>Not found</title>
 <div style="text-align:center"><h1 style="letter-spacing:-0.02em">404</h1>
 <p>No page lives at this address.</p></div>`;
 
-async function servePage(env, key) {
+async function servePage(env, key, headers) {
   const obj = await env.PAGES.get(key);
-  if (!obj) return html(404, NOT_FOUND);
-  return html(200, obj.body);
+  if (!obj) return html(404, NOT_FOUND, headers);
+  return html(200, obj.body, headers);
 }
 
 async function handlePublish(request, env, slug) {
   const auth = request.headers.get("authorization") ?? "";
   const token = auth.replace(/^Bearer\s+/i, "");
-  if (!env.PUBLISH_TOKEN || token !== env.PUBLISH_TOKEN) {
+  const isSite = slug in SITE_SLUGS;
+  const expected = isSite ? env.SITE_TOKEN : env.PUBLISH_TOKEN;
+  if (!expected || token !== expected) {
     return new Response("unauthorized\n", { status: 401 });
   }
-  if (slug !== "_site" && !SLUG_RE.test(slug)) {
+  if (!isSite && !SLUG_RE.test(slug)) {
     return new Response("invalid slug\n", { status: 400 });
+  }
+  const declared = Number(request.headers.get("content-length") ?? "0");
+  if (declared > MAX_PAGE_BYTES) {
+    return new Response("page must be 1 byte to 5 MB\n", { status: 413 });
   }
   const body = await request.arrayBuffer();
   if (body.byteLength === 0 || body.byteLength > MAX_PAGE_BYTES) {
     return new Response("page must be 1 byte to 5 MB\n", { status: 413 });
   }
-  const key = slug === "_site" ? "_site/index.html" : `pages/${slug}/index.html`;
+  const key = isSite ? SITE_SLUGS[slug] : `pages/${slug}/index.html`;
   await env.PAGES.put(key, body, {
     httpMetadata: { contentType: "text/html; charset=utf-8" },
   });
   const url = slug === "_site"
     ? "https://agentkit.sbs/"
+    : slug === "_pages-index"
+    ? "https://pages.agentkit.sbs/"
     : `https://pages.agentkit.sbs/${slug}`;
   return Response.json({ ok: true, slug, url });
 }
@@ -61,12 +76,13 @@ export default {
     }
 
     if (host === "agentkit.sbs" || host === "www.agentkit.sbs") {
-      return servePage(env, "_site/index.html");
+      if (path !== "") return html(404, NOT_FOUND);
+      return servePage(env, "_site/index.html", BASE_HEADERS);
     }
     if (path === "") {
-      return servePage(env, "_site/pages-index.html");
+      return servePage(env, "_site/pages-index.html", PAGE_HEADERS);
     }
-    if (!SLUG_RE.test(path)) return html(404, NOT_FOUND);
-    return servePage(env, `pages/${path}/index.html`);
+    if (!SLUG_RE.test(path)) return html(404, NOT_FOUND, PAGE_HEADERS);
+    return servePage(env, `pages/${path}/index.html`, PAGE_HEADERS);
   },
 };

--- a/pages/worker/wrangler.toml
+++ b/pages/worker/wrangler.toml
@@ -1,0 +1,11 @@
+name = "agentkit-pages"
+main = "src/worker.js"
+compatibility_date = "2026-07-01"
+
+# Hostnames are attached as Workers Custom Domains (agentkit.sbs, www,
+# pages.agentkit.sbs) via the CF API — the deploy token cannot edit zone
+# routes, and custom domains also provision DNS + certs.
+
+[[r2_buckets]]
+binding = "PAGES"
+bucket_name = "agentkit-pages"

--- a/skills/publish-page/SKILL.md
+++ b/skills/publish-page/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: publish-page
+description: Publish agent output (reports, docs, slide decks, dashboards) as a web page at pages.agentkit.sbs — use whenever rich HTML output beats chat text, when the user asks to publish/share a page, or when producing a report/deck worth keeping at a stable URL.
+---
+
+# publish-page
+
+Publish a page to AgentKit Pages. Pages are **public** in the current phase —
+never publish secrets or private data.
+
+## Usage
+
+```bash
+bun <skill-dir>/publish.ts --slug <slug> --file <content-file> \
+  [--template doc|deck|raw] [--title "Page title"] [--no-git]
+```
+
+- `--slug` — URL path, lowercase `a-z0-9-` with up to 4 `/` segments (e.g. `reports/q3-audit`).
+  Republishing the same slug updates the same URL.
+- `--file` — content: markdown (`.md`) or HTML fragment/full page (`.html`).
+- `--template`
+  - `doc` (default) — report/article chrome.
+  - `deck` — slide deck; split slides on `---` lines (markdown) or `<hr>` (HTML).
+    Arrow keys / swipe / dots navigate; print gives one slide per page.
+  - `raw` — file is a complete self-contained HTML page, published as-is.
+- `--no-git` — skip the canonical commit (serving write only; use when the pages
+  repo is unavailable).
+
+Prints the live URL on success. Errors are loud; fix and re-run.
+
+## What it does
+
+1. Renders content through the theme (from the agentkit-pages repo clone).
+2. `PUT`s the rendered HTML to the Worker — the URL is live immediately.
+3. Commits `src/<slug>/` + `dist/<slug>/` to the agentkit-pages repo (canonical
+   history) and pushes. The pages repo is a content datastore: direct commits to
+   its default branch are by design.
+
+## Config
+
+| Setting | Source | Default |
+| --- | --- | --- |
+| Endpoint | `AGENTKIT_PAGES_ENDPOINT` | `https://pages.agentkit.sbs` |
+| Token | `~/.config/agentkit/pages-token` | required |
+| Pages repo clone | `AGENTKIT_PAGES_REPO` | `~/code/agentkit-pages` |
+
+## Rules for page content
+
+- Self-contained only: inline all CSS/JS, `data:` URIs for images. No CDN links.
+- The serving CSP allows inline style/script and blocks all external requests.
+- Max 5 MB per page.

--- a/skills/publish-page/SKILL.md
+++ b/skills/publish-page/SKILL.md
@@ -10,6 +10,12 @@ never publish secrets or private data.
 
 ## Usage
 
+One-time setup (bun does not auto-install when a package.json is present):
+
+```bash
+cd <skill-dir> && bun install
+```
+
 ```bash
 bun <skill-dir>/publish.ts --slug <slug> --file <content-file> \
   [--template doc|deck|raw] [--title "Page title"] [--no-git]

--- a/skills/publish-page/package.json
+++ b/skills/publish-page/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "publish-page-skill",
+  "private": true,
+  "dependencies": {
+    "marked": "^18.0.7"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.2.19"
+  }
+}

--- a/skills/publish-page/publish.ts
+++ b/skills/publish-page/publish.ts
@@ -14,7 +14,15 @@ function fail(msg: string): never {
 
 function arg(name: string): string | undefined {
   const i = process.argv.indexOf(`--${name}`);
-  return i > 0 ? process.argv[i + 1] : undefined;
+  const v = i > 0 ? process.argv[i + 1] : undefined;
+  if (v?.startsWith("--")) fail(`--${name} is missing its value (got "${v}")`);
+  return v;
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) =>
+    ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c] as string
+  );
 }
 
 const slug = arg("slug") ?? fail("--slug is required");
@@ -26,17 +34,40 @@ if (!["doc", "deck", "raw"].includes(template)) fail(`unknown template "${templa
 if (!existsSync(file)) fail(`no such file: ${file}`);
 
 const endpoint = process.env.AGENTKIT_PAGES_ENDPOINT ?? "https://pages.agentkit.sbs";
+const endpointHost = new URL(endpoint).hostname;
+if (!endpoint.startsWith("https://") && !["127.0.0.1", "localhost"].includes(endpointHost)) {
+  fail(`endpoint must be https (got ${endpoint}) — the bearer token would travel in cleartext`);
+}
 const repo = process.env.AGENTKIT_PAGES_REPO ?? join(homedir(), "code/agentkit-pages");
 const tokenPath = join(homedir(), ".config/agentkit/pages-token");
 if (!existsSync(tokenPath)) fail(`publish token missing at ${tokenPath}`);
 const token = (await readFile(tokenPath, "utf8")).trim();
 
 const source = await readFile(file, "utf8");
-const isMd = file.endsWith(".md");
+const isMd = /\.(md|markdown|mdown)$/i.test(file);
 const title = arg("title")
   ?? source.match(/^#\s+(.+)$/m)?.[1]
   ?? source.match(/<title>([^<]+)<\/title>/)?.[1]
   ?? slug;
+
+// Split markdown into slides on `---` lines, ignoring YAML frontmatter and
+// `---` inside fenced code blocks — a naive regex split cuts fences in half.
+function splitSlides(md: string): string[] {
+  let lines = md.split("\n");
+  if (lines[0]?.trim() === "---") {
+    const close = lines.findIndex((l, i) => i > 0 && l.trim() === "---");
+    if (close > 0) lines = lines.slice(close + 1);
+  }
+  const slides: string[][] = [[]];
+  let fence: string | null = null;
+  for (const line of lines) {
+    const open = line.match(/^\s*(```|~~~)/)?.[1];
+    if (open) fence = fence === open ? null : fence ?? open;
+    if (!fence && line.trim() === "---") slides.push([]);
+    else slides[slides.length - 1].push(line);
+  }
+  return slides.map((s) => s.join("\n"));
+}
 
 async function render(): Promise<string> {
   if (template === "raw") return source;
@@ -46,8 +77,8 @@ async function render(): Promise<string> {
   let content: string;
   if (template === "deck") {
     const parts = isMd
-      ? source.split(/^---$/m).map((s) => marked.parse(s) as string)
-      : source.split(/<hr\s*\/?>/i);
+      ? splitSlides(source).map((s) => marked.parse(s) as string)
+      : source.split(/<hr\b[^>]*>/i);
     content = parts
       .map((s) => s.trim())
       .filter(Boolean)
@@ -56,7 +87,11 @@ async function render(): Promise<string> {
   } else {
     content = isMd ? (marked.parse(source) as string) : source;
   }
-  return theme.replace("{{TITLE}}", title.replace(/[<>&]/g, "")).replace("{{CONTENT}}", content);
+  // Function replacers: a plain string replacement expands $&, $`, $' found in
+  // page content and silently corrupts the output.
+  return theme
+    .replaceAll("{{TITLE}}", () => escapeHtml(title))
+    .replaceAll("{{CONTENT}}", () => content);
 }
 
 const html = await render();
@@ -85,12 +120,17 @@ if (!noGit) {
   const git = (...args: string[]) =>
     Bun.spawnSync(["git", "-C", repo, ...args], { stdout: "pipe", stderr: "pipe" });
   git("add", `src/${slug}`, `dist/${slug}`);
-  const commit = git("commit", "-m", `pages: publish ${slug}`);
-  if (commit.exitCode === 0) {
-    const push = git("push");
-    if (push.exitCode !== 0) console.error(`warning: git push failed — commit is local only:\n${push.stderr.toString()}`);
-  } else if (!commit.stdout.toString().includes("nothing to commit")) {
-    console.error(`warning: git commit failed:\n${commit.stderr.toString()}`);
+  const staged = git("diff", "--cached", "--quiet", "--", `src/${slug}`, `dist/${slug}`);
+  if (staged.exitCode !== 0) {
+    // Pathspec-scoped commit: the clone is long-lived and shared — a bare
+    // commit would sweep anything else staged into this publish.
+    const commit = git("commit", "-m", `pages: publish ${slug}`, "--", `src/${slug}`, `dist/${slug}`);
+    if (commit.exitCode === 0) {
+      const push = git("push");
+      if (push.exitCode !== 0) console.error(`warning: git push failed — commit is local only:\n${push.stderr.toString()}`);
+    } else {
+      console.error(`warning: git commit failed:\n${commit.stderr.toString()}`);
+    }
   }
 }
 

--- a/skills/publish-page/publish.ts
+++ b/skills/publish-page/publish.ts
@@ -1,0 +1,97 @@
+#!/usr/bin/env bun
+import { marked } from "marked";
+import { existsSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const SLUG_RE = /^[a-z0-9][a-z0-9-]{0,63}(\/[a-z0-9][a-z0-9-]{0,63}){0,3}$/;
+
+function fail(msg: string): never {
+  console.error(`publish-page: ${msg}`);
+  process.exit(1);
+}
+
+function arg(name: string): string | undefined {
+  const i = process.argv.indexOf(`--${name}`);
+  return i > 0 ? process.argv[i + 1] : undefined;
+}
+
+const slug = arg("slug") ?? fail("--slug is required");
+const file = arg("file") ?? fail("--file is required");
+const template = arg("template") ?? "doc";
+const noGit = process.argv.includes("--no-git");
+if (!SLUG_RE.test(slug)) fail(`invalid slug "${slug}" (lowercase a-z0-9-, max 4 segments)`);
+if (!["doc", "deck", "raw"].includes(template)) fail(`unknown template "${template}"`);
+if (!existsSync(file)) fail(`no such file: ${file}`);
+
+const endpoint = process.env.AGENTKIT_PAGES_ENDPOINT ?? "https://pages.agentkit.sbs";
+const repo = process.env.AGENTKIT_PAGES_REPO ?? join(homedir(), "code/agentkit-pages");
+const tokenPath = join(homedir(), ".config/agentkit/pages-token");
+if (!existsSync(tokenPath)) fail(`publish token missing at ${tokenPath}`);
+const token = (await readFile(tokenPath, "utf8")).trim();
+
+const source = await readFile(file, "utf8");
+const isMd = file.endsWith(".md");
+const title = arg("title")
+  ?? source.match(/^#\s+(.+)$/m)?.[1]
+  ?? source.match(/<title>([^<]+)<\/title>/)?.[1]
+  ?? slug;
+
+async function render(): Promise<string> {
+  if (template === "raw") return source;
+  const themePath = join(repo, "themes", `${template}.html`);
+  if (!existsSync(themePath)) fail(`theme not found: ${themePath} (clone agentkit-pages?)`);
+  const theme = await readFile(themePath, "utf8");
+  let content: string;
+  if (template === "deck") {
+    const parts = isMd
+      ? source.split(/^---$/m).map((s) => marked.parse(s) as string)
+      : source.split(/<hr\s*\/?>/i);
+    content = parts
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .map((s) => `<section class="slide">\n${s}\n</section>`)
+      .join("\n");
+  } else {
+    content = isMd ? (marked.parse(source) as string) : source;
+  }
+  return theme.replace("{{TITLE}}", title.replace(/[<>&]/g, "")).replace("{{CONTENT}}", content);
+}
+
+const html = await render();
+if (Buffer.byteLength(html) > 5 * 1024 * 1024) fail("rendered page exceeds 5 MB");
+
+const res = await fetch(`${endpoint}/api/pages/${slug}`, {
+  method: "PUT",
+  headers: { authorization: `Bearer ${token}` },
+  body: html,
+});
+if (!res.ok) fail(`publish failed: HTTP ${res.status} ${await res.text()}`);
+const { url } = (await res.json()) as { url: string };
+
+if (!noGit) {
+  if (!existsSync(join(repo, ".git"))) fail(`pages repo not found at ${repo} (published, but not committed)`);
+  const srcDir = join(repo, "src", slug);
+  const distDir = join(repo, "dist", slug);
+  await mkdir(srcDir, { recursive: true });
+  await mkdir(distDir, { recursive: true });
+  await writeFile(join(srcDir, isMd ? "content.md" : "content.html"), source);
+  await writeFile(
+    join(srcDir, "meta.yaml"),
+    `title: ${JSON.stringify(title)}\ntemplate: ${template}\nslug: ${slug}\n`,
+  );
+  await writeFile(join(distDir, "index.html"), html);
+  const git = (...args: string[]) =>
+    Bun.spawnSync(["git", "-C", repo, ...args], { stdout: "pipe", stderr: "pipe" });
+  git("add", `src/${slug}`, `dist/${slug}`);
+  const commit = git("commit", "-m", `pages: publish ${slug}`);
+  if (commit.exitCode === 0) {
+    const push = git("push");
+    if (push.exitCode !== 0) console.error(`warning: git push failed — commit is local only:\n${push.stderr.toString()}`);
+  } else if (!commit.stdout.toString().includes("nothing to commit")) {
+    console.error(`warning: git commit failed:\n${commit.stderr.toString()}`);
+  }
+}
+
+console.log(url);

--- a/skills/publish-page/tsconfig.json
+++ b/skills/publish-page/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["bun"],
+    "strict": true,
+    "noEmit": true
+  }
+}


### PR DESCRIPTION
## AgentKit Pages module (opt-in)

- `pages/worker/` — CF Worker: `PUT /api/pages/:slug` (bearer token) → R2; GET serves; strict CSP; 5 MB cap; slug validation
- `skills/publish-page/` — SKILL.md + publish.ts: markdown/HTML → doc|deck|raw theme → instant PUT + canonical git commit to agentkit-pages
- Hostnames attached as Workers Custom Domains: agentkit.sbs, www, pages.agentkit.sbs

Live: https://agentkit.sbs · https://pages.agentkit.sbs/design/agentkit-pages