### PR TITLE
feat(pages): diagram polish — themed mermaid, isometric kit, treatment router

### DIFF
--- a/skills/publish-page/SKILL.md
+++ b/skills/publish-page/SKILL.md
@@ -46,7 +46,10 @@ strongest component for each idea — don't produce walls of prose:
   tool, and never ASCII art. Wrap EVERY diagram in
   `<div class="figure">…<div class="figcaption"><strong>Name</strong> — what it shows</div></div>`
   with a caption describing the content (say "Publish flow — from agent to live
-  page", never the technology used to draw it).
+  page", never the technology used to draw it). CRITICAL for markdown files:
+  leave a BLANK LINE after `<div class="figure">` and before the closing
+  markup — CommonMark otherwise swallows a fence inside an HTML block and the
+  page silently shows literal backticks instead of a diagram.
   - **System/architecture topology** → the isometric kit (the standout look):
     `<div class="iso"><div class="iso-node hot"><div class="tile"><div class="side"></div><div class="top"><div class="glyph">SVG</div></div></div><div class="tag">name</div></div>…</div>`
     Variants `.hot` (green) / `.gold` for emphasis. Draw each glyph as a simple
@@ -59,10 +62,15 @@ strongest component for each idea — don't produce walls of prose:
     runtime is auto-inlined, themed to the navy palette; costs ~3.4 MB of the
     5 MB cap, leaving ~1.4 MB for content):
     ````
+    <div class="figure">
+
     ```mermaid
     sequenceDiagram
       agent->>worker: PUT page
     ```
+
+    <div class="figcaption"><strong>Publish sequence</strong> — write path</div>
+    </div>
     ````
   - **Charts (data)** → hand-built inline SVG following chart discipline: thin
     marks, one axis only (never dual-axis), a muted recessive grid, series

--- a/skills/publish-page/SKILL.md
+++ b/skills/publish-page/SKILL.md
@@ -42,16 +42,34 @@ mono eyebrows) — never re-explain or re-style these basics.
 **Be illustrative by default.** Structure every doc page as sections and pick the
 strongest component for each idea — don't produce walls of prose:
 
