### PR TITLE
feat(product-intelligence): schemas, validator, fixtures (slice 1)

### DIFF
--- a/plugins-cc/agentkit/skills/product-intelligence/schemas/brief.schema.json
+++ b/plugins-cc/agentkit/skills/product-intelligence/schemas/brief.schema.json
@@ -1,0 +1,250 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agentkit.sbs/schemas/product-intelligence/brief.schema.json",
+  "title": "Product brief",
+  "description": "Evidence-backed statement of what a product is, who it serves, and what its surfaces say. The brief carries the story; the companion evidence ledger carries the proof. Every material assertion cites ledger claim ids. Every field is optional except brief_version, subject and evidence — but the fewer sections filled in, the less the brief says, and downstream consumers report that plainly rather than implying coverage.",
+  "type": "object",
+  "required": ["brief_version", "subject", "evidence"],
+  "additionalProperties": false,
+  "properties": {
+    "brief_version": {
+      "description": "Semver of the brief schema this document targets. Backward-compatible across minors.",
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+(\\.[0-9]+)?$"
+    },
+    "subject": {
+      "type": "object",
+      "required": ["name"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "description": "Product name as its makers use it.",
+          "type": "string",
+          "minLength": 1
+        },
+        "homepage": {
+          "description": "Canonical marketing/site URL.",
+          "type": "string",
+          "minLength": 1
+        },
+        "repo": {
+          "description": "Source repository locator, e.g. 'github.com/org/name'.",
+          "type": "string",
+          "minLength": 1
+        },
+        "one_liner": {
+          "description": "What the product is in one sentence, from a user's point of view — not the architecture.",
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "required": ["ledger"],
+      "additionalProperties": false,
+      "properties": {
+        "ledger": {
+          "description": "Path to the evidence ledger, relative to this file. Claim ids cited throughout the brief resolve there.",
+          "type": "string",
+          "minLength": 1
+        },
+        "acquired_at": {
+          "description": "ISO-8601 date the underlying evidence was gathered.",
+          "type": "string",
+          "format": "date"
+        },
+        "acquisition": {
+          "description": "What was fetched and with which tool, so a reader can re-run the acquisition.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/acquisition" }
+        }
+      }
+    },
+    "positioning": {
+      "description": "Moore positioning statement, one slot per field: for <target_customer> who <need>, <subject.name> is a <category> that <key_benefit>; unlike <alternative>, it <differentiation>.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "target_customer": { "type": "string", "minLength": 1 },
+        "need": { "type": "string", "minLength": 1 },
+        "category": { "type": "string", "minLength": 1 },
+        "key_benefit": { "type": "string", "minLength": 1 },
+        "alternative": { "type": "string", "minLength": 1 },
+        "differentiation": { "type": "string", "minLength": 1 },
+        "claims": { "$ref": "#/$defs/claim_refs" }
+      }
+    },
+    "value_map": {
+      "description": "Dunford attribute→value→proof rows. An attribute nobody can name a value for, or a value nobody can prove, is flagged by the analyze pass — leave the field out rather than padding it.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["attribute", "value"],
+        "additionalProperties": false,
+        "properties": {
+          "attribute": {
+            "description": "A capability the product actually has.",
+            "type": "string",
+            "minLength": 1
+          },
+          "value": {
+            "description": "What that capability enables for the customer.",
+            "type": "string",
+            "minLength": 1
+          },
+          "proof": {
+            "description": "How a skeptic would check the value holds, in prose.",
+            "type": "string",
+            "minLength": 1
+          },
+          "claims": { "$ref": "#/$defs/claim_refs" }
+        }
+      }
+    },
+    "job_stories": {
+      "description": "JTBD job stories: when <situation>, I want <motivation>, so I can <outcome>.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["situation", "motivation", "outcome"],
+        "additionalProperties": false,
+        "properties": {
+          "situation": { "type": "string", "minLength": 1 },
+          "motivation": { "type": "string", "minLength": 1 },
+          "outcome": { "type": "string", "minLength": 1 },
+          "claims": { "$ref": "#/$defs/claim_refs" }
+        }
+      }
+    },
+    "workflows": {
+      "description": "Customer workflows the product participates in, mapped to Ulwick's universal job steps. Steps the product does not touch are simply absent — gaps are the analyze pass's job to call out.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "steps"],
+        "additionalProperties": false,
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "steps": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["step", "description"],
+              "additionalProperties": false,
+              "properties": {
+                "step": {
+                  "enum": [
+                    "define",
+                    "locate",
+                    "prepare",
+                    "confirm",
+                    "execute",
+                    "monitor",
+                    "modify",
+                    "conclude"
+                  ]
+                },
+                "description": {
+                  "description": "What happens at this step and where the product shows up in it.",
+                  "type": "string",
+                  "minLength": 1
+                },
+                "claims": { "$ref": "#/$defs/claim_refs" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "site_inventory": {
+      "description": "Content audit of the product's public surfaces: one row per page, what kind of page it is, and what should happen to it. disposition 'create' marks a page that does not exist yet.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["locator", "page_type"],
+        "additionalProperties": false,
+        "properties": {
+          "locator": {
+            "description": "Structural pointer matching ledger source locators, e.g. 'site:/pricing'.",
+            "type": "string",
+            "minLength": 1
+          },
+          "page_type": {
+            "enum": [
+              "home",
+              "about",
+              "pricing",
+              "product",
+              "docs",
+              "blog",
+              "faq",
+              "contact",
+              "checkout",
+              "collection",
+              "item",
+              "profile",
+              "qa",
+              "search",
+              "legal",
+              "changelog",
+              "landing",
+              "other"
+            ]
+          },
+          "title": { "type": "string", "minLength": 1 },
+          "disposition": {
+            "enum": ["keep", "revise", "consolidate", "remove", "create"]
+          },
+          "rationale": {
+            "description": "Why the disposition. Required whenever a disposition is stated — an unexplained verdict is not auditable.",
+            "type": "string",
+            "minLength": 1
+          },
+          "claims": { "$ref": "#/$defs/claim_refs" }
+        }
+      }
+    },
+    "cannot_verify": {
+      "description": "What could not be established and why. Stated plainly so absence of a section reads as 'unknown', never as 'does not exist'.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["what", "why"],
+        "additionalProperties": false,
+        "properties": {
+          "what": { "type": "string", "minLength": 1 },
+          "why": { "type": "string", "minLength": 1 }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "claim_refs": {
+      "description": "Ledger claim ids backing this section.",
+      "type": "array",
+      "items": { "type": "string", "pattern": "^C-[0-9]{3,}$" }
+    },
+    "acquisition": {
+      "type": "object",
+      "required": ["tool", "target", "retrieved_at"],
+      "additionalProperties": false,
+      "properties": {
+        "tool": {
+          "description": "Acquisition command or wrapper name, e.g. 'trafilatura', 'repomix --remote', 'gh api'.",
+          "type": "string",
+          "minLength": 1
+        },
+        "target": {
+          "description": "URL or repo the tool was pointed at.",
+          "type": "string",
+          "minLength": 1
+        },
+        "retrieved_at": {
+          "type": "string",
+          "format": "date"
+        }
+      }
+    }
+  }
+}

--- a/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/brief-dangling-ledger.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/brief-dangling-ledger.yaml
@@ -1,0 +1,5 @@
+brief_version: "1.0"
+subject:
+  name: acme-notes
+evidence:
+  ledger: does-not-exist.yaml

--- a/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/brief-disposition-without-rationale.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/brief-disposition-without-rationale.yaml
@@ -1,0 +1,9 @@
+brief_version: "1.0"
+subject:
+  name: acme-notes
+evidence:
+  ledger: ../valid/ledger.yaml
+site_inventory:
+  - locator: "site:/pricing"
+    page_type: pricing
+    disposition: remove

--- a/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/brief-missing-subject-name.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/brief-missing-subject-name.yaml
@@ -1,0 +1,5 @@
+brief_version: "1.0"
+subject:
+  homepage: https://acme-notes.example
+evidence:
+  ledger: ../valid/ledger.yaml

--- a/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/brief-unknown-claim.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/brief-unknown-claim.yaml
@@ -1,0 +1,8 @@
+brief_version: "1.0"
+subject:
+  name: acme-notes
+evidence:
+  ledger: ../valid/ledger.yaml
+positioning:
+  target_customer: solo developers
+  claims: [C-999]

--- a/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/ledger-contradicts-asymmetric.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/ledger-contradicts-asymmetric.yaml
@@ -1,0 +1,23 @@
+ledger_version: "1.0"
+generated_by: product-intelligence
+generated_at: "2026-07-27T10:00:00Z"
+claims:
+  - id: C-001
+    statement: The free tier allows three projects.
+    class: observed
+    confidence: high
+    contradicts: [C-002]
+    sources:
+      - locator: "site:/pricing"
+        quote: "up to 3 projects"
+        stance: supports
+        as_of: "2026-07-25"
+  - id: C-002
+    statement: The free tier allows five projects.
+    class: observed
+    confidence: high
+    sources:
+      - locator: "repo:README.md:12"
+        quote: "up to 5 projects"
+        stance: supports
+        as_of: "2026-07-25"

--- a/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/ledger-derived-from-observed.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/ledger-derived-from-observed.yaml
@@ -1,0 +1,23 @@
+ledger_version: "1.0"
+generated_by: product-intelligence
+generated_at: "2026-07-27T10:00:00Z"
+claims:
+  - id: C-001
+    statement: The pricing page lists a free tier.
+    class: observed
+    confidence: high
+    derived_from: [C-002]
+    sources:
+      - locator: "site:/pricing"
+        quote: "Free tier"
+        stance: supports
+        as_of: "2026-07-25"
+  - id: C-002
+    statement: The README mentions a free plan.
+    class: observed
+    confidence: high
+    sources:
+      - locator: "repo:README.md:3"
+        quote: "free plan"
+        stance: supports
+        as_of: "2026-07-25"

--- a/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/ledger-duplicate-id.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/ledger-duplicate-id.yaml
@@ -1,0 +1,12 @@
+ledger_version: "1.0"
+generated_by: product-intelligence
+generated_at: "2026-07-27T10:00:00Z"
+claims:
+  - id: C-001
+    statement: A migration guide should be added.
+    class: proposed
+    confidence: low
+  - id: C-001
+    statement: A comparison page should be added.
+    class: proposed
+    confidence: low

--- a/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/ledger-inferred-from-proposed.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/ledger-inferred-from-proposed.yaml
@@ -1,0 +1,18 @@
+ledger_version: "1.0"
+generated_by: product-intelligence
+generated_at: "2026-07-27T10:00:00Z"
+claims:
+  - id: C-001
+    statement: A migration guide should be added.
+    class: proposed
+    confidence: low
+  - id: C-002
+    statement: The docs cover migration from CompetitorX.
+    class: inferred
+    confidence: low
+    derived_from: [C-001]
+    sources:
+      - locator: "site:/docs"
+        quote: "Guides"
+        stance: context
+        as_of: "2026-07-25"

--- a/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/ledger-merged-class-confidence.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/ledger-merged-class-confidence.yaml
@@ -1,0 +1,13 @@
+ledger_version: "1.0"
+generated_by: product-intelligence
+generated_at: "2026-07-27T10:00:00Z"
+claims:
+  - id: C-001
+    statement: The pricing page lists a free tier.
+    class: high-confidence-observed
+    confidence: high
+    sources:
+      - locator: "site:/pricing"
+        quote: "Free tier"
+        stance: supports
+        as_of: "2026-07-25"

--- a/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/ledger-missing-sources.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/ledger-missing-sources.yaml
@@ -1,0 +1,8 @@
+ledger_version: "1.0"
+generated_by: product-intelligence
+generated_at: "2026-07-27T10:00:00Z"
+claims:
+  - id: C-001
+    statement: The pricing page lists a free tier.
+    class: observed
+    confidence: high

--- a/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/ledger-source-missing-quote.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/ledger-source-missing-quote.yaml
@@ -1,0 +1,12 @@
+ledger_version: "1.0"
+generated_by: product-intelligence
+generated_at: "2026-07-27T10:00:00Z"
+claims:
+  - id: C-001
+    statement: The pricing page lists a free tier.
+    class: observed
+    confidence: high
+    sources:
+      - locator: "site:/pricing"
+        stance: supports
+        as_of: "2026-07-25"

--- a/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/ledger-unknown-derived-ref.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/ledger-unknown-derived-ref.yaml
@@ -1,0 +1,14 @@
+ledger_version: "1.0"
+generated_by: product-intelligence
+generated_at: "2026-07-27T10:00:00Z"
+claims:
+  - id: C-001
+    statement: The product targets solo developers.
+    class: inferred
+    confidence: moderate
+    derived_from: [C-099]
+    sources:
+      - locator: "site:/pricing"
+        quote: "Perfect for personal projects"
+        stance: context
+        as_of: "2026-07-25"

--- a/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/ledger-unknown-field.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/ledger-unknown-field.yaml
@@ -1,0 +1,9 @@
+ledger_version: "1.0"
+generated_by: product-intelligence
+generated_at: "2026-07-27T10:00:00Z"
+claims:
+  - id: C-001
+    statement: A migration guide should be added.
+    class: proposed
+    confidence: low
+    severity: high

--- a/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/valid/brief.minimal.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/valid/brief.minimal.yaml
@@ -1,0 +1,5 @@
+brief_version: "1.0"
+subject:
+  name: acme-notes
+evidence:
+  ledger: ledger.yaml

--- a/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/valid/brief.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/valid/brief.yaml
@@ -1,0 +1,56 @@
+brief_version: "1.0"
+subject:
+  name: acme-notes
+  homepage: https://acme-notes.example
+  repo: github.com/acme/acme-notes
+  one_liner: Note-taking app that keeps every note in a plain git repository.
+evidence:
+  ledger: ledger.yaml
+  acquired_at: "2026-07-25"
+  acquisition:
+    - tool: trafilatura
+      target: https://acme-notes.example
+      retrieved_at: "2026-07-25"
+    - tool: repomix --remote
+      target: github.com/acme/acme-notes
+      retrieved_at: "2026-07-25"
+positioning:
+  target_customer: solo developers
+  need: notes that live next to their code
+  category: git-native note-taking app
+  key_benefit: notes are versioned and greppable like source
+  alternative: hosted note SaaS
+  differentiation: works offline against a repository the user already owns
+  claims: [C-003]
+value_map:
+  - attribute: stores notes as plain markdown in git
+    value: no lock-in — notes outlive the product
+    proof: clone the repo and read the notes with any editor
+    claims: [C-002]
+job_stories:
+  - situation: I am deep in a debugging session
+    motivation: I want to capture what I ruled out
+    outcome: I can pick the thread back up tomorrow without re-deriving it
+    claims: [C-003]
+workflows:
+  - name: capture a finding
+    steps:
+      - step: execute
+        description: write the note in the editor alongside the code
+      - step: conclude
+        description: commit lands the note in history with the change it explains
+site_inventory:
+  - locator: "site:/pricing"
+    page_type: pricing
+    title: Plans
+    disposition: revise
+    rationale: the stated free-tier limit contradicts the README
+    claims: [C-001, C-002]
+  - locator: "site:/docs/migrate-from-competitorx"
+    page_type: docs
+    disposition: create
+    rationale: no migration path is documented for the most-cited alternative
+    claims: [C-004]
+cannot_verify:
+  - what: SOC 2 certification claim
+    why: no audit report or trust page is published anywhere reachable

--- a/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/valid/ledger.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/valid/ledger.yaml
@@ -1,0 +1,42 @@
+ledger_version: "1.0"
+generated_by: product-intelligence
+generated_at: "2026-07-27T10:00:00Z"
+claims:
+  - id: C-001
+    statement: The pricing page lists a free tier limited to three projects.
+    class: observed
+    confidence: high
+    contradicts: [C-002]
+    sources:
+      - locator: "site:/pricing#plans"
+        quote: "Free — up to 3 projects"
+        stance: supports
+        as_of: "2026-07-25"
+  - id: C-002
+    statement: The repository README states the free tier allows five projects.
+    class: observed
+    confidence: high
+    contradicts: [C-001]
+    sources:
+      - locator: "repo:README.md:12-14"
+        quote: "The free plan covers up to 5 projects."
+        stance: supports
+        as_of: "2026-07-25"
+  - id: C-003
+    statement: The product is aimed at solo developers rather than teams.
+    class: inferred
+    confidence: moderate
+    derived_from: [C-001]
+    sources:
+      - locator: "site:/pricing#plans"
+        quote: "Perfect for personal projects"
+        stance: context
+        as_of: "2026-07-25"
+  - id: C-004
+    statement: A migration guide from CompetitorX should be added to the docs.
+    class: proposed
+    confidence: low
+  - id: C-005
+    statement: The product holds SOC 2 Type II certification.
+    class: unverified
+    confidence: low

--- a/plugins-cc/agentkit/skills/product-intelligence/schemas/ledger.schema.json
+++ b/plugins-cc/agentkit/skills/product-intelligence/schemas/ledger.schema.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agentkit.sbs/schemas/product-intelligence/ledger.schema.json",
+  "title": "Product-intelligence evidence ledger",
+  "description": "Flat, auditable record of every material claim in a product brief. Each claim is one atomic proposition carrying its source, evidence class, and confidence. Contradictions are recorded, never reconciled.",
+  "type": "object",
+  "required": ["ledger_version", "generated_by", "generated_at", "claims"],
+  "additionalProperties": false,
+  "properties": {
+    "ledger_version": {
+      "description": "Semver of the ledger schema this document targets. Backward-compatible across minors.",
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+(\\.[0-9]+)?$"
+    },
+    "generated_by": {
+      "description": "Tool/skill identifier that produced this ledger.",
+      "type": "string",
+      "minLength": 1
+    },
+    "generated_at": {
+      "description": "ISO-8601 date (or date-time) the ledger was produced.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "claims": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/claim" }
+    }
+  },
+  "$defs": {
+    "claim": {
+      "type": "object",
+      "required": ["id", "statement", "class", "confidence"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "description": "Stable, referenceable handle. A claim may be restated in prose anywhere without duplicating the entry.",
+          "type": "string",
+          "pattern": "^C-[0-9]{3,}$"
+        },
+        "statement": {
+          "description": "Exactly one atomic proposition. A statement needing 'and' is two claims.",
+          "type": "string",
+          "minLength": 1
+        },
+        "class": {
+          "description": "What kind of statement this is. Independent of confidence and never merged with it.",
+          "enum": ["observed", "inferred", "proposed", "unverified"]
+        },
+        "confidence": {
+          "description": "How solid the basis is. Independent of class.",
+          "enum": ["high", "moderate", "low"]
+        },
+        "sources": {
+          "description": "Where the claim comes from. Required for observed/inferred; empty is only valid for proposed/unverified.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/source" }
+        },
+        "derived_from": {
+          "description": "Claim ids this claim is inferred from. Populated only when class is 'inferred'.",
+          "type": "array",
+          "items": { "type": "string", "pattern": "^C-[0-9]{3,}$" }
+        },
+        "contradicts": {
+          "description": "Claim ids this claim stands in unresolved contradiction with. A populated value is a valid terminal state — rendered in the brief, never silently resolved.",
+          "type": "array",
+          "items": { "type": "string", "pattern": "^C-[0-9]{3,}$" }
+        }
+      }
+    },
+    "source": {
+      "type": "object",
+      "required": ["locator", "quote", "stance", "as_of"],
+      "additionalProperties": false,
+      "properties": {
+        "locator": {
+          "description": "Structural pointer that survives edits: 'site:/pricing#plans', 'repo:README.md:40-52', 'doc:brief.pdf#p3'.",
+          "type": "string",
+          "minLength": 1
+        },
+        "quote": {
+          "description": "Verbatim excerpt from the source. The quote is what makes a fabricated citation catchable without opening the source.",
+          "type": "string",
+          "minLength": 1
+        },
+        "stance": {
+          "description": "How this source relates to the claim.",
+          "enum": ["supports", "refutes", "context"]
+        },
+        "as_of": {
+          "description": "ISO-8601 date the source was retrieved or published.",
+          "type": "string",
+          "format": "date"
+        }
+      }
+    }
+  }
+}

