### PR TITLE
fix(workflow): correct runner and worktree guidance

### DIFF
--- a/instructions/coding-discipline.md
+++ b/instructions/coding-discipline.md
@@ -91,12 +91,19 @@ git branch -vv | awk '/: gone]/ {print $1}' | xargs -r git branch -D
 
 - Always cut new branches from the freshly pulled default branch — never from another feature
   branch in a squash-merge repo (the follow-up MR will conflict once the first one squashes).
-- At most one feature branch alive per repo at a time, mirroring the mr-police limit.
+- Keep one open agent-authored MR per repo by default, mirroring the mr-police limit. Explicitly
+  coordinated concurrent branches may use separate worktrees, but converge before opening another
+  authored MR.
+
+Use the primary checkout for sequential work. Create a temporary, task-owned worktree only when a
+tool needs checkout isolation or explicitly coordinated work must proceed concurrently. Put it in a
+scratch location outside the repository, and do not keep a permanent worktrees directory. Each task
+owns its checkout; never remove or reuse another active task's worktree.
 
 If the branch had a worktree, **remove the worktree in the same breath as merging it** — a merged
-worktree is a stale checkout of code that no longer exists anywhere else, and they accumulate far
-more quietly than branches do. `git worktree remove` deletes only the checkout; the branch ref
-survives, so this is safe whenever the tree is clean:
+worktree otherwise remains a stale checkout of the pre-squash branch commit even after equivalent
+changes land on the default branch. `git worktree remove` deletes only the checkout; the branch ref
+survives until branch cleanup, so removal is safe whenever the tree is clean:
 
 ```bash
 git worktree list                       # audit BEFORE removing anything

--- a/plugins-cc/agentkit/skills/autonomous-workflow/SKILL.md
+++ b/plugins-cc/agentkit/skills/autonomous-workflow/SKILL.md
@@ -142,8 +142,9 @@ afternoon on a slow suite. Replace each with a constant and re-run.
   can exist until it does. This is the case that motivated the rule.
 - **Confirm the mutation applied and compiled** before believing any result. An
   invalid mutation reads exactly like "covered".
-- **Judge by the run's output markers, never its exit status** — see
-  **resource-safe-execution**. Runners report success on builds that never ran.
+- **Use the run's exit status and output markers together** — see
+  **resource-safe-execution**. A non-zero status fails; a zero status without the expected summary
+  does not prove the intended build or test ran.
 
 If replacing a load-bearing value with a constant leaves the suite green, the
 tests do not observe that value yet.

--- a/plugins-cc/agentkit/skills/resource-safe-execution/SKILL.md
+++ b/plugins-cc/agentkit/skills/resource-safe-execution/SKILL.md
@@ -73,14 +73,13 @@ daemon or user-systemd socket after launch. Preserve the host-level service limi
 capacity that protect the agent host, ingress, and tunnels even if a child evades the workload
 slice.
 
-## Judge by output markers, not exit status
+## Judge by exit status and output markers
 
-`bounded-run` returns exit 0 even on a hard build failure, and a harness completion notice
-repeats that exit code — so a run that never compiled anything reads as success. Judge every
-build and test run by its own output markers (`test result:`, `N pass`, a compiler summary
-line) and treat a missing summary line as failure, not as a silent pass. Treat EMPTY output
-the same way — a run that printed nothing did not pass, it did not run (a lock collision or a
-killed process looks identical to zero failures).
+`bounded-run` propagates the wrapped workload's exit status. Treat a non-zero exit status as
+failure. For builds and test suites, also confirm the expected tool summary (`test result:`,
+`N pass`, or a compiler summary line) before reporting success. A zero status with no expected
+summary, or empty output, does not prove that the intended workload ran. Preserve both signals and
+investigate whenever the exit status and tool output disagree.
 
 ## Preserve connectivity
 

--- a/skills/autonomous-workflow/SKILL.md
+++ b/skills/autonomous-workflow/SKILL.md
@@ -142,8 +142,9 @@ afternoon on a slow suite. Replace each with a constant and re-run.
   can exist until it does. This is the case that motivated the rule.
 - **Confirm the mutation applied and compiled** before believing any result. An
   invalid mutation reads exactly like "covered".
-- **Judge by the run's output markers, never its exit status** — see
-  **resource-safe-execution**. Runners report success on builds that never ran.
+- **Use the run's exit status and output markers together** — see
+  **resource-safe-execution**. A non-zero status fails; a zero status without the expected summary
+  does not prove the intended build or test ran.
 
 If replacing a load-bearing value with a constant leaves the suite green, the
 tests do not observe that value yet.

--- a/skills/resource-safe-execution/SKILL.md
+++ b/skills/resource-safe-execution/SKILL.md
@@ -73,14 +73,13 @@ daemon or user-systemd socket after launch. Preserve the host-level service limi
 capacity that protect the agent host, ingress, and tunnels even if a child evades the workload
 slice.
 
-## Judge by output markers, not exit status
+## Judge by exit status and output markers
 
-`bounded-run` returns exit 0 even on a hard build failure, and a harness completion notice
-repeats that exit code — so a run that never compiled anything reads as success. Judge every
-build and test run by its own output markers (`test result:`, `N pass`, a compiler summary
-line) and treat a missing summary line as failure, not as a silent pass. Treat EMPTY output
-the same way — a run that printed nothing did not pass, it did not run (a lock collision or a
-killed process looks identical to zero failures).
+`bounded-run` propagates the wrapped workload's exit status. Treat a non-zero exit status as
+failure. For builds and test suites, also confirm the expected tool summary (`test result:`,
+`N pass`, or a compiler summary line) before reporting success. A zero status with no expected
+summary, or empty output, does not prove that the intended workload ran. Preserve both signals and
+investigate whenever the exit status and tool output disagree.
 
 ## Preserve connectivity
 

--- a/tests/review-disciplines.test.ts
+++ b/tests/review-disciplines.test.ts
@@ -3,8 +3,14 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const skillsDir = join(import.meta.dir, '..', 'skills');
+const instructionsDir = join(import.meta.dir, '..', 'instructions');
 const autonomousWorkflow = readFileSync(join(skillsDir, 'autonomous-workflow', 'SKILL.md'), 'utf-8');
 const productReview = readFileSync(join(skillsDir, 'product-review', 'SKILL.md'), 'utf-8');
+const resourceSafeExecution = readFileSync(
+  join(skillsDir, 'resource-safe-execution', 'SKILL.md'),
+  'utf-8',
+);
+const codingDiscipline = readFileSync(join(instructionsDir, 'coding-discipline.md'), 'utf-8');
 
 describe('review disciplines', () => {
   test('keeps evidence checks in the review workflow', () => {
@@ -29,5 +35,19 @@ describe('review disciplines', () => {
 
   test('requires mutation checks to restore the original value', () => {
     expect(autonomousWorkflow).toMatch(/restore the original value/i);
+  });
+
+  test('uses exit status and output evidence together', () => {
+    expect(resourceSafeExecution).not.toContain('returns exit 0 even on a hard build failure');
+    expect(resourceSafeExecution).toMatch(/Treat a non-zero exit status as\s+failure/);
+    expect(resourceSafeExecution).toContain('confirm the expected tool summary');
+    expect(autonomousWorkflow).not.toContain('never its exit status');
+  });
+
+  test('keeps worktrees temporary and task-owned', () => {
+    expect(codingDiscipline).toContain('Use the primary checkout for sequential work');
+    expect(codingDiscipline).toContain('temporary, task-owned worktree');
+    expect(codingDiscipline).toMatch(/do not keep a permanent worktrees directory/i);
+    expect(codingDiscipline).not.toContain('code that no longer exists anywhere else');
   });
 });


### PR DESCRIPTION
Refs #117.

## Scope

- Corrects the false claim that bounded-run hides hard workload failures behind exit 0.
- Requires exit status and tool summaries to be evaluated together.
- Defines the normal checkout as the sequential-work default.
- Defines worktrees as temporary, task-owned isolation in an external scratch location.
- Corrects the squash-merge wording: the stale checkout holds the pre-squash branch commit while its ref remains until cleanup.
- Keeps the source skills and Claude plugin mirrors byte-identical.

## TDD evidence

- RED: the targeted discipline suite failed on the false exit-status claim and missing temporary-worktree contract.
- GREEN: targeted suite passed, 7 tests / 17 assertions / 0 failures.
- GREEN: full bounded suite passed, 507 pass / 5 documented systemd skips / 0 failures / 1,506 assertions across 25 files.
- Changed files pass dprint and git diff --check.
- Source/plugin mirrors compare byte-identically.
- Public AgentKit endpoints remained HTTP 200 and eda-k3s remained running.
