### PR TITLE
feat(skills): diagram + architect — excalidraw-quality visuals and living architecture docs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -93,7 +93,7 @@ install_skills() {
 				(cd "$target" && bun install --silent)
 				# Build-time artifacts (e.g. browser bundles) are gitignored and
 				# produced at install via the skill's own build script.
-				if grep -q '"build"' "$target/package.json"; then
+				if grep -A3 '"scripts"' "$target/package.json" | grep -q '"build"'; then
 					echo "[skills] Building: $skill_name"
 					(cd "$target" && bun run build >/dev/null)
 				fi

--- a/install.sh
+++ b/install.sh
@@ -91,6 +91,12 @@ install_skills() {
 			if command -v bun >/dev/null 2>&1; then
 				echo "[skills] Installing dependencies: $skill_name"
 				(cd "$target" && bun install --silent)
+				# Build-time artifacts (e.g. browser bundles) are gitignored and
+				# produced at install via the skill's own build script.
+				if grep -q '"build"' "$target/package.json"; then
+					echo "[skills] Building: $skill_name"
+					(cd "$target" && bun run build >/dev/null)
+				fi
 			else
 				echo "[skills] WARNING: $skill_name needs 'bun install' in $target (bun not found)"
 			fi

--- a/skills/architect/SKILL.md
+++ b/skills/architect/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: architect
+description: Study a system and produce living architecture documentation — explanatory pages with high-quality diagrams. Use AUTOMATICALLY when the user asks to document, explain, map, or review an architecture ("how does this system work", "architecture diagram of this repo", "create/refresh the design docs"), or to keep architecture pages current after changes. Orchestrates the diagram and publish-page skills.
+---
+
+# architect
+
+You are producing the document a strong staff engineer would write after
+genuinely understanding a system — not a file listing with boxes around it.
+
+## Workflow
+
+1. **Scope**: name the system(s) and the audience question the page must
+   answer ("how does a request flow", "what owns what", "where does state
+   live"). One page per question; link pages rather than bloating one.
+2. **Study before drawing.** Read entry points, deploy/infra configs, service
+   boundaries, schemas, and the seams between components. Verify claims in
+   code — including absences ("nothing else writes this table" needs grepping,
+   not assuming). For third-party pieces, check the real docs; never draw from
+   memory.
+3. **Find the load-bearing structure**: the 3–7 components whose removal would
+   change the story, the flows between them, the state stores, and the
+   trust/ownership boundaries. Everything else is detail inside a zone.
+4. **Produce**:
+   - the centerpiece diagram(s) via the **diagram** skill (technical depth:
+     real names, real payloads, evidence artifacts),
+   - a page via **publish-page** (doc template): overview strip, the diagrams
+     in `.figure` blocks with semantic captions, a "decisions & constraints"
+     section (why it is shaped this way, what must not be broken), and a
+     "sharp edges" section for the traps a newcomer hits,
+   - use a stable `--name` (e.g. `<system>-architecture`) so refreshes update
+     the SAME URL.
+5. **Refresh mode**: when asked to update (or triggered after merges), diff
+   what changed since the page's last git version in the pages repo, update
+   only the affected zones/sections, republish the same name, and note the
+   delta at the top of the page.
+
+## Rules
+
+- Accuracy outranks beauty: a wrong arrow is worse than a missing one. If the
+  code contradicts the docs, the code wins and the page says so.
+- State your confidence and name what you did NOT verify.
+- Never invent architecture direction — document what exists; proposals go in
+  a clearly separated "open questions" section, not the diagrams.

--- a/skills/architect/SKILL.md
+++ b/skills/architect/SKILL.md
@@ -35,6 +35,27 @@ genuinely understanding a system — not a file listing with boxes around it.
    only the affected zones/sections, republish the same name, and note the
    delta at the top of the page.
 
+## The bar: impress a staff engineer
+
+An experienced architect looking at your centerpiece diagram should learn
+something and find nothing to correct. That means the diagram shows what
+seniors actually look for, not just boxes and arrows:
+
+- **Boundaries drawn as boundaries** — trust, ownership, network, and process
+  boundaries as visible zones, not implied by proximity.
+- **Edges that say something**: protocol + direction + what actually travels
+  (`PUT /api/pages/:slug · HTML ≤5MB`, not "sends data"). Sync vs async
+  distinguishable at a glance (solid vs dashed).
+- **State made explicit** — every store shown with what owns it and what only
+  reads it.
+- **The failure story** — what breaks when each critical edge dies, marked on
+  the diagram (error-role color), not left to the appendix.
+- **Numbers where they exist** — caps, timeouts, quotas, cardinalities pulled
+  from config/code, never invented.
+- **The why on the page** — one decisions-and-constraints section that names
+  the forces that shaped the design; a diagram that only shows "what" is half
+  a diagram.
+
 ## Rules
 
 - Accuracy outranks beauty: a wrong arrow is worse than a missing one. If the
@@ -42,3 +63,7 @@ genuinely understanding a system — not a file listing with boxes around it.
 - State your confidence and name what you did NOT verify.
 - Never invent architecture direction — document what exists; proposals go in
   a clearly separated "open questions" section, not the diagrams.
+- **Publishing internal systems requires the user's explicit go-ahead**: pages
+  are public-by-slug until the accounts phase, and architecture pages are by
+  nature internal material — confirm before the first publish of a system's
+  page (refreshes of an already-approved page are fine).

--- a/skills/diagram/.gitignore
+++ b/skills/diagram/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+renderer/bundle.js

--- a/skills/diagram/SKILL.md
+++ b/skills/diagram/SKILL.md
@@ -44,6 +44,14 @@ concepts should reuse the same pattern.
 hierarchy beats a box unless the element is a focal point, an arrow target, or
 a true container.
 
+**The table is a floor, not a ceiling.** For the concept that matters most,
+invent the visual metaphor that IS that concept: a review gate drawn as an
+actual gate across the flow; backpressure as a pipe narrowing; a cache as a
+shadow copy sitting between planes; fan-out that visibly loses order.
+Two tests before you keep a metaphor: strip the labels — does the structure
+still say it? and would a newcomer _learn_ the mechanism from the picture
+alone? If either fails, the metaphor is decoration; redesign it.
+
 ## 3 — Compose at three zoom levels (large diagrams)
 
 1. a one-line overview strip (the whole story at a glance),
@@ -75,15 +83,49 @@ strokes with classic pastel fills (`#a5d8ff`, `#b2f2bb`, `#ffec99`).
 
 ## 5 — Render, LOOK, fix (mandatory loop)
 
+JSON cannot be judged as JSON. Render, view the PNG with the Read tool, fix,
+repeat — expect 2–4 rounds; one pass is never the final pass.
+
 ```bash
 bun <skill-dir>/render.ts --in diagram.excalidraw --out diagram.svg --png diagram.png
 ```
 
-Read the PNG. Judge it like a reviewer: overlaps, clipped text, cramped zones,
-a missing visual story. Fix the JSON and re-render until it is genuinely good —
-one render is never the final render. (One-time setup: `cd <skill-dir> && bun
-install && bun run build`; rendering needs a local Chromium — set
-`AGENTKIT_CHROMIUM` if it isn't auto-found.)
+Each round, in order:
+
+1. **Vision audit first** — compare against the plan from steps 1–3, before
+   hunting bugs: does the visual structure mirror the concepts? does each zone
+   use its intended pattern? does the eye travel the path you designed? do
+   hero elements dominate? are evidence artifacts readable where they belong?
+2. **Defect sweep** — clipped or overflowing text; unintended overlaps; arrows
+   cutting through shapes or landing in empty space; labels that don't clearly
+   belong to anything; ragged spacing between siblings; one zone cramped while
+   another floats in emptiness; text too small at render size; a lopsided
+   whole.
+3. **Fix in JSON** — widen containers for clipped text; shift `x`/`y` for
+   spacing; add waypoints to arrow `points` to route around shapes; pull
+   labels next to their subjects; resize to rebalance visual weight.
+
+**Stop only when** the render matches the planned design, nothing is clipped
+or ambiguous, arrows land exactly, spacing is deliberate — and you would show
+it to a staff engineer without a single caveat. "No critical bugs" is not the
+bar; "couldn't be composed better" is.
+
+(One-time setup: `cd <skill-dir> && bun install && bun run build`; rendering
+needs a local Chromium — set `AGENTKIT_CHROMIUM` if it isn't auto-found.)
+
+## Quality gate — every diagram answers yes to all of these
+
+- **Depth**: researched real names/formats? evidence artifacts present
+  (technical)? multi-zoom present (large)? teaches something concrete?
+- **Concept**: structure would still communicate with labels removed? shows
+  what prose could not? every major concept a different pattern? no uniform
+  card grid anywhere?
+- **Containers**: under ~30% of text boxed? trees/timelines built from lines +
+  text? size/weight/color doing the hierarchy work?
+- **Structure**: every relationship drawn? one clear eye-path? importance
+  visible through scale and surrounding space?
+- **Render**: PNG inspected this round? zero clipping/overlap? arrows exact?
+  spacing consistent? composition balanced?
 
 ## 6 — Ship the SVG
 

--- a/skills/diagram/SKILL.md
+++ b/skills/diagram/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: diagram
+description: Craft high-quality hand-drawn-style diagrams (Excalidraw JSON rendered to self-contained SVG). Use AUTOMATICALLY when the user asks to visualize, draw, diagram, or sketch anything — system architectures, workflows, protocols, timelines, comparisons, mental models — or when a task needs a visual that outclasses mermaid/box kits. Renders headlessly at generation time; output embeds anywhere HTML or markdown does.
+---
+
+# diagram
+
+Turn concepts into diagrams that **make an argument**. The structure must carry
+the meaning: cover the labels and the shape should still tell the story. If a
+diagram is five identical boxes with different names, it has said nothing.
+
+Method inspired by coleam00/excalidraw-diagram-skill; text and tooling here are
+original.
+
+## 1 — Decide the depth
+
+- **Conceptual**: mental models, philosophies, quick overviews. Abstract shapes
+  and relationships are enough.
+- **Technical**: real systems, protocols, integrations. You MUST research the
+  real thing first — actual endpoint names, event names, payload shapes, config
+  keys — and show **concrete evidence inside the diagram**: a real (sanitized)
+  payload snippet, the true API call, a mini mockup of the actual output.
+  Placeholder labels like "API" or "Event 1" are a failure; write
+  `PUT /api/pages/:slug` and `RUN_STARTED`, not "endpoint" and "event".
+
+## 2 — Map each concept to a structural pattern
+
+Pick the shape that behaves like the concept. In one diagram, no two major
+concepts should reuse the same pattern.
+
+| Concept behaves like…       | Draw it as…                                                |
+| --------------------------- | ---------------------------------------------------------- |
+| one source feeding many     | fan-out: center node, radiating arrows                     |
+| many inputs producing one   | merge: arrows converging into a single node                |
+| containment / hierarchy     | tree: trunk lines + free-floating labels, no boxes         |
+| ordered steps in time       | timeline: one line, dots, labels above/below               |
+| repetition that improves    | cycle: loop of arrows returning to start                   |
+| input transformed to output | pipeline: before → machine → after, visibly different ends |
+| two options weighed         | side-by-side halves with mirrored structure                |
+| phases with a hard boundary | zones separated by whitespace or a divider line            |
+| fuzzy context or state      | overlapping ellipses (cloud), no hard border               |
+
+**Boxes are earned, not default.** Free-floating text with size/weight
+hierarchy beats a box unless the element is a focal point, an arrow target, or
+a true container.
+
+## 3 — Compose at three zoom levels (large diagrams)
+
+1. a one-line overview strip (the whole story at a glance),
+2. labeled zones grouping related parts,
+3. teaching detail inside zones — the evidence artifacts.
+
+Trace the eye-path before writing any JSON: where does the viewer start, what
+do they follow, where do they end.
+
+## 4 — Write the Excalidraw JSON section by section
+
+Hand-write `.excalidraw` JSON — never generate the whole file in one pass (a
+comprehensive diagram exceeds a single response's output budget and truncates):
+
+1. Start the file with the wrapper (`type`, `version`, `appState`, `files`) and
+   the first zone's elements.
+2. Add ONE zone per edit, deliberately: layout, spacing, connections to what
+   exists.
+3. Use descriptive ids (`worker_rect`, `arrow_put`) and namespace `seed` per
+   zone (100x, 200x…). When a new arrow binds to an earlier element, update
+   that element's `boundElements` in the same edit.
+4. After the last zone: re-read the whole file — bindings valid both ends,
+   spacing balanced, every referenced id exists.
+
+Palette: match the destination. For AgentKit Pages (navy figures): strokes
+`#dce7f5`, muted `#8fa8c7`, accents `#34d3a6` / `#e8b444`, fills transparent or
+`#102847`, background transparent. For READMEs/light surfaces: near-black
+strokes with classic pastel fills (`#a5d8ff`, `#b2f2bb`, `#ffec99`).
+
+## 5 — Render, LOOK, fix (mandatory loop)
+
+```bash
+bun <skill-dir>/render.ts --in diagram.excalidraw --out diagram.svg --png diagram.png
+```
+
+Read the PNG. Judge it like a reviewer: overlaps, clipped text, cramped zones,
+a missing visual story. Fix the JSON and re-render until it is genuinely good —
+one render is never the final render. (One-time setup: `cd <skill-dir> && bun
+install && bun run build`; rendering needs a local Chromium — set
+`AGENTKIT_CHROMIUM` if it isn't auto-found.)
+
+## 6 — Ship the SVG
+
+The SVG is fully self-contained (fonts embedded as data: URIs). Inline it
+directly into a page (wrap in `<div class="figure">` with a semantic
+`figcaption` when publishing via publish-page), drop it into a repo's docs, or
+attach the PNG where images are needed. Caption by content, never by tool.

--- a/skills/diagram/package.json
+++ b/skills/diagram/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "diagram-skill",
+  "private": true,
+  "dependencies": {
+    "@excalidraw/excalidraw": "0.18.1",
+    "react": "19.2.8",
+    "react-dom": "19.2.8"
+  },
+  "devDependencies": {
+    "playwright-core": "1.62.0",
+    "@types/bun": "^1.2.19"
+  },
+  "scripts": {
+    "build": "bun build renderer/entry.ts --bundle --outfile renderer/bundle.js --target browser --define process.env.NODE_ENV='\"production\"'"
+  }
+}

--- a/skills/diagram/references/elements.md
+++ b/skills/diagram/references/elements.md
@@ -1,0 +1,90 @@
+# Excalidraw JSON authoring reference
+
+File wrapper:
+
+```json
+{
+  "type": "excalidraw",
+  "version": 2,
+  "source": "agentkit-diagram",
+  "elements": [],
+  "appState": { "viewBackgroundColor": "transparent", "gridSize": 20 },
+  "files": {}
+}
+```
+
+## Fields every element needs
+
+`id` (descriptive string), `type`, `x`, `y`, `width`, `height`, `angle: 0`,
+`strokeColor`, `backgroundColor`, `fillStyle: "solid"`, `strokeWidth`,
+`strokeStyle: "solid"`, `roughness`, `opacity: 100`, `seed` (namespace per
+zone: 100x, 200x…), `version: 1`, `versionNonce` (any int), `isDeleted: false`,
+`groupIds: []`, `frameId: null`, `boundElements: null`, `updated: 1`,
+`link: null`, `locked: false`.
+
+## Per-type additions
+
+| Type        | Extra fields                                                                                                                                                                         | Notes                                                                 |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------- |
+| `rectangle` | `roundness: {"type":3}` for rounded                                                                                                                                                  | processes, components, evidence panels                                |
+| `ellipse`   | —                                                                                                                                                                                    | entry/exit, external systems; 10–20px dots = timeline markers/anchors |
+| `diamond`   | —                                                                                                                                                                                    | decisions and conditions only                                         |
+| `text`      | `text`, `originalText` (same words), `fontSize`, `fontFamily`, `textAlign`, `verticalAlign`, `containerId: null`, `autoResize: true`, `lineHeight: 1.25`                             | free-floating labels; `containerId` only when truly inside a shape    |
+| `arrow`     | `points: [[0,0],[dx,dy]]`, `startBinding`/`endBinding` (`{"elementId":"id","focus":0,"gap":2}` or null), `startArrowhead: null`, `endArrowhead: "arrow"`, `lastCommittedPoint: null` | when bound, add this arrow's id to the target's `boundElements`       |
+| `line`      | `points` like arrow, no arrowheads                                                                                                                                                   | tree trunks, dividers, structure                                      |
+
+Fonts: `fontFamily: 1` = hand-drawn (headers, labels — the excalidraw feel),
+`3` = monospace (evidence artifacts: payloads, endpoints, code). Sizes: titles
+20–28, labels 16, evidence text 12–14.
+
+## Look
+
+- `roughness`: 0 = crisp/professional (default), 1 = sketch/brainstorm. Pick
+  one per diagram, never mix.
+- `strokeWidth`: 1 subtle lines/dividers, 2 shapes and normal arrows, 3 only
+  for the single main flow. `opacity` always 100 — hierarchy comes from size,
+  color, and whitespace, not transparency.
+- Scale hierarchy: hero element ~300×150, primary ~180×90, secondary ~120×60,
+  markers 12px. The most important element also gets the most empty space.
+- If two elements are related, draw the connection — proximity alone reads as
+  coincidence.
+
+## Container/text pairing and arrows
+
+- Text inside a shape is a two-way link: the text carries `containerId:
+  "<shape-id>"` AND the shape carries `boundElements: [{"id": "<text-id>",
+  "type": "text"}]`. One side alone breaks centering.
+- Bound arrows likewise: the arrow holds `startBinding`/`endBinding` and each
+  bound shape lists the arrow in its `boundElements`.
+- Curved arrows: 3+ entries in `points`; waypoints are also how an arrow routes
+  around shapes instead of through them.
+- An arrow inherits the stroke color of its SOURCE's semantic role; arrows
+  never introduce colors of their own.
+
+## Semantic palettes (stroke / fill pairs — one role, one pair, always)
+
+Navy pages (background transparent, sits on the `.figure` glow):
+
+| Role                        | stroke           | fill                                                  |
+| --------------------------- | ---------------- | ----------------------------------------------------- |
+| default / neutral           | `#dce7f5`        | `transparent` or `#102847`                            |
+| start / trigger             | `#e8b444`        | `#2a2410`                                             |
+| end / success / active path | `#34d3a6`        | `#0d2f3a`                                             |
+| decision (diamond)          | `#e8b444`        | `transparent`                                         |
+| agent / AI                  | `#b197fc`        | `#1d1636`                                             |
+| inactive / future           | `#8fa8c7` dashed | `transparent`                                         |
+| error / removal             | `#e06c5f`        | `#2a1512`                                             |
+| evidence panel              | `#1e3a5f`        | `#071224` (mono text `#34d3a6` data, `#dce7f5` code)  |
+
+Text hierarchy without boxes (navy): titles `#dce7f5` 20-28px, subtitles
+`#34d3a6` 16px, detail/annotation `#8fa8c7` 12-14px.
+
+Light surfaces (READMEs, docs): near-black `#1e1e1e` strokes; fills `#a5d8ff`
+(neutral), `#fed7aa` (start), `#b2f2bb` (success), `#ffec99` (decision),
+`#ddd6fe` (agent/AI), `#ffc9c9` (error); inactive = dashed `#748ffc` on
+transparent; evidence panels `#1e293b` fill with `#22c55e` data / `#e2e8f0`
+code text. Text hierarchy: titles `#1e40af`, subtitles `#3b82f6`, detail
+`#64748b`.
+
+Rules: darker stroke over lighter fill, always; a concept without a role uses
+neutral, never a fresh color.

--- a/skills/diagram/render.ts
+++ b/skills/diagram/render.ts
@@ -1,0 +1,85 @@
+#!/usr/bin/env bun
+import { execSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+declare global {
+  interface Window {
+    renderExcalidrawToSvg: (scene: unknown) => Promise<string>;
+  }
+}
+
+function fail(msg: string): never {
+  console.error(`diagram-render: ${msg}`);
+  process.exit(1);
+}
+
+function arg(name: string): string | undefined {
+  const i = process.argv.indexOf(`--${name}`);
+  const v = i > 0 ? process.argv[i + 1] : undefined;
+  if (v?.startsWith("--")) fail(`--${name} is missing its value`);
+  return v;
+}
+
+const input = arg("in") ?? fail("--in <file.excalidraw> is required");
+const output = arg("out") ?? input.replace(/\.excalidraw$/, "") + ".svg";
+if (!existsSync(input)) fail(`no such file: ${input}`);
+
+const scene = JSON.parse(await readFile(input, "utf8"));
+if (scene.type !== "excalidraw") fail(`expected type "excalidraw", got "${scene.type}"`);
+if (!Array.isArray(scene.elements) || scene.elements.length === 0) {
+  fail("scene has no elements — nothing to render");
+}
+
+const bundle = join(import.meta.dir, "renderer/bundle.js");
+if (!existsSync(bundle)) {
+  console.error("diagram-render: building renderer bundle (first run)…");
+  execSync("bun run build", { cwd: import.meta.dir, stdio: "inherit" });
+}
+
+// Chromium resolution order: explicit env, playwright's own cache, system installs.
+function chromiumPath(): string {
+  const envPath = process.env.AGENTKIT_CHROMIUM;
+  if (envPath && existsSync(envPath)) return envPath;
+  const candidates = [
+    "/usr/bin/chromium", "/usr/bin/chromium-browser",
+    "/usr/bin/google-chrome", "/opt/google/chrome/chrome",
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+  ];
+  for (const c of candidates) if (existsSync(c)) return c;
+  return ""; // let playwright try its default cache
+}
+
+const { chromium } = await import("playwright-core");
+const exe = chromiumPath();
+const browser = await chromium
+  .launch(exe ? { executablePath: exe } : {})
+  .catch((e: Error) =>
+    fail(`no usable Chromium (${e.message.split("\n")[0]}) — set AGENTKIT_CHROMIUM or run: bunx playwright install chromium`)
+  );
+
+try {
+  const page = await browser.newPage();
+  const errors: string[] = [];
+  page.on("pageerror", (e) => errors.push(String(e)));
+  await page.setContent("<!doctype html><html><body></body></html>");
+  await page.addScriptTag({ path: bundle, type: "module" });
+  await page
+    .waitForFunction(() => typeof window.renderExcalidrawToSvg === "function", undefined, { timeout: 15000 })
+    .catch(() => fail(`renderer bundle failed to initialize${errors.length ? `: ${errors[0]}` : ""}`));
+  const svg: string = await page.evaluate((s) => window.renderExcalidrawToSvg(s), scene);
+  if (!svg.startsWith("<svg")) fail("renderer returned no SVG");
+  await writeFile(output, svg);
+  const png = arg("png");
+  if (png) {
+    // A PNG twin lets the authoring agent LOOK at the result (Read renders
+    // images, not SVG) for the render-view-fix loop.
+    await page.setContent(`<!doctype html><body style="margin:0;background:#fff">${svg}</body>`);
+    const el = page.locator("svg").first();
+    await el.screenshot({ path: png });
+  }
+  console.log(output);
+} finally {
+  await browser.close();
+}

--- a/skills/diagram/render.ts
+++ b/skills/diagram/render.ts
@@ -26,7 +26,12 @@ const input = arg("in") ?? fail("--in <file.excalidraw> is required");
 const output = arg("out") ?? input.replace(/\.excalidraw$/, "") + ".svg";
 if (!existsSync(input)) fail(`no such file: ${input}`);
 
-const scene = JSON.parse(await readFile(input, "utf8"));
+let scene: { type?: string; elements?: unknown[] };
+try {
+  scene = JSON.parse(await readFile(input, "utf8"));
+} catch (e) {
+  fail(`${input} is not valid JSON: ${(e as Error).message}`);
+}
 if (scene.type !== "excalidraw") fail(`expected type "excalidraw", got "${scene.type}"`);
 if (!Array.isArray(scene.elements) || scene.elements.length === 0) {
   fail("scene has no elements — nothing to render");
@@ -35,7 +40,11 @@ if (!Array.isArray(scene.elements) || scene.elements.length === 0) {
 const bundle = join(import.meta.dir, "renderer/bundle.js");
 if (!existsSync(bundle)) {
   console.error("diagram-render: building renderer bundle (first run)…");
-  execSync("bun run build", { cwd: import.meta.dir, stdio: "inherit" });
+  try {
+    execSync("bun run build", { cwd: import.meta.dir, stdio: "inherit" });
+  } catch {
+    fail(`renderer bundle build failed — run: cd ${import.meta.dir} && bun install && bun run build`);
+  }
 }
 
 // Chromium resolution order: explicit env, playwright's own cache, system installs.
@@ -59,6 +68,8 @@ const browser = await chromium
     fail(`no usable Chromium (${e.message.split("\n")[0]}) — set AGENTKIT_CHROMIUM or run: bunx playwright install chromium`)
   );
 
+// Failures inside the try are thrown (not fail()ed) so the finally can close
+// the browser — process.exit skips finally blocks.
 try {
   const page = await browser.newPage();
   const errors: string[] = [];
@@ -67,19 +78,28 @@ try {
   await page.addScriptTag({ path: bundle, type: "module" });
   await page
     .waitForFunction(() => typeof window.renderExcalidrawToSvg === "function", undefined, { timeout: 15000 })
-    .catch(() => fail(`renderer bundle failed to initialize${errors.length ? `: ${errors[0]}` : ""}`));
+    .catch(() => {
+      throw new Error(`renderer bundle failed to initialize${errors.length ? `: ${errors[0]}` : ""}`);
+    });
   const svg: string = await page.evaluate((s) => window.renderExcalidrawToSvg(s), scene);
-  if (!svg.startsWith("<svg")) fail("renderer returned no SVG");
-  await writeFile(output, svg);
+  if (!svg.startsWith("<svg")) throw new Error("renderer returned no SVG");
+  await writeFile(output, svg).catch((e: Error) => {
+    throw new Error(`cannot write ${output}: ${e.message}`);
+  });
   const png = arg("png");
   if (png) {
     // A PNG twin lets the authoring agent LOOK at the result (Read renders
     // images, not SVG) for the render-view-fix loop.
     await page.setContent(`<!doctype html><body style="margin:0;background:#fff">${svg}</body>`);
     const el = page.locator("svg").first();
-    await el.screenshot({ path: png });
+    await el.screenshot({ path: png }).catch((e: Error) => {
+      throw new Error(`cannot write ${png}: ${e.message}`);
+    });
   }
   console.log(output);
-} finally {
+} catch (e) {
   await browser.close();
+  fail((e as Error).message);
+} finally {
+  await browser.close().catch(() => {});
 }

--- a/skills/diagram/renderer/entry.ts
+++ b/skills/diagram/renderer/entry.ts
@@ -1,0 +1,20 @@
+import { exportToSvg } from "@excalidraw/excalidraw";
+
+declare global {
+  interface Window {
+    renderExcalidrawToSvg: (scene: {
+      elements: unknown[];
+      appState?: Record<string, unknown>;
+      files?: Record<string, unknown> | null;
+    }) => Promise<string>;
+  }
+}
+
+window.renderExcalidrawToSvg = async (scene) => {
+  const svg = await exportToSvg({
+    elements: scene.elements as never,
+    appState: { exportBackground: false, exportEmbedScene: false, ...scene.appState } as never,
+    files: (scene.files ?? null) as never,
+  });
+  return svg.outerHTML;
+};

--- a/skills/publish-page/SKILL.md
+++ b/skills/publish-page/SKILL.md
@@ -55,6 +55,11 @@ strongest component for each idea — don't produce walls of prose:
   leave a BLANK LINE after `<div class="figure">` and before the closing
   markup — CommonMark otherwise swallows a fence inside an HTML block and the
   page silently shows literal backticks instead of a diagram.
+  - **Hand-crafted architecture/explainer diagrams (highest quality)** → the
+    `diagram` skill: author Excalidraw JSON per its methodology, render to
+    self-contained SVG, inline the SVG inside a `.figure` with a semantic
+    caption. Zero page runtime. Prefer this for the centerpiece diagram of a
+    page; use the kits below for quick supporting visuals.
   - **System/architecture topology** → the isometric kit (the standout look):
     `<div class="iso"><div class="iso-node hot"><div class="tile"><div class="side"></div><div class="top"><div class="glyph">SVG</div></div></div><div class="tag">name</div></div>…</div>`
     Variants `.hot` (green) / `.gold` for emphasis. Draw each glyph as a simple


### PR DESCRIPTION
- skills/diagram: original methodology (argue-not-display, depth assessment, evidence artifacts, pattern mapping, 3-zoom composition, section-by-section JSON, render-LOOK-fix loop) + TS renderer: bun + playwright-core + vendored MIT @excalidraw/excalidraw 0.18.1 (exact pins) bundled at install time via bun build; exports self-contained SVG (fonts as data: URIs) + optional PNG twin for agent self-review. Ideas credited to coleam00/excalidraw-diagram-skill; all prose/tooling original (that repo has no license).
- skills/architect: thin role skill — study system, find load-bearing structure, produce/refresh architecture pages via diagram + publish-page with stable names; accuracy rules.
- install.sh: runs a skill's build script after bun install (bundle is gitignored, built per machine).
- publish-page router: centerpiece diagrams route to the diagram skill (inline SVG, zero page runtime).
- proven: headless render produced correct SVG+PNG (hand-drawn look verified visually).