### PR TITLE
fix(hooks): dual Claude/Grok payload parsing so police enforce on Grok

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,24 @@ cp rules/credential-bootstrap.md your-project/.opencode/rules/
 cp plugins/version-police.ts your-project/.opencode/plugins/
 ```
 
+### Grok CLI
+
+Grok loads agentkit **hooks** via Claude settings compatibility (`~/.claude/settings.json`
+when `[compat.claude] hooks = true`, the default). Soft guidance (skills/rules/instructions)
+is separate. Full install, soft-vs-hard table, and a deny probe:
+
+**[docs/grok.md](./docs/grok.md)**
+
+Police scripts accept both Claude snake_case and Grok camelCase payloads and dual-emit deny
+JSON so either harness can block. Matcher aliases alone are not enough.
+
+### Agent review / merge gate
+
+`review-police` blocks forge merges unless an independent review record covers the exact
+commit being merged. Record shape, who may write what, and the consent path:
+
+**[docs/review-process.md](./docs/review-process.md)**
+
 ### Tools
 
 Global installs place tools on `~/.local/bin/` and preserve a mirror in `~/.claude/tools/`.

--- a/docs/grok.md
+++ b/docs/grok.md
@@ -1,0 +1,106 @@
+# Grok CLI — agentkit install and enforcement
+
+Agentkit supports [Grok CLI](https://github.com/xai-org/grok-cli) (Grok Build TUI)
+through two layers: **always-on instructions/skills** and **Claude-compatible
+lifecycle hooks**.
+
+## Soft vs hard enforcement
+
+| Layer | What it is | How Grok gets it | Blocks tools? |
+| --- | --- | --- | --- |
+| **Soft** | Rules, instructions, skills | `~/.grok/rules/*.md`, `~/.grok/skills/*` | No — model guidance only |
+| **Hard** | Police hooks (git/resource/pkg/…) | Loaded from `~/.claude/settings.json` when `compat.claude.hooks` is on (default) | Yes — PreToolUse deny |
+
+`grok inspect` listing hooks under `Hooks` means they are **registered**, not that
+they enforced the last command. After install, verify with the probe below.
+
+## Install
+
+```bash
+git clone git@github.com:developerinlondon/agentkit.git
+cd agentkit
+./install.sh --global
+```
+
+What that does for Grok specifically:
+
+1. **Claude hooks** land in `~/.claude/hooks/` (including `lib/hook-input.sh`) and
+   are merged into `~/.claude/settings.json`. Grok loads those hooks by default
+   (`[compat.claude] hooks = true`).
+2. **Tools** land on `PATH` as `bounded-run` / `agentkit-run`.
+3. **Instructions / skills / rules** for Grok depend on the installer revision:
+   - Current `main` + shared-root install (see PR that introduces
+     `~/.agentkit/`): per-name symlinks under `~/.grok/skills` and
+     `~/.grok/rules`, including always-on instructions as rules.
+   - If your install predates that, copy or symlink rules/skills manually, or
+     re-run a shared-root global install.
+
+Restart Grok (or start a new session) after install so hooks reload.
+
+### Confirm
+
+```bash
+grok inspect | sed -n '/Hooks/,/Config Sources/p'
+# Expect git-police, resource-police, format-police, etc. tagged [claude]
+
+# Functional probe (must DENY on both shapes after this fix):
+echo '{"tool_name":"Bash","tool_input":{"command":"git push --force origin main"}}' \
+  | ~/.claude/hooks/git-police.sh
+echo '{"toolName":"run_terminal_command","toolInput":{"command":"git push --force origin main"}}' \
+  | ~/.claude/hooks/git-police.sh
+```
+
+Both must print a deny JSON with `decision: "deny"` **and**
+`hookSpecificOutput.permissionDecision: "deny"`.
+
+### Optional: disable Claude harness scan
+
+Only if you intentionally do not want Grok to load Claude hooks/skills:
+
+```toml
+# ~/.grok/config.toml
+[compat.claude]
+hooks = false
+skills = false
+```
+
+## Payload contract (why hooks used to fail open)
+
+| Harness | Tool name examples | Stdin keys |
+| --- | --- | --- |
+| Claude Code | `Bash`, `Edit`, `Write` | `tool_name`, `tool_input`, `session_id` |
+| Grok CLI | `run_terminal_command`, `search_replace`, `write` | `toolName`, `toolInput`, `sessionId` |
+
+Grok **matcher** aliases map Claude names onto Grok tools, so a settings entry
+with `matcher: "Bash"` still fires on `run_terminal_command`. Scripts must still
+read **both** key styles and treat Grok tool names as Bash/Edit/Write families.
+That logic lives in `hooks/claude/lib/hook-input.sh`.
+
+Deny responses dual-emit:
+
+```json
+{
+  "decision": "deny",
+  "reason": "…",
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "…"
+  }
+}
+```
+
+## Resource bounding on Grok
+
+`resource-police` requires `bounded-run` the same way as on Claude. Grok does not
+rewrite the agent’s shell command; the model (and soft rules) must use
+`bounded-run --profile … -- <cmd>`. The hook only **denies** unbounded heavy
+commands.
+
+Host requirements: cgroup v2, `agent-work.slice`, matching
+`/etc/agentkit/resource-guard.conf`. See `skills/resource-safe-execution/`.
+
+## Related
+
+- Review / merge gate: [docs/review-process.md](./review-process.md)
+- Issue: Grok fail-open gap (payload keys) — tracked with the dual-payload PR

--- a/docs/review-process.md
+++ b/docs/review-process.md
@@ -1,0 +1,98 @@
+# Agent review process (review-police)
+
+This is the **merge gate**, not a code-style linter. It blocks forge merges
+unless an independent review record covers the exact commit being merged.
+
+## What it is / is not
+
+| | |
+| --- | --- |
+| **Is** | Mechanical gate: missing/stale/blocked review → merge denied |
+| **Is not** | Security. Agents can write the record. Forge required approvals are real enforcement |
+| **Honest path** | Reviewer writes pass/block → agent fixes HIGH/BLOCKER → re-review → merge via CLI |
+
+Historical failure mode (2026-07-19): reviewer returned HIGH, merge ran in
+parallel, agent judged the finding inert, machine broke as predicted.
+`review-police` makes that path hard without user-written consent.
+
+## Artifacts
+
+| Artifact | Path | Committed? |
+| --- | --- | --- |
+| Review record | `.agentkit/reviews/<source-branch-slug>.json` | **No** (gitignored) |
+| Product manifest | `.agentkit/product.yaml` | **Yes** (product-review skill) |
+| Audit log | `~/.agentkit/review-audit.log` | n/a (machine-local) |
+
+Branch slug: feature branch name with `/` → `__`
+(e.g. `feat/grok-hook-compat` → `feat__grok-hook-compat.json`).
+
+### Record shape
+
+```json
+{
+  "head_sha": "<full sha of the commit reviewed>",
+  "verdict": "pass | blocked",
+  "findings": [
+    {
+      "severity": "BLOCKER | HIGH | MEDIUM | LOW",
+      "summary": "…",
+      "resolved": true
+    }
+  ],
+  "user_consent": {
+    "granted": true,
+    "quote": "<user's exact words allowing the merge>",
+    "at": "<ISO-8601>"
+  }
+}
+```
+
+Gate rules (summary):
+
+1. Resolve **real** source branch + head sha from the forge (MR/PR), not the local checkout.
+2. Require a record for that branch.
+3. Record `head_sha` must equal the sha being merged.
+4. Unresolved **BLOCKER** or **HIGH** findings → deny unless `user_consent.granted` is true with a quote.
+5. `verdict` must be `pass` (or consent path).
+
+## Who writes what
+
+| Actor | May write |
+| --- | --- |
+| **Reviewing agent** (separate from implementer) | `head_sha`, `verdict`, `findings` |
+| **Implementing agent** | Fixes code; may re-request review; must **not** invent a pass |
+| **User only** | `user_consent` when deliberately overriding unresolved HIGH/BLOCKER |
+
+Overrides are logged to `~/.agentkit/review-audit.log`. Prefer fixing findings.
+
+## How to run a review that the gate accepts
+
+1. Implement on a feature branch; open MR/PR.
+2. Spawn or hand off an **independent** reviewer (diff review skill, separate session/subagent).
+3. Reviewer writes `.agentkit/reviews/<slug>.json` for the **MR source branch** and the **head sha the forge will merge**.
+4. If blocked: implementer fixes, push, re-review with updated `head_sha`.
+5. Merge only via CLI paths the hook inspects (`glab mr merge`, `gh pr merge`, …). MCP merge tools are denied.
+
+Product review (build/run/use) is a separate lane — see
+`skills/product-review/`. It is **not** required by review-police today; absence
+of `.agentkit/product.yaml` is a product-review finding, not a merge blocker
+unless you raise that policy later.
+
+## Agent / human checklist
+
+```text
+implement ──► independent review ──► record pass for head_sha
+                    │
+                    ▼
+              unresolved HIGH/BLOCKER? ──yes──► fix or user_consent
+                    │
+                   no
+                    ▼
+              glab mr merge / gh pr merge  (review-police allows)
+```
+
+## Grok / Claude
+
+Same hook script. After dual-payload support, Grok shell merges are gated when
+the tool is `run_terminal_command` with a merge command; MCP merge tool names
+still deny. See [docs/grok.md](./grok.md).

--- a/hooks/claude/coding-police.sh
+++ b/hooks/claude/coding-police.sh
@@ -74,18 +74,23 @@ load_config() {
 }
 load_config
 
+# shellcheck source=lib/hook-input.sh
+# Pure bash dirname: external `dirname` is missing when PATH is empty (the
+# missing-jq fail-open probe), and a source failure under set -e would silence
+# the gate. BASH_SOURCE is absolute when the harness invokes the script by path.
+source "${BASH_SOURCE[0]%/*}/lib/hook-input.sh"
 # ── Input parsing ───────────────────────────────────────────────────────────
-INPUT=$(cat)
-TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
+agentkit_slurp_input
+TOOL_NAME=$(agentkit_tool_name)
+TOOL_FAMILY=$(agentkit_tool_family "$TOOL_NAME")
 
-# Only trigger on Edit or Write tools
-case "$TOOL_NAME" in
-  Edit|Write|edit|write) ;;
-  *) exit 0 ;;
-esac
+# Only trigger on Edit or Write tools (incl. Grok search_replace / write)
+if ! agentkit_is_file_write_tool "$TOOL_NAME"; then
+  exit 0
+fi
 
 # Extract the file path from tool input
-FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.filePath // empty')
+FILE_PATH=$(agentkit_file_path)
 [[ -z "$FILE_PATH" ]] && exit 0
 
 IS_CODE_FILE=false
@@ -353,8 +358,8 @@ check_export_count() {
 
 # ── Check 6: Monolith directory (Write only — Edit cannot create new files) ─
 check_monolith_directory() {
-  case "$TOOL_NAME" in
-    Write|write) ;;
+  case "$TOOL_FAMILY" in
+    Write) ;;
     *) return 0 ;;
   esac
   (( MAX_DIR_FILES > 0 )) || return 0

--- a/hooks/claude/comment-police.sh
+++ b/hooks/claude/comment-police.sh
@@ -68,13 +68,17 @@ load_config
 
 command -v jq >/dev/null 2>&1 || exit 0
 
-INPUT=$(cat)
-case "$(echo "$INPUT" | jq -r '.tool_name // empty')" in
-  Edit|Write|edit|write) ;;
-  *) exit 0 ;;
-esac
+# shellcheck source=lib/hook-input.sh
+# Pure bash dirname: external `dirname` is missing when PATH is empty (the
+# missing-jq fail-open probe), and a source failure under set -e would silence
+# the gate. BASH_SOURCE is absolute when the harness invokes the script by path.
+source "${BASH_SOURCE[0]%/*}/lib/hook-input.sh"
+agentkit_slurp_input
+if ! agentkit_is_file_write_tool; then
+  exit 0
+fi
 
-FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.filePath // empty')
+FILE_PATH=$(agentkit_file_path)
 [[ -z "$FILE_PATH" ]] && exit 0
 
 case "$FILE_PATH" in
@@ -88,7 +92,7 @@ for pattern in "${EXCLUDE_PATTERNS[@]+"${EXCLUDE_PATTERNS[@]}"}"; do
   [[ "$FILE_PATH" == *"$pattern"* ]] && exit 0
 done
 
-ADDED=$(echo "$INPUT" | jq -r '.tool_input.new_string // .tool_input.content // empty')
+ADDED=$(agentkit_edit_text)
 [[ -z "$ADDED" ]] && exit 0
 
 VIOLATIONS=()

--- a/hooks/claude/format-police.sh
+++ b/hooks/claude/format-police.sh
@@ -16,17 +16,21 @@ if [[ -n "${AGENTKIT_SKIP_HOOKS:-}" ]]; then
   esac
 fi
 
-INPUT=$(cat)
-TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
+# shellcheck source=lib/hook-input.sh
+# Pure bash dirname: external `dirname` is missing when PATH is empty (the
+# missing-jq fail-open probe), and a source failure under set -e would silence
+# the gate. BASH_SOURCE is absolute when the harness invokes the script by path.
+source "${BASH_SOURCE[0]%/*}/lib/hook-input.sh"
+agentkit_slurp_input
+TOOL_NAME=$(agentkit_tool_name)
 
-# Only trigger on Edit or Write tools
-case "$TOOL_NAME" in
-  Edit|Write|edit|write) ;;
-  *) exit 0 ;;
-esac
+# Only trigger on Edit or Write tools (incl. Grok search_replace / write)
+if ! agentkit_is_file_write_tool "$TOOL_NAME"; then
+  exit 0
+fi
 
 # Extract the file path from tool input
-FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.filePath // empty')
+FILE_PATH=$(agentkit_file_path)
 [[ -z "$FILE_PATH" ]] && exit 0
 
 # Only format known file types

--- a/hooks/claude/git-police.sh
+++ b/hooks/claude/git-police.sh
@@ -12,8 +12,13 @@ RE_YAML_ITEM='^[[:space:]]*-[[:space:]]+(.*)'
 PROTECTED_BRANCHES=("main" "master")
 AGENTKIT_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/agentkit/config.yaml"
 
-INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+# shellcheck source=lib/hook-input.sh
+# Pure bash dirname: external `dirname` is missing when PATH is empty (the
+# missing-jq fail-open probe), and a source failure under set -e would silence
+# the gate. BASH_SOURCE is absolute when the harness invokes the script by path.
+source "${BASH_SOURCE[0]%/*}/lib/hook-input.sh"
+agentkit_slurp_input
+COMMAND=$(agentkit_command)
 
 [[ -z "$COMMAND" ]] && exit 0
 
@@ -78,13 +83,7 @@ fi
 
 deny() {
 	local reason="$1"
-	jq -n --arg r "$reason" '{
-    hookSpecificOutput: {
-      hookEventName: "PreToolUse",
-      permissionDecision: "deny",
-      permissionDecisionReason: $r
-    }
-  }'
+	agentkit_deny_json "$reason"
 	exit 0
 }
 
@@ -95,12 +94,7 @@ deny() {
 # reaches Claude only on "deny", and stdout on exit 0 is discarded).
 advise() {
 	local msg="$1"
-	jq -n --arg m "$msg" '{
-    hookSpecificOutput: {
-      hookEventName: "PreToolUse",
-      additionalContext: $m
-    }
-  }'
+	agentkit_advise_json "$msg"
 	exit 0
 }
 

--- a/hooks/claude/kubectl-police.sh
+++ b/hooks/claude/kubectl-police.sh
@@ -4,20 +4,19 @@
 # Equivalent to: plugins/kubectl-police.ts (OpenCode)
 set -euo pipefail
 
-INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+# shellcheck source=lib/hook-input.sh
+# Pure bash dirname: external `dirname` is missing when PATH is empty (the
+# missing-jq fail-open probe), and a source failure under set -e would silence
+# the gate. BASH_SOURCE is absolute when the harness invokes the script by path.
+source "${BASH_SOURCE[0]%/*}/lib/hook-input.sh"
+agentkit_slurp_input
+COMMAND=$(agentkit_command)
 
 [[ -z "$COMMAND" ]] && exit 0
 
 deny() {
   local reason="$1"
-  jq -n --arg r "$reason" '{
-    hookSpecificOutput: {
-      hookEventName: "PreToolUse",
-      permissionDecision: "deny",
-      permissionDecisionReason: $r
-    }
-  }'
+  agentkit_deny_json "$reason"
   exit 0
 }
 

--- a/hooks/claude/lib/hook-input.sh
+++ b/hooks/claude/lib/hook-input.sh
@@ -1,0 +1,101 @@
+# Shared Pre/PostToolUse input helpers for Claude Code and Grok CLI.
+# Source from a police hook:
+#   # shellcheck source=lib/hook-input.sh
+#   source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/hook-input.sh"
+#
+# Grok sends camelCase (toolName, toolInput, sessionId). Claude sends snake_case.
+# Matchers already alias tool names; scripts must still read both key styles and
+# treat Grok tool names as their Claude family (Bash/Edit/Write).
+
+_agentkit_jq() {
+	if [[ -n "${JQ_BIN:-}" ]]; then
+		"$JQ_BIN" "$@"
+	else
+		jq "$@"
+	fi
+}
+
+agentkit_slurp_input() {
+	if [[ -n "${CAT_BIN:-}" ]]; then
+		AGENTKIT_RAW_INPUT=$("$CAT_BIN")
+	else
+		AGENTKIT_RAW_INPUT=$(cat)
+	fi
+}
+
+agentkit_jq_raw() {
+	printf '%s' "${AGENTKIT_RAW_INPUT:-}" | _agentkit_jq "$@"
+}
+
+agentkit_tool_name() {
+	agentkit_jq_raw -r '.tool_name // .toolName // empty'
+}
+
+agentkit_command() {
+	agentkit_jq_raw -r '.tool_input.command // .toolInput.command // empty'
+}
+
+agentkit_session_id() {
+	agentkit_jq_raw -r '.session_id // .sessionId // "unknown"'
+}
+
+agentkit_file_path() {
+	agentkit_jq_raw -r '
+    .tool_input.file_path // .tool_input.filePath // .tool_input.path //
+    .tool_input.target_file // .tool_input.targetFile //
+    .toolInput.file_path // .toolInput.filePath // .toolInput.path //
+    .toolInput.target_file // .toolInput.targetFile // empty'
+}
+
+agentkit_edit_text() {
+	agentkit_jq_raw -r '
+    .tool_input.new_string // .tool_input.content // .tool_input.newString //
+    .toolInput.new_string // .toolInput.content // .toolInput.newString // empty'
+}
+
+# Map harness-specific tool names onto Claude's Bash/Edit/Write families so
+# case filters and MCP vs shell branches stay correct under Grok.
+agentkit_tool_family() {
+	local t="${1-}"
+	if [[ -z "$t" ]]; then
+		t=$(agentkit_tool_name)
+	fi
+	case "$t" in
+	Bash | bash | run_terminal_command | Shell | shell) printf '%s' 'Bash' ;;
+	Edit | edit | MultiEdit | multi_edit | search_replace | StrReplace | str_replace) printf '%s' 'Edit' ;;
+	Write | write | create_file | Create | create) printf '%s' 'Write' ;;
+	*) printf '%s' "$t" ;;
+	esac
+}
+
+agentkit_is_file_write_tool() {
+	case "$(agentkit_tool_family "${1-}")" in
+	Edit | Write) return 0 ;;
+	*) return 1 ;;
+	esac
+}
+
+# Dual-emit Claude (hookSpecificOutput) and Grok ({decision, reason}) deny shapes.
+agentkit_deny_json() {
+	local reason="$1"
+	_agentkit_jq -n --arg r "$reason" '{
+    decision: "deny",
+    reason: $r,
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: $r
+    }
+  }'
+}
+
+agentkit_advise_json() {
+	local msg="$1"
+	_agentkit_jq -n --arg m "$msg" '{
+    systemMessage: $m,
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      additionalContext: $m
+    }
+  }'
+}

--- a/hooks/claude/mr-police.sh
+++ b/hooks/claude/mr-police.sh
@@ -14,8 +14,13 @@
 # mr create …`) — inline assignments never reach the hook process.
 set -euo pipefail
 
-INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+# shellcheck source=lib/hook-input.sh
+# Pure bash dirname: external `dirname` is missing when PATH is empty (the
+# missing-jq fail-open probe), and a source failure under set -e would silence
+# the gate. BASH_SOURCE is absolute when the harness invokes the script by path.
+source "${BASH_SOURCE[0]%/*}/lib/hook-input.sh"
+agentkit_slurp_input
+COMMAND=$(agentkit_command)
 [[ -z "$COMMAND" ]] && exit 0
 
 # Only act on MR-creation commands; everything else passes through instantly.
@@ -24,13 +29,7 @@ if ! echo "$COMMAND" | grep -qiE 'glab[[:space:]]+mr[[:space:]]+create|merge_req
 fi
 
 deny() {
-	jq -n --arg r "$1" '{
-    hookSpecificOutput: {
-      hookEventName: "PreToolUse",
-      permissionDecision: "deny",
-      permissionDecisionReason: $r
-    }
-  }'
+	agentkit_deny_json "$1"
 	exit 0
 }
 

--- a/hooks/claude/pkg-police.sh
+++ b/hooks/claude/pkg-police.sh
@@ -4,8 +4,13 @@
 # Equivalent to: plugins/pkg-police.ts (OpenCode)
 set -euo pipefail
 
-INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+# shellcheck source=lib/hook-input.sh
+# Pure bash dirname: external `dirname` is missing when PATH is empty (the
+# missing-jq fail-open probe), and a source failure under set -e would silence
+# the gate. BASH_SOURCE is absolute when the harness invokes the script by path.
+source "${BASH_SOURCE[0]%/*}/lib/hook-input.sh"
+agentkit_slurp_input
+COMMAND=$(agentkit_command)
 
 [[ -z "$COMMAND" ]] && exit 0
 
@@ -21,13 +26,7 @@ fi
 
 deny() {
   local reason="$1"
-  jq -n --arg r "$reason" '{
-    hookSpecificOutput: {
-      hookEventName: "PreToolUse",
-      permissionDecision: "deny",
-      permissionDecisionReason: $r
-    }
-  }'
+  agentkit_deny_json "$reason"
   exit 0
 }
 

--- a/hooks/claude/resource-police.sh
+++ b/hooks/claude/resource-police.sh
@@ -82,8 +82,13 @@ if [[ ! -r /sys/fs/cgroup/cgroup.controllers ]]; then
 	exit 0
 fi
 
-INPUT=$("$CAT_BIN")
-COMMAND=$(printf '%s' "$INPUT" | "$JQ_BIN" -r '.tool_input.command // empty')
+# shellcheck source=lib/hook-input.sh
+# Pure bash dirname: external `dirname` is missing when PATH is empty (the
+# missing-jq fail-open probe), and a source failure under set -e would silence
+# the gate. BASH_SOURCE is absolute when the harness invokes the script by path.
+source "${BASH_SOURCE[0]%/*}/lib/hook-input.sh"
+agentkit_slurp_input
+COMMAND=$(agentkit_command)
 [[ -z "$COMMAND" ]] && exit 0
 
 # User-approved escape hatch for sanctioned delegated workloads (e.g. an
@@ -114,13 +119,7 @@ deny() {
 	else
 		reason="BLOCKED: resource-intensive command is not contained: $segment. Run it through $runner_hint, for example: $runner_hint --profile compile -- bun run typecheck. Use profile browser for Playwright and browser builds."
 	fi
-	"$JQ_BIN" -n --arg r "$reason" '{
-    hookSpecificOutput: {
-      hookEventName: "PreToolUse",
-      permissionDecision: "deny",
-      permissionDecisionReason: $r
-    }
-  }'
+	agentkit_deny_json "$reason"
 	exit 0
 }
 

--- a/hooks/claude/review-police.sh
+++ b/hooks/claude/review-police.sh
@@ -33,15 +33,21 @@ set -euo pipefail
 # environment alone: `jq` missing (exit 127 on the first parse) and HOME unset
 # (set -u on the audit path). Neither is exotic; both silently disarmed the
 # gate. Refuse loudly instead of dying quietly.
+# shellcheck source=lib/hook-input.sh
+# Pure bash dirname: external `dirname` is missing when PATH is empty (the
+# missing-jq fail-open probe), and a source failure under set -e would silence
+# the gate. BASH_SOURCE is absolute when the harness invokes the script by path.
+source "${BASH_SOURCE[0]%/*}/lib/hook-input.sh"
 if ! command -v jq >/dev/null 2>&1; then
-	printf '%s\n' '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"BLOCKED: review-police cannot run — jq is not installed, so the merge cannot be checked against its review record. Install jq."}}'
+	printf '%s\n' '{"decision":"deny","reason":"BLOCKED: review-police cannot run — jq is not installed, so the merge cannot be checked against its review record. Install jq.","hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"BLOCKED: review-police cannot run — jq is not installed, so the merge cannot be checked against its review record. Install jq."}}'
 	exit 0
 fi
 
-INPUT=$(cat)
-TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty')
-RAW_COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
-SESSION=$(echo "$INPUT" | jq -r '.session_id // "unknown"')
+agentkit_slurp_input
+TOOL=$(agentkit_tool_name)
+TOOL_FAMILY=$(agentkit_tool_family "$TOOL")
+RAW_COMMAND=$(agentkit_command)
+SESSION=$(agentkit_session_id)
 
 # TOKENISE the way a shell does, then match on tokens joined by newlines.
 #
@@ -151,19 +157,13 @@ AUDIT="${HOME:-/tmp}/.agentkit/review-audit.log"
 deny() {
 	mkdir -p "$(dirname "$AUDIT")" 2>/dev/null || true
 	printf '%s\tDENY\tsession=%s\t%s\n' "$(date -Is)" "$SESSION" "${1//$'\n'/ }" >>"$AUDIT" 2>/dev/null || true
-	jq -n --arg r "$1" '{
-    hookSpecificOutput: {
-      hookEventName: "PreToolUse",
-      permissionDecision: "deny",
-      permissionDecisionReason: $r
-    }
-  }'
+	agentkit_deny_json "$1"
 	exit 0
 }
 
 # --- MCP merge tools: no Bash to inspect, so refuse outright ---------------
 # These bypass every command-shaped check. The CLI path is the reviewed path.
-if [[ -n "$TOOL" && "$TOOL" != "Bash" ]]; then
+if [[ -n "$TOOL" && "$TOOL_FAMILY" != "Bash" ]]; then
 	if echo "$TOOL" | grep -qiE 'merge_(pull_request|request)|pull_request_merge|mr_merge'; then
 		deny "BLOCKED: merging through an MCP tool bypasses the review gate.
 

--- a/install.sh
+++ b/install.sh
@@ -452,6 +452,14 @@ install_claude_hooks() {
 		chmod +x "$hooks_dir/$name"
 	done
 
+	# Shared helpers (Claude + Grok dual payload parsing). Scripts source
+	# $hooks_dir/lib/hook-input.sh via dirname of the hook script.
+	if [[ -d "$REPO_DIR/hooks/claude/lib" ]]; then
+		mkdir -p "$hooks_dir/lib"
+		cp -a "$REPO_DIR"/hooks/claude/lib/. "$hooks_dir/lib/"
+		echo "[claude] Installed hook lib/ helpers"
+	fi
+
 	# Merge hooks into settings.json
 	merge_claude_settings "$settings_file" "$hooks_dir"
 }

--- a/plugins-cc/agentkit/hooks/coding-police.sh
+++ b/plugins-cc/agentkit/hooks/coding-police.sh
@@ -74,18 +74,23 @@ load_config() {
 }
 load_config
 
+# shellcheck source=lib/hook-input.sh
+# Pure bash dirname: external `dirname` is missing when PATH is empty (the
+# missing-jq fail-open probe), and a source failure under set -e would silence
+# the gate. BASH_SOURCE is absolute when the harness invokes the script by path.
+source "${BASH_SOURCE[0]%/*}/lib/hook-input.sh"
 # ── Input parsing ───────────────────────────────────────────────────────────
-INPUT=$(cat)
-TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
+agentkit_slurp_input
+TOOL_NAME=$(agentkit_tool_name)
+TOOL_FAMILY=$(agentkit_tool_family "$TOOL_NAME")
 
-# Only trigger on Edit or Write tools
-case "$TOOL_NAME" in
-  Edit|Write|edit|write) ;;
-  *) exit 0 ;;
-esac
+# Only trigger on Edit or Write tools (incl. Grok search_replace / write)
+if ! agentkit_is_file_write_tool "$TOOL_NAME"; then
+  exit 0
+fi
 
 # Extract the file path from tool input
-FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.filePath // empty')
+FILE_PATH=$(agentkit_file_path)
 [[ -z "$FILE_PATH" ]] && exit 0
 
 IS_CODE_FILE=false
@@ -353,8 +358,8 @@ check_export_count() {
 
 # ── Check 6: Monolith directory (Write only — Edit cannot create new files) ─
 check_monolith_directory() {
-  case "$TOOL_NAME" in
-    Write|write) ;;
+  case "$TOOL_FAMILY" in
+    Write) ;;
     *) return 0 ;;
   esac
   (( MAX_DIR_FILES > 0 )) || return 0

--- a/plugins-cc/agentkit/hooks/comment-police.sh
+++ b/plugins-cc/agentkit/hooks/comment-police.sh
@@ -68,13 +68,17 @@ load_config
 
 command -v jq >/dev/null 2>&1 || exit 0
 
-INPUT=$(cat)
-case "$(echo "$INPUT" | jq -r '.tool_name // empty')" in
-  Edit|Write|edit|write) ;;
-  *) exit 0 ;;
-esac
+# shellcheck source=lib/hook-input.sh
+# Pure bash dirname: external `dirname` is missing when PATH is empty (the
+# missing-jq fail-open probe), and a source failure under set -e would silence
+# the gate. BASH_SOURCE is absolute when the harness invokes the script by path.
+source "${BASH_SOURCE[0]%/*}/lib/hook-input.sh"
+agentkit_slurp_input
+if ! agentkit_is_file_write_tool; then
+  exit 0
+fi
 
-FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.filePath // empty')
+FILE_PATH=$(agentkit_file_path)
 [[ -z "$FILE_PATH" ]] && exit 0
 
 case "$FILE_PATH" in
@@ -88,7 +92,7 @@ for pattern in "${EXCLUDE_PATTERNS[@]+"${EXCLUDE_PATTERNS[@]}"}"; do
   [[ "$FILE_PATH" == *"$pattern"* ]] && exit 0
 done
 
-ADDED=$(echo "$INPUT" | jq -r '.tool_input.new_string // .tool_input.content // empty')
+ADDED=$(agentkit_edit_text)
 [[ -z "$ADDED" ]] && exit 0
 
 VIOLATIONS=()

--- a/plugins-cc/agentkit/hooks/format-police.sh
+++ b/plugins-cc/agentkit/hooks/format-police.sh
@@ -16,17 +16,21 @@ if [[ -n "${AGENTKIT_SKIP_HOOKS:-}" ]]; then
   esac
 fi
 
-INPUT=$(cat)
-TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
+# shellcheck source=lib/hook-input.sh
+# Pure bash dirname: external `dirname` is missing when PATH is empty (the
+# missing-jq fail-open probe), and a source failure under set -e would silence
+# the gate. BASH_SOURCE is absolute when the harness invokes the script by path.
+source "${BASH_SOURCE[0]%/*}/lib/hook-input.sh"
+agentkit_slurp_input
+TOOL_NAME=$(agentkit_tool_name)
 
-# Only trigger on Edit or Write tools
-case "$TOOL_NAME" in
-  Edit|Write|edit|write) ;;
-  *) exit 0 ;;
-esac
+# Only trigger on Edit or Write tools (incl. Grok search_replace / write)
+if ! agentkit_is_file_write_tool "$TOOL_NAME"; then
+  exit 0
+fi
 
 # Extract the file path from tool input
-FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.filePath // empty')
+FILE_PATH=$(agentkit_file_path)
 [[ -z "$FILE_PATH" ]] && exit 0
 
 # Only format known file types

--- a/plugins-cc/agentkit/hooks/git-police.sh
+++ b/plugins-cc/agentkit/hooks/git-police.sh
@@ -12,8 +12,13 @@ RE_YAML_ITEM='^[[:space:]]*-[[:space:]]+(.*)'
 PROTECTED_BRANCHES=("main" "master")
 AGENTKIT_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/agentkit/config.yaml"
 
-INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+# shellcheck source=lib/hook-input.sh
+# Pure bash dirname: external `dirname` is missing when PATH is empty (the
+# missing-jq fail-open probe), and a source failure under set -e would silence
+# the gate. BASH_SOURCE is absolute when the harness invokes the script by path.
+source "${BASH_SOURCE[0]%/*}/lib/hook-input.sh"
+agentkit_slurp_input
+COMMAND=$(agentkit_command)
 
 [[ -z "$COMMAND" ]] && exit 0
 
@@ -78,13 +83,7 @@ fi
 
 deny() {
 	local reason="$1"
-	jq -n --arg r "$reason" '{
-    hookSpecificOutput: {
-      hookEventName: "PreToolUse",
-      permissionDecision: "deny",
-      permissionDecisionReason: $r
-    }
-  }'
+	agentkit_deny_json "$reason"
 	exit 0
 }
 
@@ -95,12 +94,7 @@ deny() {
 # reaches Claude only on "deny", and stdout on exit 0 is discarded).
 advise() {
 	local msg="$1"
-	jq -n --arg m "$msg" '{
-    hookSpecificOutput: {
-      hookEventName: "PreToolUse",
-      additionalContext: $m
-    }
-  }'
+	agentkit_advise_json "$msg"
 	exit 0
 }
 

--- a/plugins-cc/agentkit/hooks/kubectl-police.sh
+++ b/plugins-cc/agentkit/hooks/kubectl-police.sh
@@ -4,20 +4,19 @@
 # Equivalent to: plugins/kubectl-police.ts (OpenCode)
 set -euo pipefail
 
-INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+# shellcheck source=lib/hook-input.sh
+# Pure bash dirname: external `dirname` is missing when PATH is empty (the
+# missing-jq fail-open probe), and a source failure under set -e would silence
+# the gate. BASH_SOURCE is absolute when the harness invokes the script by path.
+source "${BASH_SOURCE[0]%/*}/lib/hook-input.sh"
+agentkit_slurp_input
+COMMAND=$(agentkit_command)
 
 [[ -z "$COMMAND" ]] && exit 0
 
 deny() {
   local reason="$1"
-  jq -n --arg r "$reason" '{
-    hookSpecificOutput: {
-      hookEventName: "PreToolUse",
-      permissionDecision: "deny",
-      permissionDecisionReason: $r
-    }
-  }'
+  agentkit_deny_json "$reason"
   exit 0
 }
 

--- a/plugins-cc/agentkit/hooks/lib/hook-input.sh
+++ b/plugins-cc/agentkit/hooks/lib/hook-input.sh
@@ -1,0 +1,101 @@
+# Shared Pre/PostToolUse input helpers for Claude Code and Grok CLI.
+# Source from a police hook:
+#   # shellcheck source=lib/hook-input.sh
+#   source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/hook-input.sh"
+#
+# Grok sends camelCase (toolName, toolInput, sessionId). Claude sends snake_case.
+# Matchers already alias tool names; scripts must still read both key styles and
+# treat Grok tool names as their Claude family (Bash/Edit/Write).
+
+_agentkit_jq() {
+	if [[ -n "${JQ_BIN:-}" ]]; then
+		"$JQ_BIN" "$@"
+	else
+		jq "$@"
+	fi
+}
+
+agentkit_slurp_input() {
+	if [[ -n "${CAT_BIN:-}" ]]; then
+		AGENTKIT_RAW_INPUT=$("$CAT_BIN")
+	else
+		AGENTKIT_RAW_INPUT=$(cat)
+	fi
+}
+
+agentkit_jq_raw() {
+	printf '%s' "${AGENTKIT_RAW_INPUT:-}" | _agentkit_jq "$@"
+}
+
+agentkit_tool_name() {
+	agentkit_jq_raw -r '.tool_name // .toolName // empty'
+}
+
+agentkit_command() {
+	agentkit_jq_raw -r '.tool_input.command // .toolInput.command // empty'
+}
+
+agentkit_session_id() {
+	agentkit_jq_raw -r '.session_id // .sessionId // "unknown"'
+}
+
+agentkit_file_path() {
+	agentkit_jq_raw -r '
+    .tool_input.file_path // .tool_input.filePath // .tool_input.path //
+    .tool_input.target_file // .tool_input.targetFile //
+    .toolInput.file_path // .toolInput.filePath // .toolInput.path //
+    .toolInput.target_file // .toolInput.targetFile // empty'
+}
+
+agentkit_edit_text() {
+	agentkit_jq_raw -r '
+    .tool_input.new_string // .tool_input.content // .tool_input.newString //
+    .toolInput.new_string // .toolInput.content // .toolInput.newString // empty'
+}
+
+# Map harness-specific tool names onto Claude's Bash/Edit/Write families so
+# case filters and MCP vs shell branches stay correct under Grok.
+agentkit_tool_family() {
+	local t="${1-}"
+	if [[ -z "$t" ]]; then
+		t=$(agentkit_tool_name)
+	fi
+	case "$t" in
+	Bash | bash | run_terminal_command | Shell | shell) printf '%s' 'Bash' ;;
+	Edit | edit | MultiEdit | multi_edit | search_replace | StrReplace | str_replace) printf '%s' 'Edit' ;;
+	Write | write | create_file | Create | create) printf '%s' 'Write' ;;
+	*) printf '%s' "$t" ;;
+	esac
+}
+
+agentkit_is_file_write_tool() {
+	case "$(agentkit_tool_family "${1-}")" in
+	Edit | Write) return 0 ;;
+	*) return 1 ;;
+	esac
+}
+
+# Dual-emit Claude (hookSpecificOutput) and Grok ({decision, reason}) deny shapes.
+agentkit_deny_json() {
+	local reason="$1"
+	_agentkit_jq -n --arg r "$reason" '{
+    decision: "deny",
+    reason: $r,
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: $r
+    }
+  }'
+}
+
+agentkit_advise_json() {
+	local msg="$1"
+	_agentkit_jq -n --arg m "$msg" '{
+    systemMessage: $m,
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      additionalContext: $m
+    }
+  }'
+}

--- a/plugins-cc/agentkit/hooks/mr-police.sh
+++ b/plugins-cc/agentkit/hooks/mr-police.sh
@@ -14,8 +14,13 @@
 # mr create …`) — inline assignments never reach the hook process.
 set -euo pipefail
 
-INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+# shellcheck source=lib/hook-input.sh
+# Pure bash dirname: external `dirname` is missing when PATH is empty (the
+# missing-jq fail-open probe), and a source failure under set -e would silence
+# the gate. BASH_SOURCE is absolute when the harness invokes the script by path.
+source "${BASH_SOURCE[0]%/*}/lib/hook-input.sh"
+agentkit_slurp_input
+COMMAND=$(agentkit_command)
 [[ -z "$COMMAND" ]] && exit 0
 
 # Only act on MR-creation commands; everything else passes through instantly.
@@ -24,13 +29,7 @@ if ! echo "$COMMAND" | grep -qiE 'glab[[:space:]]+mr[[:space:]]+create|merge_req
 fi
 
 deny() {
-	jq -n --arg r "$1" '{
-    hookSpecificOutput: {
-      hookEventName: "PreToolUse",
-      permissionDecision: "deny",
-      permissionDecisionReason: $r
-    }
-  }'
+	agentkit_deny_json "$1"
 	exit 0
 }
 

--- a/plugins-cc/agentkit/hooks/pkg-police.sh
+++ b/plugins-cc/agentkit/hooks/pkg-police.sh
@@ -4,8 +4,13 @@
 # Equivalent to: plugins/pkg-police.ts (OpenCode)
 set -euo pipefail
 
-INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+# shellcheck source=lib/hook-input.sh
+# Pure bash dirname: external `dirname` is missing when PATH is empty (the
+# missing-jq fail-open probe), and a source failure under set -e would silence
+# the gate. BASH_SOURCE is absolute when the harness invokes the script by path.
+source "${BASH_SOURCE[0]%/*}/lib/hook-input.sh"
+agentkit_slurp_input
+COMMAND=$(agentkit_command)
 
 [[ -z "$COMMAND" ]] && exit 0
 
@@ -21,13 +26,7 @@ fi
 
 deny() {
   local reason="$1"
-  jq -n --arg r "$reason" '{
-    hookSpecificOutput: {
-      hookEventName: "PreToolUse",
-      permissionDecision: "deny",
-      permissionDecisionReason: $r
-    }
-  }'
+  agentkit_deny_json "$reason"
   exit 0
 }
 

--- a/plugins-cc/agentkit/hooks/resource-police.sh
+++ b/plugins-cc/agentkit/hooks/resource-police.sh
@@ -82,8 +82,13 @@ if [[ ! -r /sys/fs/cgroup/cgroup.controllers ]]; then
 	exit 0
 fi
 
-INPUT=$("$CAT_BIN")
-COMMAND=$(printf '%s' "$INPUT" | "$JQ_BIN" -r '.tool_input.command // empty')
+# shellcheck source=lib/hook-input.sh
+# Pure bash dirname: external `dirname` is missing when PATH is empty (the
+# missing-jq fail-open probe), and a source failure under set -e would silence
+# the gate. BASH_SOURCE is absolute when the harness invokes the script by path.
+source "${BASH_SOURCE[0]%/*}/lib/hook-input.sh"
+agentkit_slurp_input
+COMMAND=$(agentkit_command)
 [[ -z "$COMMAND" ]] && exit 0
 
 # User-approved escape hatch for sanctioned delegated workloads (e.g. an
@@ -114,13 +119,7 @@ deny() {
 	else
 		reason="BLOCKED: resource-intensive command is not contained: $segment. Run it through $runner_hint, for example: $runner_hint --profile compile -- bun run typecheck. Use profile browser for Playwright and browser builds."
 	fi
-	"$JQ_BIN" -n --arg r "$reason" '{
-    hookSpecificOutput: {
-      hookEventName: "PreToolUse",
-      permissionDecision: "deny",
-      permissionDecisionReason: $r
-    }
-  }'
+	agentkit_deny_json "$reason"
 	exit 0
 }
 

--- a/plugins-cc/agentkit/hooks/review-police.sh
+++ b/plugins-cc/agentkit/hooks/review-police.sh
@@ -33,15 +33,21 @@ set -euo pipefail
 # environment alone: `jq` missing (exit 127 on the first parse) and HOME unset
 # (set -u on the audit path). Neither is exotic; both silently disarmed the
 # gate. Refuse loudly instead of dying quietly.
+# shellcheck source=lib/hook-input.sh
+# Pure bash dirname: external `dirname` is missing when PATH is empty (the
+# missing-jq fail-open probe), and a source failure under set -e would silence
+# the gate. BASH_SOURCE is absolute when the harness invokes the script by path.
+source "${BASH_SOURCE[0]%/*}/lib/hook-input.sh"
 if ! command -v jq >/dev/null 2>&1; then
-	printf '%s\n' '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"BLOCKED: review-police cannot run — jq is not installed, so the merge cannot be checked against its review record. Install jq."}}'
+	printf '%s\n' '{"decision":"deny","reason":"BLOCKED: review-police cannot run — jq is not installed, so the merge cannot be checked against its review record. Install jq.","hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"BLOCKED: review-police cannot run — jq is not installed, so the merge cannot be checked against its review record. Install jq."}}'
 	exit 0
 fi
 
-INPUT=$(cat)
-TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty')
-RAW_COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
-SESSION=$(echo "$INPUT" | jq -r '.session_id // "unknown"')
+agentkit_slurp_input
+TOOL=$(agentkit_tool_name)
+TOOL_FAMILY=$(agentkit_tool_family "$TOOL")
+RAW_COMMAND=$(agentkit_command)
+SESSION=$(agentkit_session_id)
 
 # TOKENISE the way a shell does, then match on tokens joined by newlines.
 #
@@ -151,19 +157,13 @@ AUDIT="${HOME:-/tmp}/.agentkit/review-audit.log"
 deny() {
 	mkdir -p "$(dirname "$AUDIT")" 2>/dev/null || true
 	printf '%s\tDENY\tsession=%s\t%s\n' "$(date -Is)" "$SESSION" "${1//$'\n'/ }" >>"$AUDIT" 2>/dev/null || true
-	jq -n --arg r "$1" '{
-    hookSpecificOutput: {
-      hookEventName: "PreToolUse",
-      permissionDecision: "deny",
-      permissionDecisionReason: $r
-    }
-  }'
+	agentkit_deny_json "$1"
 	exit 0
 }
 
 # --- MCP merge tools: no Bash to inspect, so refuse outright ---------------
 # These bypass every command-shaped check. The CLI path is the reviewed path.
-if [[ -n "$TOOL" && "$TOOL" != "Bash" ]]; then
+if [[ -n "$TOOL" && "$TOOL_FAMILY" != "Bash" ]]; then
 	if echo "$TOOL" | grep -qiE 'merge_(pull_request|request)|pull_request_merge|mr_merge'; then
 		deny "BLOCKED: merging through an MCP tool bypasses the review gate.
 

--- a/scripts/sync-cc-plugin.sh
+++ b/scripts/sync-cc-plugin.sh
@@ -14,6 +14,14 @@ for hook in "$REPO_DIR"/hooks/claude/*.sh; do
 done
 echo "[sync] hooks/claude/*.sh -> plugins-cc/agentkit/hooks/"
 
+# Shared helpers (dual Claude/Grok payload parsing). Must live next to the
+# scripts so `source "$(dirname …)/lib/hook-input.sh"` resolves.
+if [[ -d "$REPO_DIR/hooks/claude/lib" ]]; then
+	mkdir -p "$PLUGIN_DIR/hooks/lib"
+	cp -a "$REPO_DIR"/hooks/claude/lib/. "$PLUGIN_DIR/hooks/lib/"
+	echo "[sync] hooks/claude/lib -> plugins-cc/agentkit/hooks/lib/"
+fi
+
 # Skills: full mirror — remove skills that no longer exist at top level.
 for plugin_skill in "$PLUGIN_DIR"/skills/*/; do
 	name="$(basename "$plugin_skill")"

