### PR TITLE
feat: split platform-aware resource policy

### DIFF
--- a/.agentkit/product.yaml
+++ b/.agentkit/product.yaml
@@ -10,10 +10,10 @@ summary: >-
 surfaces:
   - name: test-suite
     kind: library
-    # Use the machine-policy entry point. It resolves to the installed
-    # bounded-run compatibility alias and satisfies the active execution gate.
-    build: agentkit-run --profile default -- bun install
-    verify: agentkit-run --profile default -- bun test
+    # This repo-owned adapter keeps the command verbatim on every host: Linux
+    # delegates to installed agentkit-run; other platforms execute directly.
+    build: scripts/product-command default -- bun install
+    verify: scripts/product-command default -- bun test
     expect: |
       The suite passes with 0 failures (a few skips are expected). Deliberately
       not a pinned count — this file exists to catch stale expectations, so it
@@ -35,23 +35,18 @@ surfaces:
       in `.agentkit/reviews/` is refused with a BLOCKED message rather than
       silently allowed.
 
-  - name: bounded-run
+  - name: platform-command
     kind: cli
-    # The INSTALLED path, not ./tools/bounded-run. resource-police trusts the
-    # runner by installed path rather than by name (anything can be called
-    # `bounded-run`, and trusting the name would let a spoof neuter every
-    # limit), so running it in place from a fresh clone is refused. Declaring
-    # the in-place path here was the first thing dogfooding this manifest
-    # caught.
-    run: agentkit-run --profile default -- echo ok
+    run: scripts/product-command default -- echo ok
     expect: |
       On Linux, prints `ok` having run the command inside a systemd scope with
       memory and CPU limits. A workload that exceeds the profile is killed
-      rather than allowed to exhaust the host.
+      rather than allowed to exhaust the host. On non-Linux, where that runner
+      is unsupported, the same verbatim command prints `ok` directly.
 
   - name: infra-tools-mcp
     kind: api
-    run: agentkit-run --profile default -- bun plugins-cc/agentkit/server/index.ts
+    run: scripts/product-command default -- bun plugins-cc/agentkit/server/index.ts
     expect: |
       Speaks JSON-RPC on stdin/stdout; `tools/list` returns ten read-only git,
       helm and tofu tools and nothing that mutates infrastructure.
@@ -61,13 +56,16 @@ requires:
   credentials: []
   notes:
     - Claude Code (or OpenCode) must be installed to exercise the `plugin`
-      surface. The exact test-suite commands need bun and the installed
-      `agentkit-run` entry point.
+      surface. The exact test-suite commands need bun. On Linux,
+      `scripts/product-command` also requires the installed `agentkit-run`
+      entry point and fails closed if it is absent.
     - >-
       Local containment is Linux-only and requires cgroup v2, a systemd user
       manager, and a provisioned agent-work.slice. On non-Linux hosts the
-      installer omits bounded-run and its Codex resource policy; Claude and
-      OpenCode delegation protections remain active.
+      installer omits bounded-run and its Codex resource policy. OpenCode
+      delegation protection remains active. Claude hook protection requires
+      jq, awk, and cat; when one is unavailable the hook warns and intentionally
+      fails open.
     - >-
       This repo's own hooks are usually already active on a developer machine
       and will intercept naive verification. Two you WILL hit: running the

--- a/.agentkit/product.yaml
+++ b/.agentkit/product.yaml
@@ -2,21 +2,18 @@
 # See plugins-cc/agentkit/skills/product-review/SKILL.md for the contract.
 
 summary: >-
-  A Claude Code / OpenCode plugin that installs enforcement hooks (git, MR,
-  package, resource, review, formatting and comment discipline), a set of
-  agent skills, a memory-and-CPU-bounded command runner, and two MCP servers.
-  Installed once per machine; from then on it constrains how agents work in
-  every repo on that machine.
+  Cross-platform enforcement hooks (git, MR, package, resource, review,
+  formatting and comment discipline), agent skills, two MCP servers, and a
+  Linux-only memory-and-CPU-bounded command runner. The full installer supports
+  global and project-local use; the Claude Code plugin is a separate bundle.
 
 surfaces:
   - name: test-suite
     kind: library
-    # Wrapped in bounded-run because agentkit's own resource-police DENIES a
-    # bare `bun install` / `bun test`. A reviewer following this manifest is,
-    # by definition, on a machine where these hooks are live — declaring the
-    # naive form would block them at step one of the skill's own procedure.
-    build: bounded-run --profile default -- bun install
-    verify: bounded-run --profile default -- bun test
+    # Use the machine-policy entry point. It resolves to the installed
+    # bounded-run compatibility alias and satisfies the active execution gate.
+    build: agentkit-run --profile default -- bun install
+    verify: agentkit-run --profile default -- bun test
     expect: |
       The suite passes with 0 failures (a few skips are expected). Deliberately
       not a pinned count — this file exists to catch stale expectations, so it
@@ -46,15 +43,15 @@ surfaces:
     # limit), so running it in place from a fresh clone is refused. Declaring
     # the in-place path here was the first thing dogfooding this manifest
     # caught.
-    run: bounded-run --profile default -- echo ok
+    run: agentkit-run --profile default -- echo ok
     expect: |
-      Prints `ok` having run the command inside a systemd scope with memory
-      and CPU limits. A workload that exceeds the profile is killed rather
-      than allowed to exhaust the host.
+      On Linux, prints `ok` having run the command inside a systemd scope with
+      memory and CPU limits. A workload that exceeds the profile is killed
+      rather than allowed to exhaust the host.
 
   - name: infra-tools-mcp
     kind: api
-    run: bun plugins-cc/agentkit/server/index.ts
+    run: agentkit-run --profile default -- bun plugins-cc/agentkit/server/index.ts
     expect: |
       Speaks JSON-RPC on stdin/stdout; `tools/list` returns ten read-only git,
       helm and tofu tools and nothing that mutates infrastructure.
@@ -64,7 +61,13 @@ requires:
   credentials: []
   notes:
     - Claude Code (or OpenCode) must be installed to exercise the `plugin`
-      surface; the test suite needs only bun.
+      surface. The exact test-suite commands need bun and the installed
+      `agentkit-run` entry point.
+    - >-
+      Local containment is Linux-only and requires cgroup v2, a systemd user
+      manager, and a provisioned agent-work.slice. On non-Linux hosts the
+      installer omits bounded-run and its Codex resource policy; Claude and
+      OpenCode delegation protections remain active.
     - >-
       This repo's own hooks are usually already active on a developer machine
       and will intercept naive verification. Two you WILL hit: running the

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "agentkit",
       "source": "./plugins-cc/agentkit",