--- a/plugins-cc/agentkit/skills/product-intelligence/scripts/validate.ts
+++ b/plugins-cc/agentkit/skills/product-intelligence/scripts/validate.ts
@@ -1,0 +1,247 @@
+#!/usr/bin/env bun
+// Self-contained validator for product-intelligence ledgers and briefs.
+// The JSON Schema files are the source of truth for structure; this file
+// implements only the schema subset they use, plus the cross-field rules a
+// schema cannot express (class/source coupling, contradiction symmetry,
+// cross-document claim references).
+
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+
+type Json = unknown;
+type Schema = Record<string, Json>;
+
+const schemasDir = join(import.meta.dir, '..', 'schemas');
+export const ledgerSchema = loadSchema('ledger.schema.json');
+export const briefSchema = loadSchema('brief.schema.json');
+
+function loadSchema(name: string): Schema {
+  return JSON.parse(readFileSync(join(schemasDir, name), 'utf-8'));
+}
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+// The ledger declares generated_at as "date (or date-time)"; accept both.
+const DATE_TIME_RE = /^\d{4}-\d{2}-\d{2}([T ]\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:?\d{2})?)?$/;
+
+function resolveRef(root: Schema, ref: string): Schema {
+  if (!ref.startsWith('#/')) throw new Error(`unsupported $ref: ${ref}`);
+  let node: Json = root;
+  for (const part of ref.slice(2).split('/')) {
+    node = (node as Record<string, Json>)[part];
+    if (node === undefined) throw new Error(`dangling $ref: ${ref}`);
+  }
+  return node as Schema;
+}
+
+function typeOf(value: Json): string {
+  if (Array.isArray(value)) return 'array';
+  if (value === null) return 'null';
+  return typeof value;
+}
+
+export function checkSchema(value: Json, schema: Schema, root: Schema, path: string, errors: string[]): void {
+  if (typeof schema.$ref === 'string') {
+    checkSchema(value, resolveRef(root, schema.$ref), root, path, errors);
+    return;
+  }
+  if (Array.isArray(schema.enum)) {
+    if (!schema.enum.some((v) => v === value)) {
+      errors.push(`${path}: must be one of ${schema.enum.map((v) => JSON.stringify(v)).join(', ')}`);
+    }
+    return;
+  }
+  if (typeof schema.type === 'string' && typeOf(value) !== schema.type) {
+    errors.push(`${path}: expected ${schema.type}, got ${typeOf(value)}`);
+    return;
+  }
+  if (schema.type === 'string') checkString(value as string, schema, path, errors);
+  if (schema.type === 'object') checkObject(value as Record<string, Json>, schema, root, path, errors);
+  if (schema.type === 'array' && schema.items) {
+    (value as Json[]).forEach((item, i) => checkSchema(item, schema.items as Schema, root, `${path}[${i}]`, errors));
+  }
+}
+
+function checkString(value: string, schema: Schema, path: string, errors: string[]): void {
+  if (typeof schema.minLength === 'number' && value.length < schema.minLength) {
+    errors.push(`${path}: must not be empty`);
+  }
+  if (typeof schema.pattern === 'string' && !new RegExp(schema.pattern).test(value)) {
+    errors.push(`${path}: does not match pattern ${schema.pattern}`);
+  }
+  if (schema.format === 'date' && !DATE_RE.test(value)) {
+    errors.push(`${path}: expected an ISO-8601 date (YYYY-MM-DD)`);
+  }
+  if (schema.format === 'date-time' && !DATE_TIME_RE.test(value)) {
+    errors.push(`${path}: expected an ISO-8601 date or date-time`);
+  }
+}
+
+function checkObject(
+  value: Record<string, Json>,
+  schema: Schema,
+  root: Schema,
+  path: string,
+  errors: string[],
+): void {
+  const props = (schema.properties ?? {}) as Record<string, Schema>;
+  for (const key of (schema.required ?? []) as string[]) {
+    if (value[key] === undefined) errors.push(`${path}: missing required field '${key}'`);
+  }
+  for (const [key, item] of Object.entries(value)) {
+    const prop = props[key];
+    if (!prop) {
+      if (schema.additionalProperties === false) errors.push(`${path}: unknown field '${key}'`);
+      continue;
+    }
+    checkSchema(item, prop, root, `${path}.${key}`, errors);
+  }
+}
+
+interface Claim {
+  id?: string;
+  class?: string;
+  sources?: Json[];
+  derived_from?: string[];
+  contradicts?: string[];
+}
+
+export function validateLedgerDoc(doc: Json): string[] {
+  const errors: string[] = [];
+  checkSchema(doc, ledgerSchema, ledgerSchema, 'ledger', errors);
+  if (errors.length > 0) return errors;
+
+  const claims = ((doc as Record<string, Json>).claims ?? []) as Claim[];
+  const byId = new Map<string, Claim>();
+  for (const claim of claims) {
+    if (!claim.id) continue;
+    if (byId.has(claim.id)) errors.push(`ledger: duplicate claim id '${claim.id}'`);
+    byId.set(claim.id, claim);
+  }
+  for (const claim of claims) checkClaimRules(claim, byId, errors);
+  return errors;
+}
+
+function checkClaimRules(claim: Claim, byId: Map<string, Claim>, errors: string[]): void {
+  const id = claim.id ?? '?';
+  const evidenced = claim.class === 'observed' || claim.class === 'inferred';
+  if (evidenced && (claim.sources ?? []).length === 0) {
+    errors.push(`ledger claim ${id}: class '${claim.class}' requires at least one source`);
+  }
+  const derived = claim.derived_from ?? [];
+  if (derived.length > 0 && claim.class !== 'inferred') {
+    errors.push(`ledger claim ${id}: derived_from is only valid for class 'inferred'`);
+  }
+  for (const ref of derived) {
+    const target = byId.get(ref);
+    if (ref === id) errors.push(`ledger claim ${id}: derived_from must not reference itself`);
+    else if (!target) errors.push(`ledger claim ${id}: derived_from references unknown claim '${ref}'`);
+    else if (target.class === 'proposed') {
+      errors.push(
+        `ledger claim ${id}: cannot be inferred from proposed claim '${ref}' — proposals are not evidence about the present`,
+      );
+    }
+  }
+  for (const ref of claim.contradicts ?? []) {
+    const target = byId.get(ref);
+    if (ref === id) errors.push(`ledger claim ${id}: contradicts must not reference itself`);
+    else if (!target) errors.push(`ledger claim ${id}: contradicts references unknown claim '${ref}'`);
+    else if (!(target.contradicts ?? []).includes(id)) {
+      errors.push(`ledger claim ${id}: contradiction with '${ref}' is not symmetric — '${ref}' must list ${id}`);
+    }
+  }
+}
+
+export function validateBriefDoc(doc: Json, ledger?: Json): string[] {
+  const errors: string[] = [];
+  checkSchema(doc, briefSchema, briefSchema, 'brief', errors);
+  if (errors.length > 0) return errors;
+
+  const brief = doc as Record<string, Json>;
+  for (const [i, page] of (((brief.site_inventory ?? []) as Record<string, Json>[])).entries()) {
+    if (page.disposition !== undefined && page.rationale === undefined) {
+      errors.push(`brief.site_inventory[${i}]: a disposition requires a rationale`);
+    }
+  }
+  if (ledger !== undefined) {
+    const known = new Set(
+      (((ledger as Record<string, Json>).claims ?? []) as Claim[]).map((c) => c.id).filter(Boolean),
+    );
+    for (const { path, ref } of collectClaimRefs(brief, 'brief')) {
+      if (!known.has(ref)) errors.push(`${path}: references unknown ledger claim '${ref}'`);
+    }
+  }
+  return errors;
+}
+
+function collectClaimRefs(node: Json, path: string): { path: string; ref: string }[] {
+  if (Array.isArray(node)) {
+    return node.flatMap((item, i) => collectClaimRefs(item, `${path}[${i}]`));
+  }
+  if (typeOf(node) !== 'object') return [];
+  const refs: { path: string; ref: string }[] = [];
+  for (const [key, value] of Object.entries(node as Record<string, Json>)) {
+    if (key === 'claims' && Array.isArray(value)) {
+      for (const ref of value) {
+        if (typeof ref === 'string') refs.push({ path: `${path}.claims`, ref });
+      }
+    } else {
+      refs.push(...collectClaimRefs(value, `${path}.${key}`));
+    }
+  }
+  return refs;
+}
+
+export function parseDocument(path: string): Json {
+  const text = readFileSync(path, 'utf-8');
+  return path.endsWith('.json') ? JSON.parse(text) : Bun.YAML.parse(text);
+}
+
+export function validateFile(path: string): string[] {
+  let doc: Json;
+  try {
+    doc = parseDocument(path);
+  } catch (error) {
+    return [`${path}: unparseable — ${(error as Error).message}`];
+  }
+  if (typeOf(doc) !== 'object') return [`${path}: document must be a mapping`];
+  const root = doc as Record<string, Json>;
+  if (root.ledger_version !== undefined) return validateLedgerDoc(doc);
+  if (root.brief_version !== undefined) return validateBriefFile(doc, path);
+  return [`${path}: neither a ledger (ledger_version) nor a brief (brief_version)`];
+}
+
+function validateBriefFile(doc: Json, path: string): string[] {
+  const ledgerRel = ((doc as Record<string, Json>).evidence as Record<string, Json> | undefined)?.ledger;
+  if (typeof ledgerRel !== 'string') return validateBriefDoc(doc);
+  const ledgerPath = resolve(dirname(path), ledgerRel);
+  if (!existsSync(ledgerPath)) {
+    return [`${path}: evidence.ledger '${ledgerRel}' not found`, ...validateBriefDoc(doc)];
+  }
+  let ledger: Json;
+  try {
+    ledger = parseDocument(ledgerPath);
+  } catch (error) {
+    return [`${path}: evidence.ledger unparseable — ${(error as Error).message}`];
+  }
+  const ledgerErrors = validateLedgerDoc(ledger).map((e) => `${path}: evidence.ledger: ${e}`);
+  return [...ledgerErrors, ...validateBriefDoc(doc, ledger)];
+}
+
+if (import.meta.main) {
+  const files = process.argv.slice(2);
+  if (files.length === 0) {
+    console.error('usage: validate.ts <ledger-or-brief>...');
+    process.exit(2);
+  }
+  let failed = false;
+  for (const file of files) {
+    const errors = validateFile(file);
+    if (errors.length === 0) {
+      console.log(`ok: ${file}`);
+    } else {
+      failed = true;
+      for (const error of errors) console.error(`error: ${error}`);
+    }
+  }
+  process.exit(failed ? 1 : 0);
+}

