### PR TITLE
feat(pages): auto-invocable publish-page skill

### DIFF
--- a/skills/publish-page/SKILL.md
+++ b/skills/publish-page/SKILL.md
@@ -1,57 +1,45 @@
 ---
 name: publish-page
-description: Publish agent output (reports, docs, slide decks, dashboards) as a web page at pages.agentkit.sbs — use whenever rich HTML output beats chat text, when the user asks to publish/share a page, or when producing a report/deck worth keeping at a stable URL.
+description: Publish content as a live web page with a stable URL (AgentKit Pages, self-hosted artifacts). Use AUTOMATICALLY whenever the user asks to publish/share/host a page, make an artifact/report/dashboard/slide deck/design doc viewable in a browser, or when rich formatted output would clearly beat chat text. Also triggers on "make a page", "put this on a page", "publish this", "as a deck/slides", "share a link". Renders markdown or HTML through themes and returns the live URL.
 ---
 
 # publish-page
 
-Publish a page to AgentKit Pages. Pages are **public** in the current phase —
-never publish secrets or private data.
+You publish pages **end-to-end without asking the user for details**. Like creating
+an artifact: decide, publish, hand back the URL.
 
-## Usage
+## Automated workflow
 
-One-time setup (bun does not auto-install when a package.json is present):
+1. **Write the content** to a temp file (scratchpad). Markdown for docs/decks;
+   complete self-contained HTML for bespoke pages (dashboards, visualizations).
+2. **Pick the slug yourself**: short, descriptive, lowercase `a-z0-9-`, up to 4
+   `/` segments, e.g. `reports/fcar-q3`, `designs/auth-flow`, `decks/roadmap`.
+   Republishing the same slug updates the same URL — reuse the slug when
+   iterating on the same page.
+3. **Pick the template yourself**: `doc` (default, report/article), `deck`
+   (slides — split on `---` lines in markdown), `raw` (complete HTML published
+   as-is).
+4. **Run** (one-time per machine: `cd <skill-dir> && bun install`):
 
 ```bash
-cd <skill-dir> && bun install
+bun <skill-dir>/publish.ts --slug <slug> --file <content-file> [--template doc|deck|raw] [--title "Title"]
 ```
 
-```bash
-bun <skill-dir>/publish.ts --slug <slug> --file <content-file> \
-  [--template doc|deck|raw] [--title "Page title"] [--no-git]
-```
+5. **Give the user the URL** it prints (`https://pages.agentkit.sbs/<slug>`).
+   That URL is live immediately.
 
-- `--slug` — URL path, lowercase `a-z0-9-` with up to 4 `/` segments (e.g. `reports/q3-audit`).
-  Republishing the same slug updates the same URL.
-- `--file` — content: markdown (`.md`) or HTML fragment/full page (`.html`).
-- `--template`
-  - `doc` (default) — report/article chrome.
-  - `deck` — slide deck; split slides on `---` lines (markdown) or `<hr>` (HTML).
-    Arrow keys / swipe / dots navigate; print gives one slide per page.
-  - `raw` — file is a complete self-contained HTML page, published as-is.
-- `--no-git` — skip the canonical commit (serving write only; use when the pages
-  repo is unavailable).
+## Requirements and behavior
 
-Prints the live URL on success. Errors are loud; fix and re-run.
-
-## What it does
-
-1. Renders content through the theme (from the agentkit-pages repo clone).
-2. `PUT`s the rendered HTML to the Worker — the URL is live immediately.
-3. Commits `src/<slug>/` + `dist/<slug>/` to the agentkit-pages repo (canonical
-   history) and pushes. The pages repo is a content datastore: direct commits to
-   its default branch are by design.
-
-## Config
-
-| Setting | Source | Default |
-| --- | --- | --- |
-| Endpoint | `AGENTKIT_PAGES_ENDPOINT` | `https://pages.agentkit.sbs` |
-| Token | `~/.config/agentkit/pages-token` | required |
-| Pages repo clone | `AGENTKIT_PAGES_REPO` | `~/code/agentkit-pages` |
-
-## Rules for page content
-
-- Self-contained only: inline all CSS/JS, `data:` URIs for images. No CDN links.
-- The serving CSP allows inline style/script and blocks all external requests.
-- Max 5 MB per page.
+- Publish token: `~/.config/agentkit/pages-token` (mint at agentkit.sbs; on eda
+  it is already provisioned, canonical copy in OpenBao
+  `secrets/platform/agentkit/pages`).
+- Themes are bundled with the skill; if a clone of `gitlab.com/agentkit/agentkit-pages`
+  exists at `~/code/agentkit-pages` (override: `AGENTKIT_PAGES_REPO`), the publish
+  also commits `src/` + `dist/` there for canonical history — otherwise it
+  serves-only and says so. Endpoint override: `AGENTKIT_PAGES_ENDPOINT`.
+- Pages are **public by slug** (unguessable is NOT private) — never publish
+  secrets, tokens, or personal data. Accounts/private pages are a coming phase.
+- Pages must be self-contained: inline all CSS/JS, `data:` URIs for images. The
+  serving CSP blocks every external request. Max 5 MB.
+- Errors are loud; fix and re-run. Do not fall back to pasting the content into
+  chat without saying the publish failed.