-      "description": "Claude Code bundle with enforcement hooks, skills, tools/bounded-run, and the assay + infra-tools MCP toolchains. Requires jq, bun, assay, cgroup v2, a systemd user manager, and a provisioned agent-work.slice.",
+      "description": "Claude Code bundle with enforcement hooks, skills, tools/bounded-run, and the assay + infra-tools MCP toolchains. Hooks require jq, awk, and cat; MCPs require bun and assay. Linux bounded execution additionally requires cgroup v2, a systemd user manager, and a provisioned agent-work.slice.",
       "version": "0.2.0"
     },
     {

--- a/README.md
+++ b/README.md
@@ -50,21 +50,26 @@ Reusable AI agent skills, rules, plugins, hooks, and tools for OpenCode, Claude 
 | **format-police.sh**   | PostToolUse       | Auto-formats files after edit/write using dprint                                                                                                                                                                                                                                                                                                              |
 | **coding-police.sh**   | PostToolUse       | Enforces DRY code, modular files (<1000 lines), short functions, single responsibility, and capped directory file counts                                                                                                                                                                                                                                      |
 | **pkg-police.sh**      | PreToolUse        | Enforces bun as package manager — blocks npm, npx, yarn, pnpm commands                                                                                                                                                                                                                                                                                        |
-| **resource-police.sh** | PreToolUse        | Requires `bounded-run` for heavy commands on Linux; blocks delegated and undecidable commands on every platform                                                                                                                                                                                                                                               |
+| **resource-police.sh** | PreToolUse        | With `jq`, `awk`, and `cat`, requires `bounded-run` for heavy commands on Linux and blocks delegated or undecidable commands on every platform; warns and fails open when a parser dependency is missing                                                                                                                                                      |
 | **chime.sh**           | Notification/Stop | Audible nudge when Claude needs you: springy boing on permission prompts/questions, soft ping when a turn finishes. Mute: `touch ~/.claude/.chime-off` or `CLAUDE_CHIME=0`                                                                                                                                                                                    |
 | **mr-police.sh**       | PreToolUse        | Blocks opening a new MR while you already have an open MR you authored on the repo — stops unmerged MRs from stacking up                                                                                                                                                                                                                                      |
 | **review-police.sh**   | PreToolUse        | Blocks CLI/REST/MCP merges unless a review record passes for the MR's real source branch and head sha (resolved from the forge). Unresolved BLOCKER/HIGH block; overrides need the user's written consent, logged to `~/.agentkit/review-audit.log`. NOT security — the record is agent-writable; forge-side required approvals are the only real enforcement |
 
 ### Policies (Codex CLI -- exec policy)
 
-| Policy                      | Description                                                                                |
-| --------------------------- | ------------------------------------------------------------------------------------------ |
-| **git-police.rules**        | Blocks force push, --no-verify, direct push to protected branches                          |
-| **kubectl-police.rules**    | Blocks kubectl create/apply on Kargo CRDs                                                  |
-| **coding-police.rules**     | Coding standards guidance + prompts on heredoc/tee writes that may produce oversized files |
-| **pkg-police.rules**        | Enforces bun as package manager — blocks npm, npx, yarn, pnpm commands                     |
-| **delegation-police.rules** | Blocks service, container, privilege, and remote delegation on every platform              |
-| **resource-police.rules**   | On Linux, blocks direct heavy commands that do not start with the bounded runner           |
+| Policy                      | Description                                                                                                  |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **git-police.rules**        | Blocks force push, --no-verify, direct push to protected branches                                            |
+| **kubectl-police.rules**    | Blocks kubectl create/apply on Kargo CRDs                                                                    |
+| **coding-police.rules**     | Coding standards guidance + prompts on heredoc/tee writes that may produce oversized files                   |
+| **pkg-police.rules**        | Enforces bun as package manager — blocks npm, npx, yarn, pnpm commands                                       |
+| **delegation-police.rules** | Blocks direct mutating container, service-manager, privilege, and remote prefixes; allows direct diagnostics |
+| **resource-police.rules**   | On Linux, blocks direct heavy commands that do not start with the bounded runner                             |
+
+Codex exec policy evaluates literal argv prefixes. It does not recursively parse shell payloads,
+skip arbitrary options before a subcommand, or model `service NAME ACTION` with an arbitrary service
+name. `delegation-police.rules` covers the direct forms the policy language can represent; Claude
+and OpenCode `resource-police` remain the recursive command-analysis paths.
 
 ### Instructions (global agent prompts wired into Claude / Codex / OpenCode)
 
@@ -98,7 +103,7 @@ claude plugin install infra-tools
 
 | Plugin          | Provides                                                                                                                                                                                                                                                                                                 | Source                                                                                        |
 | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| **agentkit**    | Claude bundle: enforcement police hooks, skills, Linux-only `tools/bounded-run`, and both MCP toolchains. Needs `jq`, `bun`, and `assay`; bounded execution additionally needs cgroup v2, a systemd user manager, and a provisioned `agent-work.slice`.                                                  | local `plugins-cc/agentkit/`                                                                  |
+| **agentkit**    | Claude bundle: enforcement police hooks, skills, Linux-only `tools/bounded-run`, and both MCP toolchains. Hooks need `jq`, `awk`, and `cat`; MCPs need `bun` and `assay`. Linux bounded execution additionally needs cgroup v2, a systemd user manager, and a provisioned `agent-work.slice`.            | local `plugins-cc/agentkit/`                                                                  |
 | **assay**       | Gated Lua infra toolkit (`assay_run` + `assay_context`) — Kubernetes, ArgoCD, Vault, Prometheus, GitLab, AWS, … through one read-only/approval-gated tool. Requires the `assay` binary on PATH.                                                                                                          | vendored from [developerinlondon/assay](https://github.com/developerinlondon/assay) `plugin/` |
 | **infra-tools** | Read-only helm / tofu / git tools (`helm_template`/`helm_list`/`helm_get_values`, `tofu_plan`/`tofu_show`/`tofu_state_list`, `git_log`/`git_diff`/`git_status`/`git_clone_ro`) as a typed MCP server — render charts, preview plans, read git history. Never applies or mutates. Requires `bun` on PATH. | local `plugins-cc/infra-tools/`                                                               |
 
@@ -133,12 +138,12 @@ git clone git@github.com:developerinlondon/agentkit.git
 `~/.agentkit/{skills,rules,instructions,hooks,tools}`. Each client then gets **per-name**
 symlinks into that root (never a second full copy):
 
-| Client | Adapter |
-| --- | --- |
-| OpenCode | `~/.agents/skills\|rules\|instructions` → `~/.agentkit/…` |
-| Claude Code | `~/.claude/skills\|hooks\|tools` → `~/.agentkit/…` (settings still point at `~/.claude/hooks`) |
-| Grok CLI | `~/.grok/skills\|rules` → `~/.agentkit/…`; instructions also as `~/.grok/rules/*.md` (always-on) |
-| Codex CLI | policies/prompts still copied into `~/.codex/` (Starlark + `/prompt` shape differs) |
+| Client      | Adapter                                                                                          |
+| ----------- | ------------------------------------------------------------------------------------------------ |
+| OpenCode    | `~/.agents/skills\|rules\|instructions` → `~/.agentkit/…`                                        |
+| Claude Code | `~/.claude/skills\|hooks\|tools` → `~/.agentkit/…` (settings still point at `~/.claude/hooks`)   |
+| Grok CLI    | `~/.grok/skills\|rules` → `~/.agentkit/…`; instructions also as `~/.grok/rules/*.md` (always-on) |
+| Codex CLI   | policies/prompts still copied into `~/.codex/` (Starlark + `/prompt` shape differs)              |
 
 Per-name links mean non-agentkit siblings stay put — OMC skills under `~/.claude/skills/`,
 Grok builtins under `~/.grok/skills/`, etc. OpenCode plugins still install as real files under
@@ -153,7 +158,8 @@ The installer detects `linux`, `darwin`, or `unknown`; `AGENTKIT_PLATFORM` may o
 with one of those exact values for controlled packaging and tests. Artifacts carrying an
 `agentkit:platform` directive are skipped when unsupported, and stale managed copies are removed.
 On non-Linux hosts this omits `bounded-run`, its `agentkit-run` alias, and the Codex heavy-command
-policy. Claude and OpenCode still block delegated and undecidable commands.
+policy. OpenCode still blocks delegated and undecidable commands. The Claude hook does so when
+`jq`, `awk`, and `cat` are available; otherwise it warns and intentionally fails open.
 
 ### Option 3: Install into a specific project
 
@@ -220,8 +226,9 @@ targets because they can delegate work outside the transient cgroup.
 On Linux, project-only installs expose the runner as `./.claude/tools/bounded-run`. The Claude
 plugin bundles it at `$CLAUDE_PLUGIN_ROOT/tools/bounded-run`, and its hook reports that resolved
 path when denying an unbounded command. Global installs expose `bounded-run` through
-`~/.local/bin`. Non-Linux hooks keep universal delegation analysis active without requiring the
-runner.
+`~/.local/bin`. On non-Linux, OpenCode keeps delegation analysis active without the runner. The
+Claude hook does so when `jq`, `awk`, and `cat` are available and otherwise warns before failing
+open.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Reusable AI agent skills, rules, plugins, hooks, and tools for OpenCode, Claude 
 | **documentation**           | Surface-aware diagrams (Mermaid / ASCII), structured plan format, formatting rules       |
 | **issue-raiser**            | GitLab issue creation with root cause analysis and git-history-based assignees           |
 | **project-planning**        | Structured project planning: break down ideas into architecture, file structure, roadmap |
-| **resource-safe-execution** | Runs heavy developer commands inside deterministic systemd resource limits               |
+| **resource-safe-execution** | On Linux, runs heavy developer commands inside deterministic systemd resource limits     |
 
 ### Rules (auto-loaded by file glob match)
 
@@ -39,31 +39,32 @@ Reusable AI agent skills, rules, plugins, hooks, and tools for OpenCode, Claude 
 | **coding-police.ts**   | Enforces DRY code, modular files (<1000 lines), short functions, single responsibility, and capped directory file counts |
 | **comment-police.ts**  | Warns on long comment blocks, tutorial-style file headers, PR/plan/closes-#N references, and high comment-to-code ratios |
 | **pkg-police.ts**      | Enforces bun as package manager — blocks npm, npx, yarn, pnpm commands                                                   |
-| **resource-police.ts** | Requires bounded execution for heavy commands and blocks cgroup delegation escapes                                       |
+| **resource-police.ts** | Requires bounded heavy commands on Linux; blocks delegated and undecidable commands everywhere                           |
 
 ### Hooks (Claude Code -- PreToolUse / PostToolUse)
 
-| Hook                   | Type              | Description                                                                                                                                                                                                     |
-| ---------------------- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **git-police.sh**      | PreToolUse        | Blocks force push, --no-verify, Co-authored-by trailers, commits to protected branches, stale pushes (feature branch behind the default branch)                                                                 |
-| **kubectl-police.sh**  | PreToolUse        | Blocks kubectl create/apply on Kargo CRDs                                                                                                                                                                       |
-| **format-police.sh**   | PostToolUse       | Auto-formats files after edit/write using dprint                                                                                                                                                                |
-| **coding-police.sh**   | PostToolUse       | Enforces DRY code, modular files (<1000 lines), short functions, single responsibility, and capped directory file counts                                                                                        |
-| **pkg-police.sh**      | PreToolUse        | Enforces bun as package manager — blocks npm, npx, yarn, pnpm commands                                                                                                                                          |
-| **resource-police.sh** | PreToolUse        | Requires `bounded-run` for heavy commands and blocks cgroup delegation escapes                                                                                                                                  |
-| **chime.sh**           | Notification/Stop | Audible nudge when Claude needs you: springy boing on permission prompts/questions, soft ping when a turn finishes. Mute: `touch ~/.claude/.chime-off` or `CLAUDE_CHIME=0`                                      |
-| **mr-police.sh**       | PreToolUse        | Blocks opening a new MR while you already have an open MR you authored on the repo — stops unmerged MRs from stacking up                                                                                        |
+| Hook                   | Type              | Description                                                                                                                                                                                                                                                                                                                                                   |
+| ---------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **git-police.sh**      | PreToolUse        | Blocks force push, --no-verify, Co-authored-by trailers, commits to protected branches, stale pushes (feature branch behind the default branch)                                                                                                                                                                                                               |
+| **kubectl-police.sh**  | PreToolUse        | Blocks kubectl create/apply on Kargo CRDs                                                                                                                                                                                                                                                                                                                     |
+| **format-police.sh**   | PostToolUse       | Auto-formats files after edit/write using dprint                                                                                                                                                                                                                                                                                                              |
+| **coding-police.sh**   | PostToolUse       | Enforces DRY code, modular files (<1000 lines), short functions, single responsibility, and capped directory file counts                                                                                                                                                                                                                                      |
+| **pkg-police.sh**      | PreToolUse        | Enforces bun as package manager — blocks npm, npx, yarn, pnpm commands                                                                                                                                                                                                                                                                                        |
+| **resource-police.sh** | PreToolUse        | Requires `bounded-run` for heavy commands on Linux; blocks delegated and undecidable commands on every platform                                                                                                                                                                                                                                               |
+| **chime.sh**           | Notification/Stop | Audible nudge when Claude needs you: springy boing on permission prompts/questions, soft ping when a turn finishes. Mute: `touch ~/.claude/.chime-off` or `CLAUDE_CHIME=0`                                                                                                                                                                                    |
+| **mr-police.sh**       | PreToolUse        | Blocks opening a new MR while you already have an open MR you authored on the repo — stops unmerged MRs from stacking up                                                                                                                                                                                                                                      |
 | **review-police.sh**   | PreToolUse        | Blocks CLI/REST/MCP merges unless a review record passes for the MR's real source branch and head sha (resolved from the forge). Unresolved BLOCKER/HIGH block; overrides need the user's written consent, logged to `~/.agentkit/review-audit.log`. NOT security — the record is agent-writable; forge-side required approvals are the only real enforcement |
 
 ### Policies (Codex CLI -- exec policy)
 
-| Policy                    | Description                                                                                |
-| ------------------------- | ------------------------------------------------------------------------------------------ |
-| **git-police.rules**      | Blocks force push, --no-verify, direct push to protected branches                          |
-| **kubectl-police.rules**  | Blocks kubectl create/apply on Kargo CRDs                                                  |
-| **coding-police.rules**   | Coding standards guidance + prompts on heredoc/tee writes that may produce oversized files |
-| **pkg-police.rules**      | Enforces bun as package manager — blocks npm, npx, yarn, pnpm commands                     |
-| **resource-police.rules** | Blocks direct heavy commands and service or container delegation escape paths              |
+| Policy                      | Description                                                                                |
+| --------------------------- | ------------------------------------------------------------------------------------------ |
+| **git-police.rules**        | Blocks force push, --no-verify, direct push to protected branches                          |
+| **kubectl-police.rules**    | Blocks kubectl create/apply on Kargo CRDs                                                  |
+| **coding-police.rules**     | Coding standards guidance + prompts on heredoc/tee writes that may produce oversized files |
+| **pkg-police.rules**        | Enforces bun as package manager — blocks npm, npx, yarn, pnpm commands                     |
+| **delegation-police.rules** | Blocks service, container, privilege, and remote delegation on every platform              |
+| **resource-police.rules**   | On Linux, blocks direct heavy commands that do not start with the bounded runner           |
 
 ### Instructions (global agent prompts wired into Claude / Codex / OpenCode)
 
@@ -79,7 +80,7 @@ Reusable AI agent skills, rules, plugins, hooks, and tools for OpenCode, Claude 
 Hooks, skills, and tools ship as Claude Code plugins (ADR #45 — the generic units — MCP tools,
 skills, hook scripts — are the source of truth; plugins are convenience wrappers). Add the
 marketplace once, then install. The **agentkit** plugin is the recommended Claude bundle: a single
-`claude plugin install agentkit` gives you the enforcement hooks, the skills, the bounded runner,
+`claude plugin install agentkit` gives you the enforcement hooks, the skills, the Linux-only bounded runner,
 and **both** MCP toolchains (assay + infra-tools). Resource execution additionally requires a
 configured systemd user manager and the host-provisioned `agent-work.slice`. The
 granular **assay** and **infra-tools** plugins remain for à-la-carte installs.
@@ -97,7 +98,7 @@ claude plugin install infra-tools
 
 | Plugin          | Provides                                                                                                                                                                                                                                                                                                 | Source                                                                                        |
 | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| **agentkit**    | Claude bundle: enforcement police hooks, skills, `tools/bounded-run`, and both MCP toolchains. Needs `jq`, `bun`, `assay`, cgroup v2, a systemd user manager, and a provisioned `agent-work.slice`.                                                                                                      | local `plugins-cc/agentkit/`                                                                  |
+| **agentkit**    | Claude bundle: enforcement police hooks, skills, Linux-only `tools/bounded-run`, and both MCP toolchains. Needs `jq`, `bun`, and `assay`; bounded execution additionally needs cgroup v2, a systemd user manager, and a provisioned `agent-work.slice`.                                                  | local `plugins-cc/agentkit/`                                                                  |
 | **assay**       | Gated Lua infra toolkit (`assay_run` + `assay_context`) — Kubernetes, ArgoCD, Vault, Prometheus, GitLab, AWS, … through one read-only/approval-gated tool. Requires the `assay` binary on PATH.                                                                                                          | vendored from [developerinlondon/assay](https://github.com/developerinlondon/assay) `plugin/` |
 | **infra-tools** | Read-only helm / tofu / git tools (`helm_template`/`helm_list`/`helm_get_values`, `tofu_plan`/`tofu_show`/`tofu_state_list`, `git_log`/`git_diff`/`git_status`/`git_clone_ro`) as a typed MCP server — render charts, preview plans, read git history. Never applies or mutates. Requires `bun` on PATH. | local `plugins-cc/infra-tools/`                                                               |
 
@@ -148,6 +149,12 @@ Grok builtins under `~/.grok/skills/`, etc. OpenCode plugins still install as re
 
 Override the shared root with `AGENTKIT_HOME=/path` if needed.
 
+The installer detects `linux`, `darwin`, or `unknown`; `AGENTKIT_PLATFORM` may override detection
+with one of those exact values for controlled packaging and tests. Artifacts carrying an
+`agentkit:platform` directive are skipped when unsupported, and stale managed copies are removed.
+On non-Linux hosts this omits `bounded-run`, its `agentkit-run` alias, and the Codex heavy-command
+policy. Claude and OpenCode still block delegated and undecidable commands.
+
 ### Option 3: Install into a specific project
 
 ```bash
@@ -186,11 +193,12 @@ commit being merged. Record shape, who may write what, and the consent path:
 
 ### Tools
 
-Global installs place tools on `~/.local/bin/` and preserve a mirror in `~/.claude/tools/`.
+On Linux, global installs place the bounded runner on `~/.local/bin/` and preserve a mirror in
+`~/.claude/tools/`. Portable tools install on every supported host.
 
 | Tool                   | Description                                                                          |
 | ---------------------- | ------------------------------------------------------------------------------------ |
-| **bounded-run**        | Runs one direct-argv workload in the bounded `agent-work.slice` systemd user service |
+| **bounded-run**        | Linux-only direct-argv workload runner for the bounded `agent-work.slice` service    |
 | **fix-ascii-boxes.py** | Fixes ASCII box-drawing alignment in markdown files, handles nested boxes inside-out |
 
 `bounded-run` fails closed unless the aggregate slice matches its expected limits (default
@@ -209,9 +217,11 @@ checks pass. Its profiles are fixed and tested together with the host configurat
 Container engines, direct `systemd-run`, and remote execution are not supported containment
 targets because they can delegate work outside the transient cgroup.
 
-Project-only installs expose the runner as `./.claude/tools/bounded-run`. The Claude plugin bundles
-it at `$CLAUDE_PLUGIN_ROOT/tools/bounded-run`, and its hook reports that resolved path when denying
-an unbounded command. Global installs expose `bounded-run` through `~/.local/bin`.
+On Linux, project-only installs expose the runner as `./.claude/tools/bounded-run`. The Claude
+plugin bundles it at `$CLAUDE_PLUGIN_ROOT/tools/bounded-run`, and its hook reports that resolved
+path when denying an unbounded command. Global installs expose `bounded-run` through
+`~/.local/bin`. Non-Linux hooks keep universal delegation analysis active without requiring the
+runner.
 
 ## Configuration
 

--- a/docs/grok.md
+++ b/docs/grok.md
@@ -27,7 +27,9 @@ What that does for Grok specifically:
 1. **Claude hooks** land in `~/.claude/hooks/` (including `lib/hook-input.sh`) and
    are merged into `~/.claude/settings.json`. Grok loads those hooks by default
    (`[compat.claude] hooks = true`).
-2. **Tools** land on `PATH` as `bounded-run` / `agentkit-run`.
+2. On Linux, **tools** land on `PATH` as `bounded-run` / `agentkit-run`. The
+   installer omits them on non-Linux hosts, where their systemd cgroup boundary
+   cannot run.
 3. **Instructions / skills / rules** for Grok depend on the installer revision:
    - Current `main` + shared-root install (see PR that introduces
      `~/.agentkit/`): per-name symlinks under `~/.grok/skills` and
@@ -92,13 +94,16 @@ Deny responses dual-emit:
 
 ## Resource bounding on Grok
 
-`resource-police` requires `bounded-run` the same way as on Claude. Grok does not
-rewrite the agent’s shell command; the model (and soft rules) must use
-`bounded-run --profile … -- <cmd>`. The hook only **denies** unbounded heavy
-commands.
+On Linux, `resource-police` requires `bounded-run` the same way as on Claude.
+Grok does not rewrite the agent’s shell command; the model (and soft rules) must
+use `bounded-run --profile … -- <cmd>`. The hook only **denies** unbounded heavy
+commands. Linux host requirements are cgroup v2, `agent-work.slice`, and matching
+`/etc/agentkit/resource-guard.conf`.
 
-Host requirements: cgroup v2, `agent-work.slice`, matching
-`/etc/agentkit/resource-guard.conf`. See `skills/resource-safe-execution/`.
+On non-Linux hosts, local heavy-command containment stands down. Delegation
+analysis remains active when the Claude-compatible hook can load `jq`, `awk`,
+and `cat`; if one is missing, the hook warns and intentionally fails open. See
+`skills/resource-safe-execution/`.
 
 ## Related
 

--- a/hooks/claude/resource-police.sh
+++ b/hooks/claude/resource-police.sh
@@ -21,6 +21,7 @@ RE_SHELL='^(bash|dash|fish|sh|zsh)$'
 RE_SYSTEMCTL_READONLY='^(cat|get-default|is-active|is-enabled|is-failed|list-|show|status)'
 RE_UV_HEAVY='^(add|sync)$'
 RE_YARN_HEAVY='^(add|install|up|upgrade|test)$'
+readonly MAX_ANALYSIS_DEPTH=4
 
 
 # Absolute paths are deliberate: a hook that inspects a command must not
@@ -59,7 +60,9 @@ if [[ -z "$AWK_BIN" || -z "$CAT_BIN" || -z "$JQ_BIN" ]]; then
 	exit 0
 fi
 
-# Stand down where bounding is IMPOSSIBLE, not merely unconfigured.
+# Stand down from LOCAL containment where bounding is impossible, but keep
+# parsing commands: delegated work and undecidable nesting remain blocked on
+# every platform because neither becomes safe when cgroups are unavailable.
 #
 # bounded-run contains work in a systemd scope backed by cgroup v2, and dies
 # with 'cgroup v2 is unavailable' without it. macOS has neither cgroups nor
@@ -70,16 +73,31 @@ fi
 # Announced once per session rather than per command: a warning on every Bash
 # call is the kind of noise that trains people to ignore hooks, but silently
 # disabling a guard is how it stays broken for months.
-if [[ ! -r /sys/fs/cgroup/cgroup.controllers ]]; then
+detect_platform() {
+	if [[ -n "${AGENTKIT_PLATFORM:-}" ]]; then
+		printf '%s' "$AGENTKIT_PLATFORM"
+		return
+	fi
+	case "$(uname -s 2>/dev/null || true)" in
+	Linux) printf 'linux' ;;
+	Darwin) printf 'darwin' ;;
+	*) printf 'unknown' ;;
+	esac
+}
+
+PLATFORM="$(detect_platform)"
+CONTAINMENT_REQUIRED=0
+if [[ "$PLATFORM" == linux && -r /sys/fs/cgroup/cgroup.controllers ]]; then
+	CONTAINMENT_REQUIRED=1
+else
 	# Keyed on PPID — the client process, stable across every hook invocation
 	# in one session. $$ is this hook's own pid and changes each time, which
 	# would make "once" mean "always".
 	notice="${TMPDIR:-/tmp}/.agentkit-resource-police-inactive.$PPID"
 	if [[ ! -e "$notice" ]]; then
 		: >"$notice" 2>/dev/null || true
-		printf 'resource-police: INACTIVE on this host — cgroup v2 is unavailable, so bounded-run cannot contain anything. Heavy commands are not being bounded.\n' >&2
+		printf 'resource-police: local containment INACTIVE on %s — bounded-run is unavailable. Delegated and undecidable commands remain blocked.\n' "$PLATFORM" >&2
 	fi
-	exit 0
 fi
 
 # shellcheck source=lib/hook-input.sh
@@ -116,6 +134,8 @@ deny() {
 		reason="BLOCKED: that is not a recognised bounded-run: $segment. Anything can be named \`bounded-run\`, so it is trusted by INSTALLED PATH, not by name — otherwise a spoof could silently neuter every limit. AGENTKIT_ALLOW_DELEGATED=1 does NOT clear this. Install the runner (\`~/.local/bin/bounded-run\`) and invoke it from there, or use the plugin's copy under \$CLAUDE_PLUGIN_ROOT/tools/. In a fresh clone of agentkit itself, install it first rather than running ./tools/bounded-run in place."
 	elif [[ "$kind" == delegated ]]; then
 		reason="BLOCKED: delegated workload cannot be contained by bounded-run: $segment. Use a separately approved dedicated runner or verified engine-native limits. User-approved delegated workloads: prefix with AGENTKIT_ALLOW_DELEGATED=1."
+	elif [[ "$kind" == undecidable ]]; then
+		reason="BLOCKED: command could not be analyzed safely: $segment. Wrapper or shell nesting exceeded the $MAX_ANALYSIS_DEPTH-level analysis bound."
 	else
 		reason="BLOCKED: resource-intensive command is not contained: $segment. Run it through $runner_hint, for example: $runner_hint --profile compile -- bun run typecheck. Use profile browser for Playwright and browser builds."
 	fi
@@ -176,6 +196,8 @@ parse_launch() {
 	local segment="$1"
 	local token
 	local index=0
+	local wrapper_depth=0
+	PARSE_UNDECIDABLE=0
 	read -r -a TOKENS <<<"$segment"
 	while [[ -n "${TOKENS[$index]:-}" ]]; do
 		while [[ "${TOKENS[$index]:-}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
@@ -191,6 +213,11 @@ parse_launch() {
 			return 0
 			;;
 		env)
+			wrapper_depth=$((wrapper_depth + 1))
+			if ((wrapper_depth > MAX_ANALYSIS_DEPTH)); then
+				PARSE_UNDECIDABLE=1
+				return 0
+			fi
 			index=$((index + 1))
 			while [[ "${TOKENS[$index]:-}" == -* \
 				|| "${TOKENS[$index]:-}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
@@ -198,6 +225,11 @@ parse_launch() {
 			done
 			;;
 		command | nohup | time)
+			wrapper_depth=$((wrapper_depth + 1))
+			if ((wrapper_depth > MAX_ANALYSIS_DEPTH)); then
+				PARSE_UNDECIDABLE=1
+				return 0
+			fi
 			index=$((index + 1))
 			while [[ "${TOKENS[$index]:-}" == -* ]]; do index=$((index + 1)); done
 			;;
@@ -337,13 +369,12 @@ unwrap_environment() {
 	ARGS=("${ARGS[@]:$((index + 1))}")
 }
 
-parse_wrapped_launch() {
+parse_wrapped_command() {
 	local index
+	WRAPPED_COMMAND=''
 	for index in "${!ARGS[@]}"; do
 		if [[ "${ARGS[$index]}" == -- && -n "${ARGS[$((index + 1))]:-}" ]]; then
-			EXECUTABLE="${ARGS[$((index + 1))]##*/}"
-			EXECUTABLE_TOKEN="${ARGS[$((index + 1))]}"
-			ARGS=("${ARGS[@]:$((index + 2))}")
+			WRAPPED_COMMAND="${ARGS[*]:$((index + 1))}"
 			return 0
 		fi
 	done
@@ -353,13 +384,16 @@ parse_wrapped_launch() {
 analyze_command() {
 	local command="$1"
 	local depth="$2"
+	local contained="${3:-0}"
 	local segments segment
-	((depth <= 3)) || deny "shell nesting exceeds analysis depth: $command"
+	((depth <= MAX_ANALYSIS_DEPTH)) \
+		|| deny "shell or wrapper nesting exceeds analysis depth: $command" undecidable
 	segments=$(printf '%s\n' "$command" | split_segments) \
-		|| deny 'command could not be parsed safely'
+		|| deny 'command could not be parsed safely' undecidable
 	while IFS= read -r segment; do
 		[[ -n "$segment" ]] || continue
 		parse_launch "$segment"
+		if [[ "$PARSE_UNDECIDABLE" == 1 ]]; then deny "$segment" undecidable; fi
 		if [[ "$EXECUTABLE" == bounded-run || "$EXECUTABLE" == agentkit-run ]]; then
 			# NOT `delegated`: that message advertises AGENTKIT_ALLOW_DELEGATED=1,
 			# which this branch never consults, so it sent people chasing an
@@ -367,27 +401,34 @@ analyze_command() {
 			# path is not a recognised runner — anything can be named
 			# `bounded-run`, and trusting it by name alone would let a spoof
 			# neuter every limit.
-			if ! is_trusted_runner; then deny "$segment" untrusted_runner; fi
-			if parse_wrapped_launch; then
-				unwrap_environment
-				if is_delegating && [[ "$DELEGATED_OK" != 1 ]]; then
-					deny "$segment" delegated
-				fi
+			local trusted_runner=0
+			is_trusted_runner && trusted_runner=1
+			if parse_wrapped_command; then
+				local nested_command="$WRAPPED_COMMAND"
+				parse_launch "$nested_command"
+				if [[ "$PARSE_UNDECIDABLE" == 1 ]]; then deny "$segment" undecidable; fi
+				if is_delegating && [[ "$DELEGATED_OK" != 1 ]]; then deny "$segment" delegated; fi
+				analyze_command "$nested_command" $((depth + 1)) 1
+			fi
+			if [[ "$CONTAINMENT_REQUIRED" == 1 && "$trusted_runner" != 1 ]]; then
+				deny "$segment" untrusted_runner
 			fi
 			continue
 		fi
 		if [[ "$EXECUTABLE" =~ $RE_SHELL ]] && shell_command_payload; then
-			analyze_command "$PAYLOAD" $((depth + 1))
+			analyze_command "$PAYLOAD" $((depth + 1)) "$contained"
 			continue
 		fi
 		if is_delegating && [[ "$DELEGATED_OK" != 1 ]]; then
 			deny "$segment" delegated
 		fi
-		if is_heavy; then deny "$segment"; fi
+		if [[ "$CONTAINMENT_REQUIRED" == 1 && "$contained" != 1 ]] && is_heavy; then
+			deny "$segment"
+		fi
 	done <<<"$segments"
 }
 
-declare EXECUTABLE EXECUTABLE_TOKEN PAYLOAD
+declare EXECUTABLE EXECUTABLE_TOKEN PARSE_UNDECIDABLE PAYLOAD WRAPPED_COMMAND
 declare -a TOKENS ARGS
 analyze_command "$COMMAND" 0
 

--- a/install.sh
+++ b/install.sh
@@ -75,6 +75,11 @@ if [[ "$CLAUDE_PLUGIN" == true && "$GLOBAL" != true ]]; then
 	exit 1
 fi
 
+# shellcheck source=lib/install-platform.sh
+source "$REPO_DIR/lib/install-platform.sh"
+PLATFORM="$(detect_platform)"
+validate_platform "$PLATFORM"
+
 # ─── Shared: Skills ──────────────────────────────────────────────────────────
 
 # Point dest at src as a symlink. Replaces a previous real file/dir or wrong
@@ -606,33 +611,6 @@ merge_claude_settings() {
 	fi
 }
 
-# ─── Standalone Tools (Python/Bash scripts) ──────────────────────────────────
-
-install_tools() {
-	local tools_dir="$1"
-	mkdir -p "$tools_dir"
-
-	for tool_file in "$REPO_DIR"/tools/*; do
-		[[ -f "$tool_file" ]] || continue
-		local name
-		name="$(basename "$tool_file")"
-
-		if [[ -f "$tools_dir/$name" ]]; then
-			echo "[tools] Updating: $name"
-		else
-			echo "[tools] Installing: $name"
-		fi
-
-		cp "$tool_file" "$tools_dir/$name"
-		chmod +x "$tools_dir/$name"
-	done
-
-	# Compat alias: bounded-run was previously named agentkit-run.
-	if [[ -f "$tools_dir/bounded-run" ]]; then
-		ln -sf bounded-run "$tools_dir/agentkit-run"
-	fi
-}
-
 # ─── Per-Session Resource Shims ──────────────────────────────────────────────
 
 readonly SESSION_RUNTIMES=(claude codex opencode grok)
@@ -750,27 +728,6 @@ install_shim_path() {
 	} >>"$rc_file"
 
 	echo "[shims] Added PATH entry to $rc_file"
-}
-
-# ─── Codex CLI: Starlark .rules Files ────────────────────────────────────────
-
-install_codex_policies() {
-	local rules_dir="$1"
-	mkdir -p "$rules_dir"
-
-	for rules_file in "$REPO_DIR"/policies/codex/*.rules; do
-		[[ -f "$rules_file" ]] || continue
-		local name
-		name="$(basename "$rules_file")"
-
-		if [[ -f "$rules_dir/$name" ]]; then
-			echo "[codex] Updating policy: $name"
-		else
-			echo "[codex] Installing policy: $name"
-		fi
-
-		cp "$rules_file" "$rules_dir/$name"
-	done
 }
 
 # ─── Codex CLI: Skills as Custom Prompts ─────────────────────────────────────
@@ -922,6 +879,7 @@ if [[ "$GLOBAL" == true ]]; then
 	# Claude tools dir: per-tool symlinks into the shared tools root (not a
 	# second full copy). Keep ~/.local/bin as real files for PATH.
 	link_children "$TOOLS_CANON" "$CLAUDE_TOOLS"
+	reconcile_tool_links "$CLAUDE_TOOLS"
 	echo ""
 
 	# ── Per-session resource scoping ──

--- a/instructions/resource-safety.md
+++ b/instructions/resource-safety.md
@@ -9,9 +9,10 @@ Use `bounded-run` for dependency changes, compilers, typechecks, builds, linters
 browser automation, code generation, Cargo, Go, and pytest.
 
 On non-Linux hosts, the installer omits `bounded-run` because systemd cgroup containment is
-unavailable. Local heavy-command containment stands down. Delegated-workload protections remain
-active: use only a separately approved platform-native runner with verified limits for container,
-remote, or service-managed work.
+unavailable. Local heavy-command containment stands down. OpenCode protection remains active.
+Claude hook protection remains active when `jq`, `awk`, and `cat` are available; when one is
+missing, the hook warns and intentionally fails open. Use only a separately approved platform-native
+runner with verified limits for container, remote, or service-managed work.
 
 - Start unfamiliar tools and new toolchain versions with `bounded-run --profile canary -- ...`.
 - Use `compile` for established compilers and builds, `browser` for Playwright, and `default` for
@@ -24,7 +25,8 @@ remote, or service-managed work.
   execution, or container execution. The child work can escape its cgroup. Use a separately approved
   dedicated runner or verified native limits.
 - Treat shell hooks and Codex prefix policies as defense-in-depth detection, not a hostile-code
-  sandbox. Arbitrary scripts can deliberately delegate through APIs or sockets. The deterministic
+  sandbox. Codex rules cover direct prefixes only; they do not recursively parse shell payloads.
+  Arbitrary scripts can deliberately delegate through APIs or sockets. The deterministic
   connectivity boundary combines `bounded-run` and its aggregate slice with
   host service resource limits that reserve capacity for the agent host and ingress path.
 - Do not restart or reconfigure live services, Cloudflare tunnels, ingress, Kubernetes, networking,

--- a/instructions/resource-safety.md
+++ b/instructions/resource-safety.md
@@ -2,9 +2,16 @@
 
 # Resource-safe Execution
 
+On Linux:
+
 Never run resource-intensive developer commands directly on a shared or production-adjacent host.
 Use `bounded-run` for dependency changes, compilers, typechecks, builds, linters, test suites,
 browser automation, code generation, Cargo, Go, and pytest.
+
+On non-Linux hosts, the installer omits `bounded-run` because systemd cgroup containment is
+unavailable. Local heavy-command containment stands down. Delegated-workload protections remain
+active: use only a separately approved platform-native runner with verified limits for container,
+remote, or service-managed work.
 
 - Start unfamiliar tools and new toolchain versions with `bounded-run --profile canary -- ...`.
 - Use `compile` for established compilers and builds, `browser` for Playwright, and `default` for

--- a/lib/install-platform.sh
+++ b/lib/install-platform.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+
+detect_platform() {
+	if [[ -n "${AGENTKIT_PLATFORM:-}" ]]; then
+		printf '%s' "$AGENTKIT_PLATFORM"
+		return
+	fi
+
+	case "$(uname -s 2>/dev/null || true)" in
+	Linux) printf 'linux' ;;
+	Darwin) printf 'darwin' ;;
+	*) printf 'unknown' ;;
+	esac
+}
+
+validate_platform() {
+	case "$1" in
+	linux | darwin | unknown) return 0 ;;
+	*)
+		echo "ERROR: invalid AGENTKIT_PLATFORM '$1' (expected linux, darwin, or unknown)." >&2
+		return 1
+		;;
+	esac
+}
+
+# Managed artifacts may opt into specific hosts with a directive in their
+# first 15 lines: `agentkit:platform linux` or `agentkit:platforms linux darwin`.
+# No directive means portable. This parser is shared by tools and Codex rules
+# so platform support is metadata, not installer-specific filename knowledge.
+artifact_supports_platform() {
+	local file="$1"
+	local platform="$2"
+	local directive supported
+	directive="$(head -n 15 "$file" | grep -m1 -E 'agentkit:platforms?[[:space:]]+' || true)"
+	[[ -n "$directive" ]] || return 0
+
+	directive="${directive#*agentkit:platform}"
+	directive="${directive#s}"
+	directive="${directive%%#*}"
+	directive="${directive//$'\r'/}"
+	for supported in $directive; do
+		[[ "$supported" == "$platform" ]] && return 0
+	done
+	return 1
+}
+
+install_tools() {
+	local tools_dir="$1"
+	mkdir -p "$tools_dir"
+
+	for tool_file in "$REPO_DIR"/tools/*; do
+		[[ -f "$tool_file" ]] || continue
+		local name
+		name="$(basename "$tool_file")"
+		if ! artifact_supports_platform "$tool_file" "$PLATFORM"; then
+			if [[ -e "$tools_dir/$name" || -L "$tools_dir/$name" ]]; then
+				rm -f "$tools_dir/$name"
+				echo "[tools] Removing unsupported: $name ($PLATFORM)"
+			else
+				echo "[tools] Skipping unsupported: $name ($PLATFORM)"
+			fi
+			continue
+		fi
+
+		if [[ -f "$tools_dir/$name" ]]; then
+			echo "[tools] Updating: $name"
+		else
+			echo "[tools] Installing: $name"
+		fi
+
+		cp "$tool_file" "$tools_dir/$name"
+		chmod +x "$tools_dir/$name"
+	done
+
+	# Compat alias: bounded-run was previously named agentkit-run.
+	if [[ -f "$tools_dir/bounded-run" ]]; then
+		ln -sf bounded-run "$tools_dir/agentkit-run"
+	elif [[ -e "$tools_dir/agentkit-run" || -L "$tools_dir/agentkit-run" ]]; then
+		rm -f "$tools_dir/agentkit-run"
+	fi
+}
+
+reconcile_tool_links() {
+	local tools_dir="$1"
+	local tool_file name
+	for tool_file in "$REPO_DIR"/tools/*; do
+		[[ -f "$tool_file" ]] || continue
+		artifact_supports_platform "$tool_file" "$PLATFORM" && continue
+		name="$(basename "$tool_file")"
+		[[ -e "$tools_dir/$name" || -L "$tools_dir/$name" ]] && rm -f "$tools_dir/$name"
+	done
+	if [[ ! -f "$tools_dir/bounded-run" && ( -e "$tools_dir/agentkit-run" || -L "$tools_dir/agentkit-run" ) ]]; then
+		rm -f "$tools_dir/agentkit-run"
+	fi
+}
+
+install_codex_policies() {
+	local rules_dir="$1"
+	mkdir -p "$rules_dir"
+
+	for rules_file in "$REPO_DIR"/policies/codex/*.rules; do
+		[[ -f "$rules_file" ]] || continue
+		local name
+		name="$(basename "$rules_file")"
+		if ! artifact_supports_platform "$rules_file" "$PLATFORM"; then
+			if [[ -e "$rules_dir/$name" || -L "$rules_dir/$name" ]]; then
+				rm -f "$rules_dir/$name"
+				echo "[codex] Removing unsupported policy: $name ($PLATFORM)"
+			else
+				echo "[codex] Skipping unsupported policy: $name ($PLATFORM)"
+			fi
+			continue
+		fi
+
+		if [[ -f "$rules_dir/$name" ]]; then
+			echo "[codex] Updating policy: $name"
+		else
+			echo "[codex] Installing policy: $name"
+		fi
+
+		cp "$rules_file" "$rules_dir/$name"
+	done
+}

--- a/plugins-cc/agentkit/.claude-plugin/plugin.json
+++ b/plugins-cc/agentkit/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "agentkit",
   "version": "0.2.0",
-  "description": "Claude Code bundle with enforcement hooks, skills, a bounded runner, and the assay + infra-tools MCP toolchains. Requires jq, bun, assay, cgroup v2, a systemd user manager, and a provisioned agent-work.slice.",
+  "description": "Claude Code bundle with enforcement hooks, skills, a bounded runner, and the assay + infra-tools MCP toolchains. Hooks require jq, awk, and cat; MCPs require bun and assay. Linux bounded execution additionally requires cgroup v2, a systemd user manager, and a provisioned agent-work.slice.",
   "author": {
     "name": "developerinlondon",
     "url": "https://github.com/developerinlondon"

--- a/plugins-cc/agentkit/hooks/resource-police.sh
+++ b/plugins-cc/agentkit/hooks/resource-police.sh
@@ -21,6 +21,7 @@ RE_SHELL='^(bash|dash|fish|sh|zsh)$'
 RE_SYSTEMCTL_READONLY='^(cat|get-default|is-active|is-enabled|is-failed|list-|show|status)'
 RE_UV_HEAVY='^(add|sync)$'
 RE_YARN_HEAVY='^(add|install|up|upgrade|test)$'
+readonly MAX_ANALYSIS_DEPTH=4
 
 
 # Absolute paths are deliberate: a hook that inspects a command must not
@@ -59,7 +60,9 @@ if [[ -z "$AWK_BIN" || -z "$CAT_BIN" || -z "$JQ_BIN" ]]; then
 	exit 0
 fi
 
-# Stand down where bounding is IMPOSSIBLE, not merely unconfigured.
+# Stand down from LOCAL containment where bounding is impossible, but keep
+# parsing commands: delegated work and undecidable nesting remain blocked on
+# every platform because neither becomes safe when cgroups are unavailable.
 #
 # bounded-run contains work in a systemd scope backed by cgroup v2, and dies
 # with 'cgroup v2 is unavailable' without it. macOS has neither cgroups nor
@@ -70,16 +73,31 @@ fi
 # Announced once per session rather than per command: a warning on every Bash
 # call is the kind of noise that trains people to ignore hooks, but silently
 # disabling a guard is how it stays broken for months.
-if [[ ! -r /sys/fs/cgroup/cgroup.controllers ]]; then
+detect_platform() {
+	if [[ -n "${AGENTKIT_PLATFORM:-}" ]]; then
+		printf '%s' "$AGENTKIT_PLATFORM"
+		return
+	fi
+	case "$(uname -s 2>/dev/null || true)" in
+	Linux) printf 'linux' ;;
+	Darwin) printf 'darwin' ;;
+	*) printf 'unknown' ;;
+	esac
+}
+
+PLATFORM="$(detect_platform)"
+CONTAINMENT_REQUIRED=0
+if [[ "$PLATFORM" == linux && -r /sys/fs/cgroup/cgroup.controllers ]]; then
+	CONTAINMENT_REQUIRED=1
+else
 	# Keyed on PPID — the client process, stable across every hook invocation
 	# in one session. $$ is this hook's own pid and changes each time, which
 	# would make "once" mean "always".
 	notice="${TMPDIR:-/tmp}/.agentkit-resource-police-inactive.$PPID"
 	if [[ ! -e "$notice" ]]; then
 		: >"$notice" 2>/dev/null || true
-		printf 'resource-police: INACTIVE on this host — cgroup v2 is unavailable, so bounded-run cannot contain anything. Heavy commands are not being bounded.\n' >&2
+		printf 'resource-police: local containment INACTIVE on %s — bounded-run is unavailable. Delegated and undecidable commands remain blocked.\n' "$PLATFORM" >&2
 	fi
-	exit 0
 fi
 
 # shellcheck source=lib/hook-input.sh
@@ -116,6 +134,8 @@ deny() {
 		reason="BLOCKED: that is not a recognised bounded-run: $segment. Anything can be named \`bounded-run\`, so it is trusted by INSTALLED PATH, not by name — otherwise a spoof could silently neuter every limit. AGENTKIT_ALLOW_DELEGATED=1 does NOT clear this. Install the runner (\`~/.local/bin/bounded-run\`) and invoke it from there, or use the plugin's copy under \$CLAUDE_PLUGIN_ROOT/tools/. In a fresh clone of agentkit itself, install it first rather than running ./tools/bounded-run in place."
 	elif [[ "$kind" == delegated ]]; then
 		reason="BLOCKED: delegated workload cannot be contained by bounded-run: $segment. Use a separately approved dedicated runner or verified engine-native limits. User-approved delegated workloads: prefix with AGENTKIT_ALLOW_DELEGATED=1."
+	elif [[ "$kind" == undecidable ]]; then
+		reason="BLOCKED: command could not be analyzed safely: $segment. Wrapper or shell nesting exceeded the $MAX_ANALYSIS_DEPTH-level analysis bound."
 	else
 		reason="BLOCKED: resource-intensive command is not contained: $segment. Run it through $runner_hint, for example: $runner_hint --profile compile -- bun run typecheck. Use profile browser for Playwright and browser builds."
 	fi
@@ -176,6 +196,8 @@ parse_launch() {
 	local segment="$1"
 	local token
 	local index=0
+	local wrapper_depth=0
+	PARSE_UNDECIDABLE=0
 	read -r -a TOKENS <<<"$segment"
 	while [[ -n "${TOKENS[$index]:-}" ]]; do
 		while [[ "${TOKENS[$index]:-}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
@@ -191,6 +213,11 @@ parse_launch() {
 			return 0
 			;;
 		env)
+			wrapper_depth=$((wrapper_depth + 1))
+			if ((wrapper_depth > MAX_ANALYSIS_DEPTH)); then
+				PARSE_UNDECIDABLE=1
+				return 0
+			fi
 			index=$((index + 1))
 			while [[ "${TOKENS[$index]:-}" == -* \
 				|| "${TOKENS[$index]:-}" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
@@ -198,6 +225,11 @@ parse_launch() {
 			done
 			;;
 		command | nohup | time)
+			wrapper_depth=$((wrapper_depth + 1))
+			if ((wrapper_depth > MAX_ANALYSIS_DEPTH)); then
+				PARSE_UNDECIDABLE=1
+				return 0
+			fi
 			index=$((index + 1))
 			while [[ "${TOKENS[$index]:-}" == -* ]]; do index=$((index + 1)); done
 			;;
@@ -337,13 +369,12 @@ unwrap_environment() {
 	ARGS=("${ARGS[@]:$((index + 1))}")
 }
 
-parse_wrapped_launch() {
+parse_wrapped_command() {
 	local index
+	WRAPPED_COMMAND=''
 	for index in "${!ARGS[@]}"; do
 		if [[ "${ARGS[$index]}" == -- && -n "${ARGS[$((index + 1))]:-}" ]]; then
-			EXECUTABLE="${ARGS[$((index + 1))]##*/}"
-			EXECUTABLE_TOKEN="${ARGS[$((index + 1))]}"
-			ARGS=("${ARGS[@]:$((index + 2))}")
+			WRAPPED_COMMAND="${ARGS[*]:$((index + 1))}"
 			return 0
 		fi
 	done
@@ -353,13 +384,16 @@ parse_wrapped_launch() {
 analyze_command() {
 	local command="$1"
 	local depth="$2"
+	local contained="${3:-0}"
 	local segments segment
-	((depth <= 3)) || deny "shell nesting exceeds analysis depth: $command"
+	((depth <= MAX_ANALYSIS_DEPTH)) \
+		|| deny "shell or wrapper nesting exceeds analysis depth: $command" undecidable
 	segments=$(printf '%s\n' "$command" | split_segments) \
-		|| deny 'command could not be parsed safely'
+		|| deny 'command could not be parsed safely' undecidable
 	while IFS= read -r segment; do
 		[[ -n "$segment" ]] || continue
 		parse_launch "$segment"
+		if [[ "$PARSE_UNDECIDABLE" == 1 ]]; then deny "$segment" undecidable; fi
 		if [[ "$EXECUTABLE" == bounded-run || "$EXECUTABLE" == agentkit-run ]]; then
 			# NOT `delegated`: that message advertises AGENTKIT_ALLOW_DELEGATED=1,
 			# which this branch never consults, so it sent people chasing an
@@ -367,27 +401,34 @@ analyze_command() {
 			# path is not a recognised runner — anything can be named
 			# `bounded-run`, and trusting it by name alone would let a spoof
 			# neuter every limit.
-			if ! is_trusted_runner; then deny "$segment" untrusted_runner; fi
-			if parse_wrapped_launch; then
-				unwrap_environment
-				if is_delegating && [[ "$DELEGATED_OK" != 1 ]]; then
-					deny "$segment" delegated
-				fi
+			local trusted_runner=0
+			is_trusted_runner && trusted_runner=1
+			if parse_wrapped_command; then
+				local nested_command="$WRAPPED_COMMAND"
+				parse_launch "$nested_command"
+				if [[ "$PARSE_UNDECIDABLE" == 1 ]]; then deny "$segment" undecidable; fi
+				if is_delegating && [[ "$DELEGATED_OK" != 1 ]]; then deny "$segment" delegated; fi
+				analyze_command "$nested_command" $((depth + 1)) 1
+			fi
+			if [[ "$CONTAINMENT_REQUIRED" == 1 && "$trusted_runner" != 1 ]]; then
+				deny "$segment" untrusted_runner
 			fi
 			continue
 		fi
 		if [[ "$EXECUTABLE" =~ $RE_SHELL ]] && shell_command_payload; then
-			analyze_command "$PAYLOAD" $((depth + 1))
+			analyze_command "$PAYLOAD" $((depth + 1)) "$contained"
 			continue
 		fi
 		if is_delegating && [[ "$DELEGATED_OK" != 1 ]]; then
 			deny "$segment" delegated
 		fi
-		if is_heavy; then deny "$segment"; fi
+		if [[ "$CONTAINMENT_REQUIRED" == 1 && "$contained" != 1 ]] && is_heavy; then
+			deny "$segment"
+		fi
 	done <<<"$segments"
 }
 
-declare EXECUTABLE EXECUTABLE_TOKEN PAYLOAD
+declare EXECUTABLE EXECUTABLE_TOKEN PARSE_UNDECIDABLE PAYLOAD WRAPPED_COMMAND
 declare -a TOKENS ARGS
 analyze_command "$COMMAND" 0
 

--- a/plugins-cc/agentkit/skills/resource-safe-execution/SKILL.md
+++ b/plugins-cc/agentkit/skills/resource-safe-execution/SKILL.md
@@ -14,9 +14,10 @@ On Linux, use `bounded-run` for every resource-intensive command. Never fall bac
 command when preflight or containment fails.
 
 On non-Linux hosts, the installer omits `bounded-run` because its systemd and cgroup boundary cannot
-run there. Local heavy-command containment therefore stands down. Delegated-workload protections
-remain active: do not route work through container engines, remote execution, or service managers
-unless the user approved a platform-native runner with verified limits.
+run there. Local heavy-command containment therefore stands down. OpenCode delegation protection
+remains active. Claude hook protection requires `jq`, `awk`, and `cat`; when one is missing, the hook
+warns and intentionally fails open. Do not route work through container engines, remote execution,
+or service managers unless the user approved a platform-native runner with verified limits.
 
 ## Choose a profile
 
@@ -73,10 +74,10 @@ or sibling service outside the transient cgroup. Use a separately approved dedic
 verified engine-native limits for delegated workloads.
 
 PreToolUse hooks and Codex prefix rules catch common accidental bypasses, but they are
-defense-in-depth rather than a sandbox for hostile scripts. A script can deliberately contact a
-daemon or user-systemd socket after launch. Preserve the host-level service limits and reserved
-capacity that protect the agent host, ingress, and tunnels even if a child evades the workload
-slice.
+defense-in-depth rather than a sandbox for hostile scripts. Codex rules cover direct prefixes only;
+they do not recursively parse shell payloads or scripts. A script can deliberately contact a daemon
+or user-systemd socket after launch. Preserve the host-level service limits and reserved capacity
+that protect the agent host, ingress, and tunnels even if a child evades the workload slice.
 
 ## Judge by exit status and output markers
 

--- a/plugins-cc/agentkit/skills/resource-safe-execution/SKILL.md
+++ b/plugins-cc/agentkit/skills/resource-safe-execution/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: resource-safe-execution
 description: >-
-  Run resource-intensive developer commands inside deterministic systemd cgroup limits with
-  bounded-run. Use for dependency installation or upgrades, compilers, typechecks, builds, test
-  suites, linters, Playwright or browser work, code generation, Cargo, Go, and pytest, especially
-  on shared or production-adjacent hosts where an unbounded process could
-  disrupt Kubernetes, ingress, tunnels, or other services.
+  Apply Linux-only deterministic systemd cgroup limits with bounded-run to resource-intensive
+  developer commands. Use for dependency installation or upgrades, compilers, typechecks, builds,
+  test suites, linters, Playwright or browser work, code generation, Cargo, Go, and pytest,
+  especially on shared or production-adjacent Linux hosts where an unbounded process could disrupt
+  Kubernetes, ingress, tunnels, or other services.
 ---
 
 # Resource-safe Execution
 
-Use `bounded-run` for every resource-intensive command. Never fall back to an unbounded command
-when preflight or containment fails.
+On Linux, use `bounded-run` for every resource-intensive command. Never fall back to an unbounded
+command when preflight or containment fails.
+
+On non-Linux hosts, the installer omits `bounded-run` because its systemd and cgroup boundary cannot
+run there. Local heavy-command containment therefore stands down. Delegated-workload protections
+remain active: do not route work through container engines, remote execution, or service managers
+unless the user approved a platform-native runner with verified limits.
 
 ## Choose a profile
 

--- a/plugins-cc/agentkit/tools/bounded-run
+++ b/plugins-cc/agentkit/tools/bounded-run
@@ -1,4 +1,6 @@
 #!/bin/bash -p
+# agentkit:platforms linux
+# Requires systemd user scopes and cgroup v2.
 set -euo pipefail
 
 readonly EX_USAGE=64

--- a/plugins/resource-police.ts
+++ b/plugins/resource-police.ts
@@ -4,6 +4,7 @@ interface Launch {
   token: string;
   executable: string;
   args: string[];
+  undecidable?: boolean;
 }
 
 interface Finding {
@@ -12,7 +13,10 @@ interface Finding {
   /** The runner is not the INSTALLED bounded-run. Distinct from `delegated`:
    *  the delegated message advertises an escape hatch that cannot clear this. */
   untrustedRunner?: boolean;
+  undecidable?: boolean;
 }
+
+const MAX_ANALYSIS_DEPTH = 4;
 
 function splitShellSegments(command: string): string[] {
   const segments: string[] = [];
@@ -62,6 +66,7 @@ function basename(command: string): string {
 function parseLaunch(segment: string): Launch | null {
   const tokens = segment.trim().split(/\s+/);
   let index = 0;
+  let wrapperDepth = 0;
   const assignment = /^[A-Za-z_][A-Za-z0-9_]*=/;
   while (tokens[index]) {
     while (assignment.test(tokens[index] ?? '')) index += 1;
@@ -70,6 +75,10 @@ function parseLaunch(segment: string): Launch | null {
       return { token: tokens[index], executable: wrapper, args: tokens.slice(index + 1) };
     }
     if (wrapper === 'env') {
+      wrapperDepth += 1;
+      if (wrapperDepth > MAX_ANALYSIS_DEPTH) {
+        return { token: '', executable: '', args: [], undecidable: true };
+      }
       index += 1;
       while ((tokens[index] ?? '').startsWith('-') || assignment.test(tokens[index] ?? '')) {
         index += 1;
@@ -77,6 +86,10 @@ function parseLaunch(segment: string): Launch | null {
       continue;
     }
     if (/^(command|nohup|time)$/.test(wrapper)) {
+      wrapperDepth += 1;
+      if (wrapperDepth > MAX_ANALYSIS_DEPTH) {
+        return { token: '', executable: '', args: [], undecidable: true };
+      }
       index += 1;
       while ((tokens[index] ?? '').startsWith('-')) index += 1;
       continue;
@@ -206,44 +219,68 @@ function unwrapEnvironment(launch: Launch): Launch {
   };
 }
 
-function wrappedLaunch(launch: Launch): Launch | null {
+function wrappedCommand(launch: Launch): string | null {
   const separator = launch.args.indexOf('--');
   if (separator < 0 || !launch.args[separator + 1]) return null;
-  return {
-    token: launch.args[separator + 1],
-    executable: basename(launch.args[separator + 1]),
-    args: launch.args.slice(separator + 2),
-  };
+  return launch.args.slice(separator + 1).join(' ');
 }
 
 function detectUnboundedCommand(
   command: string,
   depth = 0,
   delegatedOk = false,
+  containmentRequired = true,
+  contained = false,
 ): Finding | null {
-  if (depth > 3) return { segment: command, delegated: false };
+  if (depth > MAX_ANALYSIS_DEPTH) {
+    return { segment: command, delegated: false, undecidable: true };
+  }
   for (const segment of splitShellSegments(command)) {
     const launch = parseLaunch(segment);
     if (!launch) continue;
+    if (launch.undecidable) return { segment, delegated: false, undecidable: true };
     if (launch.executable === 'bounded-run' || launch.executable === 'agentkit-run') {
-      // NOT `delegated`: that message advertises AGENTKIT_ALLOW_DELEGATED=1,
-      // which this path never consults, so it sent people chasing an escape
-      // hatch that cannot clear it.
-      if (!isTrustedRunner(launch.token)) return { segment, delegated: false, untrustedRunner: true };
-      const nested = wrappedLaunch(launch);
-      if (nested && !delegatedOk && isDelegating(nested)) return { segment, delegated: true };
+      const nestedCommand = wrappedCommand(launch);
+      if (nestedCommand) {
+        const nestedLaunch = parseLaunch(nestedCommand);
+        if (nestedLaunch?.undecidable) {
+          return { segment, delegated: false, undecidable: true };
+        }
+        if (nestedLaunch && !delegatedOk && isDelegating(nestedLaunch)) {
+          return { segment, delegated: true };
+        }
+        const finding = detectUnboundedCommand(
+          nestedCommand,
+          depth + 1,
+          delegatedOk,
+          containmentRequired,
+          true,
+        );
+        if (finding) return finding;
+      }
+      if (containmentRequired && !isTrustedRunner(launch.token)) {
+        return { segment, delegated: false, untrustedRunner: true };
+      }
       continue;
     }
     if (isShell(launch.executable)) {
       const payload = shellCommandPayload(launch);
       if (payload !== null) {
-        const finding = detectUnboundedCommand(payload, depth + 1, delegatedOk);
+        const finding = detectUnboundedCommand(
+          payload,
+          depth + 1,
+          delegatedOk,
+          containmentRequired,
+          contained,
+        );
         if (finding) return finding;
         continue;
       }
     }
     if (!delegatedOk && isDelegating(launch)) return { segment, delegated: true };
-    if (isHeavy(launch)) return { segment, delegated: false };
+    if (containmentRequired && !contained && isHeavy(launch)) {
+      return { segment, delegated: false };
+    }
   }
   return null;
 }
@@ -264,6 +301,50 @@ function isTrustedRunner(token: string): boolean {
     || /\/plugins\/.*\/tools\/bounded-run$/.test(normalized);
 }
 
+function containmentRequired(platform: string): boolean {
+  return platform === 'linux';
+}
+
+export function enforceResourcePolicy(command: string, platform = process.platform): void {
+  const finding = detectUnboundedCommand(
+    command,
+    0,
+    isDelegatedOverride(command),
+    containmentRequired(platform),
+  );
+  if (!finding) return;
+  if (finding.undecidable) {
+    throw new Error(
+      `BLOCKED: command could not be analyzed safely: ${finding.segment}\n`
+        + `Wrapper or shell nesting exceeded the ${MAX_ANALYSIS_DEPTH}-level analysis bound.`,
+    );
+  }
+  if (finding.untrustedRunner) {
+    throw new Error(
+      `BLOCKED: that is not a recognised bounded-run: ${finding.segment}\n`
+        + 'Anything can be named `bounded-run`, so it is trusted by INSTALLED PATH,\n'
+        + 'not by name — otherwise a spoof could silently neuter every limit.\n'
+        + 'AGENTKIT_ALLOW_DELEGATED=1 does NOT clear this. Install the runner\n'
+        + '(~/.local/bin/bounded-run) and invoke it from there, or use the\n'
+        + "plugin's copy under the plugin root.",
+    );
+  }
+  if (finding.delegated) {
+    throw new Error(
+      `BLOCKED: delegated workload cannot be contained by bounded-run: ${finding.segment}\n` +
+        'Use a separately approved dedicated runner or verified engine-native limits.\n' +
+        'User-approved delegated workloads: prefix with AGENTKIT_ALLOW_DELEGATED=1.',
+    );
+  }
+  throw new Error(
+    `BLOCKED: resource-intensive command is not contained: ${finding.segment}\n` +
+      'Run it through the installed runner, for example:\n' +
+      '  bounded-run --profile compile -- bun run typecheck\n' +
+      '  ./.claude/tools/bounded-run --profile compile -- bun run typecheck\n' +
+      'Use profile browser for Playwright and browser builds.',
+  );
+}
+
 export default async function resourcePolice(_ctx: PluginInput) {
   return {
     'tool.execute.before': async (
@@ -273,32 +354,7 @@ export default async function resourcePolice(_ctx: PluginInput) {
       if (input.tool?.toLowerCase() !== 'bash') return;
       const command = output.args.command as string | undefined;
       if (!command) return;
-      const finding = detectUnboundedCommand(command, 0, isDelegatedOverride(command));
-      if (!finding) return;
-      if (finding.untrustedRunner) {
-        throw new Error(
-          `BLOCKED: that is not a recognised bounded-run: ${finding.segment}\n`
-            + 'Anything can be named `bounded-run`, so it is trusted by INSTALLED PATH,\n'
-            + 'not by name — otherwise a spoof could silently neuter every limit.\n'
-            + 'AGENTKIT_ALLOW_DELEGATED=1 does NOT clear this. Install the runner\n'
-            + '(~/.local/bin/bounded-run) and invoke it from there, or use the\n'
-            + "plugin's copy under the plugin root.",
-        );
-      }
-      if (finding.delegated) {
-        throw new Error(
-          `BLOCKED: delegated workload cannot be contained by bounded-run: ${finding.segment}\n` +
-            'Use a separately approved dedicated runner or verified engine-native limits.\n' +
-            'User-approved delegated workloads: prefix with AGENTKIT_ALLOW_DELEGATED=1.',
-        );
-      }
-      throw new Error(
-        `BLOCKED: resource-intensive command is not contained: ${finding.segment}\n` +
-          'Run it through the installed runner, for example:\n' +
-          '  bounded-run --profile compile -- bun run typecheck\n' +
-          '  ./.claude/tools/bounded-run --profile compile -- bun run typecheck\n' +
-          'Use profile browser for Playwright and browser builds.',
-      );
+      enforceResourcePolicy(command, process.platform);
     },
   };
 }

--- a/policies/codex/delegation-police.rules
+++ b/policies/codex/delegation-police.rules
@@ -1,0 +1,38 @@
+# delegation-police.rules — Codex CLI exec policy
+# Delegated workloads escape local process containment on every platform.
+
+prefix_rule(
+    pattern = ["docker"],
+    decision = "forbidden",
+    justification = "Container workloads delegate to an engine outside local process containment. Use a separately approved dedicated runner or verified engine-native limits.",
+)
+
+prefix_rule(
+    pattern = ["podman"],
+    decision = "forbidden",
+    justification = "Container workloads may delegate outside local process containment. Use a separately approved dedicated runner or verified engine-native limits.",
+)
+
+prefix_rule(
+    pattern = ["systemd-run"],
+    decision = "forbidden",
+    justification = "Direct systemd-run creates a sibling cgroup outside the invoking process boundary.",
+)
+
+prefix_rule(
+    pattern = ["run0"],
+    decision = "forbidden",
+    justification = "run0 delegates to systemd-run outside the invoking process boundary.",
+)
+
+prefix_rule(
+    pattern = ["ssh"],
+    decision = "forbidden",
+    justification = "Remote workloads are outside local process containment.",
+)
+
+prefix_rule(
+    pattern = ["sudo"],
+    decision = "forbidden",
+    justification = "Privilege wrappers may delegate outside the invoking process boundary.",
+)

--- a/policies/codex/delegation-police.rules
+++ b/policies/codex/delegation-police.rules
@@ -1,22 +1,42 @@
 # delegation-police.rules — Codex CLI exec policy
 # Delegated workloads escape local process containment on every platform.
+#
+# This policy evaluates direct command prefixes only. Codex prefix rules do not
+# parse shell payloads, skip arbitrary global options, or recursively inspect a
+# launched script. Claude and OpenCode resource-police provide that recursive
+# analysis. This file blocks direct forms the prefix language can represent and
+# explicitly allows their direct read-only diagnostic forms.
+
+# Always-delegating executables have no safe direct diagnostic mode.
 
 prefix_rule(
-    pattern = ["docker"],
+    pattern = ["ansible"],
     decision = "forbidden",
-    justification = "Container workloads delegate to an engine outside local process containment. Use a separately approved dedicated runner or verified engine-native limits.",
+    justification = "Ansible delegates work to managed hosts. Use a separately approved remote runner with verified limits.",
 )
 
 prefix_rule(
-    pattern = ["podman"],
+    pattern = ["ansible-playbook"],
     decision = "forbidden",
-    justification = "Container workloads may delegate outside local process containment. Use a separately approved dedicated runner or verified engine-native limits.",
+    justification = "Ansible delegates work to managed hosts. Use a separately approved remote runner with verified limits.",
 )
 
 prefix_rule(
-    pattern = ["systemd-run"],
+    pattern = ["doas"],
     decision = "forbidden",
-    justification = "Direct systemd-run creates a sibling cgroup outside the invoking process boundary.",
+    justification = "Privilege wrappers can escape the invoking process boundary.",
+)
+
+prefix_rule(
+    pattern = ["mosh"],
+    decision = "forbidden",
+    justification = "Remote workloads are outside local process containment.",
+)
+
+prefix_rule(
+    pattern = ["pkexec"],
+    decision = "forbidden",
+    justification = "Privilege wrappers can escape the invoking process boundary.",
 )
 
 prefix_rule(
@@ -34,5 +54,148 @@ prefix_rule(
 prefix_rule(
     pattern = ["sudo"],
     decision = "forbidden",
-    justification = "Privilege wrappers may delegate outside the invoking process boundary.",
+    justification = "Privilege wrappers can escape the invoking process boundary.",
+)
+
+prefix_rule(
+    pattern = ["systemd-run"],
+    decision = "forbidden",
+    justification = "Direct systemd-run creates a sibling cgroup outside the invoking process boundary.",
+)
+
+# Container/build engines: deny direct mutating operations and allow direct
+# diagnostics. Global options placed before the subcommand are outside this
+# prefix layer and remain the responsibility of the recursive runtime hooks.
+
+prefix_rule(
+    pattern = ["buildah", ["add", "build", "bud", "commit", "config", "copy", "from", "mount", "pull", "push", "rename", "rm", "rmi", "run", "tag", "umount", "unmount"]],
+    decision = "forbidden",
+    justification = "Buildah can create delegated container workloads outside local process containment.",
+)
+
+prefix_rule(
+    pattern = ["buildah", ["containers", "images", "info", "inspect", "version"]],
+    decision = "allow",
+    justification = "Direct Buildah inspection is read-only.",
+)
+
+prefix_rule(
+    pattern = ["docker", ["attach", "build", "commit", "cp", "create", "exec", "export", "import", "kill", "load", "pause", "pull", "push", "rename", "restart", "rm", "rmi", "run", "save", "start", "stop", "tag", "unpause", "update", "wait"]],
+    decision = "forbidden",
+    justification = "Docker can delegate work to an engine outside local process containment.",
+)
+
+prefix_rule(
+    pattern = ["docker", ["builder", "buildx", "context", "network", "node", "plugin", "secret", "service", "stack", "swarm", "system", "trust", "volume"]],
+    decision = "forbidden",
+    justification = "Docker engine administration can mutate workloads outside local process containment.",
+)
+
+prefix_rule(
+    pattern = ["docker", "compose", ["build", "create", "down", "exec", "kill", "pause", "pull", "push", "restart", "rm", "run", "start", "stop", "unpause", "up"]],
+    decision = "forbidden",
+    justification = "Docker Compose can delegate workloads outside local process containment.",
+)
+
+prefix_rule(
+    pattern = ["docker", ["diff", "events", "history", "images", "info", "inspect", "logs", "port", "ps", "stats", "top", "version"]],
+    decision = "allow",
+    justification = "Direct Docker inspection is read-only.",
+)
+
+prefix_rule(
+    pattern = ["nerdctl", ["attach", "build", "commit", "cp", "create", "exec", "kill", "load", "pause", "pull", "push", "restart", "rm", "rmi", "run", "start", "stop", "tag", "unpause", "update"]],
+    decision = "forbidden",
+    justification = "nerdctl can delegate work to containerd outside local process containment.",
+)
+
+prefix_rule(
+    pattern = ["nerdctl", "compose", ["build", "create", "down", "exec", "kill", "pull", "restart", "rm", "run", "start", "stop", "up"]],
+    decision = "forbidden",
+    justification = "nerdctl Compose can delegate workloads outside local process containment.",
+)
+
+prefix_rule(
+    pattern = ["nerdctl", ["diff", "events", "history", "images", "info", "inspect", "logs", "port", "ps", "stats", "top", "version"]],
+    decision = "allow",
+    justification = "Direct nerdctl inspection is read-only.",
+)
+
+prefix_rule(
+    pattern = ["podman", ["attach", "build", "commit", "cp", "create", "exec", "export", "generate", "import", "kill", "load", "mount", "pause", "pull", "push", "rename", "restart", "rm", "rmi", "run", "start", "stop", "tag", "unmount", "unpause", "update"]],
+    decision = "forbidden",
+    justification = "Podman can delegate workloads outside local process containment.",
+)
+
+prefix_rule(
+    pattern = ["podman", ["container", "farm", "kube", "machine", "network", "pod", "secret", "system", "volume"]],
+    decision = "forbidden",
+    justification = "Podman administration can mutate workloads outside local process containment.",
+)
+
+prefix_rule(
+    pattern = ["podman", "compose", ["build", "create", "down", "exec", "kill", "pull", "restart", "rm", "run", "start", "stop", "up"]],
+    decision = "forbidden",
+    justification = "Podman Compose can delegate workloads outside local process containment.",
+)
+
+prefix_rule(
+    pattern = ["podman", ["diff", "events", "history", "images", "info", "inspect", "logs", "port", "ps", "stats", "top", "version"]],
+    decision = "allow",
+    justification = "Direct Podman inspection is read-only.",
+)
+
+# Service managers: service(8)'s `service NAME ACTION` shape cannot express an
+# arbitrary NAME in a prefix rule. systemctl direct forms are covered here;
+# recursive runtime hooks cover both forms and shell wrappers.
+
+prefix_rule(
+    pattern = ["machinectl", ["bind", "clone", "copy-from", "copy-to", "disable", "enable", "kill", "login", "mount", "poweroff", "reboot", "remove", "rename", "shell", "start", "stop", "terminate"]],
+    decision = "forbidden",
+    justification = "machinectl can create or control service-managed workloads outside local containment.",
+)
+
+prefix_rule(
+    pattern = ["machinectl", ["list", "show", "status"]],
+    decision = "allow",
+    justification = "Direct machinectl inspection is read-only.",
+)
+
+prefix_rule(
+    pattern = ["systemctl", ["cancel", "clean", "daemon-reexec", "daemon-reload", "disable", "edit", "emergency", "enable", "freeze", "halt", "hibernate", "hybrid-sleep", "import-environment", "isolate", "kexec", "kill", "link", "mask", "poweroff", "preset", "preset-all", "reboot", "reenable", "reload", "reload-or-restart", "rescue", "reset-failed", "restart", "revert", "set-default", "set-environment", "set-property", "start", "stop", "suspend", "suspend-then-hibernate", "thaw", "try-reload-or-restart", "try-restart", "unmask", "unset-environment"]],
+    decision = "forbidden",
+    justification = "systemctl can create or control service workloads outside local process containment.",
+)
+
+prefix_rule(
+    pattern = ["systemctl", ["--system", "--user"], ["cancel", "clean", "daemon-reexec", "daemon-reload", "disable", "edit", "enable", "freeze", "import-environment", "isolate", "kill", "link", "mask", "preset", "preset-all", "reenable", "reload", "reload-or-restart", "reset-failed", "restart", "revert", "set-default", "set-environment", "set-property", "start", "stop", "thaw", "try-reload-or-restart", "try-restart", "unmask", "unset-environment"]],
+    decision = "forbidden",
+    justification = "systemctl can create or control service workloads outside local process containment.",
+)
+
+prefix_rule(
+    pattern = ["systemctl", ["cat", "get-default", "is-active", "is-enabled", "is-failed", "list-dependencies", "list-jobs", "list-sockets", "list-timers", "list-unit-files", "list-units", "show", "status"]],
+    decision = "allow",
+    justification = "Direct systemctl inspection is read-only.",
+)
+
+prefix_rule(
+    pattern = ["systemctl", ["--system", "--user"], ["cat", "get-default", "is-active", "is-enabled", "is-failed", "list-dependencies", "list-jobs", "list-sockets", "list-timers", "list-unit-files", "list-units", "show", "status"]],
+    decision = "allow",
+    justification = "Direct systemctl inspection is read-only.",
+)
+
+# Kubernetes direct mutation/delegation forms. Namespace and context flags
+# placed before the subcommand cannot be skipped by a prefix rule.
+
+prefix_rule(
+    pattern = ["kubectl", ["annotate", "apply", "attach", "autoscale", "certificate", "cordon", "cp", "create", "debug", "delete", "drain", "edit", "exec", "expose", "label", "patch", "port-forward", "proxy", "replace", "rollout", "run", "scale", "set", "taint", "uncordon"]],
+    decision = "forbidden",
+    justification = "kubectl can mutate or delegate work outside local process containment.",
+)
+
+prefix_rule(
+    pattern = ["kubectl", ["api-resources", "api-versions", "auth", "cluster-info", "describe", "explain", "get", "logs", "top", "version"]],
+    decision = "allow",
+    justification = "Direct kubectl inspection is read-only.",
 )

--- a/policies/codex/resource-police.rules
+++ b/policies/codex/resource-police.rules
@@ -1,4 +1,5 @@
 # resource-police.rules — Codex CLI exec policy
+# agentkit:platforms linux
 # Heavy commands must start with bounded-run so systemd owns and limits the process tree.
 
 prefix_rule(
@@ -79,42 +80,6 @@ prefix_rule(
     pattern = ["go", ["build", "test"]],
     decision = "forbidden",
     justification = "Run Go compiler and test workloads with bounded-run.",
-)
-
-prefix_rule(
-    pattern = ["docker"],
-    decision = "forbidden",
-    justification = "Container builds delegate to an engine outside bounded-run. Use a separately approved dedicated runner or verified engine-native limits.",
-)
-
-prefix_rule(
-    pattern = ["podman"],
-    decision = "forbidden",
-    justification = "Container builds may delegate outside bounded-run. Use a separately approved dedicated runner or verified engine-native limits.",
-)
-
-prefix_rule(
-    pattern = ["systemd-run"],
-    decision = "forbidden",
-    justification = "Direct systemd-run can create a sibling cgroup outside the mandatory bounded-run boundary.",
-)
-
-prefix_rule(
-    pattern = ["run0"],
-    decision = "forbidden",
-    justification = "run0 delegates to systemd-run outside the mandatory bounded-run boundary.",
-)
-
-prefix_rule(
-    pattern = ["ssh"],
-    decision = "forbidden",
-    justification = "Remote workloads are outside the local bounded-run resource boundary.",
-)
-
-prefix_rule(
-    pattern = ["sudo"],
-    decision = "forbidden",
-    justification = "Privilege wrappers are not allowed inside the bounded-run containment workflow.",
 )
 
 prefix_rule(

--- a/policies/codex/resource-police.rules
+++ b/policies/codex/resource-police.rules
@@ -3,6 +3,18 @@
 # Heavy commands must start with bounded-run so systemd owns and limits the process tree.
 
 prefix_rule(
+    pattern = [["bounded-run", "agentkit-run"], "--profile", ["canary", "default", "compile", "browser"], "--", ["agentkit-run", "ansible", "ansible-playbook", "bounded-run", "buildah", "doas", "docker", "env", "kubectl", "machinectl", "mosh", "nerdctl", "pkexec", "podman", "run0", "service", "ssh", "su", "sudo", "systemctl", "systemd-run"]],
+    decision = "forbidden",
+    justification = "bounded-run refuses nested, privileged, remote, container, and service-managed payloads because they escape or obscure its cgroup boundary.",
+)
+
+prefix_rule(
+    pattern = [["bounded-run", "agentkit-run"], "--", ["agentkit-run", "ansible", "ansible-playbook", "bounded-run", "buildah", "doas", "docker", "env", "kubectl", "machinectl", "mosh", "nerdctl", "pkexec", "podman", "run0", "service", "ssh", "su", "sudo", "systemctl", "systemd-run"]],
+    decision = "forbidden",
+    justification = "bounded-run refuses nested, privileged, remote, container, and service-managed payloads because they escape or obscure its cgroup boundary.",
+)
+
+prefix_rule(
     pattern = ["bounded-run"],
     decision = "allow",
     justification = "bounded-run applies the mandatory cgroup, timeout, and process-tree boundary.",

--- a/scripts/product-command
+++ b/scripts/product-command
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+product_platform() {
+	case "$(/usr/bin/uname -s 2>/dev/null || true)" in
+	Linux) printf 'linux' ;;
+	Darwin) printf 'darwin' ;;
+	*) printf 'unknown' ;;
+	esac
+}
+
+run_product_command() {
+	local platform="${1:-}"
+	local profile="${2:-}"
+	if [[ $# -lt 4 || "${3:-}" != -- ]]; then
+		printf 'usage: product-command PROFILE -- COMMAND [ARG ...]\n' >&2
+		return 64
+	fi
+	shift 3
+
+	case "$profile" in
+	canary | default | compile | browser) ;;
+	*)
+		printf 'product-command: unknown profile: %s\n' "$profile" >&2
+		return 64
+		;;
+	esac
+
+	if [[ "$platform" == linux ]]; then
+		if ! command -v agentkit-run >/dev/null 2>&1; then
+			printf 'product-command: agentkit-run is required on Linux; install AgentKit before review.\n' >&2
+			return 69
+		fi
+		exec agentkit-run --profile "$profile" -- "$@"
+	fi
+
+	exec "$@"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+	run_product_command "$(product_platform)" "$@"
+fi

--- a/skills/resource-safe-execution/SKILL.md
+++ b/skills/resource-safe-execution/SKILL.md
@@ -14,9 +14,10 @@ On Linux, use `bounded-run` for every resource-intensive command. Never fall bac
 command when preflight or containment fails.
 
 On non-Linux hosts, the installer omits `bounded-run` because its systemd and cgroup boundary cannot
-run there. Local heavy-command containment therefore stands down. Delegated-workload protections
-remain active: do not route work through container engines, remote execution, or service managers
-unless the user approved a platform-native runner with verified limits.
+run there. Local heavy-command containment therefore stands down. OpenCode delegation protection
+remains active. Claude hook protection requires `jq`, `awk`, and `cat`; when one is missing, the hook
+warns and intentionally fails open. Do not route work through container engines, remote execution,
+or service managers unless the user approved a platform-native runner with verified limits.
 
 ## Choose a profile
 
@@ -73,10 +74,10 @@ or sibling service outside the transient cgroup. Use a separately approved dedic
 verified engine-native limits for delegated workloads.
 
 PreToolUse hooks and Codex prefix rules catch common accidental bypasses, but they are
-defense-in-depth rather than a sandbox for hostile scripts. A script can deliberately contact a
-daemon or user-systemd socket after launch. Preserve the host-level service limits and reserved
-capacity that protect the agent host, ingress, and tunnels even if a child evades the workload
-slice.
+defense-in-depth rather than a sandbox for hostile scripts. Codex rules cover direct prefixes only;
+they do not recursively parse shell payloads or scripts. A script can deliberately contact a daemon
+or user-systemd socket after launch. Preserve the host-level service limits and reserved capacity
+that protect the agent host, ingress, and tunnels even if a child evades the workload slice.
 
 ## Judge by exit status and output markers
 

--- a/skills/resource-safe-execution/SKILL.md
+++ b/skills/resource-safe-execution/SKILL.md
@@ -1,17 +1,22 @@
 ---
 name: resource-safe-execution
 description: >-
-  Run resource-intensive developer commands inside deterministic systemd cgroup limits with
-  bounded-run. Use for dependency installation or upgrades, compilers, typechecks, builds, test
-  suites, linters, Playwright or browser work, code generation, Cargo, Go, and pytest, especially
-  on shared or production-adjacent hosts where an unbounded process could
-  disrupt Kubernetes, ingress, tunnels, or other services.
+  Apply Linux-only deterministic systemd cgroup limits with bounded-run to resource-intensive
+  developer commands. Use for dependency installation or upgrades, compilers, typechecks, builds,
+  test suites, linters, Playwright or browser work, code generation, Cargo, Go, and pytest,
+  especially on shared or production-adjacent Linux hosts where an unbounded process could disrupt
+  Kubernetes, ingress, tunnels, or other services.
 ---
 
 # Resource-safe Execution
 
-Use `bounded-run` for every resource-intensive command. Never fall back to an unbounded command
-when preflight or containment fails.
+On Linux, use `bounded-run` for every resource-intensive command. Never fall back to an unbounded
+command when preflight or containment fails.
+
+On non-Linux hosts, the installer omits `bounded-run` because its systemd and cgroup boundary cannot
+run there. Local heavy-command containment therefore stands down. Delegated-workload protections
+remain active: do not route work through container engines, remote execution, or service managers
+unless the user approved a platform-native runner with verified limits.
 
 ## Choose a profile
 

--- a/tests/agentkit-plugin.test.ts
+++ b/tests/agentkit-plugin.test.ts
@@ -205,6 +205,8 @@ describe('marketplace lists the agentkit plugin', () => {
     expect(agentkit.version).toBe('0.2.0');
     expect(agentkit.description).toContain('bounded-run');
     expect(agentkit.description).toContain('agent-work.slice');
+    expect(agentkit.description).toContain('Linux bounded execution additionally requires');
+    expect(agentkit.description).not.toContain('Requires jq, bun, assay, cgroup v2');
   });
 });
 

--- a/tests/fixtures/resource-commands.ts
+++ b/tests/fixtures/resource-commands.ts
@@ -57,6 +57,7 @@ export const unsupportedResourceCommands = [
   'bounded-run --profile compile -- systemd-run --user cargo test',
   "bounded-run --profile compile -- bash -lc 'systemd-run --user cargo test'",
   "bounded-run --profile compile -- env CI=1 sh -c 'bun test'",
+  'bounded-run --profile compile -- command nohup bounded-run --profile compile -- docker build .',
   "bash -c 'ssh build-host bun test'",
   "bash -xc 'systemd-run --user cargo test'",
   'ansible-playbook playbooks/server.yml --check --diff',

--- a/tests/install-platform.test.ts
+++ b/tests/install-platform.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const repoRoot = dirname(import.meta.dir);
+const installScript = join(repoRoot, 'install.sh');
+
+interface Fixture {
+  home: string;
+  repo: string;
+  root: string;
+  target: string;
+}
+
+function writeFixtureFile(path: string, contents: string, executable = false): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, contents);
+  if (executable) chmodSync(path, 0o755);
+}
+
+function createFixture(): Fixture {
+  const root = mkdtempSync(join(tmpdir(), 'agentkit-platform-install-'));
+  const repo = join(root, 'repo');
+  const home = join(root, 'home');
+  const target = join(root, 'project');
+  mkdirSync(repo, { recursive: true });
+  mkdirSync(home, { recursive: true });
+  mkdirSync(target, { recursive: true });
+
+  copyFileSync(installScript, join(repo, 'install.sh'));
+  chmodSync(join(repo, 'install.sh'), 0o755);
+  writeFixtureFile(
+    join(repo, 'lib', 'install-platform.sh'),
+    readFileSync(join(repoRoot, 'lib', 'install-platform.sh'), 'utf-8'),
+  );
+  writeFixtureFile(join(repo, 'config.example.yaml'), '{}\n');
+  writeFixtureFile(join(repo, 'skills', 'sample', 'SKILL.md'), '# Sample\n');
+  writeFixtureFile(join(repo, 'rules', 'sample.md'), '# Sample\n');
+  mkdirSync(join(repo, 'instructions'), { recursive: true });
+  mkdirSync(join(repo, 'plugins'), { recursive: true });
+  writeFixtureFile(join(repo, 'hooks', 'claude', 'settings.json'), '{"hooks": {}}\n');
+  writeFixtureFile(
+    join(repo, 'tools', 'bounded-run'),
+    '#!/usr/bin/env bash\n# agentkit:platforms linux\nprintf "bounded\\n"\n',
+    true,
+  );
+  writeFixtureFile(
+    join(repo, 'tools', 'portable-tool'),
+    '#!/usr/bin/env bash\nprintf "portable\\n"\n',
+    true,
+  );
+  writeFixtureFile(
+    join(repo, 'policies', 'codex', 'resource-police.rules'),
+    '# agentkit:platform linux # local cgroup containment\n',
+  );
+  writeFixtureFile(
+    join(repo, 'policies', 'codex', 'delegation-police.rules'),
+    '# universal delegation policy\n',
+  );
+
+  return { home, repo, root, target };
+}
+
+function runInstall(fixture: Fixture, platform: string, global: boolean) {
+  const args = global
+    ? [join(fixture.repo, 'install.sh'), '--global', '--no-session-scope']
+    : [join(fixture.repo, 'install.sh'), fixture.target];
+  return spawnSync('bash', args, {
+    cwd: fixture.repo,
+    env: {
+      ...process.env,
+      AGENTKIT_HOME: join(fixture.home, '.agentkit'),
+      AGENTKIT_PLATFORM: platform,
+      HOME: fixture.home,
+      XDG_CONFIG_HOME: join(fixture.home, '.config'),
+    },
+    encoding: 'utf-8',
+  });
+}
+
+function installedPaths(fixture: Fixture, global: boolean) {
+  const tools = global ? join(fixture.home, '.local', 'bin') : join(fixture.target, '.claude', 'tools');
+  const policies = global ? join(fixture.home, '.codex', 'rules') : join(fixture.target, '.codex', 'rules');
+  return { policies, tools };
+}
+
+function expectMissing(path: string): void {
+  expect(existsSync(path)).toBe(false);
+  expect(() => lstatSync(path)).toThrow();
+}
+
+describe('platform-aware artifact installation', () => {
+  for (const global of [true, false]) {
+    const mode = global ? 'global' : 'project';
+
+    test(`${mode} install includes Linux-only and universal artifacts on Linux`, () => {
+      const fixture = createFixture();
+      try {
+        const result = runInstall(fixture, 'linux', global);
+        expect(result.status, result.stderr).toBe(0);
+
+        const { policies, tools } = installedPaths(fixture, global);
+        expect(existsSync(join(tools, 'bounded-run'))).toBe(true);
+        expect(lstatSync(join(tools, 'agentkit-run')).isSymbolicLink()).toBe(true);
+        expect(existsSync(join(tools, 'portable-tool'))).toBe(true);
+        expect(existsSync(join(policies, 'resource-police.rules'))).toBe(true);
+        expect(existsSync(join(policies, 'delegation-police.rules'))).toBe(true);
+      } finally {
+        rmSync(fixture.root, { force: true, recursive: true });
+      }
+    });
+
+    test(`${mode} install removes stale Linux-only artifacts on macOS`, () => {
+      const fixture = createFixture();
+      try {
+        const { policies, tools } = installedPaths(fixture, global);
+        for (const path of [
+          join(tools, 'bounded-run'),
+          join(tools, 'agentkit-run'),
+          join(policies, 'resource-police.rules'),
+        ]) {
+          writeFixtureFile(path, 'stale\n');
+        }
+        if (global) {
+          for (const name of ['bounded-run', 'agentkit-run']) {
+            writeFixtureFile(join(fixture.home, '.agentkit', 'tools', name), 'stale\n');
+            writeFixtureFile(join(fixture.home, '.claude', 'tools', name), 'stale\n');
+          }
+        }
+
+        const result = runInstall(fixture, 'darwin', global);
+        expect(result.status, result.stderr).toBe(0);
+
+        expectMissing(join(tools, 'bounded-run'));
+        expectMissing(join(tools, 'agentkit-run'));
+        expect(existsSync(join(tools, 'portable-tool'))).toBe(true);
+        expectMissing(join(policies, 'resource-police.rules'));
+        expect(existsSync(join(policies, 'delegation-police.rules'))).toBe(true);
+        if (global) {
+          for (const base of [
+            join(fixture.home, '.agentkit', 'tools'),
+            join(fixture.home, '.claude', 'tools'),
+          ]) {
+            expectMissing(join(base, 'bounded-run'));
+            expectMissing(join(base, 'agentkit-run'));
+          }
+        }
+      } finally {
+        rmSync(fixture.root, { force: true, recursive: true });
+      }
+    });
+  }
+
+  test('rejects an invalid AGENTKIT_PLATFORM before changing an existing install', () => {
+    const fixture = createFixture();
+    try {
+      const staleRunner = join(fixture.target, '.claude', 'tools', 'bounded-run');
+      writeFixtureFile(staleRunner, 'leave-me-alone\n');
+
+      const result = runInstall(fixture, 'Linux', false);
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain('invalid AGENTKIT_PLATFORM');
+      expect(readFileSync(staleRunner, 'utf-8')).toBe('leave-me-alone\n');
+      expect(existsSync(join(fixture.target, '.claude', 'tools', 'portable-tool'))).toBe(false);
+    } finally {
+      rmSync(fixture.root, { force: true, recursive: true });
+    }
+  });
+});

--- a/tests/product-command.test.ts
+++ b/tests/product-command.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const repoRoot = dirname(import.meta.dir);
+const commandScript = join(repoRoot, 'scripts', 'product-command');
+let root = '';
+
+function executable(name: string, body: string) {
+  const path = join(root, name);
+  writeFileSync(path, `#!/usr/bin/env bash\nset -eu\n${body}\n`);
+  chmodSync(path, 0o755);
+  return path;
+}
+
+function invoke(platform: string, profile: string, command: string[]) {
+  const shell = [
+    `source '${commandScript}'`,
+    `run_product_command '${platform}' '${profile}' -- "$@"`,
+  ].join('; ');
+  return spawnSync('bash', ['-c', shell, 'product-command-test', ...command], {
+    encoding: 'utf-8',
+    env: { ...process.env, PATH: `${root}:/usr/bin:/bin` },
+  });
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'agentkit-product-command-'));
+});
+
+afterEach(() => {
+  rmSync(root, { force: true, recursive: true });
+});
+
+describe('portable product command', () => {
+  test('delegates Linux workloads to the installed bounded runner with exact argv', () => {
+    executable('agentkit-run', "printf 'runner:%s\\n' \"$*\"");
+    const result = invoke('linux', 'default', ['bun', 'test']);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout.trim()).toBe('runner:--profile default -- bun test');
+  });
+
+  test('fails closed when Linux containment is unavailable', () => {
+    const result = invoke('linux', 'default', ['bun', 'test']);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('agentkit-run is required on Linux');
+  });
+
+  test('runs the same exact command directly on non-Linux hosts', () => {
+    const workload = executable('workload', "printf 'direct:%s\\n' \"$*\"");
+    const result = invoke('darwin', 'default', [workload, 'one', 'two']);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout.trim()).toBe('direct:one two');
+  });
+
+  test('keeps every product-review command verbatim and cross-platform', () => {
+    const product = readFileSync(join(repoRoot, '.agentkit', 'product.yaml'), 'utf-8');
+    expect(product).toContain('build: scripts/product-command default -- bun install');
+    expect(product).toContain('verify: scripts/product-command default -- bun test');
+    expect(product).toContain('run: scripts/product-command default -- echo ok');
+    expect(product).toContain(
+      'run: scripts/product-command default -- bun plugins-cc/agentkit/server/index.ts',
+    );
+  });
+});