--- a/skills/product-intelligence/schemas/brief.schema.json
+++ b/skills/product-intelligence/schemas/brief.schema.json
@@ -1,0 +1,250 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agentkit.sbs/schemas/product-intelligence/brief.schema.json",
+  "title": "Product brief",
+  "description": "Evidence-backed statement of what a product is, who it serves, and what its surfaces say. The brief carries the story; the companion evidence ledger carries the proof. Every material assertion cites ledger claim ids. Every field is optional except brief_version, subject and evidence — but the fewer sections filled in, the less the brief says, and downstream consumers report that plainly rather than implying coverage.",
+  "type": "object",
+  "required": ["brief_version", "subject", "evidence"],
+  "additionalProperties": false,
+  "properties": {
+    "brief_version": {
+      "description": "Semver of the brief schema this document targets. Backward-compatible across minors.",
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+(\\.[0-9]+)?$"
+    },
+    "subject": {
+      "type": "object",
+      "required": ["name"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "description": "Product name as its makers use it.",
+          "type": "string",
+          "minLength": 1
+        },
+        "homepage": {
+          "description": "Canonical marketing/site URL.",
+          "type": "string",
+          "minLength": 1
+        },
+        "repo": {
+          "description": "Source repository locator, e.g. 'github.com/org/name'.",
+          "type": "string",
+          "minLength": 1
+        },
+        "one_liner": {
+          "description": "What the product is in one sentence, from a user's point of view — not the architecture.",
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "required": ["ledger"],
+      "additionalProperties": false,
+      "properties": {
+        "ledger": {
+          "description": "Path to the evidence ledger, relative to this file. Claim ids cited throughout the brief resolve there.",
+          "type": "string",
+          "minLength": 1
+        },
+        "acquired_at": {
+          "description": "ISO-8601 date the underlying evidence was gathered.",
+          "type": "string",
+          "format": "date"
+        },
+        "acquisition": {
+          "description": "What was fetched and with which tool, so a reader can re-run the acquisition.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/acquisition" }
+        }
+      }
+    },
+    "positioning": {
+      "description": "Moore positioning statement, one slot per field: for <target_customer> who <need>, <subject.name> is a <category> that <key_benefit>; unlike <alternative>, it <differentiation>.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "target_customer": { "type": "string", "minLength": 1 },
+        "need": { "type": "string", "minLength": 1 },
+        "category": { "type": "string", "minLength": 1 },
+        "key_benefit": { "type": "string", "minLength": 1 },
+        "alternative": { "type": "string", "minLength": 1 },
+        "differentiation": { "type": "string", "minLength": 1 },
+        "claims": { "$ref": "#/$defs/claim_refs" }
+      }
+    },
+    "value_map": {
+      "description": "Dunford attribute→value→proof rows. An attribute nobody can name a value for, or a value nobody can prove, is flagged by the analyze pass — leave the field out rather than padding it.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["attribute", "value"],
+        "additionalProperties": false,
+        "properties": {
+          "attribute": {
+            "description": "A capability the product actually has.",
+            "type": "string",
+            "minLength": 1
+          },
+          "value": {
+            "description": "What that capability enables for the customer.",
+            "type": "string",
+            "minLength": 1
+          },
+          "proof": {
+            "description": "How a skeptic would check the value holds, in prose.",
+            "type": "string",
+            "minLength": 1
+          },
+          "claims": { "$ref": "#/$defs/claim_refs" }
+        }
+      }
+    },
+    "job_stories": {
+      "description": "JTBD job stories: when <situation>, I want <motivation>, so I can <outcome>.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["situation", "motivation", "outcome"],
+        "additionalProperties": false,
+        "properties": {
+          "situation": { "type": "string", "minLength": 1 },
+          "motivation": { "type": "string", "minLength": 1 },
+          "outcome": { "type": "string", "minLength": 1 },
+          "claims": { "$ref": "#/$defs/claim_refs" }
+        }
+      }
+    },
+    "workflows": {
+      "description": "Customer workflows the product participates in, mapped to Ulwick's universal job steps. Steps the product does not touch are simply absent — gaps are the analyze pass's job to call out.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "steps"],
+        "additionalProperties": false,
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "steps": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["step", "description"],
+              "additionalProperties": false,
+              "properties": {
+                "step": {
+                  "enum": [
+                    "define",
+                    "locate",
+                    "prepare",
+                    "confirm",
+                    "execute",
+                    "monitor",
+                    "modify",
+                    "conclude"
+                  ]
+                },
+                "description": {
+                  "description": "What happens at this step and where the product shows up in it.",
+                  "type": "string",
+                  "minLength": 1
+                },
+                "claims": { "$ref": "#/$defs/claim_refs" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "site_inventory": {
+      "description": "Content audit of the product's public surfaces: one row per page, what kind of page it is, and what should happen to it. disposition 'create' marks a page that does not exist yet.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["locator", "page_type"],
+        "additionalProperties": false,
+        "properties": {
+          "locator": {
+            "description": "Structural pointer matching ledger source locators, e.g. 'site:/pricing'.",
+            "type": "string",
+            "minLength": 1
+          },
+          "page_type": {
+            "enum": [
+              "home",
+              "about",
+              "pricing",
+              "product",
+              "docs",
+              "blog",
+              "faq",
+              "contact",
+              "checkout",
+              "collection",
+              "item",
+              "profile",
+              "qa",
+              "search",
+              "legal",
+              "changelog",
+              "landing",
+              "other"
+            ]
+          },
+          "title": { "type": "string", "minLength": 1 },
+          "disposition": {
+            "enum": ["keep", "revise", "consolidate", "remove", "create"]
+          },
+          "rationale": {
+            "description": "Why the disposition. Required whenever a disposition is stated — an unexplained verdict is not auditable.",
+            "type": "string",
+            "minLength": 1
+          },
+          "claims": { "$ref": "#/$defs/claim_refs" }
+        }
+      }
+    },
+    "cannot_verify": {
+      "description": "What could not be established and why. Stated plainly so absence of a section reads as 'unknown', never as 'does not exist'.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["what", "why"],
+        "additionalProperties": false,
+        "properties": {
+          "what": { "type": "string", "minLength": 1 },
+          "why": { "type": "string", "minLength": 1 }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "claim_refs": {
+      "description": "Ledger claim ids backing this section.",
+      "type": "array",
+      "items": { "type": "string", "pattern": "^C-[0-9]{3,}$" }
+    },
+    "acquisition": {
+      "type": "object",
+      "required": ["tool", "target", "retrieved_at"],
+      "additionalProperties": false,
+      "properties": {
+        "tool": {
+          "description": "Acquisition command or wrapper name, e.g. 'trafilatura', 'repomix --remote', 'gh api'.",
+          "type": "string",
+          "minLength": 1
+        },
+        "target": {
+          "description": "URL or repo the tool was pointed at.",
+          "type": "string",
+          "minLength": 1
+        },
+        "retrieved_at": {
+          "type": "string",
+          "format": "date"
+        }
+      }
+    }
+  }
+}

--- a/skills/product-intelligence/schemas/fixtures/invalid/brief-dangling-ledger.yaml
+++ b/skills/product-intelligence/schemas/fixtures/invalid/brief-dangling-ledger.yaml
@@ -1,0 +1,5 @@
+brief_version: "1.0"
+subject:
+  name: acme-notes
+evidence:
+  ledger: does-not-exist.yaml

--- a/skills/product-intelligence/schemas/fixtures/invalid/brief-disposition-without-rationale.yaml
+++ b/skills/product-intelligence/schemas/fixtures/invalid/brief-disposition-without-rationale.yaml
@@ -1,0 +1,9 @@
+brief_version: "1.0"
+subject:
+  name: acme-notes
+evidence:
+  ledger: ../valid/ledger.yaml
+site_inventory:
+  - locator: "site:/pricing"
+    page_type: pricing
+    disposition: remove

--- a/skills/product-intelligence/schemas/fixtures/invalid/brief-missing-subject-name.yaml
+++ b/skills/product-intelligence/schemas/fixtures/invalid/brief-missing-subject-name.yaml
@@ -1,0 +1,5 @@
+brief_version: "1.0"
+subject:
+  homepage: https://acme-notes.example
+evidence:
+  ledger: ../valid/ledger.yaml

--- a/skills/product-intelligence/schemas/fixtures/invalid/brief-unknown-claim.yaml
+++ b/skills/product-intelligence/schemas/fixtures/invalid/brief-unknown-claim.yaml
@@ -1,0 +1,8 @@
+brief_version: "1.0"
+subject:
+  name: acme-notes
+evidence:
+  ledger: ../valid/ledger.yaml
+positioning:
+  target_customer: solo developers
+  claims: [C-999]

--- a/skills/product-intelligence/schemas/fixtures/invalid/ledger-contradicts-asymmetric.yaml
+++ b/skills/product-intelligence/schemas/fixtures/invalid/ledger-contradicts-asymmetric.yaml
@@ -1,0 +1,23 @@
+ledger_version: "1.0"
+generated_by: product-intelligence
+generated_at: "2026-07-27T10:00:00Z"
+claims:
+  - id: C-001
+    statement: The free tier allows three projects.
+    class: observed
+    confidence: high
+    contradicts: [C-002]
+    sources:
+      - locator: "site:/pricing"
+        quote: "up to 3 projects"
+        stance: supports
+        as_of: "2026-07-25"
+  - id: C-002
+    statement: The free tier allows five projects.
+    class: observed
+    confidence: high
+    sources:
+      - locator: "repo:README.md:12"
+        quote: "up to 5 projects"
+        stance: supports
+        as_of: "2026-07-25"

--- a/skills/product-intelligence/schemas/fixtures/invalid/ledger-derived-from-observed.yaml
+++ b/skills/product-intelligence/schemas/fixtures/invalid/ledger-derived-from-observed.yaml
@@ -1,0 +1,23 @@
+ledger_version: "1.0"
+generated_by: product-intelligence
+generated_at: "2026-07-27T10:00:00Z"
+claims:
+  - id: C-001
+    statement: The pricing page lists a free tier.
+    class: observed
+    confidence: high
+    derived_from: [C-002]
+    sources:
+      - locator: "site:/pricing"
+        quote: "Free tier"
+        stance: supports
+        as_of: "2026-07-25"
+  - id: C-002
+    statement: The README mentions a free plan.
+    class: observed
+    confidence: high
+    sources:
+      - locator: "repo:README.md:3"
+        quote: "free plan"
+        stance: supports
+        as_of: "2026-07-25"

--- a/skills/product-intelligence/schemas/fixtures/invalid/ledger-duplicate-id.yaml
+++ b/skills/product-intelligence/schemas/fixtures/invalid/ledger-duplicate-id.yaml
@@ -1,0 +1,12 @@
+ledger_version: "1.0"
+generated_by: product-intelligence
+generated_at: "2026-07-27T10:00:00Z"
+claims:
+  - id: C-001
+    statement: A migration guide should be added.
+    class: proposed
+    confidence: low
+  - id: C-001
+    statement: A comparison page should be added.
+    class: proposed
+    confidence: low

--- a/skills/product-intelligence/schemas/fixtures/invalid/ledger-inferred-from-proposed.yaml
+++ b/skills/product-intelligence/schemas/fixtures/invalid/ledger-inferred-from-proposed.yaml
@@ -1,0 +1,18 @@
+ledger_version: "1.0"
+generated_by: product-intelligence
+generated_at: "2026-07-27T10:00:00Z"
+claims:
+  - id: C-001
+    statement: A migration guide should be added.
+    class: proposed
+    confidence: low
+  - id: C-002
+    statement: The docs cover migration from CompetitorX.
+    class: inferred
+    confidence: low
+    derived_from: [C-001]
+    sources:
+      - locator: "site:/docs"
+        quote: "Guides"
+        stance: context
+        as_of: "2026-07-25"

--- a/skills/product-intelligence/schemas/fixtures/invalid/ledger-merged-class-confidence.yaml
+++ b/skills/product-intelligence/schemas/fixtures/invalid/ledger-merged-class-confidence.yaml
@@ -1,0 +1,13 @@
+ledger_version: "1.0"
+generated_by: product-intelligence
+generated_at: "2026-07-27T10:00:00Z"
+claims:
+  - id: C-001
+    statement: The pricing page lists a free tier.
+    class: high-confidence-observed
+    confidence: high
+    sources:
+      - locator: "site:/pricing"
+        quote: "Free tier"
+        stance: supports
+        as_of: "2026-07-25"

--- a/skills/product-intelligence/schemas/fixtures/invalid/ledger-missing-sources.yaml
+++ b/skills/product-intelligence/schemas/fixtures/invalid/ledger-missing-sources.yaml
@@ -1,0 +1,8 @@
+ledger_version: "1.0"
+generated_by: product-intelligence
+generated_at: "2026-07-27T10:00:00Z"
+claims:
+  - id: C-001
+    statement: The pricing page lists a free tier.
+    class: observed
+    confidence: high

--- a/skills/product-intelligence/schemas/fixtures/invalid/ledger-source-missing-quote.yaml
+++ b/skills/product-intelligence/schemas/fixtures/invalid/ledger-source-missing-quote.yaml
@@ -1,0 +1,12 @@
+ledger_version: "1.0"
+generated_by: product-intelligence
+generated_at: "2026-07-27T10:00:00Z"
+claims:
+  - id: C-001
+    statement: The pricing page lists a free tier.
+    class: observed
+    confidence: high
+    sources:
+      - locator: "site:/pricing"
+        stance: supports
+        as_of: "2026-07-25"

--- a/skills/product-intelligence/schemas/fixtures/invalid/ledger-unknown-derived-ref.yaml
+++ b/skills/product-intelligence/schemas/fixtures/invalid/ledger-unknown-derived-ref.yaml
@@ -1,0 +1,14 @@
+ledger_version: "1.0"
+generated_by: product-intelligence
+generated_at: "2026-07-27T10:00:00Z"
+claims:
+  - id: C-001
+    statement: The product targets solo developers.
+    class: inferred
+    confidence: moderate
+    derived_from: [C-099]
+    sources:
+      - locator: "site:/pricing"
+        quote: "Perfect for personal projects"
+        stance: context
+        as_of: "2026-07-25"

--- a/skills/product-intelligence/schemas/fixtures/invalid/ledger-unknown-field.yaml
+++ b/skills/product-intelligence/schemas/fixtures/invalid/ledger-unknown-field.yaml
@@ -1,0 +1,9 @@
+ledger_version: "1.0"
+generated_by: product-intelligence
+generated_at: "2026-07-27T10:00:00Z"
+claims:
+  - id: C-001
+    statement: A migration guide should be added.
+    class: proposed
+    confidence: low
+    severity: high

--- a/skills/product-intelligence/schemas/fixtures/valid/brief.minimal.yaml
+++ b/skills/product-intelligence/schemas/fixtures/valid/brief.minimal.yaml
@@ -1,0 +1,5 @@
+brief_version: "1.0"
+subject:
+  name: acme-notes
+evidence:
+  ledger: ledger.yaml

--- a/skills/product-intelligence/schemas/fixtures/valid/brief.yaml
+++ b/skills/product-intelligence/schemas/fixtures/valid/brief.yaml
@@ -1,0 +1,56 @@
+brief_version: "1.0"
+subject:
+  name: acme-notes
+  homepage: https://acme-notes.example
+  repo: github.com/acme/acme-notes
+  one_liner: Note-taking app that keeps every note in a plain git repository.
+evidence:
+  ledger: ledger.yaml
+  acquired_at: "2026-07-25"
+  acquisition:
+    - tool: trafilatura
+      target: https://acme-notes.example
+      retrieved_at: "2026-07-25"
+    - tool: repomix --remote
+      target: github.com/acme/acme-notes
+      retrieved_at: "2026-07-25"
+positioning:
+  target_customer: solo developers
+  need: notes that live next to their code
+  category: git-native note-taking app
+  key_benefit: notes are versioned and greppable like source
+  alternative: hosted note SaaS
+  differentiation: works offline against a repository the user already owns
+  claims: [C-003]
+value_map:
+  - attribute: stores notes as plain markdown in git
+    value: no lock-in — notes outlive the product
+    proof: clone the repo and read the notes with any editor
+    claims: [C-002]
+job_stories:
+  - situation: I am deep in a debugging session
+    motivation: I want to capture what I ruled out
+    outcome: I can pick the thread back up tomorrow without re-deriving it
+    claims: [C-003]
+workflows:
+  - name: capture a finding
+    steps:
+      - step: execute
+        description: write the note in the editor alongside the code
+      - step: conclude
+        description: commit lands the note in history with the change it explains
+site_inventory:
+  - locator: "site:/pricing"
+    page_type: pricing
+    title: Plans
+    disposition: revise
+    rationale: the stated free-tier limit contradicts the README
+    claims: [C-001, C-002]
+  - locator: "site:/docs/migrate-from-competitorx"
+    page_type: docs
+    disposition: create
+    rationale: no migration path is documented for the most-cited alternative
+    claims: [C-004]
+cannot_verify:
+  - what: SOC 2 certification claim
+    why: no audit report or trust page is published anywhere reachable

--- a/skills/product-intelligence/schemas/fixtures/valid/ledger.yaml
+++ b/skills/product-intelligence/schemas/fixtures/valid/ledger.yaml
@@ -1,0 +1,42 @@
+ledger_version: "1.0"
+generated_by: product-intelligence
+generated_at: "2026-07-27T10:00:00Z"
+claims:
+  - id: C-001
+    statement: The pricing page lists a free tier limited to three projects.
+    class: observed
+    confidence: high
+    contradicts: [C-002]
+    sources:
+      - locator: "site:/pricing#plans"
+        quote: "Free — up to 3 projects"
+        stance: supports
+        as_of: "2026-07-25"
+  - id: C-002
+    statement: The repository README states the free tier allows five projects.
+    class: observed
+    confidence: high
+    contradicts: [C-001]
+    sources:
+      - locator: "repo:README.md:12-14"
+        quote: "The free plan covers up to 5 projects."
+        stance: supports
+        as_of: "2026-07-25"
+  - id: C-003
+    statement: The product is aimed at solo developers rather than teams.
+    class: inferred
+    confidence: moderate
+    derived_from: [C-001]
+    sources:
+      - locator: "site:/pricing#plans"
+        quote: "Perfect for personal projects"
+        stance: context
+        as_of: "2026-07-25"
+  - id: C-004
+    statement: A migration guide from CompetitorX should be added to the docs.
+    class: proposed
+    confidence: low
+  - id: C-005
+    statement: The product holds SOC 2 Type II certification.
+    class: unverified
+    confidence: low

--- a/skills/product-intelligence/schemas/ledger.schema.json
+++ b/skills/product-intelligence/schemas/ledger.schema.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agentkit.sbs/schemas/product-intelligence/ledger.schema.json",
+  "title": "Product-intelligence evidence ledger",
+  "description": "Flat, auditable record of every material claim in a product brief. Each claim is one atomic proposition carrying its source, evidence class, and confidence. Contradictions are recorded, never reconciled.",
+  "type": "object",
+  "required": ["ledger_version", "generated_by", "generated_at", "claims"],
+  "additionalProperties": false,
+  "properties": {
+    "ledger_version": {
+      "description": "Semver of the ledger schema this document targets. Backward-compatible across minors.",
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+(\\.[0-9]+)?$"
+    },
+    "generated_by": {
+      "description": "Tool/skill identifier that produced this ledger.",
+      "type": "string",
+      "minLength": 1
+    },
+    "generated_at": {
+      "description": "ISO-8601 date (or date-time) the ledger was produced.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "claims": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/claim" }
+    }
+  },
+  "$defs": {
+    "claim": {
+      "type": "object",
+      "required": ["id", "statement", "class", "confidence"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "description": "Stable, referenceable handle. A claim may be restated in prose anywhere without duplicating the entry.",
+          "type": "string",
+          "pattern": "^C-[0-9]{3,}$"
+        },
+        "statement": {
+          "description": "Exactly one atomic proposition. A statement needing 'and' is two claims.",
+          "type": "string",
+          "minLength": 1
+        },
+        "class": {
+          "description": "What kind of statement this is. Independent of confidence and never merged with it.",
+          "enum": ["observed", "inferred", "proposed", "unverified"]
+        },
+        "confidence": {
+          "description": "How solid the basis is. Independent of class.",
+          "enum": ["high", "moderate", "low"]
+        },
+        "sources": {
+          "description": "Where the claim comes from. Required for observed/inferred; empty is only valid for proposed/unverified.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/source" }
+        },
+        "derived_from": {
+          "description": "Claim ids this claim is inferred from. Populated only when class is 'inferred'.",
+          "type": "array",
+          "items": { "type": "string", "pattern": "^C-[0-9]{3,}$" }
+        },
+        "contradicts": {
+          "description": "Claim ids this claim stands in unresolved contradiction with. A populated value is a valid terminal state — rendered in the brief, never silently resolved.",
+          "type": "array",
+          "items": { "type": "string", "pattern": "^C-[0-9]{3,}$" }
+        }
+      }
+    },
+    "source": {
+      "type": "object",
+      "required": ["locator", "quote", "stance", "as_of"],
+      "additionalProperties": false,
+      "properties": {
+        "locator": {
+          "description": "Structural pointer that survives edits: 'site:/pricing#plans', 'repo:README.md:40-52', 'doc:brief.pdf#p3'.",
+          "type": "string",
+          "minLength": 1
+        },
+        "quote": {
+          "description": "Verbatim excerpt from the source. The quote is what makes a fabricated citation catchable without opening the source.",
+          "type": "string",
+          "minLength": 1
+        },
+        "stance": {
+          "description": "How this source relates to the claim.",
+          "enum": ["supports", "refutes", "context"]
+        },
+        "as_of": {
+          "description": "ISO-8601 date the source was retrieved or published.",
+          "type": "string",
+          "format": "date"
+        }
+      }
+    }
+  }
+}