--- a/tests/hook-payload-compat.test.ts
+++ b/tests/hook-payload-compat.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from 'bun:test';
+import { dirname, join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+
+/**
+ * Police hooks used to read only Claude snake_case (`tool_input`, `tool_name`).
+ * Grok stdin is camelCase (`toolInput`, `toolName`) and uses different tool
+ * names. A harness that lists the hooks as loaded but never feeds a shape the
+ * scripts understand is fail-open enforcement — this file pins both shapes.
+ */
+const repoRoot = dirname(import.meta.dir);
+const hooksDir = join(repoRoot, 'hooks', 'claude');
+const canBound = existsSync('/sys/fs/cgroup/cgroup.controllers');
+
+function runHook(script: string, payload: unknown): { stdout: string; status: number | null } {
+  const result = spawnSync('bash', [join(hooksDir, script)], {
+    input: JSON.stringify(payload),
+    encoding: 'utf-8',
+  });
+  return { stdout: result.stdout ?? '', status: result.status };
+}
+
+function isDeny(stdout: string): boolean {
+  try {
+    const j = JSON.parse(stdout);
+    if (j.decision === 'deny') return true;
+    if (j.hookSpecificOutput?.permissionDecision === 'deny') return true;
+  } catch {
+    // non-JSON is not a deny
+  }
+  return false;
+}
+
+function hasDualDenyShape(stdout: string): boolean {
+  try {
+    const j = JSON.parse(stdout);
+    return (
+      j.decision === 'deny' &&
+      typeof j.reason === 'string' &&
+      j.hookSpecificOutput?.permissionDecision === 'deny' &&
+      typeof j.hookSpecificOutput?.permissionDecisionReason === 'string'
+    );
+  } catch {
+    return false;
+  }
+}
+
+describe('hook payload compat (Claude + Grok)', () => {
+  const forcePush = 'git push --force origin main';
+  const claudeForce = {
+    tool_name: 'Bash',
+    tool_input: { command: forcePush },
+    session_id: 'test-claude',
+  };
+  const grokForce = {
+    toolName: 'run_terminal_command',
+    toolInput: { command: forcePush },
+    sessionId: 'test-grok',
+  };
+
+  test('git-police denies force push on Claude snake_case', () => {
+    const { stdout } = runHook('git-police.sh', claudeForce);
+    expect(isDeny(stdout)).toBe(true);
+    expect(stdout).toContain('Force push');
+  });
+
+  test('git-police denies force push on Grok camelCase', () => {
+    const { stdout } = runHook('git-police.sh', grokForce);
+    expect(isDeny(stdout)).toBe(true);
+    expect(stdout).toContain('Force push');
+  });
+
+  test('git-police dual-emits Claude and Grok deny shapes', () => {
+    const { stdout } = runHook('git-police.sh', grokForce);
+    expect(hasDualDenyShape(stdout)).toBe(true);
+  });
+
+  test('pkg-police denies npm install on Grok camelCase', () => {
+    const { stdout } = runHook('pkg-police.sh', {
+      toolName: 'run_terminal_command',
+      toolInput: { command: 'npm install lodash' },
+    });
+    expect(isDeny(stdout)).toBe(true);
+    expect(stdout).toMatch(/bun/i);
+  });
+
+  const describeResource = canBound ? describe : describe.skip;
+  describeResource('resource-police', () => {
+    test('denies unbounded cargo build on Grok camelCase', () => {
+      const { stdout } = runHook('resource-police.sh', {
+        toolName: 'run_terminal_command',
+        toolInput: { command: 'cargo build' },
+      });
+      expect(isDeny(stdout)).toBe(true);
+      expect(stdout).toContain('bounded-run');
+    });
+  });
+
+  test('format-police accepts Grok search_replace tool family (no crash)', () => {
+    // Without a dprint config this may exit 0 after a warning; the failure
+    // mode we care about is silent no-op on tool name — family must pass the
+    // gate so the path extractor runs (empty path still exits 0).
+    const { status } = runHook('format-police.sh', {
+      toolName: 'search_replace',
+      toolInput: { file_path: '/tmp/agentkit-format-probe.ts' },
+    });
+    expect(status).toBe(0);
+  });
+
+  test('coding-police accepts Grok write tool family', () => {
+    const { status, stdout } = runHook('coding-police.sh', {
+      toolName: 'write',
+      toolInput: { file_path: '/tmp/agentkit-coding-probe.ts', content: 'const x = 1\n' },
+    });
+    // May warn or pass; must not die on unknown tool family.
+    expect(status).toBe(0);
+    expect(stdout).not.toMatch(/permissionDecision":"deny"/);
+  });
+
+  test('review-police treats run_terminal_command as Bash family (not MCP exit)', () => {
+    // Non-merge bash should fall through without MCP deny.
+    const { stdout, status } = runHook('review-police.sh', {
+      toolName: 'run_terminal_command',
+      toolInput: { command: 'echo hello' },
+      sessionId: 'test-review',
+    });
+    expect(status).toBe(0);
+    expect(isDeny(stdout)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Grok CLI was loading agentkit police hooks (visible in `grok inspect`) but **not enforcing** them: Grok stdin is camelCase (`toolName` / `toolInput`) while scripts only read Claude snake_case. Empty command → exit 0 → fail-open.

## Changes

- Shared `hooks/claude/lib/hook-input.sh` — dual key styles, Grok tool → Bash/Edit/Write families, dual deny JSON
- All Pre/PostToolUse police scripts use the lib; pure-bash source path (empty PATH safe)
- `install.sh` + `sync-cc-plugin.sh` ship `lib/`
- Tests: `tests/hook-payload-compat.test.ts` (Claude + Grok shapes)
- Docs: `docs/grok.md` (install + soft/hard), `docs/review-process.md` (merge gate), README links

## Verify

```bash
bun test tests/hook-payload-compat.test.ts
# both deny:
echo '{"toolName":"run_terminal_command","toolInput":{"command":"git push --force origin main"}}' \
  | bash hooks/claude/git-police.sh
```

Related suite: 261 police tests pass.

## Docs page

https://pages.agentkit.sbs/76a9a037627640a6c153

## Related

Refs #111

Depends on Claude hooks path (`./install.sh --global`). Soft Grok skills/rules wiring is improved by #110 (shared `~/.agentkit` root); this PR fixes hard enforcement either way.