### PR TITLE
feat(skills): diagram product policy, canonical theme sync, publish repo probe

### DIFF
--- a/plugins-cc/agentkit/skills/architect/SKILL.md
+++ b/plugins-cc/agentkit/skills/architect/SKILL.md
@@ -21,19 +21,32 @@ genuinely understanding a system — not a file listing with boxes around it.
 3. **Find the load-bearing structure**: the 3–7 components whose removal would
    change the story, the flows between them, the state stores, and the
    trust/ownership boundaries. Everything else is detail inside a zone.
-4. **Produce**:
+4. **Figure plan before authoring**: emit a table of concept → concept type →
+   treatment → why-not-a-table, one row per intended visual, derived from the
+   publish-page routing table. Name exactly ONE centerpiece and 2–5 supporting
+   figures, and account for every h2 section — a section with no figure is a
+   stated choice, not an omission. Never route a flow containing a repair
+   loop, approval gate, or failure branch to the box kits: the load-bearing
+   part is the backward edge, which only a drawn figure can show. Present the
+   plan in the same message as the publish-approval request so one gate covers
+   both.
+5. **Produce**:
    - the centerpiece diagram(s) via the **diagram** skill (technical depth:
-     real names, real payloads, evidence artifacts),
+     real names, real payloads, evidence artifacts; respect its canvas and
+     density budgets — a diagram covering several separate headings is several
+     figures),
    - a page via **publish-page** (doc template): overview strip, the diagrams
      in `.figure` blocks with semantic captions, a "decisions & constraints"
      section (why it is shaped this way, what must not be broken), and a
      "sharp edges" section for the traps a newcomer hits,
    - use a stable `--name` (e.g. `<system>-architecture`) so refreshes update
      the SAME URL.
-5. **Refresh mode**: when asked to update (or triggered after merges), diff
-   what changed since the page's last git version in the pages repo, update
-   only the affected zones/sections, republish the same name, and note the
-   delta at the top of the page.
+6. **Refresh mode**: when asked to update (or triggered after merges), diff
+   what changed since the page's last git version in the pages repo, re-run
+   the figure plan against the diff (changed zones get re-authored figures; a
+   figure whose caption is no longer true is a blocker, not cosmetic lag),
+   update only the affected zones/sections, republish the same name, and note
+   the delta at the top of the page.
 
 ## The bar: impress a staff engineer
 

--- a/plugins-cc/agentkit/skills/diagram/SKILL.md
+++ b/plugins-cc/agentkit/skills/diagram/SKILL.md
@@ -76,10 +76,39 @@ comprehensive diagram exceeds a single response's output budget and truncates):
 4. After the last zone: re-read the whole file — bindings valid both ends,
    spacing balanced, every referenced id exists.
 
-Palette: match the destination. For AgentKit Pages (navy figures): strokes
-`#dce7f5`, muted `#8fa8c7`, accents `#34d3a6` / `#e8b444`, fills transparent or
-`#102847`, background transparent. For READMEs/light surfaces: near-black
-strokes with classic pastel fills (`#a5d8ff`, `#b2f2bb`, `#ffec99`).
+Palette: match the destination. For AgentKit Pages author the **navy palette
+only** — baked SVGs sit on a navy island in BOTH page themes, there is no light
+variant to produce, and a light-palette diagram would be invisible on it:
+strokes `#dce7f5`, muted `#8fa8c7`, accents `#34d3a6` / `#e8b444`, fills
+transparent or `#102847`, background transparent. For READMEs/light surfaces:
+near-black strokes with classic pastel fills (`#a5d8ff`, `#b2f2bb`, `#ffec99`).
+
+Contrast rules (worst case is the light end of the figure glow, `#0f2a4d`):
+
+- Red `#e06c5f` is a stroke color, not a text color — 4.4:1 misses AA. Use it
+  at strokeWidth ≥2 on shapes/arrows, or on text only at 16 px+.
+- Decoration never shares the hue of the text it decorates: underlines and
+  strikethroughs under colored text use muted `#8fa8c7` or are dropped — gold
+  under gold reads as a smear. Prefer size and weight over decoration.
+- Text on a filled panel takes the neutral ink `#dce7f5`, never the fill's own
+  color family; reserve the accent for a single data value.
+- Two semantic colors adjacent at the same size need a legend (≥14 px), placed
+  inside the zone it explains.
+
+## Size & density budget
+
+- **Canvas ≤ 1000 × 1400 px** for a page figure, **1000 × 620** for a deck
+  slide — the page column renders figures at ~979 px, so authoring at display
+  size means the diagram never scales below ~0.98. Hard ceiling 1200 px wide,
+  and only with every font raised proportionally (≥17 px) so nothing lands
+  below 14 px after scaling.
+- **Font floors**: annotations/legends 14 px, evidence/mono artifacts 13 px,
+  labels 16–18, zone titles 20–24, hero title 28–32. Nothing below 13 px.
+- **Density**: at most 3 zones, ~12 labeled nodes, ~25 text elements per
+  diagram. Exceeding any of the three means **split, don't shrink** — one
+  argument per figure; a fourth zone is a second figure with its own caption.
+- Vertical space is free and horizontal space is not: when a layout is tight,
+  restack zones taller rather than widening the canvas.
 
 ## 5 — Render, LOOK, fix (mandatory loop)
 
@@ -101,7 +130,10 @@ Each round, in order:
    belong to anything; ragged spacing between siblings; one zone cramped while
    another floats in emptiness; text too small at render size; a lopsided
    whole.
-3. **Fix in JSON** — widen containers for clipped text; shift `x`/`y` for
+3. **Page-scale pass** — view the PNG downscaled to ~979 px wide (the size the
+   page reader actually gets) and confirm every label is still readable; judge
+   the diagram at reading size, not authoring size.
+4. **Fix in JSON** — widen containers for clipped text; shift `x`/`y` for
    spacing; add waypoints to arrow `points` to route around shapes; pull
    labels next to their subjects; resize to rebalance visual weight.
 
@@ -129,7 +161,12 @@ needs a local Chromium — set `AGENTKIT_CHROMIUM` if it isn't auto-found.)
 
 ## 6 — Ship the SVG
 
-The SVG is fully self-contained (fonts embedded as data: URIs). Inline it
-directly into a page (wrap in `<div class="figure">` with a semantic
-`figcaption` when publishing via publish-page), drop it into a repo's docs, or
-attach the PNG where images are needed. Caption by content, never by tool.
+The SVG is fully self-contained (fonts embedded as data: URIs). **Before
+inlining, rewrite the SVG root**: replace the renderer's `width`/`height`
+attributes with `width="100%" style="height:auto"`, keep the `viewBox`, and add
+`role="img"` plus an `aria-label` matching the figcaption — the page theme
+backstops sizing in CSS, but the lightbox and every published page rely on this
+convention. Inline it directly into a page (wrap in `<div class="figure">` with
+a semantic `figcaption` when publishing via publish-page), drop it into a
+repo's docs, or attach the PNG where images are needed. Caption by content,
+never by tool.

--- a/plugins-cc/agentkit/skills/diagram/SKILL.md
+++ b/plugins-cc/agentkit/skills/diagram/SKILL.md
@@ -100,8 +100,9 @@ Contrast rules (worst case is the light end of the figure glow, `#0f2a4d`):
 - **Canvas ≤ 1000 × 1400 px** for a page figure, **1000 × 620** for a deck
   slide — the page column renders figures at ~979 px, so authoring at display
   size means the diagram never scales below ~0.98. Hard ceiling 1200 px wide,
-  and only with every font raised proportionally (≥17 px) so nothing lands
-  below 14 px after scaling.
+  and only with every font raised proportionally (≥18 px — at 1200→979 px the
+  scale is 0.816, so 18 px lands at 14.7 px) so nothing falls below the 14 px
+  floor after scaling.
 - **Font floors**: annotations/legends 14 px, evidence/mono artifacts 13 px,
   labels 16–18, zone titles 20–24, hero title 28–32. Nothing below 13 px.
 - **Density**: at most 3 zones, ~12 labeled nodes, ~25 text elements per

--- a/plugins-cc/agentkit/skills/diagram/references/elements.md
+++ b/plugins-cc/agentkit/skills/diagram/references/elements.md
@@ -65,19 +65,20 @@ Fonts: `fontFamily: 1` = hand-drawn (headers, labels — the excalidraw feel),
 
 Navy pages (background transparent, sits on the `.figure` glow):
 
-| Role                        | stroke           | fill                                                  |
-| --------------------------- | ---------------- | ----------------------------------------------------- |
-| default / neutral           | `#dce7f5`        | `transparent` or `#102847`                            |
-| start / trigger             | `#e8b444`        | `#2a2410`                                             |
-| end / success / active path | `#34d3a6`        | `#0d2f3a`                                             |
-| decision (diamond)          | `#e8b444`        | `transparent`                                         |
-| agent / AI                  | `#b197fc`        | `#1d1636`                                             |
-| inactive / future           | `#8fa8c7` dashed | `transparent`                                         |
-| error / removal             | `#e06c5f`        | `#2a1512`                                             |
-| evidence panel              | `#1e3a5f`        | `#071224` (mono text `#34d3a6` data, `#dce7f5` code)  |
+| Role                        | stroke           | fill                                                 |
+| --------------------------- | ---------------- | ---------------------------------------------------- |
+| default / neutral           | `#dce7f5`        | `transparent` or `#102847`                           |
+| start / trigger             | `#e8b444`        | `#2a2410`                                            |
+| end / success / active path | `#34d3a6`        | `#0d2f3a`                                            |
+| decision (diamond)          | `#e8b444`        | `transparent`                                        |
+| agent / AI                  | `#b197fc`        | `#1d1636`                                            |
+| inactive / future           | `#8fa8c7` dashed | `transparent`                                        |
+| error / removal             | `#e06c5f`        | `#2a1512`                                            |
+| evidence panel              | `#1e3a5f`        | `#071224` (mono text `#34d3a6` data, `#dce7f5` code) |
 
 Text hierarchy without boxes (navy): titles `#dce7f5` 20-28px, subtitles
-`#34d3a6` 16px, detail/annotation `#8fa8c7` 12-14px.
+`#34d3a6` 16px, detail/annotation `#8fa8c7` 14px (mono evidence may drop to
+13px; nothing below 13px anywhere, legends included).
 
 Light surfaces (READMEs, docs): near-black `#1e1e1e` strokes; fills `#a5d8ff`
 (neutral), `#fed7aa` (start), `#b2f2bb` (success), `#ffec99` (decision),
@@ -87,4 +88,7 @@ code text. Text hierarchy: titles `#1e40af`, subtitles `#3b82f6`, detail
 `#64748b`.
 
 Rules: darker stroke over lighter fill, always; a concept without a role uses
-neutral, never a fresh color.
+neutral, never a fresh color. Red `#e06c5f` is a stroke/shape color — as text
+only at 16px+. Text inside any filled panel uses the neutral ink, never the
+fill's own color family. Underline/strikethrough decoration never shares the
+hue of the text it decorates — use muted `#8fa8c7` or drop the decoration.

--- a/plugins-cc/agentkit/skills/publish-page/SKILL.md
+++ b/plugins-cc/agentkit/skills/publish-page/SKILL.md
@@ -53,21 +53,21 @@ strongest component for each idea — don't produce walls of prose.
 
 **Route every visual by what the concept IS**, never by the tool you used last:
 