--- a/skills/product-intelligence/scripts/validate.ts
+++ b/skills/product-intelligence/scripts/validate.ts
@@ -1,0 +1,247 @@
+#!/usr/bin/env bun
+// Self-contained validator for product-intelligence ledgers and briefs.
+// The JSON Schema files are the source of truth for structure; this file
+// implements only the schema subset they use, plus the cross-field rules a
+// schema cannot express (class/source coupling, contradiction symmetry,
+// cross-document claim references).
+
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+
+type Json = unknown;
+type Schema = Record<string, Json>;
+
+const schemasDir = join(import.meta.dir, '..', 'schemas');
+export const ledgerSchema = loadSchema('ledger.schema.json');
+export const briefSchema = loadSchema('brief.schema.json');
+
+function loadSchema(name: string): Schema {
+  return JSON.parse(readFileSync(join(schemasDir, name), 'utf-8'));
+}
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+// The ledger declares generated_at as "date (or date-time)"; accept both.
+const DATE_TIME_RE = /^\d{4}-\d{2}-\d{2}([T ]\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:?\d{2})?)?$/;
+
+function resolveRef(root: Schema, ref: string): Schema {
+  if (!ref.startsWith('#/')) throw new Error(`unsupported $ref: ${ref}`);
+  let node: Json = root;
+  for (const part of ref.slice(2).split('/')) {
+    node = (node as Record<string, Json>)[part];
+    if (node === undefined) throw new Error(`dangling $ref: ${ref}`);
+  }
+  return node as Schema;
+}
+
+function typeOf(value: Json): string {
+  if (Array.isArray(value)) return 'array';
+  if (value === null) return 'null';
+  return typeof value;
+}
+
+export function checkSchema(value: Json, schema: Schema, root: Schema, path: string, errors: string[]): void {
+  if (typeof schema.$ref === 'string') {
+    checkSchema(value, resolveRef(root, schema.$ref), root, path, errors);
+    return;
+  }
+  if (Array.isArray(schema.enum)) {
+    if (!schema.enum.some((v) => v === value)) {
+      errors.push(`${path}: must be one of ${schema.enum.map((v) => JSON.stringify(v)).join(', ')}`);
+    }
+    return;
+  }
+  if (typeof schema.type === 'string' && typeOf(value) !== schema.type) {
+    errors.push(`${path}: expected ${schema.type}, got ${typeOf(value)}`);
+    return;
+  }
+  if (schema.type === 'string') checkString(value as string, schema, path, errors);
+  if (schema.type === 'object') checkObject(value as Record<string, Json>, schema, root, path, errors);
+  if (schema.type === 'array' && schema.items) {
+    (value as Json[]).forEach((item, i) => checkSchema(item, schema.items as Schema, root, `${path}[${i}]`, errors));
+  }
+}
+
+function checkString(value: string, schema: Schema, path: string, errors: string[]): void {
+  if (typeof schema.minLength === 'number' && value.length < schema.minLength) {
+    errors.push(`${path}: must not be empty`);
+  }
+  if (typeof schema.pattern === 'string' && !new RegExp(schema.pattern).test(value)) {
+    errors.push(`${path}: does not match pattern ${schema.pattern}`);
+  }
+  if (schema.format === 'date' && !DATE_RE.test(value)) {
+    errors.push(`${path}: expected an ISO-8601 date (YYYY-MM-DD)`);
+  }
+  if (schema.format === 'date-time' && !DATE_TIME_RE.test(value)) {
+    errors.push(`${path}: expected an ISO-8601 date or date-time`);
+  }
+}
+
+function checkObject(
+  value: Record<string, Json>,
+  schema: Schema,
+  root: Schema,
+  path: string,
+  errors: string[],
+): void {
+  const props = (schema.properties ?? {}) as Record<string, Schema>;
+  for (const key of (schema.required ?? []) as string[]) {
+    if (value[key] === undefined) errors.push(`${path}: missing required field '${key}'`);
+  }
+  for (const [key, item] of Object.entries(value)) {
+    const prop = props[key];
+    if (!prop) {
+      if (schema.additionalProperties === false) errors.push(`${path}: unknown field '${key}'`);
+      continue;
+    }
+    checkSchema(item, prop, root, `${path}.${key}`, errors);
+  }
+}
+
+interface Claim {
+  id?: string;
+  class?: string;
+  sources?: Json[];
+  derived_from?: string[];
+  contradicts?: string[];
+}
+
+export function validateLedgerDoc(doc: Json): string[] {
+  const errors: string[] = [];
+  checkSchema(doc, ledgerSchema, ledgerSchema, 'ledger', errors);
+  if (errors.length > 0) return errors;
+
+  const claims = ((doc as Record<string, Json>).claims ?? []) as Claim[];
+  const byId = new Map<string, Claim>();
+  for (const claim of claims) {
+    if (!claim.id) continue;
+    if (byId.has(claim.id)) errors.push(`ledger: duplicate claim id '${claim.id}'`);
+    byId.set(claim.id, claim);
+  }
+  for (const claim of claims) checkClaimRules(claim, byId, errors);
+  return errors;
+}
+
+function checkClaimRules(claim: Claim, byId: Map<string, Claim>, errors: string[]): void {
+  const id = claim.id ?? '?';
+  const evidenced = claim.class === 'observed' || claim.class === 'inferred';
+  if (evidenced && (claim.sources ?? []).length === 0) {
+    errors.push(`ledger claim ${id}: class '${claim.class}' requires at least one source`);
+  }
+  const derived = claim.derived_from ?? [];
+  if (derived.length > 0 && claim.class !== 'inferred') {
+    errors.push(`ledger claim ${id}: derived_from is only valid for class 'inferred'`);
+  }
+  for (const ref of derived) {
+    const target = byId.get(ref);
+    if (ref === id) errors.push(`ledger claim ${id}: derived_from must not reference itself`);
+    else if (!target) errors.push(`ledger claim ${id}: derived_from references unknown claim '${ref}'`);
+    else if (target.class === 'proposed') {
+      errors.push(
+        `ledger claim ${id}: cannot be inferred from proposed claim '${ref}' — proposals are not evidence about the present`,
+      );
+    }
+  }
+  for (const ref of claim.contradicts ?? []) {
+    const target = byId.get(ref);
+    if (ref === id) errors.push(`ledger claim ${id}: contradicts must not reference itself`);
+    else if (!target) errors.push(`ledger claim ${id}: contradicts references unknown claim '${ref}'`);
+    else if (!(target.contradicts ?? []).includes(id)) {
+      errors.push(`ledger claim ${id}: contradiction with '${ref}' is not symmetric — '${ref}' must list ${id}`);
+    }
+  }
+}
+
+export function validateBriefDoc(doc: Json, ledger?: Json): string[] {
+  const errors: string[] = [];
+  checkSchema(doc, briefSchema, briefSchema, 'brief', errors);
+  if (errors.length > 0) return errors;
+
+  const brief = doc as Record<string, Json>;
+  for (const [i, page] of (((brief.site_inventory ?? []) as Record<string, Json>[])).entries()) {
+    if (page.disposition !== undefined && page.rationale === undefined) {
+      errors.push(`brief.site_inventory[${i}]: a disposition requires a rationale`);
+    }
+  }
+  if (ledger !== undefined) {
+    const known = new Set(
+      (((ledger as Record<string, Json>).claims ?? []) as Claim[]).map((c) => c.id).filter(Boolean),
+    );
+    for (const { path, ref } of collectClaimRefs(brief, 'brief')) {
+      if (!known.has(ref)) errors.push(`${path}: references unknown ledger claim '${ref}'`);
+    }
+  }
+  return errors;
+}
+
+function collectClaimRefs(node: Json, path: string): { path: string; ref: string }[] {
+  if (Array.isArray(node)) {
+    return node.flatMap((item, i) => collectClaimRefs(item, `${path}[${i}]`));
+  }
+  if (typeOf(node) !== 'object') return [];
+  const refs: { path: string; ref: string }[] = [];
+  for (const [key, value] of Object.entries(node as Record<string, Json>)) {
+    if (key === 'claims' && Array.isArray(value)) {
+      for (const ref of value) {
+        if (typeof ref === 'string') refs.push({ path: `${path}.claims`, ref });
+      }
+    } else {
+      refs.push(...collectClaimRefs(value, `${path}.${key}`));
+    }
+  }
+  return refs;
+}
+
+export function parseDocument(path: string): Json {
+  const text = readFileSync(path, 'utf-8');
+  return path.endsWith('.json') ? JSON.parse(text) : Bun.YAML.parse(text);
+}
+
+export function validateFile(path: string): string[] {
+  let doc: Json;
+  try {
+    doc = parseDocument(path);
+  } catch (error) {
+    return [`${path}: unparseable — ${(error as Error).message}`];
+  }
+  if (typeOf(doc) !== 'object') return [`${path}: document must be a mapping`];
+  const root = doc as Record<string, Json>;
+  if (root.ledger_version !== undefined) return validateLedgerDoc(doc);
+  if (root.brief_version !== undefined) return validateBriefFile(doc, path);
+  return [`${path}: neither a ledger (ledger_version) nor a brief (brief_version)`];
+}
+
+function validateBriefFile(doc: Json, path: string): string[] {
+  const ledgerRel = ((doc as Record<string, Json>).evidence as Record<string, Json> | undefined)?.ledger;
+  if (typeof ledgerRel !== 'string') return validateBriefDoc(doc);
+  const ledgerPath = resolve(dirname(path), ledgerRel);
+  if (!existsSync(ledgerPath)) {
+    return [`${path}: evidence.ledger '${ledgerRel}' not found`, ...validateBriefDoc(doc)];
+  }
+  let ledger: Json;
+  try {
+    ledger = parseDocument(ledgerPath);
+  } catch (error) {
+    return [`${path}: evidence.ledger unparseable — ${(error as Error).message}`];
+  }
+  const ledgerErrors = validateLedgerDoc(ledger).map((e) => `${path}: evidence.ledger: ${e}`);
+  return [...ledgerErrors, ...validateBriefDoc(doc, ledger)];
+}
+
+if (import.meta.main) {
+  const files = process.argv.slice(2);
+  if (files.length === 0) {
+    console.error('usage: validate.ts <ledger-or-brief>...');
+    process.exit(2);
+  }
+  let failed = false;
+  for (const file of files) {
+    const errors = validateFile(file);
+    if (errors.length === 0) {
+      console.log(`ok: ${file}`);
+    } else {
+      failed = true;
+      for (const error of errors) console.error(`error: ${error}`);
+    }
+  }
+  process.exit(failed ? 1 : 0);
+}

