### PR TITLE
feat(pages): mermaid diagrams, navy house theme, built-in component library

### DIFF
--- a/skills/publish-page/SKILL.md
+++ b/skills/publish-page/SKILL.md
@@ -32,6 +32,40 @@ bun <skill-dir>/publish.ts --name <name> --delete    # remove a page you publish
 5. **Give the user the URL** it prints (`https://pages.agentkit.sbs/<slug>`).
    That URL is live immediately.
 
+## Page design — the house style is built in
+
+Pages should look designed, not dumped. The doc/deck themes carry the house
+identity automatically (**dark navy** ground `#071224→#0a1c38`, ink `#dce7f5`,
+green accent `#34d3a6`, gold `#e8b444`, panels `#102847`, lines `#1e3a5f`,
+mono eyebrows) — never re-explain or re-style these basics.
+
+**Be illustrative by default.** Structure every doc page as sections and pick the
+strongest component for each idea — don't produce walls of prose:
+
+- **Diagrams: use mermaid fences** — they render as real diagrams (the runtime
+  is inlined automatically, only on pages that use it). Prefer mermaid over
+  ASCII art for flows, architectures, sequences:
+  ````
+  ```mermaid
+  flowchart LR
+    A[agent] -->|PUT| W[Worker] --> R2[(R2)]
+  ```
+  ````
+- **Section headers**: `<div class="kicker">01 — topic</div>` before an `## h2`.
+- **Enumerable concepts** (features, components, principles): a 2-column grid —
+  `<div class="cards"><div class="card"><h3><code>name</code></h3><p>…</p></div>…</div>`
+- **Key decisions / warnings**: `<div class="callout"><strong>Label.</strong> text</div>`
+- **Metadata rows**: `<div class="chips"><span class="chip"><strong>Status</strong> live</span>…</div>`
+- **Pipeline/stage boxes** (when mermaid is overkill):
+  `<div class="flow"><div class="frow"><div class="fbox gate"><span class="t">stage</span><span class="d">detail</span></div>…</div><div class="arrow">▼</div>…</div>`
+  — `.fbox` variants: `.gate` (gold), `.ok` (green), `.deny` (red).
+- **Facts with columns**: markdown tables (themed automatically).
+
+All of these work inside markdown files — markdown passes raw HTML through.
+Decks: one idea per slide, kicker + h2 + a few bullets or one diagram/card grid;
+put heavy diagrams on their own slide. Raw pages: full freedom, but reuse the
+navy tokens above so pages feel like one product.
+
 ## Requirements and behavior
 
 - Publish token: `~/.config/agentkit/pages-token` (mint at agentkit.sbs).

--- a/skills/publish-page/SKILL.md
+++ b/skills/publish-page/SKILL.md
@@ -43,8 +43,9 @@ mono eyebrows) — never re-explain or re-style these basics.
 strongest component for each idea — don't produce walls of prose:
 
 - **Diagrams: use mermaid fences** — they render as real diagrams (the runtime
-  is inlined automatically, only on pages that use it). Prefer mermaid over
-  ASCII art for flows, architectures, sequences:
+  is inlined automatically, only on pages that use it; it costs ~3.4 MB of the
+  5 MB page cap, leaving ~1.4 MB for content on diagram pages). Prefer mermaid
+  over ASCII art for flows, architectures, sequences:
   ````
   ```mermaid
   flowchart LR

--- a/skills/publish-page/package.json
+++ b/skills/publish-page/package.json
@@ -2,7 +2,8 @@
   "name": "publish-page-skill",
   "private": true,
   "dependencies": {
-    "marked": "^18.0.7"
+    "marked": "^18.0.7",
+    "mermaid": "^11.16.0"
   },
   "devDependencies": {
     "@types/bun": "^1.2.19"

--- a/skills/publish-page/package.json
+++ b/skills/publish-page/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "marked": "^18.0.7",
-    "mermaid": "^11.16.0"
+    "mermaid": "11.16.0"
   },
   "devDependencies": {
     "@types/bun": "^1.2.19"

--- a/skills/publish-page/publish.ts
+++ b/skills/publish-page/publish.ts
@@ -133,11 +133,15 @@ function splitSlides(md: string): string[] {
   return slides.map((s) => s.join("\n"));
 }
 
-// ```mermaid fences become <pre class="mermaid"> blocks that the inlined
-// runtime renders in the browser — same mechanism Claude artifacts use.
-function liftMermaidFences(md: string): string {
-  return md.replace(/```mermaid\n([\s\S]*?)\n```/g, (_, code) => `<pre class="mermaid">\n${code}\n</pre>`);
-}
+// Mermaid fences via marked's renderer, not a regex: fence-aware (nesting,
+// splitSlides sees real fences) and escaped (mermaid decodes via textContent).
+marked.use({
+  renderer: {
+    code({ text, lang }: { text: string; lang?: string }) {
+      return lang === "mermaid" ? `<pre class="mermaid">${escapeHtml(text)}</pre>\n` : false;
+    },
+  },
+});
 
 async function mermaidRuntime(): Promise<string> {
   const dist = join(import.meta.dir, "node_modules/mermaid/dist/mermaid.min.js");
@@ -164,19 +168,18 @@ async function render(): Promise<string> {
       console.error(`warning: bundled theme drifted from canonical ${repoTheme} — re-sync skills/publish-page/themes/`);
     }
   }