-| Concept                                                 | Treatment                                     | Never                                                          |
-| ------------------------------------------------------- | --------------------------------------------- | -------------------------------------------------------------- |
-| System topology, trust/ownership boundaries             | `diagram` skill centerpiece                   | mermaid — auto-layout destroys boundary semantics              |
-| Deployable inventory, ≤7 nodes, relationships secondary | `.iso` kit + `.edge` connectors               | `diagram` skill (overkill)                                     |
-| Linear pipeline, all edges forward, stages need prose   | `.arch` flat kit                              | —                                                              |
-| Flow with a loop-back, gate, or failure branch          | `diagram` skill                               | `.flow`/`.arch`/`.fbox` — box kits cannot draw a backward edge |
-| Ordered message exchange, ≥3 participants               | mermaid `sequenceDiagram`                     | hand-drawn (arrow bookkeeping wastes the craft)                |
-| State machine >5 states with guards/terminals           | mermaid `stateDiagram-v2`                     | —                                                              |
-| State machine ≤5 states, transitions carry the meaning  | `diagram` skill                               | mermaid (generic)                                              |
-| Comparison, N options × M criteria, cells are prose     | markdown table                                | any diagram                                                    |
-| Comparison of structurally different options, ≤3        | `diagram` skill mirrored halves               | table (flattens the structural point)                          |
-| Hierarchy/taxonomy ≤3 levels                            | `diagram` skill tree — lines + text, no boxes | mermaid flowchart TD                                           |
-| Quantitative, ≥5 data points                            | inline SVG chart (discipline below)           | mermaid, chart libraries                                       |
-| ≤4 numbers                                              | `.chips` or a table row                       | a chart                                                        |
-| Independent items, no edges between them                | `.cards` grid                                 | any diagram — no edges = decorated list                        |
+| Concept                                                 | Treatment                                     | Never                                                                         |
+| ------------------------------------------------------- | --------------------------------------------- | ----------------------------------------------------------------------------- |
+| System topology, trust/ownership boundaries             | `diagram` skill centerpiece                   | mermaid — auto-layout destroys boundary semantics                             |
+| Deployable inventory, ≤7 nodes, relationships secondary | `.iso` kit + `.edge` connectors               | `diagram` skill (overkill)                                                    |
+| Linear pipeline, all edges forward, stages need prose   | `.arch` flat kit                              | —                                                                             |
+| Flow with a loop-back, gate, or failure branch          | `diagram` skill                               | `.flow`/`.arch`/`.fbox` — box kits cannot draw a backward edge                |
+| Ordered message exchange, ≥3 participants               | mermaid `sequenceDiagram`                     | hand-drawn — sole exception: avoiding the mermaid runtime (see figure budget) |
+| State machine >5 states with guards/terminals           | mermaid `stateDiagram-v2`                     | —                                                                             |
+| State machine ≤5 states, transitions carry the meaning  | `diagram` skill                               | mermaid (generic)                                                             |
+| Comparison, N options × M criteria, cells are prose     | markdown table                                | any diagram                                                                   |
+| Comparison of structurally different options, ≤3        | `diagram` skill mirrored halves               | table (flattens the structural point)                                         |
+| Hierarchy/taxonomy ≤3 levels                            | `diagram` skill tree — lines + text, no boxes | mermaid flowchart TD                                                          |
+| Quantitative, ≥5 data points                            | inline SVG chart (discipline below)           | mermaid, chart libraries                                                      |
+| ≤4 numbers                                              | `.chips` or a table row                       | a chart                                                                       |
+| Independent items, no edges between them                | `.cards` grid                                 | any diagram — no edges = decorated list                                       |
 
 A table beats a diagram when any of these holds: cells are full sentences; the
 relation is "X has property Y", not "X acts on Y"; ≥6 uniform rows; the
@@ -79,8 +79,9 @@ but fewer than 3 figures is under-illustrated. Never diagram
 two-nodes-one-arrow (a sentence), items without relationships (`.cards`), or a
 single before/after (`.callout`). Captions are one sentence with no "and"
 joining two subjects — a caption that needs "and" is two figures. Ask the
-`diagram` skill for canvases ≤1000 px wide: the column renders figures at
-~979 px, and wider canvases scale handwriting below legibility. Mermaid inlines
+`diagram` skill for canvases ≤1000 px wide (its hard ceiling is 1200 px with
+all fonts ≥18 px): the column renders figures at ~979 px, and wider canvases
+scale handwriting below legibility. Mermaid inlines
 ~3.4 MB once — if the page already carries 3+ inline SVG figures, draw the
 sequence/state diagram with the `diagram` skill instead.
 