--- a/tests/resource-police.test.ts
+++ b/tests/resource-police.test.ts
@@ -54,47 +54,51 @@ function runHook(command: string, platform?: string): string {
   }).stdout ?? '';
 }
 
-describe('OpenCode resource-police', () => {
+describe('OpenCode Linux resource policy', () => {
   for (const command of blockedResourceCommands) {
-    test(`blocks unbounded command: ${command}`, async () => {
-      const hooks = await resourcePolice(mockCtx);
-      const { input, output } = makeInput(command);
-      expect(hooks['tool.execute.before']!(input, output)).rejects.toThrow('bounded-run');
+    test(`blocks unbounded command: ${command}`, () => {
+      expect(() => enforceResourcePolicy(command, 'linux')).toThrow('bounded-run');
     });
   }
 
   for (const command of unsupportedResourceCommands) {
-    test(`blocks delegated command: ${command}`, async () => {
-      const hooks = await resourcePolice(mockCtx);
-      const { input, output } = makeInput(command);
-      expect(hooks['tool.execute.before']!(input, output)).rejects.toThrow(
+    test(`blocks delegated command: ${command}`, () => {
+      expect(() => enforceResourcePolicy(command, 'linux')).toThrow(
         'cannot be contained by bounded-run',
       );
     });
   }
 
   for (const command of untrustedRunnerCommands) {
-    test(`refuses an unrecognised runner: ${command}`, async () => {
+    test(`refuses an unrecognised runner: ${command}`, () => {
       // This guard had ZERO coverage in the OpenCode implementation: moving
       // the fixture into its own array took it out of the loop above, and
       // deleting the guard outright still left every test passing. Two
       // parallel implementations of one policy need the same cases run
       // against BOTH, or one silently stops enforcing.
-      const hooks = await resourcePolice(mockCtx);
-      const { input, output } = makeInput(command);
-      expect(hooks['tool.execute.before']!(input, output)).rejects.toThrow(
-        'not a recognised bounded-run',
-      );
+      expect(() => enforceResourcePolicy(command, 'linux')).toThrow('not a recognised bounded-run');
     });
   }
 
-  test('allows wrapped, lightweight, and inspection commands', async () => {
-    const hooks = await resourcePolice(mockCtx);
-
+  test('allows wrapped, lightweight, and inspection commands', () => {
     for (const command of allowedResourceCommands) {
-      const { input, output } = makeInput(command);
-      expect(hooks['tool.execute.before']!(input, output)).resolves.toBeUndefined();
+      expect(() => enforceResourcePolicy(command, 'linux')).not.toThrow();
     }
+  });
+
+  test('runtime hook follows the host platform while keeping delegation universal', async () => {
+    const hooks = await resourcePolice(mockCtx);
+    const heavy = makeInput('bun test');
+    const delegated = makeInput('docker build .');
+
+    if (process.platform === 'linux') {
+      expect(hooks['tool.execute.before']!(heavy.input, heavy.output)).rejects.toThrow('bounded-run');
+    } else {
+      expect(hooks['tool.execute.before']!(heavy.input, heavy.output)).resolves.toBeUndefined();
+    }
+    expect(hooks['tool.execute.before']!(delegated.input, delegated.output)).rejects.toThrow(
+      'cannot be contained by bounded-run',
+    );
   });
 
   test('ignores non-shell tools', async () => {
@@ -193,6 +197,7 @@ describe('Codex resource policies', () => {
   test('separates universal delegation rules from Linux-only containment rules', () => {
     const contents = readFileSync(policy, 'utf-8');
     const delegation = readFileSync(delegationPolicy, 'utf-8');
+    const compactDelegation = delegation.replace(/\s+/g, ' ');
     expect(contents).toContain('# agentkit:platforms linux');
     expect(contents).not.toContain('decision = "prompt"');
     expect(delegation).not.toContain('decision = "prompt"');
@@ -202,10 +207,29 @@ describe('Codex resource policies', () => {
     for (const command of ['bun', 'bunx', 'tsc', 'playwright', 'cargo', 'go']) {
       expect(contents).toContain(`pattern = ["${command}"`);
     }
-    for (const command of ['docker', 'podman', 'systemd-run', 'run0', 'ssh', 'sudo']) {
+    for (const command of [
+      'ansible',
+      'ansible-playbook',
+      'buildah',
+      'doas',
+      'docker',
+      'machinectl',
+      'mosh',
+      'nerdctl',
+      'pkexec',
+      'podman',
+      'run0',
+      'ssh',
+      'sudo',
+      'systemctl',
+      'systemd-run',
+      'kubectl',
+    ]) {
       expect(contents).not.toContain(`pattern = ["${command}"`);
       expect(delegation).toContain(`pattern = ["${command}"`);
     }
+    expect(compactDelegation).toContain('direct command prefixes only');
+    expect(compactDelegation).toContain('parse shell payloads');
     expect(contents.match(/decision = "forbidden"/g)?.length ?? 0).toBeGreaterThanOrEqual(8);
     expect(contents).toContain('pattern = ["tsc"]');
     expect(contents).toContain('pattern = [["npm", "pnpm"]');
@@ -240,11 +264,37 @@ describe('Codex resource policies', () => {
       expect(JSON.parse(result.stdout).decision, command.join(' ')).toBe(expected);
     }
 
-    for (const command of [
+    const deniedDelegation = [
+      ['ansible', 'all', '-m', 'ping'],
+      ['ansible-playbook', 'site.yml'],
+      ['buildah', 'bud', '.'],
+      ['doas', 'make', 'test'],
       ['docker', 'run', '--rm', 'builder'],
+      ['machinectl', 'shell', 'builder'],
+      ['mosh', 'build-host'],
+      ['nerdctl', 'build', '.'],
+      ['pkexec', 'make', 'test'],
+      ['podman', 'exec', 'builder', 'bun', 'test'],
+      ['run0', 'make', 'test'],
       ['ssh', 'build-host', 'bun', 'test'],
+      ['sudo', 'make', 'test'],
+      ['systemctl', 'restart', 'build-worker'],
+      ['systemctl', '--user', 'restart', 'build-worker'],
       ['systemd-run', '--user', 'cargo', 'test'],
-    ]) {
+      ['kubectl', 'delete', 'pod', 'builder'],
+    ];
+    const allowedDiagnostics = [
+      ['buildah', 'images'],
+      ['docker', 'ps'],
+      ['machinectl', 'status', 'builder'],
+      ['nerdctl', 'inspect', 'builder'],
+      ['podman', 'logs', 'builder'],
+      ['systemctl', 'status', 'build-worker'],
+      ['systemctl', '--user', 'is-active', 'build-worker'],
+      ['kubectl', 'get', 'pods'],
+    ];
+
+    for (const command of deniedDelegation) {
       const result = spawnSync(
         'codex',
         ['execpolicy', 'check', '--rules', delegationPolicy, ...command],
@@ -253,5 +303,72 @@ describe('Codex resource policies', () => {
       expect(result.status, result.stderr).toBe(0);
       expect(JSON.parse(result.stdout).decision, command.join(' ')).toBe('forbidden');
     }
+
+    for (const command of allowedDiagnostics) {
+      const result = spawnSync(
+        'codex',
+        ['execpolicy', 'check', '--rules', delegationPolicy, ...command],
+        { encoding: 'utf-8' },
+      );
+      expect(result.status, result.stderr).toBe(0);
+      expect(JSON.parse(result.stdout).decision, command.join(' ')).toBe('allow');
+    }
+
+    const runnerWrappedDelegation = [
+      ['bounded-run', '--profile', 'compile', '--', 'docker', 'build', '.'],
+      ['agentkit-run', '--profile', 'default', '--', 'systemd-run', '--user', 'cargo', 'test'],
+      ['bounded-run', '--profile', 'canary', '--', 'ssh', 'build-host', 'true'],
+      ['agentkit-run', '--profile', 'browser', '--', 'kubectl', 'exec', 'pod/builder', '--', 'sh'],
+      ['bounded-run', '--', 'docker', 'build', '.'],
+      ['agentkit-run', '--', 'ssh', 'build-host', 'true'],
+    ];
+    for (const command of runnerWrappedDelegation) {
+      const result = spawnSync(
+        'codex',
+        [
+          'execpolicy',
+          'check',
+          '--rules',
+          policy,
+          '--rules',
+          delegationPolicy,
+          ...command,
+        ],
+        { encoding: 'utf-8' },
+      );
+      expect(result.status, result.stderr).toBe(0);
+      expect(JSON.parse(result.stdout).decision, command.join(' ')).toBe('forbidden');
+    }
+
+    for (const command of [
+      ['bounded-run', '--profile', 'default', '--', 'bun', 'test'],
+      ['agentkit-run', '--profile', 'canary', '--', 'git', 'status'],
+      ['bounded-run', '--', 'bun', 'test'],
+      ['agentkit-run', '--', 'git', 'status'],
+    ]) {
+      const result = spawnSync(
+        'codex',
+        [
+          'execpolicy',
+          'check',
+          '--rules',
+          policy,
+          '--rules',
+          delegationPolicy,
+          ...command,
+        ],
+        { encoding: 'utf-8' },
+      );
+      expect(result.status, result.stderr).toBe(0);
+      expect(JSON.parse(result.stdout).decision, command.join(' ')).toBe('allow');
+    }
+
+    const wrapped = spawnSync(
+      'codex',
+      ['execpolicy', 'check', '--rules', delegationPolicy, 'bash', '-lc', 'docker build .'],
+      { encoding: 'utf-8' },
+    );
+    expect(wrapped.status, wrapped.stderr).toBe(0);
+    expect(JSON.parse(wrapped.stdout).decision).toBeUndefined();
   });
 });

--- a/tests/resource-police.test.ts
+++ b/tests/resource-police.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { spawnSync } from 'node:child_process';
-import resourcePolice from '../plugins/resource-police';
+import resourcePolice, { enforceResourcePolicy } from '../plugins/resource-police';
 import {
   allowedResourceCommands,
   blockedResourceCommands,
@@ -28,6 +28,7 @@ const describeShellHook = canBound ? describe : describe.skip;
 const repoRoot = dirname(import.meta.dir);
 const hook = join(repoRoot, 'hooks', 'claude', 'resource-police.sh');
 const policy = join(repoRoot, 'policies', 'codex', 'resource-police.rules');
+const delegationPolicy = join(repoRoot, 'policies', 'codex', 'delegation-police.rules');
 const mockCtx = {
   client: {},
   project: {},
@@ -44,9 +45,13 @@ function makeInput(command: string, tool = 'bash') {
   };
 }
 
-function runHook(command: string): string {
+function runHook(command: string, platform?: string): string {
   const input = JSON.stringify({ tool_input: { command } });
-  return spawnSync('bash', [hook], { input, encoding: 'utf-8' }).stdout ?? '';
+  return spawnSync('bash', [hook], {
+    input,
+    encoding: 'utf-8',
+    env: { ...process.env, ...(platform ? { AGENTKIT_PLATFORM: platform } : {}) },
+  }).stdout ?? '';
 }
 
 describe('OpenCode resource-police', () => {
@@ -99,6 +104,46 @@ describe('OpenCode resource-police', () => {
   });
 });
 
+describe('platform-aware resource policy', () => {
+  test('allows local heavy work when Linux containment is unavailable', () => {
+    expect(() => enforceResourcePolicy('bun test', 'darwin')).not.toThrow();
+    expect(() =>
+      enforceResourcePolicy('./bounded-run --profile default -- bun test', 'darwin'),
+    ).not.toThrow();
+    expect(runHook('bun test', 'darwin')).not.toContain('deny');
+    expect(runHook('./bounded-run --profile default -- bun test', 'darwin')).not.toContain('deny');
+  });
+
+  test('blocks delegated work on non-Linux platforms', () => {
+    expect(() => enforceResourcePolicy('docker build .', 'darwin')).toThrow(
+      'cannot be contained by bounded-run',
+    );
+    expect(runHook('docker build .', 'darwin')).toContain('cannot be contained by bounded-run');
+  });
+
+  test('blocks delegation laundered through nested runners and no-op wrappers', () => {
+    const command =
+      'bounded-run --profile compile -- command nohup bounded-run --profile compile -- docker build .';
+    expect(() => enforceResourcePolicy(command, 'linux')).toThrow(
+      'cannot be contained by bounded-run',
+    );
+    expect(runHook(command, 'linux')).toContain('cannot be contained by bounded-run');
+  });
+
+  test('fails closed when runner or wrapper analysis exceeds its bound on every platform', () => {
+    const runner = 'bounded-run --profile default -- ';
+    const commands = [`${runner.repeat(6)}git status`, `${'command '.repeat(6)}git status`];
+    for (const command of commands) {
+      for (const platform of ['linux', 'darwin']) {
+        expect(() => enforceResourcePolicy(command, platform)).toThrow(
+          'could not be analyzed safely',
+        );
+        expect(runHook(command, platform)).toContain('could not be analyzed safely');
+      }
+    }
+  });
+});
+
 describeShellHook('Claude resource-police', () => {
   for (const command of blockedResourceCommands) {
     test(`blocks unbounded command: ${command}`, () => {
@@ -144,25 +189,22 @@ describeShellHook('Claude resource-police', () => {
   });
 });
 
-describeShellHook('Codex resource policy', () => {
-  test('forbids direct heavy command prefixes without interactive prompts', () => {
+describe('Codex resource policies', () => {
+  test('separates universal delegation rules from Linux-only containment rules', () => {
     const contents = readFileSync(policy, 'utf-8');
+    const delegation = readFileSync(delegationPolicy, 'utf-8');
+    expect(contents).toContain('# agentkit:platforms linux');
     expect(contents).not.toContain('decision = "prompt"');
+    expect(delegation).not.toContain('decision = "prompt"');
     expect(contents).toContain('pattern = ["bounded-run"]');
     expect(contents).toContain('pattern = ["agentkit-run"]');
     expect(contents).toContain('decision = "allow"');
-    for (const command of [
-      'bun',
-      'bunx',
-      'tsc',
-      'playwright',
-      'cargo',
-      'go',
-      'docker',
-      'podman',
-      'systemd-run',
-    ]) {
+    for (const command of ['bun', 'bunx', 'tsc', 'playwright', 'cargo', 'go']) {
       expect(contents).toContain(`pattern = ["${command}"`);
+    }
+    for (const command of ['docker', 'podman', 'systemd-run', 'run0', 'ssh', 'sudo']) {
+      expect(contents).not.toContain(`pattern = ["${command}"`);
+      expect(delegation).toContain(`pattern = ["${command}"`);
     }
     expect(contents.match(/decision = "forbidden"/g)?.length ?? 0).toBeGreaterThanOrEqual(8);
     expect(contents).toContain('pattern = ["tsc"]');
@@ -176,7 +218,7 @@ describeShellHook('Codex resource policy', () => {
   test('evaluates the direct-command policy matrix when Codex is installed', () => {
     if (spawnSync('codex', ['execpolicy', '--help']).status !== 0) return;
 
-    const decisions = new Map<string[], string>([
+    const resourceDecisions = new Map<string[], string>([
       [['tsc', '-p', 'tsconfig.json'], 'forbidden'],
       [['bunx', 'tsc', '-p', 'tsconfig.json'], 'forbidden'],
       [['bun', 'run', 'typecheck:ci'], 'forbidden'],
@@ -186,19 +228,30 @@ describeShellHook('Codex resource policy', () => {
       [['npx', 'tsc', '--noEmit'], 'forbidden'],
       [['pip', 'install', 'requests'], 'forbidden'],
       [['uv', 'sync'], 'forbidden'],
-      [['docker', 'run', '--rm', 'builder'], 'forbidden'],
-      [['ssh', 'build-host', 'bun', 'test'], 'forbidden'],
-      [['systemd-run', '--user', 'cargo', 'test'], 'forbidden'],
       [['bounded-run', '--profile', 'compile', '--', 'bun', 'run', 'build'], 'allow'],
       [['agentkit-run', '--profile', 'compile', '--', 'bun', 'run', 'build'], 'allow'],
     ]);
 
-    for (const [command, expected] of decisions) {
+    for (const [command, expected] of resourceDecisions) {
       const result = spawnSync('codex', ['execpolicy', 'check', '--rules', policy, ...command], {
         encoding: 'utf-8',
       });
       expect(result.status, result.stderr).toBe(0);
       expect(JSON.parse(result.stdout).decision, command.join(' ')).toBe(expected);
+    }
+
+    for (const command of [
+      ['docker', 'run', '--rm', 'builder'],
+      ['ssh', 'build-host', 'bun', 'test'],
+      ['systemd-run', '--user', 'cargo', 'test'],
+    ]) {
+      const result = spawnSync(
+        'codex',
+        ['execpolicy', 'check', '--rules', delegationPolicy, ...command],
+        { encoding: 'utf-8' },
+      );
+      expect(result.status, result.stderr).toBe(0);
+      expect(JSON.parse(result.stdout).decision, command.join(' ')).toBe('forbidden');
     }
   });
 });

--- a/tests/resource-safety-assets.test.ts
+++ b/tests/resource-safety-assets.test.ts
@@ -31,7 +31,7 @@ describe('resource-safe-execution assets', () => {
     expect(instruction).toContain('host service resource limits');
   });
 
-  test('documents Linux-only local containment without weakening universal delegation safety', () => {
+  test('documents Linux-only containment and the dependency-qualified portable policy', () => {
     const skill = readFileSync(join(skillDir, 'SKILL.md'), 'utf-8');
     const instruction = readFileSync(
       join(repoRoot, 'instructions', 'resource-safety.md'),
@@ -44,14 +44,26 @@ describe('resource-safe-execution assets', () => {
     expect(skill).toContain('Linux-only');
     expect(skill).toContain('On non-Linux hosts');
     expect(instruction).toContain('On non-Linux hosts');
-    expect(compactInstruction).toContain('Delegated-workload protections remain active');
-    expect(product).toContain('build: agentkit-run --profile default -- bun install');
-    expect(product).toContain('verify: agentkit-run --profile default -- bun test');
+    expect(compactInstruction).toContain('OpenCode protection remains active');
+    expect(compactInstruction).toContain('Claude hook protection remains active when');
+    expect(product).toContain('build: scripts/product-command default -- bun install');
+    expect(product).toContain('verify: scripts/product-command default -- bun test');
     expect(product).toContain(
-      'run: agentkit-run --profile default -- bun plugins-cc/agentkit/server/index.ts',
+      'run: scripts/product-command default -- bun plugins-cc/agentkit/server/index.ts',
     );
     expect(product).toContain('Linux-only');
-    expect(compactProduct).toContain('delegation protections remain active');
+    expect(compactProduct).toContain('OpenCode delegation protection remains active');
+    expect(compactProduct).toContain('Claude hook protection requires');
+  });
+
+  test('documents Grok resource behavior per platform and parser availability', () => {
+    const grok = readFileSync(join(repoRoot, 'docs', 'grok.md'), 'utf-8').replace(/\s+/g, ' ');
+
+    expect(grok).toContain('On Linux, `resource-police` requires `bounded-run`');
+    expect(grok).toContain('On non-Linux hosts');
+    expect(grok).toContain('`jq`, `awk`, and `cat`');
+    expect(grok).toContain('warns and intentionally fails open');
+    expect(grok).toContain('Linux host requirements');
   });
 
   test('Claude plugin mirrors stay byte-identical to their source assets', () => {

--- a/tests/resource-safety-assets.test.ts
+++ b/tests/resource-safety-assets.test.ts
@@ -31,6 +31,29 @@ describe('resource-safe-execution assets', () => {
     expect(instruction).toContain('host service resource limits');
   });
 
+  test('documents Linux-only local containment without weakening universal delegation safety', () => {
+    const skill = readFileSync(join(skillDir, 'SKILL.md'), 'utf-8');
+    const instruction = readFileSync(
+      join(repoRoot, 'instructions', 'resource-safety.md'),
+      'utf-8',
+    );
+    const product = readFileSync(join(repoRoot, '.agentkit', 'product.yaml'), 'utf-8');
+    const compactInstruction = instruction.replace(/\s+/g, ' ');
+    const compactProduct = product.replace(/\s+/g, ' ');
+
+    expect(skill).toContain('Linux-only');
+    expect(skill).toContain('On non-Linux hosts');
+    expect(instruction).toContain('On non-Linux hosts');
+    expect(compactInstruction).toContain('Delegated-workload protections remain active');
+    expect(product).toContain('build: agentkit-run --profile default -- bun install');
+    expect(product).toContain('verify: agentkit-run --profile default -- bun test');
+    expect(product).toContain(
+      'run: agentkit-run --profile default -- bun plugins-cc/agentkit/server/index.ts',
+    );
+    expect(product).toContain('Linux-only');
+    expect(compactProduct).toContain('delegation protections remain active');
+  });
+
   test('Claude plugin mirrors stay byte-identical to their source assets', () => {
     const pluginRoot = join(repoRoot, 'plugins-cc', 'agentkit');
     for (const [source, mirror] of [

--- a/tools/bounded-run
+++ b/tools/bounded-run
@@ -1,4 +1,6 @@
 #!/bin/bash -p
+# agentkit:platforms linux
+# Requires systemd user scopes and cgroup v2.
 set -euo pipefail
 
 readonly EX_USAGE=64


### PR DESCRIPTION
## Summary

- install platform-marked tools and Codex policies only on supported hosts, with stale managed-artifact cleanup
- keep recursive delegated and undecidable command analysis in Claude and OpenCode while Linux-only local containment stands down elsewhere
- apply direct-prefix Codex delegation rules honestly, including mutating direct commands and runner-wrapped payloads, while allowing direct diagnostics
- keep product-review commands verbatim and executable on Linux and non-Linux through the repo-owned platform adapter

## Review fixes

- expanded direct Codex coverage across privilege, remote, container, service-manager, and Kubernetes command families
- added combined-policy denies for both runner names, explicit-profile and default-profile syntax
- documented Codex literal-prefix limitations instead of claiming recursive parity
- qualified Claude and Grok protection on jq, awk, and cat availability
- corrected marketplace and installed-plugin Linux dependency metadata

## Verification

- focused policy suite at 5d009fca9415d7c8fac73781db8809e4c8375d78: 137 pass, 0 fail, 416 assertions
- exact pushed-head full suite: 525 pass, 5 skip, 0 fail, 1,696 assertions across 530 tests in 27 files
- the five skips are the real-systemd containment cases in tests/resource-run.integration.test.ts: cgroup boundaries, exit-status propagation, descendant cleanup after normal exit, timeout cleanup, and OOM recording
- runner evidence: exit 0, with flock acquiring the workload lock and executing /usr/bin/timeout
- independent re-review: APPROVE, 0 unresolved findings at medium or higher
- bash syntax, diff whitespace, executable mode, source/plugin parity, plugin validation, and stale-claim scans passed
- exact product build passed with no dependency changes
- TypeScript formatting check skipped: dprint has no TypeScript plugin and returned no applicable files
- live Claude plugin installation remains unverified because it mutates reviewer configuration

Refs #116