-  const prepared = isMd ? liftMermaidFences(source) : source;
   let content: string;
   if (template === "deck") {
     const parts = isMd
-      ? splitSlides(prepared).map((s) => marked.parse(s) as string)
-      : prepared.split(/<hr\b[^>]*>/i);
+      ? splitSlides(source).map((s) => marked.parse(s) as string)
+      : source.split(/<hr\b[^>]*>/i);
     content = parts
       .map((s) => s.trim())
       .filter(Boolean)
       .map((s) => `<section class="slide">\n${s}\n</section>`)
       .join("\n");
   } else {
-    content = isMd ? (marked.parse(prepared) as string) : prepared;
+    content = isMd ? (marked.parse(source) as string) : source;
   }
   if (content.includes('class="mermaid"')) content += await mermaidRuntime();
   // Function replacers: a plain string replacement expands $&, $`, $' found in
@@ -187,7 +190,12 @@ async function render(): Promise<string> {
 }
 
 const html = await render();
-if (Buffer.byteLength(html) > 5 * 1024 * 1024) fail("rendered page exceeds 5 MB");
+if (Buffer.byteLength(html) > 5 * 1024 * 1024) {
+  const hint = html.includes("mermaid.initialize")
+    ? " (the inlined mermaid runtime accounts for ~3.4 MB — diagram pages have ~1.4 MB left for content; split the page or drop diagrams)"
+    : "";
+  fail(`rendered page exceeds 5 MB${hint}`);
+}
 
 const res = await fetch(`${endpoint}/api/pages/${slug}`, {
   method: "PUT",

--- a/skills/publish-page/publish.ts
+++ b/skills/publish-page/publish.ts
@@ -133,6 +133,22 @@ function splitSlides(md: string): string[] {
   return slides.map((s) => s.join("\n"));
 }
 
+// ```mermaid fences become <pre class="mermaid"> blocks that the inlined
+// runtime renders in the browser — same mechanism Claude artifacts use.
+function liftMermaidFences(md: string): string {
+  return md.replace(/```mermaid\n([\s\S]*?)\n```/g, (_, code) => `<pre class="mermaid">\n${code}\n</pre>`);
+}
+
+async function mermaidRuntime(): Promise<string> {
+  const dist = join(import.meta.dir, "node_modules/mermaid/dist/mermaid.min.js");
+  if (!existsSync(dist)) fail(`mermaid runtime missing at ${dist} — run: cd ${import.meta.dir} && bun install`);
+  const js = await readFile(dist, "utf8");
+  // Decks render diagrams per-slide (hidden slides have zero width, which breaks
+  // mermaid's measurements) — the deck theme's show() calls mermaid.run on the
+  // active slide; docs render everything immediately.
+  return `\n<script>${js}</script>\n<script>mermaid.initialize({ startOnLoad: false, theme: "dark" }); if (!document.querySelector(".slide")) mermaid.run();</script>`;
+}
+
 async function render(): Promise<string> {
   if (template === "raw") return source;
   // Canonical themes live in the agentkit-pages repo; the skill bundles a copy
@@ -148,19 +164,21 @@ async function render(): Promise<string> {
       console.error(`warning: bundled theme drifted from canonical ${repoTheme} — re-sync skills/publish-page/themes/`);
     }
   }
+  const prepared = isMd ? liftMermaidFences(source) : source;
   let content: string;
   if (template === "deck") {
     const parts = isMd
-      ? splitSlides(source).map((s) => marked.parse(s) as string)
-      : source.split(/<hr\b[^>]*>/i);
+      ? splitSlides(prepared).map((s) => marked.parse(s) as string)
+      : prepared.split(/<hr\b[^>]*>/i);
     content = parts
       .map((s) => s.trim())
       .filter(Boolean)
       .map((s) => `<section class="slide">\n${s}\n</section>`)
       .join("\n");
   } else {
-    content = isMd ? (marked.parse(source) as string) : source;
+    content = isMd ? (marked.parse(prepared) as string) : prepared;
   }
+  if (content.includes('class="mermaid"')) content += await mermaidRuntime();
   // Function replacers: a plain string replacement expands $&, $`, $' found in
   // page content and silently corrupts the output.
   return theme

--- a/skills/publish-page/themes/deck.html
+++ b/skills/publish-page/themes/deck.html
@@ -5,20 +5,17 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>{{TITLE}}</title>
 <style>
+  /* AgentKit Pages house theme — committed dark navy (no light variant). */
   :root {
-    --bg: #f7f9fb; --ink: #16202c; --muted: #5b6b7c; --accent: #0e7490;
-    --line: #d8e0e8; --card: #ffffff; --code-bg: #eef2f6;
-  }
-  @media (prefers-color-scheme: dark) {
-    :root {
-      --bg: #0b1220; --ink: #e2e9f0; --muted: #8fa1b3; --accent: #7dd3fc;
-      --line: #223144; --card: #101a2b; --code-bg: #0e1828;
-    }
+    --navy: #0a1c38; --navy-deep: #071224; --card: #102847; --code-bg: #0d2140;
+    --line: #1e3a5f; --ink: #dce7f5; --muted: #8fa8c7;
+    --accent: #34d3a6; --gold: #e8b444; --red: #e06c5f;
   }
   * { box-sizing: border-box; }
   html, body { height: 100%; }
   body {
-    background: var(--bg); color: var(--ink); margin: 0;
+    background: linear-gradient(180deg, var(--navy-deep) 0%, var(--navy) 60vh);
+    color: var(--ink); margin: 0;
     font-family: system-ui, -apple-system, "Segoe UI", sans-serif; line-height: 1.6;
   }
   .slide {
@@ -35,10 +32,31 @@
     font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 0.85em;
     background: var(--code-bg); border-radius: 4px; padding: 0.1em 0.35em;
   }
-  pre { background: var(--code-bg); border: 1px solid var(--line); border-radius: 8px; padding: 1rem 1.2rem; overflow-x: auto; font-size: clamp(0.75rem, 1.4vw, 0.95rem); }
+  pre { background: var(--navy-deep); border: 1px solid var(--line); border-radius: 8px; padding: 1rem 1.2rem; overflow-x: auto; font-size: clamp(0.75rem, 1.4vw, 0.95rem); }
   pre code { background: none; padding: 0; }
   table { border-collapse: collapse; display: block; overflow-x: auto; }
   th, td { padding: 0.5rem 0.9rem 0.5rem 0; border-bottom: 1px solid var(--line); text-align: left; }
+  th { color: var(--muted); font-family: ui-monospace, Menlo, monospace; font-size: 0.72rem; letter-spacing: 0.1em; text-transform: uppercase; font-weight: 500; }
+  .kicker {
+    font-family: ui-monospace, Menlo, monospace; font-size: 0.75rem;
+    letter-spacing: 0.14em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.6rem;
+  }
+  .cards { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.9rem; margin: 1rem 0; }
+  @media (max-width: 40rem) { .cards { grid-template-columns: 1fr; } }
+  .card { background: var(--card); border: 1px solid var(--line); border-radius: 10px; padding: 1rem 1.2rem; }
+  .card h3 { margin: 0 0 0.35rem; font-size: 1rem; }
+  .card h3 code { color: var(--accent); background: none; padding: 0; }
+  .card p { margin: 0; color: var(--muted); font-size: 0.92rem; max-width: none; }
+  .callout {
+    border: 1px solid var(--line); background: #0d2f3a; border-radius: 8px;
+    padding: 0.8rem 1.1rem; margin: 1rem 0; max-width: 60ch;
+  }
+  .callout strong { color: var(--accent); }
+  pre.mermaid {
+    background: var(--card); border: 1px solid var(--line); border-radius: 10px;
+    padding: 1rem; overflow-x: auto; text-align: center;
+  }
+  pre.mermaid svg { max-width: 100%; height: auto; }
   .hud {
     position: fixed; bottom: 1rem; left: 0; right: 0; display: flex;
     justify-content: center; align-items: center; gap: 0.45rem; pointer-events: none;
@@ -87,6 +105,7 @@
     dots.forEach((d, k) => d.classList.toggle("on", k === i));
     count.textContent = (i + 1) + " / " + slides.length;
     history.replaceState(null, "", "#" + (i + 1));
+    if (window.mermaid) window.mermaid.run({ querySelector: ".slide.active pre.mermaid" });
   }
   addEventListener("keydown", (e) => {
     if (["ArrowRight", "PageDown", " "].includes(e.key)) { e.preventDefault(); show(i + 1); }

--- a/skills/publish-page/themes/doc.html
+++ b/skills/publish-page/themes/doc.html
@@ -5,21 +5,18 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>{{TITLE}}</title>
 <style>
+  /* AgentKit Pages house theme — committed dark navy (no light variant). */
   :root {
-    --bg: #f7f9fb; --ink: #16202c; --muted: #5b6b7c; --accent: #0e7490;
-    --accent-soft: #e0f0f4; --line: #d8e0e8; --card: #ffffff; --code-bg: #eef2f6;
-  }
-  @media (prefers-color-scheme: dark) {
-    :root {
-      --bg: #0b1220; --ink: #e2e9f0; --muted: #8fa1b3; --accent: #7dd3fc;
-      --accent-soft: #12263a; --line: #223144; --card: #101a2b; --code-bg: #0e1828;
-    }
+    --navy: #0a1c38; --navy-deep: #071224; --card: #102847; --code-bg: #0d2140;
+    --line: #1e3a5f; --ink: #dce7f5; --muted: #8fa8c7;
+    --accent: #34d3a6; --accent-soft: #0d2f3a; --gold: #e8b444; --red: #e06c5f;
   }
   * { box-sizing: border-box; }
   body {
-    background: var(--bg); color: var(--ink); margin: 0;
+    background: linear-gradient(180deg, var(--navy-deep) 0%, var(--navy) 220px);
+    color: var(--ink); margin: 0;
     font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
-    line-height: 1.65; padding: 3rem 1.25rem 5rem;
+    line-height: 1.65; padding: 3rem 1.25rem 5rem; min-height: 100vh;
   }
   main { max-width: 46rem; margin: 0 auto; }
   h1 { font-size: 2rem; line-height: 1.15; letter-spacing: -0.02em; text-wrap: balance; margin: 0 0 0.8rem; }
@@ -33,13 +30,12 @@
     background: var(--code-bg); border-radius: 4px; padding: 0.1em 0.35em;
   }
   pre {
-    background: var(--code-bg); border: 1px solid var(--line); border-radius: 8px;
+    background: var(--navy-deep); border: 1px solid var(--line); border-radius: 8px;
     padding: 1rem 1.2rem; overflow-x: auto; font-size: 0.82rem; line-height: 1.5;
   }
   pre code { background: none; padding: 0; }
   blockquote { border-left: 3px solid var(--accent); margin: 1rem 0; padding: 0.2rem 0 0.2rem 1rem; color: var(--muted); }
-  .table-wrap, table { max-width: 100%; }
-  table { border-collapse: collapse; font-size: 0.9rem; display: block; overflow-x: auto; }
+  table { border-collapse: collapse; font-size: 0.9rem; display: block; overflow-x: auto; max-width: 100%; }
   th {
     text-align: left; font-family: ui-monospace, Menlo, monospace; font-size: 0.7rem;
     letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted);
@@ -55,6 +51,61 @@
   }
   footer a { color: var(--muted); }
   :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+  /* Component library — content may use these classes directly (see SKILL.md):
+     .kicker .chips/.chip .cards/.card .callout .flow/.frow/.fbox(.gate.ok.deny) .arrow .mermaid */
+  .kicker {
+    font-family: ui-monospace, Menlo, monospace; font-size: 0.72rem;
+    letter-spacing: 0.14em; text-transform: uppercase; color: var(--accent);
+    margin: 2.2rem 0 0.3rem;
+  }
+  .kicker + h2 { margin-top: 0; border-top: none; padding-top: 0; }
+  .chips { display: flex; flex-wrap: wrap; gap: 0.5rem; margin: 0.8rem 0; }
+  .chip {
+    font-family: ui-monospace, Menlo, monospace; font-size: 0.72rem;
+    border: 1px solid var(--line); border-radius: 999px; padding: 0.15rem 0.65rem;
+    color: var(--muted); background: var(--code-bg);
+  }
+  .chip strong { color: var(--ink); font-weight: 600; }
+  .cards { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.9rem; margin: 1.2rem 0; }
+  @media (max-width: 40rem) { .cards { grid-template-columns: 1fr; } }
+  .card {
+    background: var(--card); border: 1px solid var(--line); border-radius: 10px;
+    padding: 1rem 1.2rem;
+  }
+  .card h3 { margin: 0 0 0.35rem; font-size: 0.95rem; }
+  .card h3 code { color: var(--accent); background: none; padding: 0; }
+  .card p { margin: 0; color: var(--muted); font-size: 0.9rem; max-width: none; }
+  .callout {
+    border: 1px solid var(--line); background: var(--accent-soft);
+    border-radius: 8px; padding: 0.8rem 1.1rem; font-size: 0.92rem;
+    margin: 1rem 0; max-width: none;
+  }
+  .callout strong { color: var(--accent); }
+  .flow { display: flex; flex-direction: column; margin: 1.2rem 0; }
+  .frow { display: flex; align-items: stretch; gap: 0.6rem; flex-wrap: wrap; }
+  .fbox {
+    background: var(--card); border: 1px solid var(--line); border-radius: 8px;
+    padding: 0.6rem 0.95rem; font-size: 0.85rem; flex: 1 1 10rem;
+  }
+  .fbox .t {
+    font-family: ui-monospace, Menlo, monospace; font-size: 0.7rem;
+    letter-spacing: 0.1em; text-transform: uppercase; display: block;
+    margin-bottom: 0.15rem; color: var(--accent);
+  }
+  .fbox.gate { border-color: var(--gold); } .fbox.gate .t { color: var(--gold); }
+  .fbox.ok { border-color: var(--accent); } .fbox.ok .t { color: var(--accent); }
+  .fbox.deny { border-color: var(--red); } .fbox.deny .t { color: var(--red); }
+  .fbox .d { color: var(--muted); font-size: 0.8rem; }
+  .arrow {
+    text-align: center; color: var(--muted); font-family: ui-monospace, Menlo, monospace;
+    font-size: 0.8rem; padding: 0.25rem 0;
+  }
+  pre.mermaid {
+    background: var(--card); border: 1px solid var(--line); border-radius: 10px;
+    padding: 1rem; overflow-x: auto; text-align: center;
+  }
+  pre.mermaid svg { max-width: 100%; height: auto; }
 </style>
 </head>
 <body>


### PR DESCRIPTION
- ```mermaid fences render as real diagrams: runtime (mermaid.min.js, 3.5MB) inlined ONLY into pages that use it; docs render immediately, decks render per-active-slide (hidden-slide measurement trap avoided)
- doc/deck themes: committed dark-navy house identity + component library (kicker, chips, cards, callout, flow/fbox, mermaid styling); canonical copies updated in agentkit-pages (6e2782a), bundled copies byte-identical
- SKILL.md: design system baked into the prompt — be illustrative by default, mermaid over ASCII, component usage snippets