### PR TITLE
feat(product-intelligence): worked examples (slice 4, final)

### DIFF
--- a/plugins-cc/agentkit/skills/product-intelligence/SKILL.md
+++ b/plugins-cc/agentkit/skills/product-intelligence/SKILL.md
@@ -36,6 +36,8 @@ bun skills/product-intelligence/scripts/validate.ts .agentkit/intelligence/<slug
 
 A brief validates together with the ledger it cites — dangling claim ids,
 asymmetric contradictions and unsourced observations all fail loudly.
+Worked examples of the full artifact set — website-only, repo-only and
+mixed evidence — live in `examples/`.
 
 ## Workflow
 

--- a/plugins-cc/agentkit/skills/product-intelligence/examples/README.md
+++ b/plugins-cc/agentkit/skills/product-intelligence/examples/README.md
@@ -1,0 +1,16 @@
+# Worked examples
+
+Each directory is a complete, schema-valid artifact set for one evidence
+situation. The subjects are fictional; the shapes are the contract.
+
+| Example         | Demonstrates                                                                                                                               |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `website-only/` | Site locators only; repo-side facts land in `cannot_verify`, not guesses                                                                   |
+| `repo-only/`    | Repo + release locators; adoption/registry facts are `cannot_verify`                                                                       |
+| `mixed/`        | Both surfaces, an unresolved contradiction rendered in the brief, and the full set: `brief.yaml`, `ledger.yaml`, `brief.md`, `findings.md` |
+
+Validate any of them:
+
+```sh
+bun skills/product-intelligence/scripts/validate.ts skills/product-intelligence/examples/mixed/brief.yaml
+```

--- a/plugins-cc/agentkit/skills/product-intelligence/examples/mixed/brief.md
+++ b/plugins-cc/agentkit/skills/product-intelligence/examples/mixed/brief.md
@@ -6,8 +6,8 @@ acme-notes is a note-taking app for solo developers whose notes live as
 plain markdown files inside a git repository the user already owns
 [C-003]. Where hosted note SaaS keeps your thinking on someone else's
 server, acme-notes versions it next to the code it explains — greppable,
-diffable, and readable with any editor. The product is active, with v1.4.0
-released 2026-07-02 [C-005].
+diffable, and readable with any editor. The most recent release, v1.4.0,
+shipped 2026-07-02 [C-005].
 
 ## The Problem
 
@@ -24,8 +24,7 @@ history with the change it explains).
 ## What Makes This Different
 
 No lock-in is the moat that can be proven: clone the repo and the notes
-are yours with any editor [C-003]. No fabricated technical moats beyond
-that — the rest is scope discipline.
+are yours, readable with any editor [C-003].
 
 ## Who This Serves
 

--- a/plugins-cc/agentkit/skills/product-intelligence/examples/mixed/brief.md
+++ b/plugins-cc/agentkit/skills/product-intelligence/examples/mixed/brief.md
@@ -1,0 +1,45 @@
+# Product Brief: acme-notes
+
+## Executive Summary
+
+acme-notes is a note-taking app for solo developers whose notes live as
+plain markdown files inside a git repository the user already owns
+[C-003]. Where hosted note SaaS keeps your thinking on someone else's
+server, acme-notes versions it next to the code it explains — greppable,
+diffable, and readable with any editor. The product is active, with v1.4.0
+released 2026-07-02 [C-005].
+
+## The Problem
+
+Debugging notes, decision trails and half-finished thoughts die in chat
+scrollback and hosted apps that outlive nobody's subscription. For a solo
+developer [C-004], the cost is re-deriving yesterday's dead ends.
+
+## The Solution
+
+Notes are markdown files in your repo [C-003]. Writing one is `execute`
+(edit next to the code); committing is `conclude` (the note lands in
+history with the change it explains).
+
+## What Makes This Different
+
+No lock-in is the moat that can be proven: clone the repo and the notes
+are yours with any editor [C-003]. No fabricated technical moats beyond
+that — the rest is scope discipline.
+
+## Who This Serves
+
+Solo developers on personal projects [C-004]. Team features are neither
+advertised nor evidenced.
+
+## Open Contradiction
+
+The pricing page caps the free tier at three projects [C-001]; the README
+says five [C-002]. Both sources are current as of 2026-07-27. Unresolved —
+see findings.
+
+## Not Verified
+
+- SOC 2 certification [C-007]: no audit report or trust page reachable.
+- Sync conflict dialog behavior: static acquisition cannot exercise the
+  running app.

--- a/plugins-cc/agentkit/skills/product-intelligence/examples/mixed/brief.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/examples/mixed/brief.yaml
@@ -26,7 +26,7 @@ positioning:
   category: git-native note-taking app
   key_benefit: notes are versioned and greppable like source
   alternative: hosted note SaaS
-  differentiation: works offline against a repository the user already owns
+  differentiation: notes live in a repository the user already owns
   claims: [C-003, C-004]
 value_map:
   - attribute: stores notes as plain markdown in git
@@ -57,7 +57,7 @@ site_inventory:
   - locator: "site:/docs/migrate-from-competitorx"
     page_type: docs
     disposition: create
-    rationale: no migration path is documented for the most-cited alternative
+    rationale: no migration path is documented for any named alternative
     claims: [C-006]
 cannot_verify:
   - what: SOC 2 certification claim