--- a/skills/publish-page/SKILL.md
+++ b/skills/publish-page/SKILL.md
@@ -30,15 +30,21 @@ bun <skill-dir>/publish.ts --slug <slug> --file <content-file> [--template doc|d
 
 ## Requirements and behavior
 
-- Publish token: `~/.config/agentkit/pages-token` (mint at agentkit.sbs; on eda
-  it is already provisioned, canonical copy in OpenBao
-  `secrets/platform/agentkit/pages`).
+- Publish token: `~/.config/agentkit/pages-token` (mint at agentkit.sbs).
 - Themes are bundled with the skill; if a clone of `gitlab.com/agentkit/agentkit-pages`
   exists at `~/code/agentkit-pages` (override: `AGENTKIT_PAGES_REPO`), the publish
   also commits `src/` + `dist/` there for canonical history — otherwise it
   serves-only and says so. Endpoint override: `AGENTKIT_PAGES_ENDPOINT`.
 - Pages are **public by slug** (unguessable is NOT private) — never publish
   secrets, tokens, or personal data. Accounts/private pages are a coming phase.
+  "Without asking" covers slug/template/mechanics only: when the user asked to
+  publish, publish. When YOU are proposing the page and its content derives from
+  private material (client data, internal repos, credentials-adjacent config),
+  confirm with the user before publishing.
+- Slug collisions overwrite silently, and on machines without the pages repo
+  clone there is no git history to recover from — pick distinctive slugs, and
+  reuse a slug only when deliberately updating that page. `--no-git` skips the
+  canonical commit explicitly (same effect as a missing clone).
 - Pages must be self-contained: inline all CSS/JS, `data:` URIs for images. The
   serving CSP blocks every external request. Max 5 MB.
 - Errors are loud; fix and re-run. Do not fall back to pasting the content into

--- a/skills/publish-page/publish.ts
+++ b/skills/publish-page/publish.ts
@@ -28,7 +28,7 @@ function escapeHtml(s: string): string {
 const slug = arg("slug") ?? fail("--slug is required");
 const file = arg("file") ?? fail("--file is required");
 const template = arg("template") ?? "doc";
-const noGit = process.argv.includes("--no-git");
+let noGit = process.argv.includes("--no-git");
 if (!SLUG_RE.test(slug)) fail(`invalid slug "${slug}" (lowercase a-z0-9-, max 4 segments)`);
 if (!["doc", "deck", "raw"].includes(template)) fail(`unknown template "${template}"`);
 if (!existsSync(file)) fail(`no such file: ${file}`);
@@ -71,8 +71,12 @@ function splitSlides(md: string): string[] {
 
 async function render(): Promise<string> {
   if (template === "raw") return source;
-  const themePath = join(repo, "themes", `${template}.html`);
-  if (!existsSync(themePath)) fail(`theme not found: ${themePath} (clone agentkit-pages?)`);
+  // Canonical themes live in the agentkit-pages repo; the skill bundles a copy
+  // so publishing works on machines without the repo clone.
+  const repoTheme = join(repo, "themes", `${template}.html`);
+  const bundledTheme = join(import.meta.dir, "themes", `${template}.html`);
+  const themePath = existsSync(repoTheme) ? repoTheme : bundledTheme;
+  if (!existsSync(themePath)) fail(`theme not found: ${repoTheme} or ${bundledTheme}`);
   const theme = await readFile(themePath, "utf8");
   let content: string;
   if (template === "deck") {
@@ -105,8 +109,11 @@ const res = await fetch(`${endpoint}/api/pages/${slug}`, {
 if (!res.ok) fail(`publish failed: HTTP ${res.status} ${await res.text()}`);
 const { url } = (await res.json()) as { url: string };
 
+if (!noGit && !existsSync(join(repo, ".git"))) {
+  console.error(`note: pages repo not found at ${repo} — published without canonical git commit`);
+  noGit = true;
+}
 if (!noGit) {
-  if (!existsSync(join(repo, ".git"))) fail(`pages repo not found at ${repo} (published, but not committed)`);
   const srcDir = join(repo, "src", slug);
   const distDir = join(repo, "dist", slug);
   await mkdir(srcDir, { recursive: true });

--- a/skills/publish-page/publish.ts
+++ b/skills/publish-page/publish.ts
@@ -78,6 +78,12 @@ async function render(): Promise<string> {
   const themePath = existsSync(repoTheme) ? repoTheme : bundledTheme;
   if (!existsSync(themePath)) fail(`theme not found: ${repoTheme} or ${bundledTheme}`);
   const theme = await readFile(themePath, "utf8");
+  if (themePath === repoTheme && existsSync(bundledTheme)) {
+    const bundled = await readFile(bundledTheme, "utf8");
+    if (bundled !== theme) {
+      console.error(`warning: bundled theme drifted from canonical ${repoTheme} — re-sync skills/publish-page/themes/`);
+    }
+  }
   let content: string;
   if (template === "deck") {
     const parts = isMd

--- a/skills/publish-page/themes/deck.html
+++ b/skills/publish-page/themes/deck.html
@@ -1,0 +1,108 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{{TITLE}}</title>
+<style>
+  :root {
+    --bg: #f7f9fb; --ink: #16202c; --muted: #5b6b7c; --accent: #0e7490;
+    --line: #d8e0e8; --card: #ffffff; --code-bg: #eef2f6;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0b1220; --ink: #e2e9f0; --muted: #8fa1b3; --accent: #7dd3fc;
+      --line: #223144; --card: #101a2b; --code-bg: #0e1828;
+    }
+  }
+  * { box-sizing: border-box; }
+  html, body { height: 100%; }
+  body {
+    background: var(--bg); color: var(--ink); margin: 0;
+    font-family: system-ui, -apple-system, "Segoe UI", sans-serif; line-height: 1.6;
+  }
+  .slide {
+    display: none; height: 100vh; padding: 6vh 8vw; overflow-y: auto;
+    flex-direction: column; justify-content: center;
+  }
+  .slide.active { display: flex; }
+  .slide h1 { font-size: clamp(1.8rem, 5vw, 3.2rem); letter-spacing: -0.02em; line-height: 1.1; text-wrap: balance; margin: 0 0 1rem; }
+  .slide h2 { font-size: clamp(1.4rem, 3.5vw, 2.2rem); letter-spacing: -0.01em; text-wrap: balance; margin: 0 0 1rem; }
+  .slide p, .slide li { font-size: clamp(1rem, 1.8vw, 1.25rem); max-width: 60ch; }
+  .slide li { margin-bottom: 0.5rem; }
+  a { color: var(--accent); }
+  code {
+    font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 0.85em;
+    background: var(--code-bg); border-radius: 4px; padding: 0.1em 0.35em;
+  }
+  pre { background: var(--code-bg); border: 1px solid var(--line); border-radius: 8px; padding: 1rem 1.2rem; overflow-x: auto; font-size: clamp(0.75rem, 1.4vw, 0.95rem); }
+  pre code { background: none; padding: 0; }
+  table { border-collapse: collapse; display: block; overflow-x: auto; }
+  th, td { padding: 0.5rem 0.9rem 0.5rem 0; border-bottom: 1px solid var(--line); text-align: left; }
+  .hud {
+    position: fixed; bottom: 1rem; left: 0; right: 0; display: flex;
+    justify-content: center; align-items: center; gap: 0.45rem; pointer-events: none;
+  }
+  .dot {
+    width: 7px; height: 7px; border-radius: 50%; background: var(--line);
+    transition: background 0.2s; pointer-events: auto; border: 0; padding: 0; cursor: pointer;
+  }
+  .dot.on { background: var(--accent); }
+  .count {
+    position: fixed; bottom: 0.85rem; right: 1.2rem;
+    font-family: ui-monospace, Menlo, monospace; font-size: 0.72rem; color: var(--muted);
+    font-variant-numeric: tabular-nums;
+  }
+  @media print {
+    .slide { display: flex; height: auto; min-height: 100vh; page-break-after: always; }
+    .hud, .count { display: none; }
+  }
+  @media (prefers-reduced-motion: no-preference) {
+    .slide.active { animation: rise 0.25s ease-out; }
+    @keyframes rise { from { opacity: 0; transform: translateY(8px); } }
+  }
+  :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+</style>
+</head>
+<body>
+{{CONTENT}}
+<div class="hud" id="hud"></div>
+<div class="count" id="count"></div>
+<script>
+  const slides = [...document.querySelectorAll(".slide")];
+  const hud = document.getElementById("hud");
+  const count = document.getElementById("count");
+  let i = Math.max(0, slides.findIndex((s) => location.hash === "#" + (slides.indexOf(s) + 1)));
+  const dots = slides.map((_, n) => {
+    const d = document.createElement("button");
+    d.className = "dot";
+    d.setAttribute("aria-label", "slide " + (n + 1));
+    d.onclick = () => show(n);
+    hud.appendChild(d);
+    return d;
+  });
+  function show(n) {
+    i = Math.min(Math.max(n, 0), slides.length - 1);
+    slides.forEach((s, k) => s.classList.toggle("active", k === i));
+    dots.forEach((d, k) => d.classList.toggle("on", k === i));
+    count.textContent = (i + 1) + " / " + slides.length;
+    history.replaceState(null, "", "#" + (i + 1));
+  }
+  addEventListener("keydown", (e) => {
+    if (["ArrowRight", "PageDown", " "].includes(e.key)) { e.preventDefault(); show(i + 1); }
+    if (["ArrowLeft", "PageUp"].includes(e.key)) { e.preventDefault(); show(i - 1); }
+    if (e.key === "Home") show(0);
+    if (e.key === "End") show(slides.length - 1);
+  });
+  let x0 = null;
+  addEventListener("touchstart", (e) => { x0 = e.touches[0].clientX; }, { passive: true });
+  addEventListener("touchend", (e) => {
+    if (x0 === null) return;
+    const dx = e.changedTouches[0].clientX - x0;
+    if (Math.abs(dx) > 50) show(i + (dx < 0 ? 1 : -1));
+    x0 = null;
+  }, { passive: true });
+  show(i);
+</script>
+</body>
+</html>

--- a/skills/publish-page/themes/doc.html
+++ b/skills/publish-page/themes/doc.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{{TITLE}}</title>
+<style>
+  :root {
+    --bg: #f7f9fb; --ink: #16202c; --muted: #5b6b7c; --accent: #0e7490;
+    --accent-soft: #e0f0f4; --line: #d8e0e8; --card: #ffffff; --code-bg: #eef2f6;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0b1220; --ink: #e2e9f0; --muted: #8fa1b3; --accent: #7dd3fc;
+      --accent-soft: #12263a; --line: #223144; --card: #101a2b; --code-bg: #0e1828;
+    }
+  }
+  * { box-sizing: border-box; }
+  body {
+    background: var(--bg); color: var(--ink); margin: 0;
+    font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+    line-height: 1.65; padding: 3rem 1.25rem 5rem;
+  }
+  main { max-width: 46rem; margin: 0 auto; }
+  h1 { font-size: 2rem; line-height: 1.15; letter-spacing: -0.02em; text-wrap: balance; margin: 0 0 0.8rem; }
+  h2 { font-size: 1.3rem; letter-spacing: -0.01em; margin: 2.4rem 0 0.8rem; padding-top: 1.2rem; border-top: 1px solid var(--line); text-wrap: balance; }
+  h3 { font-size: 1.05rem; margin: 1.4rem 0 0.5rem; }
+  p, li { max-width: 65ch; }
+  li { margin-bottom: 0.3rem; }
+  a { color: var(--accent); }
+  code {
+    font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 0.85em;
+    background: var(--code-bg); border-radius: 4px; padding: 0.1em 0.35em;
+  }
+  pre {
+    background: var(--code-bg); border: 1px solid var(--line); border-radius: 8px;
+    padding: 1rem 1.2rem; overflow-x: auto; font-size: 0.82rem; line-height: 1.5;
+  }
+  pre code { background: none; padding: 0; }
+  blockquote { border-left: 3px solid var(--accent); margin: 1rem 0; padding: 0.2rem 0 0.2rem 1rem; color: var(--muted); }
+  .table-wrap, table { max-width: 100%; }
+  table { border-collapse: collapse; font-size: 0.9rem; display: block; overflow-x: auto; }
+  th {
+    text-align: left; font-family: ui-monospace, Menlo, monospace; font-size: 0.7rem;
+    letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted);
+    font-weight: 500; padding: 0.5rem 0.9rem 0.5rem 0; border-bottom: 1px solid var(--line);
+  }
+  td { padding: 0.55rem 0.9rem 0.55rem 0; border-bottom: 1px solid var(--line); vertical-align: top; }
+  img { max-width: 100%; }
+  hr { border: 0; border-top: 1px solid var(--line); margin: 2rem 0; }
+  footer {
+    margin-top: 4rem; padding-top: 1rem; border-top: 1px solid var(--line);
+    font-family: ui-monospace, Menlo, monospace; font-size: 0.7rem;
+    letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted);
+  }
+  footer a { color: var(--muted); }
+  :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+</style>
+</head>
+<body>
+<main>
+{{CONTENT}}
+<footer>published with <a href="https://agentkit.sbs">agentkit pages</a></footer>
+</main>
+</body>
+</html>


### PR DESCRIPTION
- trigger-rich SKILL.md description so harnesses auto-invoke it (artifact-style UX)
- automated workflow: agent writes content, picks slug/template, publishes, returns URL
- themes bundled in the skill dir — publishing works with no agentkit-pages clone
- repo missing → serves-only with a loud note instead of failing