### PR TITLE
feat(pages): cryptic HMAC URLs + page deletion

### DIFF
--- a/pages/worker/src/worker.js
+++ b/pages/worker/src/worker.js
@@ -31,7 +31,10 @@ async function servePage(env, key, headers) {
   return html(200, obj.body, headers);
 }
 
-async function handlePublish(request, env, slug) {
+// Shared write-path gate: bearer auth (site slugs need SITE_TOKEN, pages need
+// PUBLISH_TOKEN, both fail closed when unset) + slug validation + R2 key.
+// Returns a Response on rejection, else { isSite, key }.
+function authorizeWrite(request, env, slug) {
   const auth = request.headers.get("authorization") ?? "";
   const token = auth.replace(/^Bearer\s+/i, "");
   const isSite = Object.hasOwn(SITE_SLUGS, slug);
@@ -42,6 +45,12 @@ async function handlePublish(request, env, slug) {
   if (!isSite && !SLUG_RE.test(slug)) {
     return new Response("invalid slug\n", { status: 400 });
   }
+  return { isSite, key: isSite ? SITE_SLUGS[slug] : `pages/${slug}/index.html` };
+}
+
+async function handlePublish(request, env, slug) {
+  const gate = authorizeWrite(request, env, slug);
+  if (gate instanceof Response) return gate;
   const declared = Number(request.headers.get("content-length") ?? "0");
   if (declared > MAX_PAGE_BYTES) {
     return new Response("page must be 1 byte to 5 MB\n", { status: 413 });
@@ -50,8 +59,7 @@ async function handlePublish(request, env, slug) {
   if (body.byteLength === 0 || body.byteLength > MAX_PAGE_BYTES) {
     return new Response("page must be 1 byte to 5 MB\n", { status: 413 });
   }
-  const key = isSite ? SITE_SLUGS[slug] : `pages/${slug}/index.html`;
-  await env.PAGES.put(key, body, {
+  await env.PAGES.put(gate.key, body, {
     httpMetadata: { contentType: "text/html; charset=utf-8" },
   });
   const url = slug === "_site"
@@ -62,6 +70,15 @@ async function handlePublish(request, env, slug) {
   return Response.json({ ok: true, slug, url });
 }
 
+async function handleDelete(request, env, slug) {
+  const gate = authorizeWrite(request, env, slug);
+  if (gate instanceof Response) return gate;
+  const existing = await env.PAGES.head(gate.key);
+  if (!existing) return new Response("not found\n", { status: 404 });
+  await env.PAGES.delete(gate.key);
+  return Response.json({ ok: true, deleted: slug });
+}
+
 export default {
   async fetch(request, env) {
     const url = new URL(request.url);
@@ -70,6 +87,9 @@ export default {
 
     if (request.method === "PUT" && path.startsWith("api/pages/")) {
       return handlePublish(request, env, path.slice("api/pages/".length));
+    }
+    if (request.method === "DELETE" && path.startsWith("api/pages/")) {
+      return handleDelete(request, env, path.slice("api/pages/".length));
     }
     if (request.method !== "GET" && request.method !== "HEAD") {
       return new Response("method not allowed\n", { status: 405 });

--- a/skills/publish-page/SKILL.md
+++ b/skills/publish-page/SKILL.md
@@ -12,17 +12,21 @@ an artifact: decide, publish, hand back the URL.
 
 1. **Write the content** to a temp file (scratchpad). Markdown for docs/decks;
    complete self-contained HTML for bespoke pages (dashboards, visualizations).
-2. **Pick the slug yourself**: short, descriptive, lowercase `a-z0-9-`, up to 4
-   `/` segments, e.g. `reports/fcar-q3`, `designs/auth-flow`, `decks/roadmap`.
-   Republishing the same slug updates the same URL — reuse the slug when
-   iterating on the same page.
+2. **Pick a logical name yourself**: short, descriptive, lowercase `a-z0-9-`,
+   e.g. `fcar-q3-report`, `auth-flow-design`. The URL is derived as
+   HMAC(token, name) — cryptic hex nobody can guess, but deterministic: the same
+   name republished from any machine with the token updates the SAME URL, and
+   `--delete --name <name>` finds it again. No mapping to store.
+   Use `--slug <path>` INSTEAD only when the user explicitly wants a
+   human-readable URL (up to 4 `/` segments).
 3. **Pick the template yourself**: `doc` (default, report/article), `deck`
    (slides — split on `---` lines in markdown), `raw` (complete HTML published
    as-is).
 4. **Run** (one-time per machine: `cd <skill-dir> && bun install`):
 
 ```bash
-bun <skill-dir>/publish.ts --slug <slug> --file <content-file> [--template doc|deck|raw] [--title "Title"]
+bun <skill-dir>/publish.ts --name <name> --file <content-file> [--template doc|deck|raw] [--title "Title"]
+bun <skill-dir>/publish.ts --name <name> --delete    # remove a page you published
 ```
 
 5. **Give the user the URL** it prints (`https://pages.agentkit.sbs/<slug>`).
@@ -41,10 +45,12 @@ bun <skill-dir>/publish.ts --slug <slug> --file <content-file> [--template doc|d
   publish, publish. When YOU are proposing the page and its content derives from
   private material (client data, internal repos, credentials-adjacent config),
   confirm with the user before publishing.
-- Slug collisions overwrite silently, and on machines without the pages repo
-  clone there is no git history to recover from — pick distinctive slugs, and
-  reuse a slug only when deliberately updating that page. `--no-git` skips the
-  canonical commit explicitly (same effect as a missing clone).
+- Same name (or slug) republished overwrites silently, and on machines without
+  the pages repo clone there is no git history to recover from — pick
+  distinctive names, reuse one only when deliberately updating that page.
+  `--no-git` skips the canonical commit explicitly (same effect as a missing
+  clone). Rotating the publish token changes every HMAC-derived URL on next
+  republish (old URLs keep serving until deleted).
 - Pages must be self-contained: inline all CSS/JS, `data:` URIs for images. The
   serving CSP blocks every external request. Max 5 MB.
 - Errors are loud; fix and re-run. Do not fall back to pasting the content into

--- a/skills/publish-page/SKILL.md
+++ b/skills/publish-page/SKILL.md
@@ -14,9 +14,9 @@ an artifact: decide, publish, hand back the URL.
    complete self-contained HTML for bespoke pages (dashboards, visualizations).
 2. **Pick a logical name yourself**: short, descriptive, lowercase `a-z0-9-`,
    e.g. `fcar-q3-report`, `auth-flow-design`. The URL is derived as
-   HMAC(token, name) — cryptic hex nobody can guess, but deterministic: the same
-   name republished from any machine with the token updates the SAME URL, and
-   `--delete --name <name>` finds it again. No mapping to store.
+   HMAC(slug key, name) — cryptic hex nobody can guess, but deterministic: the
+   same name republished updates the SAME URL, and `--delete --name <name>`
+   finds it again. No mapping to store.
    Use `--slug <path>` INSTEAD only when the user explicitly wants a
    human-readable URL (up to 4 `/` segments).
 3. **Pick the template yourself**: `doc` (default, report/article), `deck`
@@ -49,8 +49,13 @@ bun <skill-dir>/publish.ts --name <name> --delete    # remove a page you publish
   the pages repo clone there is no git history to recover from — pick
   distinctive names, reuse one only when deliberately updating that page.
   `--no-git` skips the canonical commit explicitly (same effect as a missing
-  clone). Rotating the publish token changes every HMAC-derived URL on next
-  republish (old URLs keep serving until deleted).
+  clone).
+- Slug key: `~/.config/agentkit/pages-slug-key`, auto-generated on first use,
+  deliberately separate from the auth token so credential rotation never
+  changes a URL. Copy the SAME key to other machines (alongside the token) or
+  the same name derives different URLs per machine. Losing the key strands
+  HMAC-derived pages from `--name` reach — recover slugs from the pages repo
+  `meta.yaml` and manage them via `--slug`.
 - Pages must be self-contained: inline all CSS/JS, `data:` URIs for images. The
   serving CSP blocks every external request. Max 5 MB.
 - Errors are loud; fix and re-run. Do not fall back to pasting the content into

--- a/skills/publish-page/publish.ts
+++ b/skills/publish-page/publish.ts
@@ -2,7 +2,7 @@
 import { marked } from "marked";
 import { createHmac, randomBytes } from "node:crypto";
 import { existsSync } from "node:fs";
-import { chmod, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -62,8 +62,7 @@ const slugKeyPath = join(homedir(), ".config/agentkit/pages-slug-key");
 async function slugKey(): Promise<string> {
   if (existsSync(slugKeyPath)) return (await readFile(slugKeyPath, "utf8")).trim();
   const key = randomBytes(32).toString("hex");
-  await writeFile(slugKeyPath, key);
-  await chmod(slugKeyPath, 0o600);
+  await writeFile(slugKeyPath, key, { mode: 0o600 });
   console.error(`note: generated new slug key at ${slugKeyPath} — copy it to other machines for same-name URL determinism`);
   return key;
 }

--- a/skills/publish-page/publish.ts
+++ b/skills/publish-page/publish.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env bun
 import { marked } from "marked";
-import { createHmac } from "node:crypto";
+import { createHmac, randomBytes } from "node:crypto";
 import { existsSync } from "node:fs";
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -53,11 +53,22 @@ const tokenPath = join(homedir(), ".config/agentkit/pages-token");
 if (!existsSync(tokenPath)) fail(`publish token missing at ${tokenPath}`);
 const token = (await readFile(tokenPath, "utf8")).trim();
 
-// Cryptic-but-deterministic slug: HMAC(token, name). Only token holders can
-// derive it, and every machine with the token derives the same slug from the
-// same logical name — update and delete need no stored mapping.
+// Cryptic-but-deterministic slug: HMAC(slug key, name). The slug key is a
+// dedicated secret — NOT the auth token — so rotating credentials never
+// changes or orphans a URL, and a leaked slug key grants no write access.
+// Generated once per install; copy the same key to other machines for
+// cross-machine determinism.
+const slugKeyPath = join(homedir(), ".config/agentkit/pages-slug-key");
+async function slugKey(): Promise<string> {
+  if (existsSync(slugKeyPath)) return (await readFile(slugKeyPath, "utf8")).trim();
+  const key = randomBytes(32).toString("hex");
+  await writeFile(slugKeyPath, key);
+  await chmod(slugKeyPath, 0o600);
+  console.error(`note: generated new slug key at ${slugKeyPath} — copy it to other machines for same-name URL determinism`);
+  return key;
+}
 const slug = explicitSlug
-  ?? createHmac("sha256", token).update(name!).digest("hex").slice(0, 20);
+  ?? createHmac("sha256", await slugKey()).update(name!).digest("hex").slice(0, 20);
 const pageLabel = name ?? slug;
 
 const git = (...args: string[]) =>
@@ -87,7 +98,7 @@ if (isDelete) {
   });
   if (res.status === 404) fail(`no page at ${slug} — nothing deleted`);
   if (!res.ok) fail(`delete failed: HTTP ${res.status} ${await res.text()}`);
-  if (repoAvailable()) {
+  if (!noGit && repoAvailable()) {
     await rm(join(repo, "src", slug), { recursive: true, force: true });
     await rm(join(repo, "dist", slug), { recursive: true, force: true });
     git("add", "-A", "--", `src/${slug}`, `dist/${slug}`);

--- a/skills/publish-page/publish.ts
+++ b/skills/publish-page/publish.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env bun
 import { marked } from "marked";
+import { createHmac } from "node:crypto";
 import { existsSync } from "node:fs";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -25,13 +26,22 @@ function escapeHtml(s: string): string {
   );
 }
 
-const slug = arg("slug") ?? fail("--slug is required");
-const file = arg("file") ?? fail("--file is required");
+const explicitSlug = arg("slug");
+const name = arg("name");
+const isDelete = process.argv.includes("--delete");
+const file = arg("file");
 const template = arg("template") ?? "doc";
 let noGit = process.argv.includes("--no-git");
-if (!SLUG_RE.test(slug)) fail(`invalid slug "${slug}" (lowercase a-z0-9-, max 4 segments)`);
+if (!explicitSlug && !name) fail("--name (cryptic URL, default) or --slug (readable URL) is required");
+if (explicitSlug && !SLUG_RE.test(explicitSlug)) {
+  fail(`invalid slug "${explicitSlug}" (lowercase a-z0-9-, max 4 segments)`);
+}
+if (name && !/^[a-z0-9][a-z0-9-]{0,63}$/.test(name)) {
+  fail(`invalid name "${name}" (lowercase a-z0-9-)`);
+}
 if (!["doc", "deck", "raw"].includes(template)) fail(`unknown template "${template}"`);
-if (!existsSync(file)) fail(`no such file: ${file}`);
+if (!isDelete && !file) fail("--file is required");
+if (!isDelete && !existsSync(file!)) fail(`no such file: ${file}`);
 
 const endpoint = process.env.AGENTKIT_PAGES_ENDPOINT ?? "https://pages.agentkit.sbs";
 const endpointHost = new URL(endpoint).hostname;
@@ -43,12 +53,56 @@ const tokenPath = join(homedir(), ".config/agentkit/pages-token");
 if (!existsSync(tokenPath)) fail(`publish token missing at ${tokenPath}`);
 const token = (await readFile(tokenPath, "utf8")).trim();
 
-const source = await readFile(file, "utf8");
-const isMd = /\.(md|markdown|mdown)$/i.test(file);
+// Cryptic-but-deterministic slug: HMAC(token, name). Only token holders can
+// derive it, and every machine with the token derives the same slug from the
+// same logical name — update and delete need no stored mapping.
+const slug = explicitSlug
+  ?? createHmac("sha256", token).update(name!).digest("hex").slice(0, 20);
+const pageLabel = name ?? slug;
+
+const git = (...args: string[]) =>
+  Bun.spawnSync(["git", "-C", repo, ...args], { stdout: "pipe", stderr: "pipe" });
+const repoAvailable = () => existsSync(join(repo, ".git"));
+
+function commitScoped(message: string, paths: string[]) {
+  const staged = git("diff", "--cached", "--quiet", "--", ...paths);
+  if (staged.exitCode === 0) return;
+  // Pathspec-scoped commit: the clone is long-lived and shared — a bare
+  // commit would sweep anything else staged into this publish.
+  const commit = git("commit", "-m", message, "--", ...paths);
+  if (commit.exitCode === 0) {
+    const push = git("push");
+    if (push.exitCode !== 0) {
+      console.error(`warning: git push failed — commit is local only:\n${push.stderr.toString()}`);
+    }
+  } else {
+    console.error(`warning: git commit failed:\n${commit.stderr.toString()}`);
+  }
+}
+
+if (isDelete) {
+  const res = await fetch(`${endpoint}/api/pages/${slug}`, {
+    method: "DELETE",
+    headers: { authorization: `Bearer ${token}` },
+  });
+  if (res.status === 404) fail(`no page at ${slug} — nothing deleted`);
+  if (!res.ok) fail(`delete failed: HTTP ${res.status} ${await res.text()}`);
+  if (repoAvailable()) {
+    await rm(join(repo, "src", slug), { recursive: true, force: true });
+    await rm(join(repo, "dist", slug), { recursive: true, force: true });
+    git("add", "-A", "--", `src/${slug}`, `dist/${slug}`);
+    commitScoped(`pages: delete ${pageLabel}`, [`src/${slug}`, `dist/${slug}`]);
+  }
+  console.log(`deleted: ${endpoint}/${slug}`);
+  process.exit(0);
+}
+
+const source = await readFile(file!, "utf8");
+const isMd = /\.(md|markdown|mdown)$/i.test(file!);
 const title = arg("title")
   ?? source.match(/^#\s+(.+)$/m)?.[1]
   ?? source.match(/<title>([^<]+)<\/title>/)?.[1]
-  ?? slug;
+  ?? pageLabel;
 
 // Split markdown into slides on `---` lines, ignoring YAML frontmatter and
 // `---` inside fenced code blocks — a naive regex split cuts fences in half.
@@ -115,7 +169,7 @@ const res = await fetch(`${endpoint}/api/pages/${slug}`, {
 if (!res.ok) fail(`publish failed: HTTP ${res.status} ${await res.text()}`);
 const { url } = (await res.json()) as { url: string };
 
-if (!noGit && !existsSync(join(repo, ".git"))) {
+if (!noGit && !repoAvailable()) {
   console.error(`note: pages repo not found at ${repo} — published without canonical git commit`);
   noGit = true;
 }
@@ -127,24 +181,11 @@ if (!noGit) {
   await writeFile(join(srcDir, isMd ? "content.md" : "content.html"), source);
   await writeFile(
     join(srcDir, "meta.yaml"),
-    `title: ${JSON.stringify(title)}\ntemplate: ${template}\nslug: ${slug}\n`,
+    `title: ${JSON.stringify(title)}\nname: ${JSON.stringify(pageLabel)}\ntemplate: ${template}\nslug: ${slug}\n`,
   );
   await writeFile(join(distDir, "index.html"), html);
-  const git = (...args: string[]) =>
-    Bun.spawnSync(["git", "-C", repo, ...args], { stdout: "pipe", stderr: "pipe" });
   git("add", `src/${slug}`, `dist/${slug}`);
-  const staged = git("diff", "--cached", "--quiet", "--", `src/${slug}`, `dist/${slug}`);
-  if (staged.exitCode !== 0) {
-    // Pathspec-scoped commit: the clone is long-lived and shared — a bare
-    // commit would sweep anything else staged into this publish.
-    const commit = git("commit", "-m", `pages: publish ${slug}`, "--", `src/${slug}`, `dist/${slug}`);
-    if (commit.exitCode === 0) {
-      const push = git("push");
-      if (push.exitCode !== 0) console.error(`warning: git push failed — commit is local only:\n${push.stderr.toString()}`);
-    } else {
-      console.error(`warning: git commit failed:\n${commit.stderr.toString()}`);
-    }
-  }
+  commitScoped(`pages: publish ${pageLabel}`, [`src/${slug}`, `dist/${slug}`]);
 }
 
 console.log(url);


### PR DESCRIPTION
- default URL is now HMAC(token, name) hex — cryptic to outsiders, deterministic for token holders: same --name republishes/deletes the same URL from any machine, no stored mapping
- --slug remains for explicitly human-readable URLs
- Worker: DELETE /api/pages/:slug (same token gates as PUT via shared authorizeWrite; 404 on absent page)
- skill: --delete removes the page + prunes src/dist from the canonical repo
- live-tested: determinism, republish, delete->404, double-delete failure, unauth 401