--- a/plugins-cc/agentkit/skills/product-intelligence/examples/mixed/brief.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/examples/mixed/brief.yaml
@@ -1,0 +1,66 @@
+brief_version: "1.0"
+subject:
+  name: acme-notes
+  homepage: https://acme-notes.example
+  repo: github.com/acme/acme-notes
+  one_liner: Note-taking app that keeps every note in a plain git repository.
+evidence:
+  ledger: ledger.yaml
+  acquired_at: "2026-07-27"
+  acquisition:
+    - tool: advertools
+      target: https://acme-notes.example
+      retrieved_at: "2026-07-27"
+    - tool: trafilatura
+      target: https://acme-notes.example/pricing
+      retrieved_at: "2026-07-27"
+    - tool: repomix --remote
+      target: acme/acme-notes
+      retrieved_at: "2026-07-27"
+    - tool: gh api
+      target: acme/acme-notes
+      retrieved_at: "2026-07-27"
+positioning:
+  target_customer: solo developers
+  need: notes that live next to their code
+  category: git-native note-taking app
+  key_benefit: notes are versioned and greppable like source
+  alternative: hosted note SaaS
+  differentiation: works offline against a repository the user already owns
+  claims: [C-003, C-004]
+value_map:
+  - attribute: stores notes as plain markdown in git
+    value: no lock-in — notes outlive the product
+    proof: clone the repo and read the notes with any editor
+    claims: [C-003]
+job_stories:
+  - situation: I am deep in a debugging session
+    motivation: I want to capture what I ruled out
+    outcome: I can pick the thread back up tomorrow without re-deriving it
+    claims: [C-004]
+workflows:
+  - name: capture a finding
+    steps:
+      - step: execute
+        description: write the note in the editor alongside the code
+        claims: [C-003]
+      - step: conclude
+        description: commit lands the note in history with the change it explains
+        claims: [C-003]
+site_inventory:
+  - locator: "site:/pricing"
+    page_type: pricing
+    title: Plans
+    disposition: revise
+    rationale: the stated free-tier limit contradicts the README
+    claims: [C-001, C-002]
+  - locator: "site:/docs/migrate-from-competitorx"
+    page_type: docs
+    disposition: create
+    rationale: no migration path is documented for the most-cited alternative
+    claims: [C-006]
+cannot_verify:
+  - what: SOC 2 certification claim
+    why: no audit report or trust page is published anywhere reachable
+  - what: behavior of the in-app sync conflict dialog
+    why: static acquisition cannot exercise the running app

--- a/plugins-cc/agentkit/skills/product-intelligence/examples/mixed/findings.md
+++ b/plugins-cc/agentkit/skills/product-intelligence/examples/mixed/findings.md
@@ -21,8 +21,8 @@ Read-only analyze pass over `brief.yaml` + `ledger.yaml`, 2026-07-27.
 
 ## Risks
 
-- [C-004] (solo-developer audience) is inferred from marketing copy plus
-  the free-tier cap — a single vendor-controlled surface family. A user
-  interview or issue-tracker signal would move it.
+- [C-004] (solo-developer audience) is inferred from the free-tier cap and
+  the marketing framing — all vendor-controlled sources, site and README
+  alike. A user interview or issue-tracker signal would move it.
 - [C-007] (SOC 2) is `unverified` and load-bearing for any
   compliance-sensitive adoption decision; treat as absent until proven.