--- a/plugins-cc/agentkit/skills/publish-page/SKILL.md
+++ b/plugins-cc/agentkit/skills/publish-page/SKILL.md
@@ -29,7 +29,11 @@ bun <skill-dir>/publish.ts --name <name> --file <content-file> [--template doc|d
 bun <skill-dir>/publish.ts --name <name> --delete    # remove a page you published
 ```
 
-5. **Give the user the URL** it prints (`https://pages.agentkit.sbs/<slug>`).
+5. **Verify before reporting**: load the printed URL in headless Chromium at
+   ~1280 px wide, screenshot BOTH themes (flip via the toggle), and Read every
+   figure. A clipped, illegible, or wrong-theme figure means fix and re-publish.
+   Never report the URL of an unviewed page.
+6. **Give the user the URL** it prints (`https://pages.agentkit.sbs/<slug>`).
    That URL is live immediately.
 
 ## Page design — the house style is built in
@@ -45,10 +49,42 @@ every card and diagram node. Add `data-tip="text"` to any node for a hover
 tooltip.
 
 **Be illustrative by default.** Structure every doc page as sections and pick the
-strongest component for each idea — don't produce walls of prose:
+strongest component for each idea — don't produce walls of prose.
 
-- **Diagrams: pick the treatment by what the diagram IS** — never default to one
-  tool, and never ASCII art. Wrap EVERY diagram in
+**Route every visual by what the concept IS**, never by the tool you used last:
+
+| Concept                                                 | Treatment                                     | Never                                                          |
+| ------------------------------------------------------- | --------------------------------------------- | -------------------------------------------------------------- |
+| System topology, trust/ownership boundaries             | `diagram` skill centerpiece                   | mermaid — auto-layout destroys boundary semantics              |
+| Deployable inventory, ≤7 nodes, relationships secondary | `.iso` kit + `.edge` connectors               | `diagram` skill (overkill)                                     |
+| Linear pipeline, all edges forward, stages need prose   | `.arch` flat kit                              | —                                                              |
+| Flow with a loop-back, gate, or failure branch          | `diagram` skill                               | `.flow`/`.arch`/`.fbox` — box kits cannot draw a backward edge |
+| Ordered message exchange, ≥3 participants               | mermaid `sequenceDiagram`                     | hand-drawn (arrow bookkeeping wastes the craft)                |
+| State machine >5 states with guards/terminals           | mermaid `stateDiagram-v2`                     | —                                                              |
+| State machine ≤5 states, transitions carry the meaning  | `diagram` skill                               | mermaid (generic)                                              |
+| Comparison, N options × M criteria, cells are prose     | markdown table                                | any diagram                                                    |
+| Comparison of structurally different options, ≤3        | `diagram` skill mirrored halves               | table (flattens the structural point)                          |
+| Hierarchy/taxonomy ≤3 levels                            | `diagram` skill tree — lines + text, no boxes | mermaid flowchart TD                                           |
+| Quantitative, ≥5 data points                            | inline SVG chart (discipline below)           | mermaid, chart libraries                                       |
+| ≤4 numbers                                              | `.chips` or a table row                       | a chart                                                        |
+| Independent items, no edges between them                | `.cards` grid                                 | any diagram — no edges = decorated list                        |
+
+A table beats a diagram when any of these holds: cells are full sentences; the
+relation is "X has property Y", not "X acts on Y"; ≥6 uniform rows; the
+reader's task is lookup, not path-following; item order is arbitrary.
+
+**Figure budget.** Exactly one centerpiece diagram — the figure that answers the
+page title's question — plus 2–5 supporting figures; a doc with ≥6 h2 sections
+but fewer than 3 figures is under-illustrated. Never diagram
+two-nodes-one-arrow (a sentence), items without relationships (`.cards`), or a
+single before/after (`.callout`). Captions are one sentence with no "and"
+joining two subjects — a caption that needs "and" is two figures. Ask the
+`diagram` skill for canvases ≤1000 px wide: the column renders figures at
+~979 px, and wider canvases scale handwriting below legibility. Mermaid inlines
+~3.4 MB once — if the page already carries 3+ inline SVG figures, draw the
+sequence/state diagram with the `diagram` skill instead.
+
+- **Diagram markup** — never ASCII art. Wrap EVERY diagram in
   `<div class="figure">…<div class="figcaption"><strong>Name</strong> — what it shows</div></div>`
   with a caption describing the content (say "Publish flow — from agent to live
   page", never the technology used to draw it). CRITICAL for markdown files:

--- a/plugins-cc/agentkit/skills/publish-page/publish.ts
+++ b/plugins-cc/agentkit/skills/publish-page/publish.ts
@@ -51,8 +51,9 @@ if (!endpoint.startsWith("https://") && !["127.0.0.1", "localhost"].includes(end
 const repoCandidates = process.env.AGENTKIT_PAGES_REPO
   ? [process.env.AGENTKIT_PAGES_REPO]
   : [join(homedir(), "code/agentkit-pages"), join(homedir(), "code/agentkit/agentkit-pages")];
-const repo = repoCandidates.find((p) => existsSync(join(p, ".git"))) ?? repoCandidates[0];
-if (!existsSync(join(repo, ".git"))) {
+const foundRepo = repoCandidates.find((p) => existsSync(join(p, ".git")));
+const repo = foundRepo ?? repoCandidates[0];
+if (!foundRepo) {
   // Publishing without the clone silently uses bundled themes (which can lag
   // canonical) and skips the canonical git commit — both have bitten before.
   console.error(
@@ -235,10 +236,7 @@ const res = await fetch(`${endpoint}/api/pages/${slug}`, {
 if (!res.ok) fail(`publish failed: HTTP ${res.status} ${await res.text()}`);
 const { url } = (await res.json()) as { url: string };
 
-if (!noGit && !repoAvailable()) {
-  console.error(`note: pages repo not found at ${repo} — published without canonical git commit`);
-  noGit = true;
-}
+if (!noGit && !foundRepo) noGit = true;
 if (!noGit) {
   const srcDir = join(repo, "src", slug);
   const distDir = join(repo, "dist", slug);

--- a/plugins-cc/agentkit/skills/publish-page/publish.ts
+++ b/plugins-cc/agentkit/skills/publish-page/publish.ts
@@ -48,7 +48,18 @@ const endpointHost = new URL(endpoint).hostname;
 if (!endpoint.startsWith("https://") && !["127.0.0.1", "localhost"].includes(endpointHost)) {
   fail(`endpoint must be https (got ${endpoint}) — the bearer token would travel in cleartext`);
 }
-const repo = process.env.AGENTKIT_PAGES_REPO ?? join(homedir(), "code/agentkit-pages");
+const repoCandidates = process.env.AGENTKIT_PAGES_REPO
+  ? [process.env.AGENTKIT_PAGES_REPO]
+  : [join(homedir(), "code/agentkit-pages"), join(homedir(), "code/agentkit/agentkit-pages")];
+const repo = repoCandidates.find((p) => existsSync(join(p, ".git"))) ?? repoCandidates[0];
+if (!existsSync(join(repo, ".git"))) {
+  // Publishing without the clone silently uses bundled themes (which can lag
+  // canonical) and skips the canonical git commit — both have bitten before.
+  console.error(
+    `warning: no agentkit-pages clone (looked at: ${repoCandidates.join(", ")}) — `
+      + `publishing with BUNDLED themes (may lag canonical) and WITHOUT a canonical git commit`,
+  );
+}
 const tokenPath = join(homedir(), ".config/agentkit/pages-token");
 if (!existsSync(tokenPath)) fail(`publish token missing at ${tokenPath}`);
 const token = (await readFile(tokenPath, "utf8")).trim();

--- a/plugins-cc/agentkit/skills/publish-page/themes/deck.html
+++ b/plugins-cc/agentkit/skills/publish-page/themes/deck.html
@@ -92,20 +92,21 @@
   /* Baked-palette diagram SVGs keep a navy island in light mode (their strokes
      are authored for a dark ground). Mermaid and HTML diagrams adapt via vars. */
   html[data-theme="light"] .figure > svg:not(.edges),
-  html[data-theme="light"] .figure > p > svg:only-child:not(.edges) {
+  html[data-theme="light"] .figure > p > svg:not(.edges) {
     background: var(--diagram-bg); border-radius: 10px; padding: 0.6rem;
   }
   @media print {
-    .figure > svg:not(.edges), .figure > p > svg:only-child:not(.edges) {
+    .figure > svg:not(.edges), .figure > p > svg:not(.edges) {
       -webkit-print-color-adjust: exact; print-color-adjust: exact;
     }
   }
   /* Scale-to-fit backstop: baked SVGs keep their viewBox but must never rely on
      authored width attributes fitting the slide. Deck ships no edges kit, so
-     :not(.edges) here is purely defensive; :only-child keeps inline icons in
-     figure prose out of the rule. */
+     :not(.edges) here is purely defensive. An inline icon inside figure prose
+     would match the p arm: known non-goal (no content uses that pattern; the
+     durable fix is an opt-in class from publish.ts). */
   .figure > svg:not(.edges),
-  .figure > p > svg:only-child:not(.edges) {
+  .figure > p > svg:not(.edges) {
     display: block; width: 100%; height: auto; margin-inline: auto;
   }
   .figure p { max-width: none; }
@@ -355,7 +356,7 @@
     const clone = fig.cloneNode(true);
     clone.classList.remove("fig-expandable");
     clone.querySelector(".fig-expand-trigger")?.remove();
-    clone.querySelectorAll(':scope > svg[viewBox]:not(.edges), :scope > p > svg[viewBox]:only-child:not(.edges)').forEach((s) => {
+    clone.querySelectorAll(':scope > svg[viewBox]:not(.edges), :scope > p > svg[viewBox]:not(.edges)').forEach((s) => {
       const vb = s.viewBox && s.viewBox.baseVal;
       if (vb && vb.width) {
         s.removeAttribute("width");

--- a/plugins-cc/agentkit/skills/publish-page/themes/deck.html
+++ b/plugins-cc/agentkit/skills/publish-page/themes/deck.html
@@ -92,18 +92,20 @@
   /* Baked-palette diagram SVGs keep a navy island in light mode (their strokes
      are authored for a dark ground). Mermaid and HTML diagrams adapt via vars. */
   html[data-theme="light"] .figure > svg:not(.edges),
-  html[data-theme="light"] .figure > p > svg:not(.edges) {
+  html[data-theme="light"] .figure > p > svg:only-child:not(.edges) {
     background: var(--diagram-bg); border-radius: 10px; padding: 0.6rem;
   }
   @media print {
-    .figure > svg:not(.edges), .figure > p > svg:not(.edges) {
+    .figure > svg:not(.edges), .figure > p > svg:only-child:not(.edges) {
       -webkit-print-color-adjust: exact; print-color-adjust: exact;
     }
   }
   /* Scale-to-fit backstop: baked SVGs keep their viewBox but must never rely on
-     authored width attributes fitting the slide. svg.edges out-specifies this. */
+     authored width attributes fitting the slide. Deck ships no edges kit, so
+     :not(.edges) here is purely defensive; :only-child keeps inline icons in
+     figure prose out of the rule. */
   .figure > svg:not(.edges),
-  .figure > p > svg:not(.edges) {
+  .figure > p > svg:only-child:not(.edges) {
     display: block; width: 100%; height: auto; margin-inline: auto;
   }
   .figure p { max-width: none; }
@@ -353,7 +355,7 @@
     const clone = fig.cloneNode(true);
     clone.classList.remove("fig-expandable");
     clone.querySelector(".fig-expand-trigger")?.remove();
-    clone.querySelectorAll(':scope > svg[viewBox]:not(.edges), :scope > p > svg[viewBox]:not(.edges)').forEach((s) => {
+    clone.querySelectorAll(':scope > svg[viewBox]:not(.edges), :scope > p > svg[viewBox]:only-child:not(.edges)').forEach((s) => {
       const vb = s.viewBox && s.viewBox.baseVal;
       if (vb && vb.width) {
         s.removeAttribute("width");

--- a/plugins-cc/agentkit/skills/publish-page/themes/deck.html
+++ b/plugins-cc/agentkit/skills/publish-page/themes/deck.html
@@ -18,6 +18,9 @@
     --accent: #34d3a6; --accent-soft: #0d2f3a; --gold: #e8b444; --red: #e06c5f;
     --fig-glow: #0f2a4d; --node-hi: #173562; --node-lo: #0c2140; --node-border: #2e4f7e;
     --tile-side: #061021;
+    /* Ground for baked-palette diagram SVGs (excalidraw); stays navy in both
+       themes so light-stroked art survives light mode. */
+    --diagram-bg: #071224;
   }
   html[data-theme="light"] {
     --navy: #f2f6fa; --navy-deep: #e6edf5; --card: #ffffff; --code-bg: #e9eff6;
@@ -85,6 +88,56 @@
   }
   .figcaption strong { color: var(--accent); font-weight: 600; }
   .figure pre.mermaid { background: none; border: 0; margin: 0; }
+
+  /* Baked-palette diagram SVGs keep a navy island in light mode (their strokes
+     are authored for a dark ground). Mermaid and HTML diagrams adapt via vars. */
+  html[data-theme="light"] .figure > svg:not(.edges),
+  html[data-theme="light"] .figure > p > svg:not(.edges) {
+    background: var(--diagram-bg); border-radius: 10px; padding: 0.6rem;
+  }
+  @media print {
+    .figure > svg:not(.edges), .figure > p > svg:not(.edges) {
+      -webkit-print-color-adjust: exact; print-color-adjust: exact;
+    }
+  }
+  /* Scale-to-fit backstop: baked SVGs keep their viewBox but must never rely on
+     authored width attributes fitting the slide. svg.edges out-specifies this. */
+  .figure > svg:not(.edges),
+  .figure > p > svg:not(.edges) {
+    display: block; width: 100%; height: auto; margin-inline: auto;
+  }
+  .figure p { max-width: none; }
+
+  /* Click-to-expand lightbox — every .figure expands to natural size. */
+  .figure.fig-expandable { cursor: zoom-in; }
+  .fig-expand-trigger {
+    position: absolute; top: 0.55rem; right: 0.7rem;
+    font-family: ui-monospace, Menlo, monospace; font-size: 0.62rem;
+    letter-spacing: 0.08em; text-transform: uppercase;
+    color: var(--muted); background: var(--navy-deep);
+    border: 1px solid var(--line); border-radius: 6px; padding: 0.12rem 0.5rem;
+    opacity: 0; transition: opacity 0.15s; cursor: zoom-in; z-index: 2;
+  }
+  .figure.fig-expandable:hover .fig-expand-trigger,
+  .fig-expand-trigger:focus-visible { opacity: 1; }
+  .fig-lightbox {
+    position: fixed; inset: 0; z-index: 70; padding: 4vh 4vw;
+    background: color-mix(in srgb, var(--navy-deep) 85%, transparent);
+    backdrop-filter: blur(6px);
+  }
+  .fig-lightbox[hidden] { display: none; }
+  .fig-lightbox-body { width: 100%; height: 100%; overflow: auto; }
+  .fig-lightbox .figure { width: max-content; max-width: none; margin: 0 auto; cursor: default; }
+  .fig-lightbox .figure p { max-width: none; }
+  .fig-lightbox-close {
+    position: fixed; top: 1rem; right: 1rem;
+    width: 2.3rem; height: 2.3rem; border-radius: 50%;
+    background: var(--card); border: 1px solid var(--line); color: var(--ink);
+    cursor: pointer; font-size: 0.95rem; line-height: 1; padding: 0;
+    display: flex; align-items: center; justify-content: center;
+  }
+  .fig-lightbox-close:hover { border-color: var(--accent); }
+  @media print { .fig-lightbox { display: none; } }
   pre.mermaid {
     background: var(--card); border: 1px solid var(--line); border-radius: 10px;
     padding: 1rem; overflow-x: auto; text-align: center;
@@ -243,6 +296,7 @@
   document.querySelector(".navbtn.prev").addEventListener("click", () => show(i - 1));
   document.querySelector(".navbtn.next").addEventListener("click", () => show(i + 1));
   addEventListener("keydown", (e) => {
+    if (document.querySelector(".fig-lightbox:not([hidden])")) return;
     if (["ArrowRight", "PageDown", " "].includes(e.key)) { e.preventDefault(); show(i + 1); }
     if (["ArrowLeft", "PageUp"].includes(e.key)) { e.preventDefault(); show(i - 1); }
     if (e.key === "Home") show(0);
@@ -252,11 +306,106 @@
   addEventListener("touchstart", (e) => { x0 = e.touches[0].clientX; }, { passive: true });
   addEventListener("touchend", (e) => {
     if (x0 === null) return;
+    if (document.querySelector(".fig-lightbox:not([hidden])")) { x0 = null; return; }
     const dx = e.changedTouches[0].clientX - x0;
     if (Math.abs(dx) > 50) show(i + (dx < 0 ? 1 : -1));
     x0 = null;
   }, { passive: true });
   show(i);
+
+  // Accessible figure lightbox: preserve focus and restore natural SVG size.
+  const lb = document.createElement("div");
+  lb.className = "fig-lightbox";
+  lb.hidden = true;
+  lb.setAttribute("role", "dialog");
+  lb.setAttribute("aria-modal", "true");
+  lb.setAttribute("aria-label", "Expanded figure");
+  lb.innerHTML = '<div class="fig-lightbox-body"></div><button class="fig-lightbox-close" type="button" aria-label="Close expanded figure">✕</button>';
+  document.body.appendChild(lb);
+  const lbBody = lb.querySelector(".fig-lightbox-body");
+  const lbClose = lb.querySelector(".fig-lightbox-close");
+  let restoreFocus = null;
+  let restoreOverflow = "";
+  let inertSnapshot = [];
+  function isolateBackground() {
+    inertSnapshot = [...document.body.children]
+      .filter((element) => element !== lb)
+      .map((element) => ({ element, value: element.getAttribute("inert") }));
+    inertSnapshot.forEach(({ element }) => element.setAttribute("inert", ""));
+  }
+  function restoreBackground() {
+    inertSnapshot.forEach(({ element, value }) => {
+      if (value === null) element.removeAttribute("inert");
+      else element.setAttribute("inert", value);
+    });
+    inertSnapshot = [];
+  }
+  function closeLightbox() {
+    if (lb.hidden) return;
+    lb.hidden = true;
+    document.body.style.overflow = restoreOverflow;
+    restoreBackground();
+    lbBody.replaceChildren();
+    restoreFocus?.focus();
+    restoreFocus = null;
+  }
+  function openLightbox(fig, trigger) {
+    const clone = fig.cloneNode(true);
+    clone.classList.remove("fig-expandable");
+    clone.querySelector(".fig-expand-trigger")?.remove();
+    clone.querySelectorAll(':scope > svg[viewBox]:not(.edges), :scope > p > svg[viewBox]:not(.edges)').forEach((s) => {
+      const vb = s.viewBox && s.viewBox.baseVal;
+      if (vb && vb.width) {
+        s.removeAttribute("width");
+        s.style.width = Math.round(vb.width) + "px";
+        s.style.maxWidth = "none";
+      }
+    });
+    restoreFocus = trigger;
+    restoreOverflow = document.body.style.overflow;
+    lbBody.replaceChildren(clone);
+    isolateBackground();
+    lb.hidden = false;
+    document.body.style.overflow = "hidden";
+    lbClose.focus();
+  }
+  document.querySelectorAll(".figure").forEach((fig) => {
+    fig.classList.add("fig-expandable");
+    const trigger = document.createElement("button");
+    trigger.className = "fig-expand-trigger";
+    trigger.type = "button";
+    trigger.setAttribute("aria-label", "Expand figure");
+    trigger.textContent = "⤢ expand";
+    trigger.addEventListener("click", () => openLightbox(fig, trigger));
+    fig.appendChild(trigger);
+    fig.addEventListener("click", (e) => {
+      if (e.target.closest("a, button")) return;
+      if (window.getSelection()?.toString()) return;
+      openLightbox(fig, trigger);
+    });
+  });
+  lb.addEventListener("click", (e) => {
+    if (e.target.closest(".fig-lightbox-close") || !e.target.closest(".figure")) closeLightbox();
+  });
+  addEventListener("keydown", (e) => {
+    if (lb.hidden) return;
+    if (e.key === "Escape") {
+      e.preventDefault();
+      closeLightbox();
+      return;
+    }
+    if (e.key !== "Tab") return;
+    const focusable = [...lb.querySelectorAll('a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])')];
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  });
 </script>
 </body>
 </html>

--- a/plugins-cc/agentkit/skills/publish-page/themes/doc.html
+++ b/plugins-cc/agentkit/skills/publish-page/themes/doc.html
@@ -160,21 +160,22 @@
   /* Baked-palette diagram SVGs keep a navy island in light mode (their strokes
      are authored for a dark ground). Mermaid and HTML diagrams adapt via vars. */
   html[data-theme="light"] .figure > svg:not(.edges),
-  html[data-theme="light"] .figure > p > svg:only-child:not(.edges) {
+  html[data-theme="light"] .figure > p > svg:not(.edges) {
     background: var(--diagram-bg); border-radius: 10px; padding: 0.6rem;
   }
   @media print {
-    .figure > svg:not(.edges), .figure > p > svg:only-child:not(.edges) {
+    .figure > svg:not(.edges), .figure > p > svg:not(.edges) {
       -webkit-print-color-adjust: exact; print-color-adjust: exact;
     }
   }
   /* Scale-to-fit backstop: baked SVGs keep their viewBox but must never rely on
-     authored width attributes fitting the column. The :not(.edges) guard is
-     load-bearing — the edges-overlay rule ties on specificity (0,2,1) and this
-     rule comes later, so without the guard it would win and break the overlay.
-     :only-child keeps inline icons in figure prose out of the rule. */
+     authored width attributes fitting the column. :not(.edges) is defensive —
+     even without it the edges-overlay rule out-specifies this one. An inline
+     icon inside figure prose would match the p arm: known non-goal (no content
+     uses that pattern; the durable fix is an opt-in class from publish.ts,
+     CSS cannot express "this p has no text"). */
   .figure > svg:not(.edges),
-  .figure > p > svg:only-child:not(.edges) {
+  .figure > p > svg:not(.edges) {
     display: block; width: 100%; height: auto; margin-inline: auto;
   }
   .figure p { max-width: none; }
@@ -440,7 +441,7 @@
     const clone = fig.cloneNode(true);
     clone.classList.remove("fig-expandable");
     clone.querySelector(".fig-expand-trigger")?.remove();
-    clone.querySelectorAll(':scope > svg[viewBox]:not(.edges), :scope > p > svg[viewBox]:only-child:not(.edges)').forEach((s) => {
+    clone.querySelectorAll(':scope > svg[viewBox]:not(.edges), :scope > p > svg[viewBox]:not(.edges)').forEach((s) => {
       const vb = s.viewBox && s.viewBox.baseVal;
       if (vb && vb.width) {
         s.removeAttribute("width");

--- a/plugins-cc/agentkit/skills/publish-page/themes/doc.html
+++ b/plugins-cc/agentkit/skills/publish-page/themes/doc.html
@@ -160,18 +160,21 @@
   /* Baked-palette diagram SVGs keep a navy island in light mode (their strokes
      are authored for a dark ground). Mermaid and HTML diagrams adapt via vars. */
   html[data-theme="light"] .figure > svg:not(.edges),
-  html[data-theme="light"] .figure > p > svg:not(.edges) {
+  html[data-theme="light"] .figure > p > svg:only-child:not(.edges) {
     background: var(--diagram-bg); border-radius: 10px; padding: 0.6rem;
   }
   @media print {
-    .figure > svg:not(.edges), .figure > p > svg:not(.edges) {
+    .figure > svg:not(.edges), .figure > p > svg:only-child:not(.edges) {
       -webkit-print-color-adjust: exact; print-color-adjust: exact;
     }
   }
   /* Scale-to-fit backstop: baked SVGs keep their viewBox but must never rely on
-     authored width attributes fitting the column. svg.edges out-specifies this. */
+     authored width attributes fitting the column. The :not(.edges) guard is
+     load-bearing — the edges-overlay rule ties on specificity (0,2,1) and this
+     rule comes later, so without the guard it would win and break the overlay.
+     :only-child keeps inline icons in figure prose out of the rule. */
   .figure > svg:not(.edges),
-  .figure > p > svg:not(.edges) {
+  .figure > p > svg:only-child:not(.edges) {
     display: block; width: 100%; height: auto; margin-inline: auto;
   }
   .figure p { max-width: none; }
@@ -437,7 +440,7 @@
     const clone = fig.cloneNode(true);
     clone.classList.remove("fig-expandable");
     clone.querySelector(".fig-expand-trigger")?.remove();
-    clone.querySelectorAll(':scope > svg[viewBox]:not(.edges), :scope > p > svg[viewBox]:not(.edges)').forEach((s) => {
+    clone.querySelectorAll(':scope > svg[viewBox]:not(.edges), :scope > p > svg[viewBox]:only-child:not(.edges)').forEach((s) => {
       const vb = s.viewBox && s.viewBox.baseVal;
       if (vb && vb.width) {
         s.removeAttribute("width");

--- a/plugins-cc/agentkit/skills/publish-page/themes/doc.html
+++ b/plugins-cc/agentkit/skills/publish-page/themes/doc.html
@@ -18,6 +18,9 @@
     --accent: #34d3a6; --accent-soft: #0d2f3a; --gold: #e8b444; --red: #e06c5f;
     --fig-glow: #0f2a4d; --node-hi: #173562; --node-lo: #0c2140; --node-border: #2e4f7e;
     --tile-side: #061021;
+    /* Ground for baked-palette diagram SVGs (excalidraw); stays navy in both
+       themes so light-stroked art survives light mode. */
+    --diagram-bg: #071224;
   }
   html[data-theme="light"] {
     --navy: #f2f6fa; --navy-deep: #e6edf5; --card: #ffffff; --code-bg: #e9eff6;
@@ -153,6 +156,57 @@
     letter-spacing: 0.6px; text-transform: uppercase;
   }
   .figure svg.edges .edge-label-bg { fill: var(--navy-deep); stroke: var(--line); stroke-width: 1; rx: 4; opacity: 0.95; }
+
+  /* Baked-palette diagram SVGs keep a navy island in light mode (their strokes
+     are authored for a dark ground). Mermaid and HTML diagrams adapt via vars. */
+  html[data-theme="light"] .figure > svg:not(.edges),
+  html[data-theme="light"] .figure > p > svg:not(.edges) {
+    background: var(--diagram-bg); border-radius: 10px; padding: 0.6rem;
+  }
+  @media print {
+    .figure > svg:not(.edges), .figure > p > svg:not(.edges) {
+      -webkit-print-color-adjust: exact; print-color-adjust: exact;
+    }
+  }
+  /* Scale-to-fit backstop: baked SVGs keep their viewBox but must never rely on
+     authored width attributes fitting the column. svg.edges out-specifies this. */
+  .figure > svg:not(.edges),
+  .figure > p > svg:not(.edges) {
+    display: block; width: 100%; height: auto; margin-inline: auto;
+  }
+  .figure p { max-width: none; }
+  @media (min-width: 72rem) { .figure { margin-inline: -9rem; } }
+
+  /* Click-to-expand lightbox — every .figure expands to natural size. */
+  .figure.fig-expandable { cursor: zoom-in; }
+  .fig-expand-trigger {
+    position: absolute; top: 0.55rem; right: 0.7rem;
+    font-family: ui-monospace, Menlo, monospace; font-size: 0.62rem;
+    letter-spacing: 0.08em; text-transform: uppercase;
+    color: var(--muted); background: var(--navy-deep);
+    border: 1px solid var(--line); border-radius: 6px; padding: 0.12rem 0.5rem;
+    opacity: 0; transition: opacity 0.15s; cursor: zoom-in; z-index: 2;
+  }
+  .figure.fig-expandable:hover .fig-expand-trigger,
+  .fig-expand-trigger:focus-visible { opacity: 1; }
+  .fig-lightbox {
+    position: fixed; inset: 0; z-index: 70; padding: 4vh 4vw;
+    background: color-mix(in srgb, var(--navy-deep) 85%, transparent);
+    backdrop-filter: blur(6px);
+  }
+  .fig-lightbox[hidden] { display: none; }
+  .fig-lightbox-body { width: 100%; height: 100%; overflow: auto; }
+  .fig-lightbox .figure { width: max-content; max-width: none; margin: 0 auto; cursor: default; }
+  .fig-lightbox .figure p { max-width: none; }
+  .fig-lightbox-close {
+    position: fixed; top: 1rem; right: 1rem;
+    width: 2.3rem; height: 2.3rem; border-radius: 50%;
+    background: var(--card); border: 1px solid var(--line); color: var(--ink);
+    cursor: pointer; font-size: 0.95rem; line-height: 1; padding: 0;
+    display: flex; align-items: center; justify-content: center;
+  }
+  .fig-lightbox-close:hover { border-color: var(--accent); }
+  @media print { .fig-lightbox { display: none; } }
   .iso {
     display: grid; grid-template-columns: repeat(3, minmax(7.5rem, 1fr));
     gap: 0.6rem 1.2rem; justify-items: center; padding: 1.6rem 0 0.4rem;
@@ -342,6 +396,101 @@
   addEventListener("load", drawEdges);
   addEventListener("agentkit-theme", () => setTimeout(drawEdges, 350));
   addEventListener("resize", () => { clearTimeout(window.__et); window.__et = setTimeout(drawEdges, 150); });
+
+  // Accessible figure lightbox: preserve focus and restore natural SVG size.
+  const lb = document.createElement("div");
+  lb.className = "fig-lightbox";
+  lb.hidden = true;
+  lb.setAttribute("role", "dialog");
+  lb.setAttribute("aria-modal", "true");
+  lb.setAttribute("aria-label", "Expanded figure");
+  lb.innerHTML = '<div class="fig-lightbox-body"></div><button class="fig-lightbox-close" type="button" aria-label="Close expanded figure">✕</button>';
+  document.body.appendChild(lb);
+  const lbBody = lb.querySelector(".fig-lightbox-body");
+  const lbClose = lb.querySelector(".fig-lightbox-close");
+  let restoreFocus = null;
+  let restoreOverflow = "";
+  let inertSnapshot = [];
+  function isolateBackground() {
+    inertSnapshot = [...document.body.children]
+      .filter((element) => element !== lb)
+      .map((element) => ({ element, value: element.getAttribute("inert") }));
+    inertSnapshot.forEach(({ element }) => element.setAttribute("inert", ""));
+  }
+  function restoreBackground() {
+    inertSnapshot.forEach(({ element, value }) => {
+      if (value === null) element.removeAttribute("inert");
+      else element.setAttribute("inert", value);
+    });
+    inertSnapshot = [];
+  }
+  function closeLightbox() {
+    if (lb.hidden) return;
+    lb.hidden = true;
+    document.body.style.overflow = restoreOverflow;
+    restoreBackground();
+    lbBody.replaceChildren();
+    restoreFocus?.focus();
+    restoreFocus = null;
+  }
+  function openLightbox(fig, trigger) {
+    const clone = fig.cloneNode(true);
+    clone.classList.remove("fig-expandable");
+    clone.querySelector(".fig-expand-trigger")?.remove();
+    clone.querySelectorAll(':scope > svg[viewBox]:not(.edges), :scope > p > svg[viewBox]:not(.edges)').forEach((s) => {
+      const vb = s.viewBox && s.viewBox.baseVal;
+      if (vb && vb.width) {
+        s.removeAttribute("width");
+        s.style.width = Math.round(vb.width) + "px";
+        s.style.maxWidth = "none";
+      }
+    });
+    restoreFocus = trigger;
+    restoreOverflow = document.body.style.overflow;
+    lbBody.replaceChildren(clone);
+    isolateBackground();
+    lb.hidden = false;
+    document.body.style.overflow = "hidden";
+    lbClose.focus();
+    drawEdges();
+  }
+  document.querySelectorAll(".figure").forEach((fig) => {
+    fig.classList.add("fig-expandable");
+    const trigger = document.createElement("button");
+    trigger.className = "fig-expand-trigger";
+    trigger.type = "button";
+    trigger.setAttribute("aria-label", "Expand figure");
+    trigger.textContent = "⤢ expand";
+    trigger.addEventListener("click", () => openLightbox(fig, trigger));
+    fig.appendChild(trigger);
+    fig.addEventListener("click", (e) => {
+      if (e.target.closest("a, button")) return;
+      if (window.getSelection()?.toString()) return;
+      openLightbox(fig, trigger);
+    });
+  });
+  lb.addEventListener("click", (e) => {
+    if (e.target.closest(".fig-lightbox-close") || !e.target.closest(".figure")) closeLightbox();
+  });
+  addEventListener("keydown", (e) => {
+    if (lb.hidden) return;
+    if (e.key === "Escape") {
+      e.preventDefault();
+      closeLightbox();
+      return;
+    }
+    if (e.key !== "Tab") return;
+    const focusable = [...lb.querySelectorAll('a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])')];
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  });
 </script>
 </body>
 </html>

--- a/skills/architect/SKILL.md
+++ b/skills/architect/SKILL.md
@@ -21,19 +21,32 @@ genuinely understanding a system — not a file listing with boxes around it.
 3. **Find the load-bearing structure**: the 3–7 components whose removal would
    change the story, the flows between them, the state stores, and the
    trust/ownership boundaries. Everything else is detail inside a zone.
-4. **Produce**:
+4. **Figure plan before authoring**: emit a table of concept → concept type →
+   treatment → why-not-a-table, one row per intended visual, derived from the
+   publish-page routing table. Name exactly ONE centerpiece and 2–5 supporting
+   figures, and account for every h2 section — a section with no figure is a
+   stated choice, not an omission. Never route a flow containing a repair
+   loop, approval gate, or failure branch to the box kits: the load-bearing
+   part is the backward edge, which only a drawn figure can show. Present the
+   plan in the same message as the publish-approval request so one gate covers
+   both.
+5. **Produce**:
    - the centerpiece diagram(s) via the **diagram** skill (technical depth:
-     real names, real payloads, evidence artifacts),
+     real names, real payloads, evidence artifacts; respect its canvas and
+     density budgets — a diagram covering several separate headings is several
+     figures),
    - a page via **publish-page** (doc template): overview strip, the diagrams
      in `.figure` blocks with semantic captions, a "decisions & constraints"
      section (why it is shaped this way, what must not be broken), and a
      "sharp edges" section for the traps a newcomer hits,
    - use a stable `--name` (e.g. `<system>-architecture`) so refreshes update
      the SAME URL.
-5. **Refresh mode**: when asked to update (or triggered after merges), diff
-   what changed since the page's last git version in the pages repo, update
-   only the affected zones/sections, republish the same name, and note the
-   delta at the top of the page.
+6. **Refresh mode**: when asked to update (or triggered after merges), diff
+   what changed since the page's last git version in the pages repo, re-run
+   the figure plan against the diff (changed zones get re-authored figures; a
+   figure whose caption is no longer true is a blocker, not cosmetic lag),
+   update only the affected zones/sections, republish the same name, and note
+   the delta at the top of the page.
 
 ## The bar: impress a staff engineer
 

--- a/skills/diagram/SKILL.md
+++ b/skills/diagram/SKILL.md
@@ -76,10 +76,39 @@ comprehensive diagram exceeds a single response's output budget and truncates):
 4. After the last zone: re-read the whole file — bindings valid both ends,
    spacing balanced, every referenced id exists.
 
-Palette: match the destination. For AgentKit Pages (navy figures): strokes
-`#dce7f5`, muted `#8fa8c7`, accents `#34d3a6` / `#e8b444`, fills transparent or
-`#102847`, background transparent. For READMEs/light surfaces: near-black
-strokes with classic pastel fills (`#a5d8ff`, `#b2f2bb`, `#ffec99`).
+Palette: match the destination. For AgentKit Pages author the **navy palette
+only** — baked SVGs sit on a navy island in BOTH page themes, there is no light
+variant to produce, and a light-palette diagram would be invisible on it:
+strokes `#dce7f5`, muted `#8fa8c7`, accents `#34d3a6` / `#e8b444`, fills
+transparent or `#102847`, background transparent. For READMEs/light surfaces:
+near-black strokes with classic pastel fills (`#a5d8ff`, `#b2f2bb`, `#ffec99`).
+
+Contrast rules (worst case is the light end of the figure glow, `#0f2a4d`):
+
+- Red `#e06c5f` is a stroke color, not a text color — 4.4:1 misses AA. Use it
+  at strokeWidth ≥2 on shapes/arrows, or on text only at 16 px+.
+- Decoration never shares the hue of the text it decorates: underlines and
+  strikethroughs under colored text use muted `#8fa8c7` or are dropped — gold
+  under gold reads as a smear. Prefer size and weight over decoration.
+- Text on a filled panel takes the neutral ink `#dce7f5`, never the fill's own
+  color family; reserve the accent for a single data value.
+- Two semantic colors adjacent at the same size need a legend (≥14 px), placed
+  inside the zone it explains.
+
+## Size & density budget
+
+- **Canvas ≤ 1000 × 1400 px** for a page figure, **1000 × 620** for a deck
+  slide — the page column renders figures at ~979 px, so authoring at display
+  size means the diagram never scales below ~0.98. Hard ceiling 1200 px wide,
+  and only with every font raised proportionally (≥17 px) so nothing lands
+  below 14 px after scaling.
+- **Font floors**: annotations/legends 14 px, evidence/mono artifacts 13 px,
+  labels 16–18, zone titles 20–24, hero title 28–32. Nothing below 13 px.
+- **Density**: at most 3 zones, ~12 labeled nodes, ~25 text elements per
+  diagram. Exceeding any of the three means **split, don't shrink** — one
+  argument per figure; a fourth zone is a second figure with its own caption.
+- Vertical space is free and horizontal space is not: when a layout is tight,
+  restack zones taller rather than widening the canvas.
 
 ## 5 — Render, LOOK, fix (mandatory loop)
 
@@ -101,7 +130,10 @@ Each round, in order:
    belong to anything; ragged spacing between siblings; one zone cramped while
    another floats in emptiness; text too small at render size; a lopsided
    whole.
-3. **Fix in JSON** — widen containers for clipped text; shift `x`/`y` for
+3. **Page-scale pass** — view the PNG downscaled to ~979 px wide (the size the
+   page reader actually gets) and confirm every label is still readable; judge
+   the diagram at reading size, not authoring size.
+4. **Fix in JSON** — widen containers for clipped text; shift `x`/`y` for
    spacing; add waypoints to arrow `points` to route around shapes; pull
    labels next to their subjects; resize to rebalance visual weight.
 
@@ -129,7 +161,12 @@ needs a local Chromium — set `AGENTKIT_CHROMIUM` if it isn't auto-found.)
 
 ## 6 — Ship the SVG
 
-The SVG is fully self-contained (fonts embedded as data: URIs). Inline it
-directly into a page (wrap in `<div class="figure">` with a semantic
-`figcaption` when publishing via publish-page), drop it into a repo's docs, or
-attach the PNG where images are needed. Caption by content, never by tool.
+The SVG is fully self-contained (fonts embedded as data: URIs). **Before
+inlining, rewrite the SVG root**: replace the renderer's `width`/`height`
+attributes with `width="100%" style="height:auto"`, keep the `viewBox`, and add
+`role="img"` plus an `aria-label` matching the figcaption — the page theme
+backstops sizing in CSS, but the lightbox and every published page rely on this
+convention. Inline it directly into a page (wrap in `<div class="figure">` with
+a semantic `figcaption` when publishing via publish-page), drop it into a
+repo's docs, or attach the PNG where images are needed. Caption by content,
+never by tool.

--- a/skills/diagram/SKILL.md
+++ b/skills/diagram/SKILL.md
@@ -100,8 +100,9 @@ Contrast rules (worst case is the light end of the figure glow, `#0f2a4d`):
 - **Canvas ≤ 1000 × 1400 px** for a page figure, **1000 × 620** for a deck
   slide — the page column renders figures at ~979 px, so authoring at display
   size means the diagram never scales below ~0.98. Hard ceiling 1200 px wide,
-  and only with every font raised proportionally (≥17 px) so nothing lands
-  below 14 px after scaling.
+  and only with every font raised proportionally (≥18 px — at 1200→979 px the
+  scale is 0.816, so 18 px lands at 14.7 px) so nothing falls below the 14 px
+  floor after scaling.
 - **Font floors**: annotations/legends 14 px, evidence/mono artifacts 13 px,
   labels 16–18, zone titles 20–24, hero title 28–32. Nothing below 13 px.
 - **Density**: at most 3 zones, ~12 labeled nodes, ~25 text elements per

--- a/skills/diagram/references/elements.md
+++ b/skills/diagram/references/elements.md
@@ -65,19 +65,20 @@ Fonts: `fontFamily: 1` = hand-drawn (headers, labels — the excalidraw feel),
 
 Navy pages (background transparent, sits on the `.figure` glow):
 
-| Role                        | stroke           | fill                                                  |
-| --------------------------- | ---------------- | ----------------------------------------------------- |
-| default / neutral           | `#dce7f5`        | `transparent` or `#102847`                            |
-| start / trigger             | `#e8b444`        | `#2a2410`                                             |
-| end / success / active path | `#34d3a6`        | `#0d2f3a`                                             |
-| decision (diamond)          | `#e8b444`        | `transparent`                                         |
-| agent / AI                  | `#b197fc`        | `#1d1636`                                             |
-| inactive / future           | `#8fa8c7` dashed | `transparent`                                         |
-| error / removal             | `#e06c5f`        | `#2a1512`                                             |
-| evidence panel              | `#1e3a5f`        | `#071224` (mono text `#34d3a6` data, `#dce7f5` code)  |
+| Role                        | stroke           | fill                                                 |
+| --------------------------- | ---------------- | ---------------------------------------------------- |
+| default / neutral           | `#dce7f5`        | `transparent` or `#102847`                           |
+| start / trigger             | `#e8b444`        | `#2a2410`                                            |
+| end / success / active path | `#34d3a6`        | `#0d2f3a`                                            |
+| decision (diamond)          | `#e8b444`        | `transparent`                                        |
+| agent / AI                  | `#b197fc`        | `#1d1636`                                            |
+| inactive / future           | `#8fa8c7` dashed | `transparent`                                        |
+| error / removal             | `#e06c5f`        | `#2a1512`                                            |
+| evidence panel              | `#1e3a5f`        | `#071224` (mono text `#34d3a6` data, `#dce7f5` code) |
 
 Text hierarchy without boxes (navy): titles `#dce7f5` 20-28px, subtitles
-`#34d3a6` 16px, detail/annotation `#8fa8c7` 12-14px.
+`#34d3a6` 16px, detail/annotation `#8fa8c7` 14px (mono evidence may drop to
+13px; nothing below 13px anywhere, legends included).
 
 Light surfaces (READMEs, docs): near-black `#1e1e1e` strokes; fills `#a5d8ff`
 (neutral), `#fed7aa` (start), `#b2f2bb` (success), `#ffec99` (decision),
@@ -87,4 +88,7 @@ code text. Text hierarchy: titles `#1e40af`, subtitles `#3b82f6`, detail
 `#64748b`.
 
 Rules: darker stroke over lighter fill, always; a concept without a role uses
-neutral, never a fresh color.
+neutral, never a fresh color. Red `#e06c5f` is a stroke/shape color — as text
+only at 16px+. Text inside any filled panel uses the neutral ink, never the
+fill's own color family. Underline/strikethrough decoration never shares the
+hue of the text it decorates — use muted `#8fa8c7` or drop the decoration.

--- a/skills/publish-page/SKILL.md
+++ b/skills/publish-page/SKILL.md
@@ -53,21 +53,21 @@ strongest component for each idea — don't produce walls of prose.
 
 **Route every visual by what the concept IS**, never by the tool you used last:
 
-| Concept                                                 | Treatment                                     | Never                                                          |
-| ------------------------------------------------------- | --------------------------------------------- | -------------------------------------------------------------- |
-| System topology, trust/ownership boundaries             | `diagram` skill centerpiece                   | mermaid — auto-layout destroys boundary semantics              |
-| Deployable inventory, ≤7 nodes, relationships secondary | `.iso` kit + `.edge` connectors               | `diagram` skill (overkill)                                     |
-| Linear pipeline, all edges forward, stages need prose   | `.arch` flat kit                              | —                                                              |
-| Flow with a loop-back, gate, or failure branch          | `diagram` skill                               | `.flow`/`.arch`/`.fbox` — box kits cannot draw a backward edge |
-| Ordered message exchange, ≥3 participants               | mermaid `sequenceDiagram`                     | hand-drawn (arrow bookkeeping wastes the craft)                |
-| State machine >5 states with guards/terminals           | mermaid `stateDiagram-v2`                     | —                                                              |
-| State machine ≤5 states, transitions carry the meaning  | `diagram` skill                               | mermaid (generic)                                              |
-| Comparison, N options × M criteria, cells are prose     | markdown table                                | any diagram                                                    |
-| Comparison of structurally different options, ≤3        | `diagram` skill mirrored halves               | table (flattens the structural point)                          |
-| Hierarchy/taxonomy ≤3 levels                            | `diagram` skill tree — lines + text, no boxes | mermaid flowchart TD                                           |
-| Quantitative, ≥5 data points                            | inline SVG chart (discipline below)           | mermaid, chart libraries                                       |
-| ≤4 numbers                                              | `.chips` or a table row                       | a chart                                                        |
-| Independent items, no edges between them                | `.cards` grid                                 | any diagram — no edges = decorated list                        |
+| Concept                                                 | Treatment                                     | Never                                                                         |
+| ------------------------------------------------------- | --------------------------------------------- | ----------------------------------------------------------------------------- |
+| System topology, trust/ownership boundaries             | `diagram` skill centerpiece                   | mermaid — auto-layout destroys boundary semantics                             |
+| Deployable inventory, ≤7 nodes, relationships secondary | `.iso` kit + `.edge` connectors               | `diagram` skill (overkill)                                                    |
+| Linear pipeline, all edges forward, stages need prose   | `.arch` flat kit                              | —                                                                             |
+| Flow with a loop-back, gate, or failure branch          | `diagram` skill                               | `.flow`/`.arch`/`.fbox` — box kits cannot draw a backward edge                |
+| Ordered message exchange, ≥3 participants               | mermaid `sequenceDiagram`                     | hand-drawn — sole exception: avoiding the mermaid runtime (see figure budget) |
+| State machine >5 states with guards/terminals           | mermaid `stateDiagram-v2`                     | —                                                                             |
+| State machine ≤5 states, transitions carry the meaning  | `diagram` skill                               | mermaid (generic)                                                             |
+| Comparison, N options × M criteria, cells are prose     | markdown table                                | any diagram                                                                   |
+| Comparison of structurally different options, ≤3        | `diagram` skill mirrored halves               | table (flattens the structural point)                                         |
+| Hierarchy/taxonomy ≤3 levels                            | `diagram` skill tree — lines + text, no boxes | mermaid flowchart TD                                                          |
+| Quantitative, ≥5 data points                            | inline SVG chart (discipline below)           | mermaid, chart libraries                                                      |
+| ≤4 numbers                                              | `.chips` or a table row                       | a chart                                                                       |
+| Independent items, no edges between them                | `.cards` grid                                 | any diagram — no edges = decorated list                                       |
 
 A table beats a diagram when any of these holds: cells are full sentences; the
 relation is "X has property Y", not "X acts on Y"; ≥6 uniform rows; the
@@ -79,8 +79,9 @@ but fewer than 3 figures is under-illustrated. Never diagram
 two-nodes-one-arrow (a sentence), items without relationships (`.cards`), or a
 single before/after (`.callout`). Captions are one sentence with no "and"
 joining two subjects — a caption that needs "and" is two figures. Ask the
-`diagram` skill for canvases ≤1000 px wide: the column renders figures at
-~979 px, and wider canvases scale handwriting below legibility. Mermaid inlines
+`diagram` skill for canvases ≤1000 px wide (its hard ceiling is 1200 px with
+all fonts ≥18 px): the column renders figures at ~979 px, and wider canvases
+scale handwriting below legibility. Mermaid inlines
 ~3.4 MB once — if the page already carries 3+ inline SVG figures, draw the
 sequence/state diagram with the `diagram` skill instead.
 

--- a/skills/publish-page/SKILL.md
+++ b/skills/publish-page/SKILL.md
@@ -29,7 +29,11 @@ bun <skill-dir>/publish.ts --name <name> --file <content-file> [--template doc|d
 bun <skill-dir>/publish.ts --name <name> --delete    # remove a page you published
 ```
 
-5. **Give the user the URL** it prints (`https://pages.agentkit.sbs/<slug>`).
+5. **Verify before reporting**: load the printed URL in headless Chromium at
+   ~1280 px wide, screenshot BOTH themes (flip via the toggle), and Read every
+   figure. A clipped, illegible, or wrong-theme figure means fix and re-publish.
+   Never report the URL of an unviewed page.
+6. **Give the user the URL** it prints (`https://pages.agentkit.sbs/<slug>`).
    That URL is live immediately.
 
 ## Page design — the house style is built in
@@ -45,10 +49,42 @@ every card and diagram node. Add `data-tip="text"` to any node for a hover
 tooltip.
 
 **Be illustrative by default.** Structure every doc page as sections and pick the
-strongest component for each idea — don't produce walls of prose:
+strongest component for each idea — don't produce walls of prose.
 
-- **Diagrams: pick the treatment by what the diagram IS** — never default to one
-  tool, and never ASCII art. Wrap EVERY diagram in
+**Route every visual by what the concept IS**, never by the tool you used last:
+
+| Concept                                                 | Treatment                                     | Never                                                          |
+| ------------------------------------------------------- | --------------------------------------------- | -------------------------------------------------------------- |
+| System topology, trust/ownership boundaries             | `diagram` skill centerpiece                   | mermaid — auto-layout destroys boundary semantics              |
+| Deployable inventory, ≤7 nodes, relationships secondary | `.iso` kit + `.edge` connectors               | `diagram` skill (overkill)                                     |
+| Linear pipeline, all edges forward, stages need prose   | `.arch` flat kit                              | —                                                              |
+| Flow with a loop-back, gate, or failure branch          | `diagram` skill                               | `.flow`/`.arch`/`.fbox` — box kits cannot draw a backward edge |
+| Ordered message exchange, ≥3 participants               | mermaid `sequenceDiagram`                     | hand-drawn (arrow bookkeeping wastes the craft)                |
+| State machine >5 states with guards/terminals           | mermaid `stateDiagram-v2`                     | —                                                              |
+| State machine ≤5 states, transitions carry the meaning  | `diagram` skill                               | mermaid (generic)                                              |
+| Comparison, N options × M criteria, cells are prose     | markdown table                                | any diagram                                                    |
+| Comparison of structurally different options, ≤3        | `diagram` skill mirrored halves               | table (flattens the structural point)                          |
+| Hierarchy/taxonomy ≤3 levels                            | `diagram` skill tree — lines + text, no boxes | mermaid flowchart TD                                           |
+| Quantitative, ≥5 data points                            | inline SVG chart (discipline below)           | mermaid, chart libraries                                       |
+| ≤4 numbers                                              | `.chips` or a table row                       | a chart                                                        |
+| Independent items, no edges between them                | `.cards` grid                                 | any diagram — no edges = decorated list                        |
+
+A table beats a diagram when any of these holds: cells are full sentences; the
+relation is "X has property Y", not "X acts on Y"; ≥6 uniform rows; the
+reader's task is lookup, not path-following; item order is arbitrary.
+
+**Figure budget.** Exactly one centerpiece diagram — the figure that answers the
+page title's question — plus 2–5 supporting figures; a doc with ≥6 h2 sections
+but fewer than 3 figures is under-illustrated. Never diagram
+two-nodes-one-arrow (a sentence), items without relationships (`.cards`), or a
+single before/after (`.callout`). Captions are one sentence with no "and"
+joining two subjects — a caption that needs "and" is two figures. Ask the
+`diagram` skill for canvases ≤1000 px wide: the column renders figures at
+~979 px, and wider canvases scale handwriting below legibility. Mermaid inlines
+~3.4 MB once — if the page already carries 3+ inline SVG figures, draw the
+sequence/state diagram with the `diagram` skill instead.
+
+- **Diagram markup** — never ASCII art. Wrap EVERY diagram in
   `<div class="figure">…<div class="figcaption"><strong>Name</strong> — what it shows</div></div>`
   with a caption describing the content (say "Publish flow — from agent to live
   page", never the technology used to draw it). CRITICAL for markdown files:

--- a/skills/publish-page/publish.ts
+++ b/skills/publish-page/publish.ts
@@ -51,8 +51,9 @@ if (!endpoint.startsWith("https://") && !["127.0.0.1", "localhost"].includes(end
 const repoCandidates = process.env.AGENTKIT_PAGES_REPO
   ? [process.env.AGENTKIT_PAGES_REPO]
   : [join(homedir(), "code/agentkit-pages"), join(homedir(), "code/agentkit/agentkit-pages")];
-const repo = repoCandidates.find((p) => existsSync(join(p, ".git"))) ?? repoCandidates[0];
-if (!existsSync(join(repo, ".git"))) {
+const foundRepo = repoCandidates.find((p) => existsSync(join(p, ".git")));
+const repo = foundRepo ?? repoCandidates[0];
+if (!foundRepo) {
   // Publishing without the clone silently uses bundled themes (which can lag
   // canonical) and skips the canonical git commit — both have bitten before.
   console.error(
@@ -235,10 +236,7 @@ const res = await fetch(`${endpoint}/api/pages/${slug}`, {
 if (!res.ok) fail(`publish failed: HTTP ${res.status} ${await res.text()}`);
 const { url } = (await res.json()) as { url: string };
 
-if (!noGit && !repoAvailable()) {
-  console.error(`note: pages repo not found at ${repo} — published without canonical git commit`);
-  noGit = true;
-}
+if (!noGit && !foundRepo) noGit = true;
 if (!noGit) {
   const srcDir = join(repo, "src", slug);
   const distDir = join(repo, "dist", slug);

--- a/skills/publish-page/publish.ts
+++ b/skills/publish-page/publish.ts
@@ -48,7 +48,18 @@ const endpointHost = new URL(endpoint).hostname;
 if (!endpoint.startsWith("https://") && !["127.0.0.1", "localhost"].includes(endpointHost)) {
   fail(`endpoint must be https (got ${endpoint}) — the bearer token would travel in cleartext`);
 }
-const repo = process.env.AGENTKIT_PAGES_REPO ?? join(homedir(), "code/agentkit-pages");
+const repoCandidates = process.env.AGENTKIT_PAGES_REPO
+  ? [process.env.AGENTKIT_PAGES_REPO]
+  : [join(homedir(), "code/agentkit-pages"), join(homedir(), "code/agentkit/agentkit-pages")];
+const repo = repoCandidates.find((p) => existsSync(join(p, ".git"))) ?? repoCandidates[0];
+if (!existsSync(join(repo, ".git"))) {
+  // Publishing without the clone silently uses bundled themes (which can lag
+  // canonical) and skips the canonical git commit — both have bitten before.
+  console.error(
+    `warning: no agentkit-pages clone (looked at: ${repoCandidates.join(", ")}) — `
+      + `publishing with BUNDLED themes (may lag canonical) and WITHOUT a canonical git commit`,
+  );
+}
 const tokenPath = join(homedir(), ".config/agentkit/pages-token");
 if (!existsSync(tokenPath)) fail(`publish token missing at ${tokenPath}`);
 const token = (await readFile(tokenPath, "utf8")).trim();

--- a/skills/publish-page/themes/deck.html
+++ b/skills/publish-page/themes/deck.html
@@ -92,20 +92,21 @@
   /* Baked-palette diagram SVGs keep a navy island in light mode (their strokes
      are authored for a dark ground). Mermaid and HTML diagrams adapt via vars. */
   html[data-theme="light"] .figure > svg:not(.edges),
-  html[data-theme="light"] .figure > p > svg:only-child:not(.edges) {
+  html[data-theme="light"] .figure > p > svg:not(.edges) {
     background: var(--diagram-bg); border-radius: 10px; padding: 0.6rem;
   }
   @media print {
-    .figure > svg:not(.edges), .figure > p > svg:only-child:not(.edges) {
+    .figure > svg:not(.edges), .figure > p > svg:not(.edges) {
       -webkit-print-color-adjust: exact; print-color-adjust: exact;
     }
   }
   /* Scale-to-fit backstop: baked SVGs keep their viewBox but must never rely on
      authored width attributes fitting the slide. Deck ships no edges kit, so
-     :not(.edges) here is purely defensive; :only-child keeps inline icons in
-     figure prose out of the rule. */
+     :not(.edges) here is purely defensive. An inline icon inside figure prose
+     would match the p arm: known non-goal (no content uses that pattern; the
+     durable fix is an opt-in class from publish.ts). */
   .figure > svg:not(.edges),
-  .figure > p > svg:only-child:not(.edges) {
+  .figure > p > svg:not(.edges) {
     display: block; width: 100%; height: auto; margin-inline: auto;
   }
   .figure p { max-width: none; }
@@ -355,7 +356,7 @@
     const clone = fig.cloneNode(true);
     clone.classList.remove("fig-expandable");
     clone.querySelector(".fig-expand-trigger")?.remove();
-    clone.querySelectorAll(':scope > svg[viewBox]:not(.edges), :scope > p > svg[viewBox]:only-child:not(.edges)').forEach((s) => {
+    clone.querySelectorAll(':scope > svg[viewBox]:not(.edges), :scope > p > svg[viewBox]:not(.edges)').forEach((s) => {
       const vb = s.viewBox && s.viewBox.baseVal;
       if (vb && vb.width) {
         s.removeAttribute("width");

--- a/skills/publish-page/themes/deck.html
+++ b/skills/publish-page/themes/deck.html
@@ -92,18 +92,20 @@
   /* Baked-palette diagram SVGs keep a navy island in light mode (their strokes
      are authored for a dark ground). Mermaid and HTML diagrams adapt via vars. */
   html[data-theme="light"] .figure > svg:not(.edges),
-  html[data-theme="light"] .figure > p > svg:not(.edges) {
+  html[data-theme="light"] .figure > p > svg:only-child:not(.edges) {
     background: var(--diagram-bg); border-radius: 10px; padding: 0.6rem;
   }
   @media print {
-    .figure > svg:not(.edges), .figure > p > svg:not(.edges) {
+    .figure > svg:not(.edges), .figure > p > svg:only-child:not(.edges) {
       -webkit-print-color-adjust: exact; print-color-adjust: exact;
     }
   }
   /* Scale-to-fit backstop: baked SVGs keep their viewBox but must never rely on
-     authored width attributes fitting the slide. svg.edges out-specifies this. */
+     authored width attributes fitting the slide. Deck ships no edges kit, so
+     :not(.edges) here is purely defensive; :only-child keeps inline icons in
+     figure prose out of the rule. */
   .figure > svg:not(.edges),
-  .figure > p > svg:not(.edges) {
+  .figure > p > svg:only-child:not(.edges) {
     display: block; width: 100%; height: auto; margin-inline: auto;
   }
   .figure p { max-width: none; }
@@ -353,7 +355,7 @@
     const clone = fig.cloneNode(true);
     clone.classList.remove("fig-expandable");
     clone.querySelector(".fig-expand-trigger")?.remove();
-    clone.querySelectorAll(':scope > svg[viewBox]:not(.edges), :scope > p > svg[viewBox]:not(.edges)').forEach((s) => {
+    clone.querySelectorAll(':scope > svg[viewBox]:not(.edges), :scope > p > svg[viewBox]:only-child:not(.edges)').forEach((s) => {
       const vb = s.viewBox && s.viewBox.baseVal;
       if (vb && vb.width) {
         s.removeAttribute("width");

--- a/skills/publish-page/themes/deck.html
+++ b/skills/publish-page/themes/deck.html
@@ -18,6 +18,9 @@
     --accent: #34d3a6; --accent-soft: #0d2f3a; --gold: #e8b444; --red: #e06c5f;
     --fig-glow: #0f2a4d; --node-hi: #173562; --node-lo: #0c2140; --node-border: #2e4f7e;
     --tile-side: #061021;
+    /* Ground for baked-palette diagram SVGs (excalidraw); stays navy in both
+       themes so light-stroked art survives light mode. */
+    --diagram-bg: #071224;
   }
   html[data-theme="light"] {
     --navy: #f2f6fa; --navy-deep: #e6edf5; --card: #ffffff; --code-bg: #e9eff6;
@@ -85,6 +88,56 @@
   }
   .figcaption strong { color: var(--accent); font-weight: 600; }
   .figure pre.mermaid { background: none; border: 0; margin: 0; }
+
+  /* Baked-palette diagram SVGs keep a navy island in light mode (their strokes
+     are authored for a dark ground). Mermaid and HTML diagrams adapt via vars. */
+  html[data-theme="light"] .figure > svg:not(.edges),
+  html[data-theme="light"] .figure > p > svg:not(.edges) {
+    background: var(--diagram-bg); border-radius: 10px; padding: 0.6rem;
+  }
+  @media print {
+    .figure > svg:not(.edges), .figure > p > svg:not(.edges) {
+      -webkit-print-color-adjust: exact; print-color-adjust: exact;
+    }
+  }
+  /* Scale-to-fit backstop: baked SVGs keep their viewBox but must never rely on
+     authored width attributes fitting the slide. svg.edges out-specifies this. */
+  .figure > svg:not(.edges),
+  .figure > p > svg:not(.edges) {
+    display: block; width: 100%; height: auto; margin-inline: auto;
+  }
+  .figure p { max-width: none; }
+
+  /* Click-to-expand lightbox — every .figure expands to natural size. */
+  .figure.fig-expandable { cursor: zoom-in; }
+  .fig-expand-trigger {
+    position: absolute; top: 0.55rem; right: 0.7rem;
+    font-family: ui-monospace, Menlo, monospace; font-size: 0.62rem;
+    letter-spacing: 0.08em; text-transform: uppercase;
+    color: var(--muted); background: var(--navy-deep);
+    border: 1px solid var(--line); border-radius: 6px; padding: 0.12rem 0.5rem;
+    opacity: 0; transition: opacity 0.15s; cursor: zoom-in; z-index: 2;
+  }
+  .figure.fig-expandable:hover .fig-expand-trigger,
+  .fig-expand-trigger:focus-visible { opacity: 1; }
+  .fig-lightbox {
+    position: fixed; inset: 0; z-index: 70; padding: 4vh 4vw;
+    background: color-mix(in srgb, var(--navy-deep) 85%, transparent);
+    backdrop-filter: blur(6px);
+  }
+  .fig-lightbox[hidden] { display: none; }
+  .fig-lightbox-body { width: 100%; height: 100%; overflow: auto; }
+  .fig-lightbox .figure { width: max-content; max-width: none; margin: 0 auto; cursor: default; }
+  .fig-lightbox .figure p { max-width: none; }
+  .fig-lightbox-close {
+    position: fixed; top: 1rem; right: 1rem;
+    width: 2.3rem; height: 2.3rem; border-radius: 50%;
+    background: var(--card); border: 1px solid var(--line); color: var(--ink);
+    cursor: pointer; font-size: 0.95rem; line-height: 1; padding: 0;
+    display: flex; align-items: center; justify-content: center;
+  }
+  .fig-lightbox-close:hover { border-color: var(--accent); }
+  @media print { .fig-lightbox { display: none; } }
   pre.mermaid {
     background: var(--card); border: 1px solid var(--line); border-radius: 10px;
     padding: 1rem; overflow-x: auto; text-align: center;
@@ -243,6 +296,7 @@
   document.querySelector(".navbtn.prev").addEventListener("click", () => show(i - 1));
   document.querySelector(".navbtn.next").addEventListener("click", () => show(i + 1));
   addEventListener("keydown", (e) => {
+    if (document.querySelector(".fig-lightbox:not([hidden])")) return;
     if (["ArrowRight", "PageDown", " "].includes(e.key)) { e.preventDefault(); show(i + 1); }
     if (["ArrowLeft", "PageUp"].includes(e.key)) { e.preventDefault(); show(i - 1); }
     if (e.key === "Home") show(0);
@@ -252,11 +306,106 @@
   addEventListener("touchstart", (e) => { x0 = e.touches[0].clientX; }, { passive: true });
   addEventListener("touchend", (e) => {
     if (x0 === null) return;
+    if (document.querySelector(".fig-lightbox:not([hidden])")) { x0 = null; return; }
     const dx = e.changedTouches[0].clientX - x0;
     if (Math.abs(dx) > 50) show(i + (dx < 0 ? 1 : -1));
     x0 = null;
   }, { passive: true });
   show(i);
+
+  // Accessible figure lightbox: preserve focus and restore natural SVG size.
+  const lb = document.createElement("div");
+  lb.className = "fig-lightbox";
+  lb.hidden = true;
+  lb.setAttribute("role", "dialog");
+  lb.setAttribute("aria-modal", "true");
+  lb.setAttribute("aria-label", "Expanded figure");
+  lb.innerHTML = '<div class="fig-lightbox-body"></div><button class="fig-lightbox-close" type="button" aria-label="Close expanded figure">✕</button>';
+  document.body.appendChild(lb);
+  const lbBody = lb.querySelector(".fig-lightbox-body");
+  const lbClose = lb.querySelector(".fig-lightbox-close");
+  let restoreFocus = null;
+  let restoreOverflow = "";
+  let inertSnapshot = [];
+  function isolateBackground() {
+    inertSnapshot = [...document.body.children]
+      .filter((element) => element !== lb)
+      .map((element) => ({ element, value: element.getAttribute("inert") }));
+    inertSnapshot.forEach(({ element }) => element.setAttribute("inert", ""));
+  }
+  function restoreBackground() {
+    inertSnapshot.forEach(({ element, value }) => {
+      if (value === null) element.removeAttribute("inert");
+      else element.setAttribute("inert", value);
+    });
+    inertSnapshot = [];
+  }
+  function closeLightbox() {
+    if (lb.hidden) return;
+    lb.hidden = true;
+    document.body.style.overflow = restoreOverflow;
+    restoreBackground();
+    lbBody.replaceChildren();
+    restoreFocus?.focus();
+    restoreFocus = null;
+  }
+  function openLightbox(fig, trigger) {
+    const clone = fig.cloneNode(true);
+    clone.classList.remove("fig-expandable");
+    clone.querySelector(".fig-expand-trigger")?.remove();
+    clone.querySelectorAll(':scope > svg[viewBox]:not(.edges), :scope > p > svg[viewBox]:not(.edges)').forEach((s) => {
+      const vb = s.viewBox && s.viewBox.baseVal;
+      if (vb && vb.width) {
+        s.removeAttribute("width");
+        s.style.width = Math.round(vb.width) + "px";
+        s.style.maxWidth = "none";
+      }
+    });
+    restoreFocus = trigger;
+    restoreOverflow = document.body.style.overflow;
+    lbBody.replaceChildren(clone);
+    isolateBackground();
+    lb.hidden = false;
+    document.body.style.overflow = "hidden";
+    lbClose.focus();
+  }
+  document.querySelectorAll(".figure").forEach((fig) => {
+    fig.classList.add("fig-expandable");
+    const trigger = document.createElement("button");
+    trigger.className = "fig-expand-trigger";
+    trigger.type = "button";
+    trigger.setAttribute("aria-label", "Expand figure");
+    trigger.textContent = "⤢ expand";
+    trigger.addEventListener("click", () => openLightbox(fig, trigger));
+    fig.appendChild(trigger);
+    fig.addEventListener("click", (e) => {
+      if (e.target.closest("a, button")) return;
+      if (window.getSelection()?.toString()) return;
+      openLightbox(fig, trigger);
+    });
+  });
+  lb.addEventListener("click", (e) => {
+    if (e.target.closest(".fig-lightbox-close") || !e.target.closest(".figure")) closeLightbox();
+  });
+  addEventListener("keydown", (e) => {
+    if (lb.hidden) return;
+    if (e.key === "Escape") {
+      e.preventDefault();
+      closeLightbox();
+      return;
+    }
+    if (e.key !== "Tab") return;
+    const focusable = [...lb.querySelectorAll('a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])')];
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  });
 </script>
 </body>
 </html>

--- a/skills/publish-page/themes/doc.html
+++ b/skills/publish-page/themes/doc.html
@@ -160,21 +160,22 @@
   /* Baked-palette diagram SVGs keep a navy island in light mode (their strokes
      are authored for a dark ground). Mermaid and HTML diagrams adapt via vars. */
   html[data-theme="light"] .figure > svg:not(.edges),
-  html[data-theme="light"] .figure > p > svg:only-child:not(.edges) {
+  html[data-theme="light"] .figure > p > svg:not(.edges) {
     background: var(--diagram-bg); border-radius: 10px; padding: 0.6rem;
   }
   @media print {
-    .figure > svg:not(.edges), .figure > p > svg:only-child:not(.edges) {
+    .figure > svg:not(.edges), .figure > p > svg:not(.edges) {
       -webkit-print-color-adjust: exact; print-color-adjust: exact;
     }
   }
   /* Scale-to-fit backstop: baked SVGs keep their viewBox but must never rely on
-     authored width attributes fitting the column. The :not(.edges) guard is
-     load-bearing — the edges-overlay rule ties on specificity (0,2,1) and this
-     rule comes later, so without the guard it would win and break the overlay.
-     :only-child keeps inline icons in figure prose out of the rule. */
+     authored width attributes fitting the column. :not(.edges) is defensive —
+     even without it the edges-overlay rule out-specifies this one. An inline
+     icon inside figure prose would match the p arm: known non-goal (no content
+     uses that pattern; the durable fix is an opt-in class from publish.ts,
+     CSS cannot express "this p has no text"). */
   .figure > svg:not(.edges),
-  .figure > p > svg:only-child:not(.edges) {
+  .figure > p > svg:not(.edges) {
     display: block; width: 100%; height: auto; margin-inline: auto;
   }
   .figure p { max-width: none; }
@@ -440,7 +441,7 @@
     const clone = fig.cloneNode(true);
     clone.classList.remove("fig-expandable");
     clone.querySelector(".fig-expand-trigger")?.remove();
-    clone.querySelectorAll(':scope > svg[viewBox]:not(.edges), :scope > p > svg[viewBox]:only-child:not(.edges)').forEach((s) => {
+    clone.querySelectorAll(':scope > svg[viewBox]:not(.edges), :scope > p > svg[viewBox]:not(.edges)').forEach((s) => {
       const vb = s.viewBox && s.viewBox.baseVal;
       if (vb && vb.width) {
         s.removeAttribute("width");

--- a/skills/publish-page/themes/doc.html
+++ b/skills/publish-page/themes/doc.html
@@ -160,18 +160,21 @@
   /* Baked-palette diagram SVGs keep a navy island in light mode (their strokes
      are authored for a dark ground). Mermaid and HTML diagrams adapt via vars. */
   html[data-theme="light"] .figure > svg:not(.edges),
-  html[data-theme="light"] .figure > p > svg:not(.edges) {
+  html[data-theme="light"] .figure > p > svg:only-child:not(.edges) {
     background: var(--diagram-bg); border-radius: 10px; padding: 0.6rem;
   }
   @media print {
-    .figure > svg:not(.edges), .figure > p > svg:not(.edges) {
+    .figure > svg:not(.edges), .figure > p > svg:only-child:not(.edges) {
       -webkit-print-color-adjust: exact; print-color-adjust: exact;
     }
   }
   /* Scale-to-fit backstop: baked SVGs keep their viewBox but must never rely on
-     authored width attributes fitting the column. svg.edges out-specifies this. */
+     authored width attributes fitting the column. The :not(.edges) guard is
+     load-bearing — the edges-overlay rule ties on specificity (0,2,1) and this
+     rule comes later, so without the guard it would win and break the overlay.
+     :only-child keeps inline icons in figure prose out of the rule. */
   .figure > svg:not(.edges),
-  .figure > p > svg:not(.edges) {
+  .figure > p > svg:only-child:not(.edges) {
     display: block; width: 100%; height: auto; margin-inline: auto;
   }
   .figure p { max-width: none; }
@@ -437,7 +440,7 @@
     const clone = fig.cloneNode(true);
     clone.classList.remove("fig-expandable");
     clone.querySelector(".fig-expand-trigger")?.remove();
-    clone.querySelectorAll(':scope > svg[viewBox]:not(.edges), :scope > p > svg[viewBox]:not(.edges)').forEach((s) => {
+    clone.querySelectorAll(':scope > svg[viewBox]:not(.edges), :scope > p > svg[viewBox]:only-child:not(.edges)').forEach((s) => {
       const vb = s.viewBox && s.viewBox.baseVal;
       if (vb && vb.width) {
         s.removeAttribute("width");

--- a/skills/publish-page/themes/doc.html
+++ b/skills/publish-page/themes/doc.html
@@ -18,6 +18,9 @@
     --accent: #34d3a6; --accent-soft: #0d2f3a; --gold: #e8b444; --red: #e06c5f;
     --fig-glow: #0f2a4d; --node-hi: #173562; --node-lo: #0c2140; --node-border: #2e4f7e;
     --tile-side: #061021;
+    /* Ground for baked-palette diagram SVGs (excalidraw); stays navy in both
+       themes so light-stroked art survives light mode. */
+    --diagram-bg: #071224;
   }
   html[data-theme="light"] {
     --navy: #f2f6fa; --navy-deep: #e6edf5; --card: #ffffff; --code-bg: #e9eff6;
@@ -153,6 +156,57 @@
     letter-spacing: 0.6px; text-transform: uppercase;
   }
   .figure svg.edges .edge-label-bg { fill: var(--navy-deep); stroke: var(--line); stroke-width: 1; rx: 4; opacity: 0.95; }
+
+  /* Baked-palette diagram SVGs keep a navy island in light mode (their strokes
+     are authored for a dark ground). Mermaid and HTML diagrams adapt via vars. */
+  html[data-theme="light"] .figure > svg:not(.edges),
+  html[data-theme="light"] .figure > p > svg:not(.edges) {
+    background: var(--diagram-bg); border-radius: 10px; padding: 0.6rem;
+  }
+  @media print {
+    .figure > svg:not(.edges), .figure > p > svg:not(.edges) {
+      -webkit-print-color-adjust: exact; print-color-adjust: exact;
+    }
+  }
+  /* Scale-to-fit backstop: baked SVGs keep their viewBox but must never rely on
+     authored width attributes fitting the column. svg.edges out-specifies this. */
+  .figure > svg:not(.edges),
+  .figure > p > svg:not(.edges) {
+    display: block; width: 100%; height: auto; margin-inline: auto;
+  }
+  .figure p { max-width: none; }
+  @media (min-width: 72rem) { .figure { margin-inline: -9rem; } }
+
+  /* Click-to-expand lightbox — every .figure expands to natural size. */
+  .figure.fig-expandable { cursor: zoom-in; }
+  .fig-expand-trigger {
+    position: absolute; top: 0.55rem; right: 0.7rem;
+    font-family: ui-monospace, Menlo, monospace; font-size: 0.62rem;
+    letter-spacing: 0.08em; text-transform: uppercase;
+    color: var(--muted); background: var(--navy-deep);
+    border: 1px solid var(--line); border-radius: 6px; padding: 0.12rem 0.5rem;
+    opacity: 0; transition: opacity 0.15s; cursor: zoom-in; z-index: 2;
+  }
+  .figure.fig-expandable:hover .fig-expand-trigger,
+  .fig-expand-trigger:focus-visible { opacity: 1; }
+  .fig-lightbox {
+    position: fixed; inset: 0; z-index: 70; padding: 4vh 4vw;
+    background: color-mix(in srgb, var(--navy-deep) 85%, transparent);
+    backdrop-filter: blur(6px);
+  }
+  .fig-lightbox[hidden] { display: none; }
+  .fig-lightbox-body { width: 100%; height: 100%; overflow: auto; }
+  .fig-lightbox .figure { width: max-content; max-width: none; margin: 0 auto; cursor: default; }
+  .fig-lightbox .figure p { max-width: none; }
+  .fig-lightbox-close {
+    position: fixed; top: 1rem; right: 1rem;
+    width: 2.3rem; height: 2.3rem; border-radius: 50%;
+    background: var(--card); border: 1px solid var(--line); color: var(--ink);
+    cursor: pointer; font-size: 0.95rem; line-height: 1; padding: 0;
+    display: flex; align-items: center; justify-content: center;
+  }
+  .fig-lightbox-close:hover { border-color: var(--accent); }
+  @media print { .fig-lightbox { display: none; } }
   .iso {
     display: grid; grid-template-columns: repeat(3, minmax(7.5rem, 1fr));
     gap: 0.6rem 1.2rem; justify-items: center; padding: 1.6rem 0 0.4rem;
@@ -342,6 +396,101 @@
   addEventListener("load", drawEdges);
   addEventListener("agentkit-theme", () => setTimeout(drawEdges, 350));
   addEventListener("resize", () => { clearTimeout(window.__et); window.__et = setTimeout(drawEdges, 150); });
+
+  // Accessible figure lightbox: preserve focus and restore natural SVG size.
+  const lb = document.createElement("div");
+  lb.className = "fig-lightbox";
+  lb.hidden = true;
+  lb.setAttribute("role", "dialog");
+  lb.setAttribute("aria-modal", "true");
+  lb.setAttribute("aria-label", "Expanded figure");
+  lb.innerHTML = '<div class="fig-lightbox-body"></div><button class="fig-lightbox-close" type="button" aria-label="Close expanded figure">✕</button>';
+  document.body.appendChild(lb);
+  const lbBody = lb.querySelector(".fig-lightbox-body");
+  const lbClose = lb.querySelector(".fig-lightbox-close");
+  let restoreFocus = null;
+  let restoreOverflow = "";
+  let inertSnapshot = [];
+  function isolateBackground() {
+    inertSnapshot = [...document.body.children]
+      .filter((element) => element !== lb)
+      .map((element) => ({ element, value: element.getAttribute("inert") }));
+    inertSnapshot.forEach(({ element }) => element.setAttribute("inert", ""));
+  }
+  function restoreBackground() {
+    inertSnapshot.forEach(({ element, value }) => {
+      if (value === null) element.removeAttribute("inert");
+      else element.setAttribute("inert", value);
+    });
+    inertSnapshot = [];
+  }
+  function closeLightbox() {
+    if (lb.hidden) return;
+    lb.hidden = true;
+    document.body.style.overflow = restoreOverflow;
+    restoreBackground();
+    lbBody.replaceChildren();
+    restoreFocus?.focus();
+    restoreFocus = null;
+  }
+  function openLightbox(fig, trigger) {
+    const clone = fig.cloneNode(true);
+    clone.classList.remove("fig-expandable");
+    clone.querySelector(".fig-expand-trigger")?.remove();
+    clone.querySelectorAll(':scope > svg[viewBox]:not(.edges), :scope > p > svg[viewBox]:not(.edges)').forEach((s) => {
+      const vb = s.viewBox && s.viewBox.baseVal;
+      if (vb && vb.width) {
+        s.removeAttribute("width");
+        s.style.width = Math.round(vb.width) + "px";
+        s.style.maxWidth = "none";
+      }
+    });
+    restoreFocus = trigger;
+    restoreOverflow = document.body.style.overflow;
+    lbBody.replaceChildren(clone);
+    isolateBackground();
+    lb.hidden = false;
+    document.body.style.overflow = "hidden";
+    lbClose.focus();
+    drawEdges();
+  }
+  document.querySelectorAll(".figure").forEach((fig) => {
+    fig.classList.add("fig-expandable");
+    const trigger = document.createElement("button");
+    trigger.className = "fig-expand-trigger";
+    trigger.type = "button";
+    trigger.setAttribute("aria-label", "Expand figure");
+    trigger.textContent = "⤢ expand";
+    trigger.addEventListener("click", () => openLightbox(fig, trigger));
+    fig.appendChild(trigger);
+    fig.addEventListener("click", (e) => {
+      if (e.target.closest("a, button")) return;
+      if (window.getSelection()?.toString()) return;
+      openLightbox(fig, trigger);
+    });
+  });
+  lb.addEventListener("click", (e) => {
+    if (e.target.closest(".fig-lightbox-close") || !e.target.closest(".figure")) closeLightbox();
+  });
+  addEventListener("keydown", (e) => {
+    if (lb.hidden) return;
+    if (e.key === "Escape") {
+      e.preventDefault();
+      closeLightbox();
+      return;
+    }
+    if (e.key !== "Tab") return;
+    const focusable = [...lb.querySelectorAll('a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])')];
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  });
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Why
The flagship published page (Neutron architecture) shipped with a clipped 1480px diagram, illegible light mode, and no canonical git commit. Root causes: bundled themes drifted behind canonical (navy island + lightbox never synced), no scale-to-fit backstop for baked SVGs, publish.ts silently downgrades when the pages clone isn't at its single hardcoded path, and no product-level policy for what gets diagrammed.

## What
- **themes (doc+deck, + plugins-cc mirrors)**: canonical sync (navy island for baked SVGs in light mode, accessible lightbox) plus new: `.figure > svg` scale-to-fit backstop, `.figure p { max-width:none }` (65ch was shrinking wrapped SVGs), 64rem doc figure breakout at ≥72rem, island padding + print color-adjust, lightbox natural-size via viewBox instead of `width="100%"` attr
- **publish.ts**: probes `~/code/agentkit-pages` and `~/code/agentkit/agentkit-pages`; loud warning when no clone exists (bundled themes may lag + no canonical commit) — previously silent
- **publish-page SKILL**: concept→treatment routing table, figure budget (1 centerpiece + 2–5 supporting), mandatory both-theme screenshot verification before reporting a URL
- **diagram SKILL + elements.md**: canvas ≤1000px / density / font-floor budgets, contrast rules (red-as-stroke, no same-hue decoration, neutral ink on filled panels), page-scale render pass, SVG root rewrite convention
- **architect SKILL**: figure-plan gate before authoring, backward-edge flows banned from box kits, refresh mode re-plans figures

Same theme deltas land canonically in agentkit-pages MR !2 (Playwright 7/7 green there; verified against a real 1480px-SVG page in both themes + lightbox).