### PR TITLE
fix(install): stop self-symlinking hooks/lib after shared-root install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -533,10 +533,12 @@ install_claude_hooks() {
 		chmod +x "$install_dir/$name"
 	done
 
-	# Shared helpers (Claude + Grok dual payload). Live next to scripts so
-	# `source "${BASH_SOURCE[0]%/*}/lib/hook-input.sh"` resolves in canon and
-	# in client dirs that symlink the hook scripts.
+	# Shared helpers (Claude + Grok dual payload). Real files live in the
+	# install (canon) dir. Client dirs get lib/ via the top-level
+	# link_children below as a *directory* symlink — never re-link files
+	# inside lib/, or path resolution turns into self-symlinks.
 	if [[ -d "$REPO_DIR/hooks/claude/lib" ]]; then
+		rm -rf "$install_dir/lib"
 		mkdir -p "$install_dir/lib"
 		cp -a "$REPO_DIR"/hooks/claude/lib/. "$install_dir/lib/"
 		echo "[claude] Installed hook lib/ helpers"
@@ -544,13 +546,6 @@ install_claude_hooks() {
 
 	if [[ -n "$canon_dir" && "$hooks_dir" != "$canon_dir" ]]; then
 		link_children "$canon_dir" "$hooks_dir"
-		# lib/ is a directory — link_children is per-name for top-level entries;
-		# ensure the client hooks dir also has lib/ (symlink tree or copy).
-		if [[ -d "$canon_dir/lib" ]]; then
-			mkdir -p "$hooks_dir/lib"
-			# Prefer linking individual files so lib stays in sync with canon.
-			link_children "$canon_dir/lib" "$hooks_dir/lib"
-		fi
 	fi
 
 	# Merge hooks into settings.json — commands still resolve under hooks_dir

--- a/tests/install-shared-root.test.ts
+++ b/tests/install-shared-root.test.ts
@@ -72,6 +72,34 @@ describe("shared ~/.agentkit root + client symlinks", () => {
         readlinkSync(join(home, ".claude", "hooks", "git-police.sh")),
       ).toBe(join(home, ".agentkit", "hooks", "git-police.sh"));
 
+      // Dual-payload helper: real file in canon; client lib is a directory
+      // symlink (not nested file self-links — that loop made every police
+      // fail open after shared-root install).
+      const canonLibDir = join(home, ".agentkit", "hooks", "lib");
+      const canonLib = join(canonLibDir, "hook-input.sh");
+      const clientLibDir = join(home, ".claude", "hooks", "lib");
+      const clientLib = join(clientLibDir, "hook-input.sh");
+      expect(existsSync(canonLib)).toBe(true);
+      expect(lstatSync(canonLib).isSymbolicLink()).toBe(false);
+      expect(lstatSync(clientLibDir).isSymbolicLink()).toBe(true);
+      expect(readlinkSync(clientLibDir)).toBe(canonLibDir);
+      expect(existsSync(clientLib)).toBe(true);
+      expect(readFileSync(clientLib, "utf-8")).toContain("agentkit_command");
+      const probe = spawnSync(
+        "bash",
+        [join(home, ".claude", "hooks", "git-police.sh")],
+        {
+          input: JSON.stringify({
+            toolName: "run_terminal_command",
+            toolInput: { command: "git push --force origin main" },
+          }),
+          encoding: "utf-8",
+          env: { ...process.env, HOME: home },
+        },
+      );
+      expect(probe.status, probe.stderr + "\n" + probe.stdout).toBe(0);
+      expect(probe.stdout).toContain('"decision": "deny"');
+
       // Shared root is advertised in the summary.
       expect(result.stdout).toContain(`Shared root:     ${join(home, ".agentkit")}`);
       expect(readdirSync(canon).length).toBeGreaterThan(5);


### PR DESCRIPTION
## Summary

#113 install left `~/.agentkit/hooks/lib/hook-input.sh` as a **self-symlink**. Every police script failed open with `Too many levels of symbolic links`.

Root cause: nested `link_children` on `lib/` after the client already had `lib` as a directory symlink into canon — destinations resolved to the same path as sources.

## Fix

- Real files only in canon (`rm -rf` + `cp`)
- Client gets `lib/` via top-level `link_children` only (directory symlink)
- Regression assertions + camelCase deny probe in `tests/install-shared-root.test.ts`

## Verify

```bash
bounded-run --profile default -- bun test tests/install-shared-root.test.ts
./install.sh --global
# must deny, not loop:
printf '%s' '{"toolName":"run_terminal_command","toolInput":{"command":"git push --force origin main"}}' | ~/.claude/hooks/git-police.sh
```

Follow-up to #112 / #113.