--- a/plugins-cc/agentkit/skills/product-intelligence/examples/mixed/findings.md
+++ b/plugins-cc/agentkit/skills/product-intelligence/examples/mixed/findings.md
@@ -1,0 +1,28 @@
+# Findings: acme-notes
+
+Read-only analyze pass over `brief.yaml` + `ledger.yaml`, 2026-07-27.
+
+## Contradictions
+
+- **Free-tier project cap: 3 vs 5.** [C-001] (site:/pricing, "up to 3
+  projects") vs [C-002] (repo:README.md, "up to 5 projects"). Both
+  observed, both high confidence, same retrieval date — one surface is
+  stale. The site inventory already marks `site:/pricing` as `revise`.
+
+## Gaps
+
+- No `alternative`-side evidence: the positioning names "hosted note SaaS"
+  but no claim examines any specific alternative.
+- Ulwick coverage is thin: only `execute` and `conclude` have product
+  presence; `locate`, `monitor` and `modify` (finding an old note,
+  noticing staleness, updating it) are unevidenced either way.
+- Do-not-invent topics with no evidence in any direction: pricing history,
+  customer counts, roadmap.
+
+## Risks
+
+- [C-004] (solo-developer audience) is inferred from marketing copy plus
+  the free-tier cap — a single vendor-controlled surface family. A user
+  interview or issue-tracker signal would move it.
+- [C-007] (SOC 2) is `unverified` and load-bearing for any
+  compliance-sensitive adoption decision; treat as absent until proven.

--- a/plugins-cc/agentkit/skills/product-intelligence/examples/mixed/ledger.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/examples/mixed/ledger.yaml
@@ -1,0 +1,64 @@
+ledger_version: "1.0"
+generated_by: product-intelligence
+generated_at: "2026-07-27T10:00:00Z"
+claims:
+  - id: C-001
+    statement: The pricing page lists a free tier limited to three projects.
+    class: observed
+    confidence: high
+    contradicts: [C-002]
+    sources:
+      - locator: "site:/pricing#plans"
+        quote: "Free — up to 3 projects"
+        stance: supports
+        as_of: "2026-07-27"
+  - id: C-002
+    statement: The repository README states the free tier allows five projects.
+    class: observed
+    confidence: high
+    contradicts: [C-001]
+    sources:
+      - locator: "repo:README.md:12-14"
+        quote: "The free plan covers up to 5 projects."
+        stance: supports
+        as_of: "2026-07-27"
+  - id: C-003
+    statement: acme-notes stores notes as markdown files inside a git repository.
+    class: observed
+    confidence: high
+    sources:
+      - locator: "repo:README.md:1-4"
+        quote: "Your notes are plain markdown in your own repo."
+        stance: supports
+        as_of: "2026-07-27"
+      - locator: "site:/"
+        quote: "Notes that live in git, next to your code"
+        stance: supports
+        as_of: "2026-07-27"
+  - id: C-004
+    statement: The product is aimed at solo developers rather than teams.
+    class: inferred
+    confidence: moderate
+    derived_from: [C-001, C-003]
+    sources:
+      - locator: "site:/pricing#plans"
+        quote: "Perfect for personal projects"
+        stance: context
+        as_of: "2026-07-27"
+  - id: C-005
+    statement: The latest release is v1.4.0, published 2026-07-02.
+    class: observed
+    confidence: high
+    sources:
+      - locator: "gh:releases/v1.4.0"
+        quote: "v1.4.0 — 2026-07-02"
+        stance: supports
+        as_of: "2026-07-27"
+  - id: C-006
+    statement: A migration guide from CompetitorX should be added to the docs.
+    class: proposed
+    confidence: low
+  - id: C-007
+    statement: The product holds SOC 2 Type II certification.
+    class: unverified
+    confidence: low

--- a/plugins-cc/agentkit/skills/product-intelligence/examples/repo-only/brief.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/examples/repo-only/brief.yaml
@@ -1,0 +1,40 @@
+brief_version: "1.0"
+subject:
+  name: tidyenv
+  repo: github.com/example/tidyenv
+  one_liner: CLI that strips .env entries nothing in the codebase reads.
+evidence:
+  ledger: ledger.yaml
+  acquired_at: "2026-07-27"
+  acquisition:
+    - tool: repomix --remote
+      target: example/tidyenv
+      retrieved_at: "2026-07-27"
+    - tool: gh api
+      target: example/tidyenv
+      retrieved_at: "2026-07-27"
+positioning:
+  target_customer: developers on aging codebases
+  need: knowing which env vars are actually read
+  category: developer hygiene CLI
+  key_benefit: dead configuration is found, not guessed at
+  claims: [C-001]
+job_stories:
+  - situation: I inherit a service with a 200-line .env.example
+    motivation: I want to know which entries still matter
+    outcome: I can onboard without cargo-culting dead configuration
+    claims: [C-001]
+workflows:
+  - name: clean a service's configuration
+    steps:
+      - step: locate
+        description: tidyenv scans the codebase for env reads
+        claims: [C-001]
+      - step: execute
+        description: unused entries are stripped from the .env files
+        claims: [C-001]
+cannot_verify:
+  - what: adoption, download counts or anyone using it in production
+    why: only the repository was acquired; no site or registry stats
+  - what: behavior on Windows
+    why: CI matrix in the packed repo covers Linux and macOS only

--- a/plugins-cc/agentkit/skills/product-intelligence/examples/repo-only/brief.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/examples/repo-only/brief.yaml
@@ -37,4 +37,4 @@ cannot_verify:
   - what: adoption, download counts or anyone using it in production
     why: only the repository was acquired; no site or registry stats
   - what: behavior on Windows
-    why: CI matrix in the packed repo covers Linux and macOS only
+    why: no acquired source states platform support in either direction

--- a/plugins-cc/agentkit/skills/product-intelligence/examples/repo-only/ledger.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/examples/repo-only/ledger.yaml
@@ -23,7 +23,7 @@ claims:
   - id: C-003
     statement: The project is pre-1.0 and its interface may still change.
     class: inferred
-    confidence: moderate
+    confidence: high
     derived_from: [C-002]
     sources:
       - locator: "repo:CHANGELOG.md:3-6"

--- a/plugins-cc/agentkit/skills/product-intelligence/examples/repo-only/ledger.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/examples/repo-only/ledger.yaml
@@ -1,0 +1,36 @@
+ledger_version: "1.0"
+generated_by: product-intelligence
+generated_at: "2026-07-27T09:30:00Z"
+claims:
+  - id: C-001
+    statement: tidyenv is a CLI that removes unused entries from .env files.
+    class: observed
+    confidence: high
+    sources:
+      - locator: "repo:README.md:1-4"
+        quote: "tidyenv scans your codebase and strips .env entries nothing reads."
+        stance: supports
+        as_of: "2026-07-27"
+  - id: C-002
+    statement: The latest release is v0.9.2, published in June 2026.
+    class: observed
+    confidence: high
+    sources:
+      - locator: "gh:releases/v0.9.2"
+        quote: "v0.9.2 — 2026-06-14"
+        stance: supports
+        as_of: "2026-07-27"
+  - id: C-003
+    statement: The project is pre-1.0 and its interface may still change.
+    class: inferred
+    confidence: moderate
+    derived_from: [C-002]
+    sources:
+      - locator: "repo:CHANGELOG.md:3-6"
+        quote: "Breaking: renamed --prune to --strip"
+        stance: supports
+        as_of: "2026-07-27"
+  - id: C-004
+    statement: A homebrew formula should be added to ease installation.
+    class: proposed
+    confidence: low

--- a/plugins-cc/agentkit/skills/product-intelligence/examples/website-only/brief.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/examples/website-only/brief.yaml
@@ -17,14 +17,14 @@ positioning:
   target_customer: home coffee enthusiasts
   need: remembering what changed between shots
   category: brewing journal
-  key_benefit: every shot's grind, dose and outcome in one searchable log
+  key_benefit: every shot's grind, dose, yield and time in one log
   alternative: notes apps and paper logs
   differentiation: espresso-specific fields instead of free text
-  claims: [C-003]
+  claims: [C-003, C-005]
 value_map:
   - attribute: free plan capped at one journal
     value: try the full workflow before paying
-    proof: create a journal on the free tier without a card
+    proof: sign up for the free plan and start a journal
     claims: [C-001]
 site_inventory:
   - locator: "site:/"
@@ -37,8 +37,13 @@ site_inventory:
     disposition: keep
     rationale: plans and caps are explicit
     claims: [C-001, C-002]
+  - locator: "site:/features"
+    page_type: product
+    disposition: keep
+    rationale: the field structure is the differentiator and is stated concretely
+    claims: [C-005]
 cannot_verify:
   - what: anything about the codebase, release cadence or maturity
     why: no repository is public; only the website was acquired
-  - what: the mobile app the footer hints at
-    why: no store link or screenshot is reachable from the crawled pages
+  - what: whether a mobile app exists
+    why: no store link, screenshot or app page is reachable from the crawled pages

--- a/plugins-cc/agentkit/skills/product-intelligence/examples/website-only/brief.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/examples/website-only/brief.yaml
@@ -1,0 +1,44 @@
+brief_version: "1.0"
+subject:
+  name: brewlog
+  homepage: https://brewlog.example
+  one_liner: Journal for dialing in home espresso shots.
+evidence:
+  ledger: ledger.yaml
+  acquired_at: "2026-07-27"
+  acquisition:
+    - tool: advertools
+      target: https://brewlog.example
+      retrieved_at: "2026-07-27"
+    - tool: trafilatura
+      target: https://brewlog.example/pricing
+      retrieved_at: "2026-07-27"
+positioning:
+  target_customer: home coffee enthusiasts
+  need: remembering what changed between shots
+  category: brewing journal
+  key_benefit: every shot's grind, dose and outcome in one searchable log
+  alternative: notes apps and paper logs
+  differentiation: espresso-specific fields instead of free text
+  claims: [C-003]
+value_map:
+  - attribute: free plan capped at one journal
+    value: try the full workflow before paying
+    proof: create a journal on the free tier without a card
+    claims: [C-001]
+site_inventory:
+  - locator: "site:/"
+    page_type: home
+    disposition: keep
+    rationale: states the audience plainly and matches the pricing story
+    claims: [C-003]
+  - locator: "site:/pricing"
+    page_type: pricing
+    disposition: keep
+    rationale: plans and caps are explicit
+    claims: [C-001, C-002]
+cannot_verify:
+  - what: anything about the codebase, release cadence or maturity
+    why: no repository is public; only the website was acquired
+  - what: the mobile app the footer hints at
+    why: no store link or screenshot is reachable from the crawled pages

--- a/plugins-cc/agentkit/skills/product-intelligence/examples/website-only/ledger.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/examples/website-only/ledger.yaml
@@ -44,7 +44,7 @@ claims:
         stance: supports
         as_of: "2026-07-27"
   - id: C-006
-    statement: Brewlog integrates with bluetooth coffee scales.
+    statement: Brewlog claims compatibility with coffee scales, without naming which.
     class: observed
     confidence: low
     sources:

--- a/plugins-cc/agentkit/skills/product-intelligence/examples/website-only/ledger.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/examples/website-only/ledger.yaml
@@ -34,3 +34,21 @@ claims:
     statement: Brewlog has a mobile app.
     class: unverified
     confidence: low
+  - id: C-005
+    statement: Journal entries record grind, dose, yield and shot time as structured fields.
+    class: observed
+    confidence: high
+    sources:
+      - locator: "site:/features"
+        quote: "Log grind, dose, yield and time for every shot"
+        stance: supports
+        as_of: "2026-07-27"
+  - id: C-006
+    statement: Brewlog integrates with bluetooth coffee scales.
+    class: observed
+    confidence: low
+    sources:
+      - locator: "site:/features"
+        quote: "Works with your favorite scales*"
+        stance: supports
+        as_of: "2026-07-27"

--- a/plugins-cc/agentkit/skills/product-intelligence/examples/website-only/ledger.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/examples/website-only/ledger.yaml
@@ -1,0 +1,36 @@
+ledger_version: "1.0"
+generated_by: product-intelligence
+generated_at: "2026-07-27T09:00:00Z"
+claims:
+  - id: C-001
+    statement: Brewlog offers a free plan capped at one brew journal.
+    class: observed
+    confidence: high
+    sources:
+      - locator: "site:/pricing#plans"
+        quote: "Free — one journal, unlimited entries"
+        stance: supports
+        as_of: "2026-07-27"
+  - id: C-002
+    statement: The paid plan is priced at $6 per month.
+    class: observed
+    confidence: high
+    sources:
+      - locator: "site:/pricing#plans"
+        quote: "Pro — $6/month, unlimited journals"
+        stance: supports
+        as_of: "2026-07-27"
+  - id: C-003
+    statement: Brewlog positions itself for home coffee enthusiasts rather than cafés.
+    class: inferred
+    confidence: moderate
+    derived_from: [C-001]
+    sources:
+      - locator: "site:/"
+        quote: "Dial in your home espresso, one shot at a time"
+        stance: supports
+        as_of: "2026-07-27"
+  - id: C-004
+    statement: Brewlog has a mobile app.
+    class: unverified
+    confidence: low

--- a/plugins-cc/agentkit/skills/product-intelligence/schemas/ledger.schema.json
+++ b/plugins-cc/agentkit/skills/product-intelligence/schemas/ledger.schema.json
@@ -74,7 +74,7 @@
       "additionalProperties": false,
       "properties": {
         "locator": {
-          "description": "Structural pointer that survives edits: 'site:/pricing#plans', 'repo:README.md:40-52', 'doc:brief.pdf#p3'.",
+          "description": "Structural pointer that survives edits: 'site:/pricing#plans', 'repo:README.md:40-52', 'gh:releases/v1.2.0', 'doc:brief.pdf#p3'.",
           "type": "string",
           "minLength": 1
         },

--- a/skills/product-intelligence/SKILL.md
+++ b/skills/product-intelligence/SKILL.md
@@ -36,6 +36,8 @@ bun skills/product-intelligence/scripts/validate.ts .agentkit/intelligence/<slug
 
 A brief validates together with the ledger it cites — dangling claim ids,
 asymmetric contradictions and unsourced observations all fail loudly.
+Worked examples of the full artifact set — website-only, repo-only and
+mixed evidence — live in `examples/`.
 
 ## Workflow
 

--- a/skills/product-intelligence/examples/README.md
+++ b/skills/product-intelligence/examples/README.md
@@ -1,0 +1,16 @@
+# Worked examples
+
+Each directory is a complete, schema-valid artifact set for one evidence
+situation. The subjects are fictional; the shapes are the contract.
+
+| Example         | Demonstrates                                                                                                                               |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `website-only/` | Site locators only; repo-side facts land in `cannot_verify`, not guesses                                                                   |
+| `repo-only/`    | Repo + release locators; adoption/registry facts are `cannot_verify`                                                                       |
+| `mixed/`        | Both surfaces, an unresolved contradiction rendered in the brief, and the full set: `brief.yaml`, `ledger.yaml`, `brief.md`, `findings.md` |
+
+Validate any of them:
+
+```sh
+bun skills/product-intelligence/scripts/validate.ts skills/product-intelligence/examples/mixed/brief.yaml
+```

--- a/skills/product-intelligence/examples/mixed/brief.md
+++ b/skills/product-intelligence/examples/mixed/brief.md
@@ -6,8 +6,8 @@ acme-notes is a note-taking app for solo developers whose notes live as
 plain markdown files inside a git repository the user already owns
 [C-003]. Where hosted note SaaS keeps your thinking on someone else's
 server, acme-notes versions it next to the code it explains — greppable,
-diffable, and readable with any editor. The product is active, with v1.4.0
-released 2026-07-02 [C-005].
+diffable, and readable with any editor. The most recent release, v1.4.0,
+shipped 2026-07-02 [C-005].
 
 ## The Problem
 
@@ -24,8 +24,7 @@ history with the change it explains).
 ## What Makes This Different
 
 No lock-in is the moat that can be proven: clone the repo and the notes
-are yours with any editor [C-003]. No fabricated technical moats beyond
-that — the rest is scope discipline.
+are yours, readable with any editor [C-003].
 
 ## Who This Serves
 

--- a/skills/product-intelligence/examples/mixed/brief.md
+++ b/skills/product-intelligence/examples/mixed/brief.md
@@ -1,0 +1,45 @@
+# Product Brief: acme-notes
+
+## Executive Summary
+
+acme-notes is a note-taking app for solo developers whose notes live as
+plain markdown files inside a git repository the user already owns
+[C-003]. Where hosted note SaaS keeps your thinking on someone else's
+server, acme-notes versions it next to the code it explains — greppable,
+diffable, and readable with any editor. The product is active, with v1.4.0
+released 2026-07-02 [C-005].
+
+## The Problem
+
+Debugging notes, decision trails and half-finished thoughts die in chat
+scrollback and hosted apps that outlive nobody's subscription. For a solo
+developer [C-004], the cost is re-deriving yesterday's dead ends.
+
+## The Solution
+
+Notes are markdown files in your repo [C-003]. Writing one is `execute`
+(edit next to the code); committing is `conclude` (the note lands in
+history with the change it explains).
+
+## What Makes This Different
+
+No lock-in is the moat that can be proven: clone the repo and the notes
+are yours with any editor [C-003]. No fabricated technical moats beyond
+that — the rest is scope discipline.
+
+## Who This Serves
+
+Solo developers on personal projects [C-004]. Team features are neither
+advertised nor evidenced.
+
+## Open Contradiction
+
+The pricing page caps the free tier at three projects [C-001]; the README
+says five [C-002]. Both sources are current as of 2026-07-27. Unresolved —
+see findings.
+
+## Not Verified
+
+- SOC 2 certification [C-007]: no audit report or trust page reachable.
+- Sync conflict dialog behavior: static acquisition cannot exercise the
+  running app.

--- a/skills/product-intelligence/examples/mixed/brief.yaml
+++ b/skills/product-intelligence/examples/mixed/brief.yaml
@@ -26,7 +26,7 @@ positioning:
   category: git-native note-taking app
   key_benefit: notes are versioned and greppable like source
   alternative: hosted note SaaS
-  differentiation: works offline against a repository the user already owns
+  differentiation: notes live in a repository the user already owns
   claims: [C-003, C-004]
 value_map:
   - attribute: stores notes as plain markdown in git
@@ -57,7 +57,7 @@ site_inventory:
   - locator: "site:/docs/migrate-from-competitorx"
     page_type: docs
     disposition: create
-    rationale: no migration path is documented for the most-cited alternative
+    rationale: no migration path is documented for any named alternative
     claims: [C-006]
 cannot_verify:
   - what: SOC 2 certification claim

--- a/skills/product-intelligence/examples/mixed/brief.yaml
+++ b/skills/product-intelligence/examples/mixed/brief.yaml
@@ -1,0 +1,66 @@
+brief_version: "1.0"
+subject:
+  name: acme-notes
+  homepage: https://acme-notes.example
+  repo: github.com/acme/acme-notes
+  one_liner: Note-taking app that keeps every note in a plain git repository.
+evidence:
+  ledger: ledger.yaml
+  acquired_at: "2026-07-27"
+  acquisition:
+    - tool: advertools
+      target: https://acme-notes.example
+      retrieved_at: "2026-07-27"
+    - tool: trafilatura
+      target: https://acme-notes.example/pricing
+      retrieved_at: "2026-07-27"
+    - tool: repomix --remote
+      target: acme/acme-notes
+      retrieved_at: "2026-07-27"
+    - tool: gh api
+      target: acme/acme-notes
+      retrieved_at: "2026-07-27"
+positioning:
+  target_customer: solo developers
+  need: notes that live next to their code
+  category: git-native note-taking app
+  key_benefit: notes are versioned and greppable like source
+  alternative: hosted note SaaS
+  differentiation: works offline against a repository the user already owns
+  claims: [C-003, C-004]
+value_map:
+  - attribute: stores notes as plain markdown in git
+    value: no lock-in — notes outlive the product
+    proof: clone the repo and read the notes with any editor
+    claims: [C-003]
+job_stories:
+  - situation: I am deep in a debugging session
+    motivation: I want to capture what I ruled out
+    outcome: I can pick the thread back up tomorrow without re-deriving it
+    claims: [C-004]
+workflows:
+  - name: capture a finding
+    steps:
+      - step: execute
+        description: write the note in the editor alongside the code
+        claims: [C-003]
+      - step: conclude
+        description: commit lands the note in history with the change it explains
+        claims: [C-003]
+site_inventory:
+  - locator: "site:/pricing"
+    page_type: pricing
+    title: Plans
+    disposition: revise
+    rationale: the stated free-tier limit contradicts the README
+    claims: [C-001, C-002]
+  - locator: "site:/docs/migrate-from-competitorx"
+    page_type: docs
+    disposition: create
+    rationale: no migration path is documented for the most-cited alternative
+    claims: [C-006]
+cannot_verify:
+  - what: SOC 2 certification claim
+    why: no audit report or trust page is published anywhere reachable
+  - what: behavior of the in-app sync conflict dialog
+    why: static acquisition cannot exercise the running app

--- a/skills/product-intelligence/examples/mixed/findings.md
+++ b/skills/product-intelligence/examples/mixed/findings.md
@@ -21,8 +21,8 @@ Read-only analyze pass over `brief.yaml` + `ledger.yaml`, 2026-07-27.
 
 ## Risks
 
-- [C-004] (solo-developer audience) is inferred from marketing copy plus
-  the free-tier cap — a single vendor-controlled surface family. A user
-  interview or issue-tracker signal would move it.
+- [C-004] (solo-developer audience) is inferred from the free-tier cap and
+  the marketing framing — all vendor-controlled sources, site and README
+  alike. A user interview or issue-tracker signal would move it.
 - [C-007] (SOC 2) is `unverified` and load-bearing for any
   compliance-sensitive adoption decision; treat as absent until proven.

--- a/skills/product-intelligence/examples/mixed/findings.md
+++ b/skills/product-intelligence/examples/mixed/findings.md
@@ -1,0 +1,28 @@
+# Findings: acme-notes
+
+Read-only analyze pass over `brief.yaml` + `ledger.yaml`, 2026-07-27.
+
+## Contradictions
+
+- **Free-tier project cap: 3 vs 5.** [C-001] (site:/pricing, "up to 3
+  projects") vs [C-002] (repo:README.md, "up to 5 projects"). Both
+  observed, both high confidence, same retrieval date — one surface is
+  stale. The site inventory already marks `site:/pricing` as `revise`.
+
+## Gaps
+
+- No `alternative`-side evidence: the positioning names "hosted note SaaS"
+  but no claim examines any specific alternative.
+- Ulwick coverage is thin: only `execute` and `conclude` have product
+  presence; `locate`, `monitor` and `modify` (finding an old note,
+  noticing staleness, updating it) are unevidenced either way.
+- Do-not-invent topics with no evidence in any direction: pricing history,
+  customer counts, roadmap.
+
+## Risks
+
+- [C-004] (solo-developer audience) is inferred from marketing copy plus
+  the free-tier cap — a single vendor-controlled surface family. A user
+  interview or issue-tracker signal would move it.
+- [C-007] (SOC 2) is `unverified` and load-bearing for any
+  compliance-sensitive adoption decision; treat as absent until proven.

--- a/skills/product-intelligence/examples/mixed/ledger.yaml
+++ b/skills/product-intelligence/examples/mixed/ledger.yaml
@@ -1,0 +1,64 @@
+ledger_version: "1.0"
+generated_by: product-intelligence
+generated_at: "2026-07-27T10:00:00Z"
+claims:
+  - id: C-001
+    statement: The pricing page lists a free tier limited to three projects.
+    class: observed
+    confidence: high
+    contradicts: [C-002]
+    sources:
+      - locator: "site:/pricing#plans"
+        quote: "Free — up to 3 projects"
+        stance: supports
+        as_of: "2026-07-27"
+  - id: C-002
+    statement: The repository README states the free tier allows five projects.
+    class: observed
+    confidence: high
+    contradicts: [C-001]
+    sources:
+      - locator: "repo:README.md:12-14"
+        quote: "The free plan covers up to 5 projects."
+        stance: supports
+        as_of: "2026-07-27"
+  - id: C-003
+    statement: acme-notes stores notes as markdown files inside a git repository.
+    class: observed
+    confidence: high
+    sources:
+      - locator: "repo:README.md:1-4"
+        quote: "Your notes are plain markdown in your own repo."
+        stance: supports
+        as_of: "2026-07-27"
+      - locator: "site:/"
+        quote: "Notes that live in git, next to your code"
+        stance: supports
+        as_of: "2026-07-27"
+  - id: C-004
+    statement: The product is aimed at solo developers rather than teams.
+    class: inferred
+    confidence: moderate
+    derived_from: [C-001, C-003]
+    sources:
+      - locator: "site:/pricing#plans"
+        quote: "Perfect for personal projects"
+        stance: context
+        as_of: "2026-07-27"
+  - id: C-005
+    statement: The latest release is v1.4.0, published 2026-07-02.
+    class: observed
+    confidence: high
+    sources:
+      - locator: "gh:releases/v1.4.0"
+        quote: "v1.4.0 — 2026-07-02"
+        stance: supports
+        as_of: "2026-07-27"
+  - id: C-006
+    statement: A migration guide from CompetitorX should be added to the docs.
+    class: proposed
+    confidence: low
+  - id: C-007
+    statement: The product holds SOC 2 Type II certification.
+    class: unverified
+    confidence: low

--- a/skills/product-intelligence/examples/repo-only/brief.yaml
+++ b/skills/product-intelligence/examples/repo-only/brief.yaml
@@ -1,0 +1,40 @@
+brief_version: "1.0"
+subject:
+  name: tidyenv
+  repo: github.com/example/tidyenv
+  one_liner: CLI that strips .env entries nothing in the codebase reads.
+evidence:
+  ledger: ledger.yaml
+  acquired_at: "2026-07-27"
+  acquisition:
+    - tool: repomix --remote
+      target: example/tidyenv
+      retrieved_at: "2026-07-27"
+    - tool: gh api
+      target: example/tidyenv
+      retrieved_at: "2026-07-27"
+positioning:
+  target_customer: developers on aging codebases
+  need: knowing which env vars are actually read
+  category: developer hygiene CLI
+  key_benefit: dead configuration is found, not guessed at
+  claims: [C-001]
+job_stories:
+  - situation: I inherit a service with a 200-line .env.example
+    motivation: I want to know which entries still matter
+    outcome: I can onboard without cargo-culting dead configuration
+    claims: [C-001]
+workflows:
+  - name: clean a service's configuration
+    steps:
+      - step: locate
+        description: tidyenv scans the codebase for env reads
+        claims: [C-001]
+      - step: execute
+        description: unused entries are stripped from the .env files
+        claims: [C-001]
+cannot_verify:
+  - what: adoption, download counts or anyone using it in production
+    why: only the repository was acquired; no site or registry stats
+  - what: behavior on Windows
+    why: CI matrix in the packed repo covers Linux and macOS only

--- a/skills/product-intelligence/examples/repo-only/brief.yaml
+++ b/skills/product-intelligence/examples/repo-only/brief.yaml
@@ -37,4 +37,4 @@ cannot_verify:
   - what: adoption, download counts or anyone using it in production
     why: only the repository was acquired; no site or registry stats
   - what: behavior on Windows
-    why: CI matrix in the packed repo covers Linux and macOS only
+    why: no acquired source states platform support in either direction

--- a/skills/product-intelligence/examples/repo-only/ledger.yaml
+++ b/skills/product-intelligence/examples/repo-only/ledger.yaml
@@ -23,7 +23,7 @@ claims:
   - id: C-003
     statement: The project is pre-1.0 and its interface may still change.
     class: inferred
-    confidence: moderate
+    confidence: high
     derived_from: [C-002]
     sources:
       - locator: "repo:CHANGELOG.md:3-6"

--- a/skills/product-intelligence/examples/repo-only/ledger.yaml
+++ b/skills/product-intelligence/examples/repo-only/ledger.yaml
@@ -1,0 +1,36 @@
+ledger_version: "1.0"
+generated_by: product-intelligence
+generated_at: "2026-07-27T09:30:00Z"
+claims:
+  - id: C-001
+    statement: tidyenv is a CLI that removes unused entries from .env files.
+    class: observed
+    confidence: high
+    sources:
+      - locator: "repo:README.md:1-4"
+        quote: "tidyenv scans your codebase and strips .env entries nothing reads."
+        stance: supports
+        as_of: "2026-07-27"
+  - id: C-002
+    statement: The latest release is v0.9.2, published in June 2026.
+    class: observed
+    confidence: high
+    sources:
+      - locator: "gh:releases/v0.9.2"
+        quote: "v0.9.2 — 2026-06-14"
+        stance: supports
+        as_of: "2026-07-27"
+  - id: C-003
+    statement: The project is pre-1.0 and its interface may still change.
+    class: inferred
+    confidence: moderate
+    derived_from: [C-002]
+    sources:
+      - locator: "repo:CHANGELOG.md:3-6"
+        quote: "Breaking: renamed --prune to --strip"
+        stance: supports
+        as_of: "2026-07-27"
+  - id: C-004
+    statement: A homebrew formula should be added to ease installation.
+    class: proposed
+    confidence: low

--- a/skills/product-intelligence/examples/website-only/brief.yaml
+++ b/skills/product-intelligence/examples/website-only/brief.yaml
@@ -17,14 +17,14 @@ positioning:
   target_customer: home coffee enthusiasts
   need: remembering what changed between shots
   category: brewing journal
-  key_benefit: every shot's grind, dose and outcome in one searchable log
+  key_benefit: every shot's grind, dose, yield and time in one log
   alternative: notes apps and paper logs
   differentiation: espresso-specific fields instead of free text
-  claims: [C-003]
+  claims: [C-003, C-005]
 value_map:
   - attribute: free plan capped at one journal
     value: try the full workflow before paying
-    proof: create a journal on the free tier without a card
+    proof: sign up for the free plan and start a journal
     claims: [C-001]
 site_inventory:
   - locator: "site:/"
@@ -37,8 +37,13 @@ site_inventory:
     disposition: keep
     rationale: plans and caps are explicit
     claims: [C-001, C-002]
+  - locator: "site:/features"
+    page_type: product
+    disposition: keep
+    rationale: the field structure is the differentiator and is stated concretely
+    claims: [C-005]
 cannot_verify:
   - what: anything about the codebase, release cadence or maturity
     why: no repository is public; only the website was acquired
-  - what: the mobile app the footer hints at
-    why: no store link or screenshot is reachable from the crawled pages
+  - what: whether a mobile app exists
+    why: no store link, screenshot or app page is reachable from the crawled pages

--- a/skills/product-intelligence/examples/website-only/brief.yaml
+++ b/skills/product-intelligence/examples/website-only/brief.yaml
@@ -1,0 +1,44 @@
+brief_version: "1.0"
+subject:
+  name: brewlog
+  homepage: https://brewlog.example
+  one_liner: Journal for dialing in home espresso shots.
+evidence:
+  ledger: ledger.yaml
+  acquired_at: "2026-07-27"
+  acquisition:
+    - tool: advertools
+      target: https://brewlog.example
+      retrieved_at: "2026-07-27"
+    - tool: trafilatura
+      target: https://brewlog.example/pricing
+      retrieved_at: "2026-07-27"
+positioning:
+  target_customer: home coffee enthusiasts
+  need: remembering what changed between shots
+  category: brewing journal
+  key_benefit: every shot's grind, dose and outcome in one searchable log
+  alternative: notes apps and paper logs
+  differentiation: espresso-specific fields instead of free text
+  claims: [C-003]
+value_map:
+  - attribute: free plan capped at one journal
+    value: try the full workflow before paying
+    proof: create a journal on the free tier without a card
+    claims: [C-001]
+site_inventory:
+  - locator: "site:/"
+    page_type: home
+    disposition: keep
+    rationale: states the audience plainly and matches the pricing story
+    claims: [C-003]
+  - locator: "site:/pricing"
+    page_type: pricing
+    disposition: keep
+    rationale: plans and caps are explicit
+    claims: [C-001, C-002]
+cannot_verify:
+  - what: anything about the codebase, release cadence or maturity
+    why: no repository is public; only the website was acquired
+  - what: the mobile app the footer hints at
+    why: no store link or screenshot is reachable from the crawled pages

--- a/skills/product-intelligence/examples/website-only/ledger.yaml
+++ b/skills/product-intelligence/examples/website-only/ledger.yaml
@@ -44,7 +44,7 @@ claims:
         stance: supports
         as_of: "2026-07-27"
   - id: C-006
-    statement: Brewlog integrates with bluetooth coffee scales.
+    statement: Brewlog claims compatibility with coffee scales, without naming which.
     class: observed
     confidence: low
     sources:

--- a/skills/product-intelligence/examples/website-only/ledger.yaml
+++ b/skills/product-intelligence/examples/website-only/ledger.yaml
@@ -34,3 +34,21 @@ claims:
     statement: Brewlog has a mobile app.
     class: unverified
     confidence: low
+  - id: C-005
+    statement: Journal entries record grind, dose, yield and shot time as structured fields.
+    class: observed
+    confidence: high
+    sources:
+      - locator: "site:/features"
+        quote: "Log grind, dose, yield and time for every shot"
+        stance: supports
+        as_of: "2026-07-27"
+  - id: C-006
+    statement: Brewlog integrates with bluetooth coffee scales.
+    class: observed
+    confidence: low
+    sources:
+      - locator: "site:/features"
+        quote: "Works with your favorite scales*"
+        stance: supports
+        as_of: "2026-07-27"

--- a/skills/product-intelligence/examples/website-only/ledger.yaml
+++ b/skills/product-intelligence/examples/website-only/ledger.yaml
@@ -1,0 +1,36 @@
+ledger_version: "1.0"
+generated_by: product-intelligence
+generated_at: "2026-07-27T09:00:00Z"
+claims:
+  - id: C-001
+    statement: Brewlog offers a free plan capped at one brew journal.
+    class: observed
+    confidence: high
+    sources:
+      - locator: "site:/pricing#plans"
+        quote: "Free — one journal, unlimited entries"
+        stance: supports
+        as_of: "2026-07-27"
+  - id: C-002
+    statement: The paid plan is priced at $6 per month.
+    class: observed
+    confidence: high
+    sources:
+      - locator: "site:/pricing#plans"
+        quote: "Pro — $6/month, unlimited journals"
+        stance: supports
+        as_of: "2026-07-27"
+  - id: C-003
+    statement: Brewlog positions itself for home coffee enthusiasts rather than cafés.
+    class: inferred
+    confidence: moderate
+    derived_from: [C-001]
+    sources:
+      - locator: "site:/"
+        quote: "Dial in your home espresso, one shot at a time"
+        stance: supports
+        as_of: "2026-07-27"
+  - id: C-004
+    statement: Brewlog has a mobile app.
+    class: unverified
+    confidence: low

--- a/skills/product-intelligence/schemas/ledger.schema.json
+++ b/skills/product-intelligence/schemas/ledger.schema.json
@@ -74,7 +74,7 @@
       "additionalProperties": false,
       "properties": {
         "locator": {
-          "description": "Structural pointer that survives edits: 'site:/pricing#plans', 'repo:README.md:40-52', 'doc:brief.pdf#p3'.",
+          "description": "Structural pointer that survives edits: 'site:/pricing#plans', 'repo:README.md:40-52', 'gh:releases/v1.2.0', 'doc:brief.pdf#p3'.",
           "type": "string",
           "minLength": 1
         },

--- a/tests/product-intelligence/schemas.test.ts
+++ b/tests/product-intelligence/schemas.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { readdirSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { validateFile } from '../../skills/product-intelligence/scripts/validate.ts';
@@ -50,6 +50,32 @@ describe('product-intelligence schemas', () => {
       expect(errors.join('\n')).toContain(message);
     });
   }
+});
+
+describe('worked examples', () => {
+  const examples = join(skillRoot, 'examples');
+  const dirs = () =>
+    readdirSync(examples, { withFileTypes: true }).filter((e) => e.isDirectory()).map((e) => e.name);
+
+  test('ships the three evidence situations, each schema-valid', () => {
+    expect(dirs().sort()).toEqual(['mixed', 'repo-only', 'website-only']);
+    for (const name of dirs()) {
+      expect(validateFile(join(examples, name, 'brief.yaml')), name).toEqual([]);
+    }
+  });
+
+  test('every claim id cited in the rendered markdown exists in the ledger', () => {
+    const ledger = Bun.YAML.parse(readFileSync(join(examples, 'mixed', 'ledger.yaml'), 'utf-8')) as {
+      claims: { id: string }[];
+    };
+    const known = new Set(ledger.claims.map((c) => c.id));
+    for (const doc of ['brief.md', 'findings.md']) {
+      const text = readFileSync(join(examples, 'mixed', doc), 'utf-8');
+      const cited = [...text.matchAll(/\[(C-\d{3,})\]/g)].map((m) => m[1]);
+      expect(cited.length, doc).toBeGreaterThan(0);
+      for (const id of cited) expect(known.has(id), `${doc} cites ${id}`).toBe(true);
+    }
+  });
 });
 
 describe('validate.ts CLI', () => {


### PR DESCRIPTION
Closes #115 — slice 4 of 4 (the planned slice-5 mirror sync collapsed into per-slice syncs, enforced by the parity test; README docs landed in slice 3).

- `examples/website-only/` — site locators only; repo-side facts in `cannot_verify`, not guessed
- `examples/repo-only/` — repo/release locators; adoption facts in `cannot_verify`
- `examples/mixed/` — both surfaces with an unresolved contradiction (site says 3 projects, README says 5) carried through `ledger.yaml` → `brief.yaml` → rendered `brief.md` + `findings.md`
- Tests: all three briefs must validate; every `[C-nnn]` cited in the rendered markdown must exist in the ledger

Verify: `scripts/product-command default -- bun test` — 604 tests, 0 fail.