--- a/tests/product-intelligence/schemas.test.ts
+++ b/tests/product-intelligence/schemas.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from 'bun:test';
+import { readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { validateFile } from '../../skills/product-intelligence/scripts/validate.ts';
+
+const repoRoot = dirname(dirname(import.meta.dir));
+const skillRoot = join(repoRoot, 'skills', 'product-intelligence');
+const validatorScript = join(skillRoot, 'scripts', 'validate.ts');
+const fixtures = join(skillRoot, 'schemas', 'fixtures');
+
+const valid = (name: string) => join(fixtures, 'valid', name);
+const invalid = (name: string) => join(fixtures, 'invalid', name);
+
+// Each invalid fixture violates exactly one rule; the expected message names
+// that rule so a validator that rejects for the wrong reason still fails here.
+const expectedFailures: Record<string, string> = {
+  'ledger-missing-sources.yaml': 'requires at least one source',
+  'ledger-derived-from-observed.yaml': "only valid for class 'inferred'",
+  'ledger-contradicts-asymmetric.yaml': 'not symmetric',
+  'ledger-inferred-from-proposed.yaml': 'proposals are not evidence',
+  'ledger-unknown-derived-ref.yaml': "unknown claim 'C-099'",
+  'ledger-duplicate-id.yaml': 'duplicate claim id',
+  'ledger-merged-class-confidence.yaml': 'must be one of',
+  'ledger-unknown-field.yaml': "unknown field 'severity'",
+  'ledger-source-missing-quote.yaml': "missing required field 'quote'",
+  'brief-unknown-claim.yaml': "unknown ledger claim 'C-999'",
+  'brief-disposition-without-rationale.yaml': 'requires a rationale',
+  'brief-missing-subject-name.yaml': "missing required field 'name'",
+  'brief-dangling-ledger.yaml': 'not found',
+};
+
+describe('product-intelligence schemas', () => {
+  test('accepts every valid fixture', () => {
+    for (const name of readdirSync(join(fixtures, 'valid'))) {
+      expect(validateFile(valid(name)), name).toEqual([]);
+    }
+  });
+
+  test('every invalid fixture is covered by an expectation', () => {
+    expect(readdirSync(join(fixtures, 'invalid')).sort()).toEqual(Object.keys(expectedFailures).sort());
+  });
+
+  for (const [name, message] of Object.entries(expectedFailures)) {
+    test(`rejects ${name} for the right reason`, () => {
+      const errors = validateFile(invalid(name));
+      expect(errors.length, errors.join('\n')).toBeGreaterThan(0);
+      expect(errors.join('\n')).toContain(message);
+    });
+  }
+});
+
+describe('validate.ts CLI', () => {
+  const run = (...args: string[]) => spawnSync('bun', [validatorScript, ...args], { encoding: 'utf-8' });
+
+  test('exits 0 and reports ok for valid documents', () => {
+    const result = run(valid('ledger.yaml'), valid('brief.yaml'));
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('ok:');
+  });
+
+  test('exits 1 and prints each violation for invalid documents', () => {
+    const result = run(invalid('ledger-contradicts-asymmetric.yaml'));
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('not symmetric');
+  });
+
+  test('exits 2 with usage when given no files', () => {
+    const result = run();
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('usage');
+  });
+});


### PR DESCRIPTION
Part of #115 — slice 1 of 5.

- `ledger.schema.json`: evidence ledger — class×confidence as two axes, sourced quotes, unresolved contradictions as terminal state
- `brief.schema.json`: Moore positioning, Dunford value map, JTBD job stories, Ulwick workflow steps, site inventory w/ disposition+rationale; every section cites ledger claim ids
- `scripts/validate.ts`: zero-dep bun validator — schema-subset engine reading the schema files + cross-field rules (sources required for observed/inferred, derived_from inferred-only and never from proposed, contradiction symmetry, brief→ledger claim refs, disposition⇒rationale)
- fixtures: 3 valid, 13 invalid (one rule each); `tests/product-intelligence/schemas.test.ts` pins each rejection to its rule
- plugins-cc mirror synced (parity test enforces it)

Verify: `scripts/product-command default -- bun test` — 543 pass, 0 fail.