-- **Diagrams: use mermaid fences** — they render as real diagrams (the runtime
-  is inlined automatically, only on pages that use it; it costs ~3.4 MB of the
-  5 MB page cap, leaving ~1.4 MB for content on diagram pages). Prefer mermaid
-  over ASCII art for flows, architectures, sequences:
-  ````
-  ```mermaid
-  flowchart LR
-    A[agent] -->|PUT| W[Worker] --> R2[(R2)]
-  ```
-  ````
+- **Diagrams: pick the treatment by what the diagram IS** — never default to one
+  tool, and never ASCII art. Wrap EVERY diagram in
+  `<div class="figure">…<div class="figcaption"><strong>Name</strong> — what it shows</div></div>`
+  with a caption describing the content (say "Publish flow — from agent to live
+  page", never the technology used to draw it).
+  - **System/architecture topology** → the isometric kit (the standout look):
+    `<div class="iso"><div class="iso-node hot"><div class="tile"><div class="side"></div><div class="top"><div class="glyph">SVG</div></div></div><div class="tag">name</div></div>…</div>`
+    Variants `.hot` (green) / `.gold` for emphasis. Draw each glyph as a simple
+    inline 24×24 SVG outline icon (stroke `#8fa8c7`, or `#34d3a6`/`#e8b444` on
+    emphasized nodes, stroke-width 1.5, fill none) matching the node's meaning —
+    a database cylinder, a globe, a cloud, a terminal chevron, a bot face.
+  - **Pipelines/flows with descriptions** → the premium flat kit:
+    `<div class="arch"><div class="arch-row"><div class="arch-node hot"><svg class="ic">…</svg><div class="nm">Name</div><div class="ds">detail</div></div></div><div class="arch-join">edge label</div>…</div>`
+  - **Sequences, state machines, dense graphs, gantt** → mermaid fences (the
+    runtime is auto-inlined, themed to the navy palette; costs ~3.4 MB of the
+    5 MB cap, leaving ~1.4 MB for content):
+    ````
+    ```mermaid
+    sequenceDiagram
+      agent->>worker: PUT page
+    ```
+    ````
+  - **Charts (data)** → hand-built inline SVG following chart discipline: thin
+    marks, one axis only (never dual-axis), a muted recessive grid, series
+    colors from the accent family, direct labels over legends when ≤ 4 series,
+    text in ink/muted tokens never in series colors. If a `dataviz` skill is
+    available in the harness, load it and follow it; these rules are the
+    baked-in fallback so charts come out right on any harness.
 - **Section headers**: `<div class="kicker">01 — topic</div>` before an `## h2`.
 - **Enumerable concepts** (features, components, principles): a 2-column grid —
   `<div class="cards"><div class="card"><h3><code>name</code></h3><p>…</p></div>…</div>`

--- a/skills/publish-page/publish.ts
+++ b/skills/publish-page/publish.ts
@@ -150,7 +150,8 @@ async function mermaidRuntime(): Promise<string> {
   // Decks render diagrams per-slide (hidden slides have zero width, which breaks
   // mermaid's measurements) — the deck theme's show() calls mermaid.run on the
   // active slide; docs render everything immediately.
-  return `\n<script>${js}</script>\n<script>mermaid.initialize({ startOnLoad: false, theme: "dark" }); if (!document.querySelector(".slide")) mermaid.run();</script>`;
+  const init = `mermaid.initialize({ startOnLoad: false, theme: "base", themeVariables: { darkMode: true, background: "transparent", primaryColor: "#102847", primaryBorderColor: "#2e4f7e", primaryTextColor: "#dce7f5", secondaryColor: "#0d2140", tertiaryColor: "#0d2f3a", lineColor: "#5f7ca3", edgeLabelBackground: "#071224", nodeBorder: "#2e4f7e", mainBkg: "#102847", clusterBkg: "#0d2140", clusterBorder: "#1e3a5f", fontFamily: "ui-monospace, Menlo, monospace", fontSize: "14px", actorBkg: "#102847", actorBorder: "#2e4f7e", actorTextColor: "#dce7f5", signalColor: "#5f7ca3", signalTextColor: "#8fa8c7", noteBkgColor: "#0d2f3a", noteTextColor: "#dce7f5", noteBorderColor: "#1e3a5f" }, flowchart: { curve: "basis", nodeSpacing: 46, rankSpacing: 56, padding: 12 } }); if (!document.querySelector(".slide")) mermaid.run();`;
+  return `\n<script>${js}</script>\n<script>${init}</script>`;
 }
 
 async function render(): Promise<string> {

--- a/skills/publish-page/themes/deck.html
+++ b/skills/publish-page/themes/deck.html
@@ -80,6 +80,79 @@
     @keyframes rise { from { opacity: 0; transform: translateY(8px); } }
   }
   :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+  /* Diagram kit — .figure/.figcaption wrap every diagram; .iso = isometric
+     architecture; .arch = premium flat flow (see SKILL.md) */
+  .figure {
+    background: radial-gradient(ellipse at 30% 0%, #0f2a4d 0%, var(--navy-deep) 70%);
+    border: 1px solid var(--line); border-radius: 14px; padding: 1.6rem 1.4rem 1rem;
+    margin: 1.2rem 0; overflow-x: auto; max-width: none;
+  }
+  .figcaption {
+    font-family: ui-monospace, Menlo, monospace; font-size: 0.74rem;
+    letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted);
+    text-align: center; margin-top: 0.9rem; padding-top: 0.9rem;
+    border-top: 1px solid var(--line);
+  }
+  .figcaption strong { color: var(--accent); font-weight: 600; }
+  .figure pre.mermaid { background: none; border: 0; margin: 0; }
+  .iso {
+    display: grid; grid-template-columns: repeat(3, minmax(7.5rem, 1fr));
+    gap: 0.6rem 1.2rem; justify-items: center; padding: 1.6rem 0 0.4rem;
+  }
+  .iso-node { display: flex; flex-direction: column; align-items: center; gap: 1.4rem; }
+  .iso-node .tile {
+    width: 6.4rem; aspect-ratio: 1; position: relative;
+    transform: rotateX(55deg) rotateZ(-45deg); transform-style: preserve-3d;
+  }
+  .iso-node .top {
+    position: absolute; inset: 0; border-radius: 14px;
+    background: linear-gradient(135deg, #173562 0%, #0e2547 60%, #0c2140 100%);
+    border: 1px solid #2e4f7e; box-shadow: inset 0 0 24px rgba(52, 211, 166, 0.07);
+    transform: translateZ(16px);
+    display: flex; align-items: center; justify-content: center;
+  }
+  .iso-node .side {
+    position: absolute; inset: 0; border-radius: 14px;
+    background: #061021; box-shadow: 0 0 0 1px #0d1e38;
+  }
+  .iso-node.hot .top { border-color: var(--accent); box-shadow: inset 0 0 26px rgba(52, 211, 166, 0.2); }
+  .iso-node.gold .top { border-color: var(--gold); box-shadow: inset 0 0 26px rgba(232, 180, 68, 0.16); }
+  .iso-node .glyph {
+    width: 46%; height: 46%;
+    transform: rotateZ(45deg) rotateX(-40deg);
+    filter: drop-shadow(0 4px 6px rgba(0, 0, 0, 0.5));
+  }
+  .iso-node .glyph svg { width: 100%; height: 100%; }
+  .iso-node .tag {
+    font-family: ui-monospace, Menlo, monospace; font-size: 0.72rem;
+    letter-spacing: 0.08em; color: var(--ink);
+    background: rgba(7, 18, 36, 0.85); border: 1px solid var(--line);
+    border-radius: 6px; padding: 0.15rem 0.6rem; white-space: nowrap;
+  }
+  .arch { display: flex; flex-direction: column; margin: 0.5rem 0; }
+  .arch-row { display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap; }
+  .arch-node {
+    background: linear-gradient(160deg, #14305a, #0d2140);
+    border: 1px solid #2e4f7e; border-radius: 12px;
+    padding: 0.8rem 1.1rem 0.7rem; min-width: 9.5rem;
+    box-shadow: 0 10px 22px -12px rgba(0, 0, 0, 0.8), inset 0 1px 0 rgba(220, 231, 245, 0.07);
+  }
+  .arch-node.hot { border-color: rgba(52, 211, 166, 0.65); }
+  .arch-node.gold { border-color: rgba(232, 180, 68, 0.6); }
+  .arch-node .ic { width: 26px; height: 26px; margin-bottom: 0.35rem; }
+  .arch-node .nm { font-weight: 600; font-size: 0.92rem; letter-spacing: -0.01em; }
+  .arch-node .ds { color: var(--muted); font-size: 0.76rem; font-family: ui-monospace, Menlo, monospace; }
+  .arch-join {
+    display: flex; justify-content: center; align-items: center; height: 2.4rem;
+    color: var(--accent); font-family: ui-monospace, Menlo, monospace; font-size: 0.72rem;
+    letter-spacing: 0.1em; gap: 0.5rem;
+  }
+  .arch-join::before, .arch-join::after {
+    content: ""; width: 2px; height: 100%;
+    background: linear-gradient(180deg, transparent, var(--accent), transparent);
+    box-shadow: 0 0 6px rgba(52, 211, 166, 0.5);
+  }
 </style>
 </head>
 <body>

--- a/skills/publish-page/themes/doc.html
+++ b/skills/publish-page/themes/doc.html
@@ -106,6 +106,79 @@
     padding: 1rem; overflow-x: auto; text-align: center;
   }
   pre.mermaid svg { max-width: 100%; height: auto; }
+
+  /* Diagram kit — .figure/.figcaption wrap every diagram; .iso = isometric
+     architecture; .arch = premium flat flow (see SKILL.md) */
+  .figure {
+    background: radial-gradient(ellipse at 30% 0%, #0f2a4d 0%, var(--navy-deep) 70%);
+    border: 1px solid var(--line); border-radius: 14px; padding: 1.6rem 1.4rem 1rem;
+    margin: 1.2rem 0; overflow-x: auto; max-width: none;
+  }
+  .figcaption {
+    font-family: ui-monospace, Menlo, monospace; font-size: 0.74rem;
+    letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted);
+    text-align: center; margin-top: 0.9rem; padding-top: 0.9rem;
+    border-top: 1px solid var(--line);
+  }
+  .figcaption strong { color: var(--accent); font-weight: 600; }
+  .figure pre.mermaid { background: none; border: 0; margin: 0; }
+  .iso {
+    display: grid; grid-template-columns: repeat(3, minmax(7.5rem, 1fr));
+    gap: 0.6rem 1.2rem; justify-items: center; padding: 1.6rem 0 0.4rem;
+  }
+  .iso-node { display: flex; flex-direction: column; align-items: center; gap: 1.4rem; }
+  .iso-node .tile {
+    width: 6.4rem; aspect-ratio: 1; position: relative;
+    transform: rotateX(55deg) rotateZ(-45deg); transform-style: preserve-3d;
+  }
+  .iso-node .top {
+    position: absolute; inset: 0; border-radius: 14px;
+    background: linear-gradient(135deg, #173562 0%, #0e2547 60%, #0c2140 100%);
+    border: 1px solid #2e4f7e; box-shadow: inset 0 0 24px rgba(52, 211, 166, 0.07);
+    transform: translateZ(16px);
+    display: flex; align-items: center; justify-content: center;
+  }
+  .iso-node .side {
+    position: absolute; inset: 0; border-radius: 14px;
+    background: #061021; box-shadow: 0 0 0 1px #0d1e38;
+  }
+  .iso-node.hot .top { border-color: var(--accent); box-shadow: inset 0 0 26px rgba(52, 211, 166, 0.2); }
+  .iso-node.gold .top { border-color: var(--gold); box-shadow: inset 0 0 26px rgba(232, 180, 68, 0.16); }
+  .iso-node .glyph {
+    width: 46%; height: 46%;
+    transform: rotateZ(45deg) rotateX(-40deg);
+    filter: drop-shadow(0 4px 6px rgba(0, 0, 0, 0.5));
+  }
+  .iso-node .glyph svg { width: 100%; height: 100%; }
+  .iso-node .tag {
+    font-family: ui-monospace, Menlo, monospace; font-size: 0.72rem;
+    letter-spacing: 0.08em; color: var(--ink);
+    background: rgba(7, 18, 36, 0.85); border: 1px solid var(--line);
+    border-radius: 6px; padding: 0.15rem 0.6rem; white-space: nowrap;
+  }
+  .arch { display: flex; flex-direction: column; margin: 0.5rem 0; }
+  .arch-row { display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap; }
+  .arch-node {
+    background: linear-gradient(160deg, #14305a, #0d2140);
+    border: 1px solid #2e4f7e; border-radius: 12px;
+    padding: 0.8rem 1.1rem 0.7rem; min-width: 9.5rem;
+    box-shadow: 0 10px 22px -12px rgba(0, 0, 0, 0.8), inset 0 1px 0 rgba(220, 231, 245, 0.07);
+  }
+  .arch-node.hot { border-color: rgba(52, 211, 166, 0.65); }
+  .arch-node.gold { border-color: rgba(232, 180, 68, 0.6); }
+  .arch-node .ic { width: 26px; height: 26px; margin-bottom: 0.35rem; }
+  .arch-node .nm { font-weight: 600; font-size: 0.92rem; letter-spacing: -0.01em; }
+  .arch-node .ds { color: var(--muted); font-size: 0.76rem; font-family: ui-monospace, Menlo, monospace; }
+  .arch-join {
+    display: flex; justify-content: center; align-items: center; height: 2.4rem;
+    color: var(--accent); font-family: ui-monospace, Menlo, monospace; font-size: 0.72rem;
+    letter-spacing: 0.1em; gap: 0.5rem;
+  }
+  .arch-join::before, .arch-join::after {
+    content: ""; width: 2px; height: 100%;
+    background: linear-gradient(180deg, transparent, var(--accent), transparent);
+    box-shadow: 0 0 6px rgba(52, 211, 166, 0.5);
+  }
 </style>
 </head>
 <body>


### PR DESCRIPTION
- mermaid init: base theme + navy themeVariables (mono type, navy nodes, matched edges) — stock look replaced
- themes gain a diagram kit: .figure/.figcaption (semantic captions, never technology names), .iso isometric architecture tiles with inline-SVG glyphs, .arch premium flat flow with glowing joins
- SKILL.md routes treatment by diagram type (topology→iso, pipeline→arch, sequence/state/dense→mermaid, charts→inline-SVG discipline) — self-contained on every harness agentkit installs to; dataviz skill used only if present
- canonical themes updated in agentkit-pages (06eb389a), bundles byte-identical
- live-verified: https://pages.agentkit.sbs/5c83a672e38372e106f5 (themed sequence + isometric from plain markdown)