### PR TITLE
feat(product-intelligence): multi-origin subjects (#130)

### DIFF
--- a/plugins-cc/agentkit/skills/product-intelligence/SKILL.md
+++ b/plugins-cc/agentkit/skills/product-intelligence/SKILL.md
@@ -173,6 +173,22 @@ earn their place, and do not fabricate technical moats. Inline claim ids
 to its evidence. Render contradictions and `cannot_verify` in the brief
 proper — they are results, not footnotes.
 
+## Multi-source subjects
+
+A product is not a repository — one subject may span several repos, a
+marketing site, docs, and supplied documents. It still gets **one brief and
+one ledger**: acquire each source into the same output directory (the
+`acquisition` list accumulates), then declare the sources as
+`subject.origins` — `{id, kind: site|repo|docset, target}`.
+
+The moment two origins share a kind, locators of that kind must name their
+origin — `repo:server:README.md:12`, `gh:cli:releases/v2.3.0`,
+`site:docs:/quickstart` — and the validator rejects plain ones as ambiguous.
+With at most one origin per kind, plain locators stay valid, so
+single-source briefs are unaffected. Cross-origin contradictions (the site
+promising what no repo implements) are exactly what the single shared
+ledger exists to surface.
+
 ## Refresh mode
 
 Re-running against the same subject keeps the section order stable and diffs

--- a/plugins-cc/agentkit/skills/product-intelligence/SKILL.md
+++ b/plugins-cc/agentkit/skills/product-intelligence/SKILL.md
@@ -183,9 +183,10 @@ one ledger**: acquire each source into the same output directory (the
 
 The moment two origins share a kind, locators of that kind must name their
 origin — `repo:server:README.md:12`, `gh:cli:releases/v2.3.0`,
-`site:docs:/quickstart` — and the validator rejects plain ones as ambiguous.
-With at most one origin per kind, plain locators stay valid, so
-single-source briefs are unaffected. Cross-origin contradictions (the site
+`site:docs:/quickstart`, `doc:contracts:msa.pdf#p3` — and the validator
+rejects plain ones as ambiguous. With at most one origin per kind, plain
+locators stay valid, so single-source briefs are unaffected. Origin ids are
+one namespace across kinds: a handle names exactly one source. Cross-origin contradictions (the site
 promising what no repo implements) are exactly what the single shared
 ledger exists to surface.
 

--- a/plugins-cc/agentkit/skills/product-intelligence/schemas/brief.schema.json
+++ b/plugins-cc/agentkit/skills/product-intelligence/schemas/brief.schema.json
@@ -36,6 +36,28 @@
           "description": "What the product is in one sentence, from a user's point of view — not the architecture.",
           "type": "string",
           "minLength": 1
+        },
+        "origins": {
+          "description": "Every source the product spans, for subjects wider than one repo and one site. Once two origins share a kind, locators of that kind must name their origin: 'repo:<id>:README.md:12', 'site:<id>:/pricing', 'gh:<id>:releases/v1.0'. With at most one origin per kind, plain locators stay valid.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["id", "kind", "target"],
+            "additionalProperties": false,
+            "properties": {
+              "id": {
+                "description": "Short handle used inside locators.",
+                "type": "string",
+                "pattern": "^[a-z0-9][a-z0-9-]*$"
+              },
+              "kind": { "enum": ["site", "repo", "docset"] },
+              "target": {
+                "description": "What was acquired: a URL, owner/repo, or document set name.",
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
         }
       }
     },

--- a/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/brief-multi-origin-unqualified.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/brief-multi-origin-unqualified.yaml
@@ -1,0 +1,12 @@
+brief_version: "1.0"
+subject:
+  name: acme-platform
+  origins:
+    - id: server
+      kind: repo
+      target: acme/server
+    - id: cli
+      kind: repo
+      target: acme/cli
+evidence:
+  ledger: ../valid/ledger.yaml

--- a/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/brief-origin-duplicate-id.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/brief-origin-duplicate-id.yaml
@@ -1,0 +1,12 @@
+brief_version: "1.0"
+subject:
+  name: acme-platform
+  origins:
+    - id: server
+      kind: repo
+      target: acme/server
+    - id: server
+      kind: repo
+      target: acme/server-v2
+evidence:
+  ledger: ../valid/ledger.yaml

--- a/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/valid/brief-multi.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/valid/brief-multi.yaml
@@ -1,0 +1,39 @@
+brief_version: "1.0"
+subject:
+  name: acme-platform
+  homepage: https://acme.example
+  one_liner: Server plus CLI sold and documented as one product.
+  origins:
+    - id: server
+      kind: repo
+      target: acme/server
+    - id: cli
+      kind: repo
+      target: acme/cli
+    - id: www
+      kind: site
+      target: https://acme.example
+evidence:
+  ledger: ledger-multi.yaml
+  acquired_at: "2026-07-28"
+  acquisition:
+    - tool: repomix --remote
+      target: acme/server
+      retrieved_at: "2026-07-28"
+    - tool: repomix --remote
+      target: acme/cli
+      retrieved_at: "2026-07-28"
+    - tool: advertools
+      target: https://acme.example
+      retrieved_at: "2026-07-28"
+positioning:
+  target_customer: platform teams
+  need: one product surface across server and CLI
+  category: developer platform
+  claims: [C-003]
+site_inventory:
+  - locator: "site:/pricing"
+    page_type: pricing
+    disposition: keep
+    rationale: states the single-license model plainly
+    claims: [C-003]

--- a/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/valid/ledger-multi.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/valid/ledger-multi.yaml
@@ -1,0 +1,31 @@
+ledger_version: "1.0"
+generated_by: product-intelligence
+generated_at: "2026-07-28T09:00:00Z"
+claims:
+  - id: C-001
+    statement: The server exposes a REST API documented in its README.
+    class: observed
+    confidence: high
+    sources:
+      - locator: "repo:server:README.md:8-14"
+        quote: "Every endpoint is available over REST at /api/v1."
+        stance: supports
+        as_of: "2026-07-28"
+  - id: C-002
+    statement: The CLI ships prebuilt binaries with each release.
+    class: observed
+    confidence: high
+    sources:
+      - locator: "gh:cli:releases/v2.3.0"
+        quote: "Assets: acme-linux-amd64, acme-darwin-arm64"
+        stance: supports
+        as_of: "2026-07-28"
+  - id: C-003
+    statement: The pricing page sells the server and CLI as one product.
+    class: observed
+    confidence: high
+    sources:
+      - locator: "site:/pricing"
+        quote: "One license covers the server and the CLI."
+        stance: supports
+        as_of: "2026-07-28"

--- a/plugins-cc/agentkit/skills/product-intelligence/scripts/validate.ts
+++ b/plugins-cc/agentkit/skills/product-intelligence/scripts/validate.ts
@@ -207,7 +207,10 @@ function checkOrigins(brief: Record<string, Json>, ledger: Json | undefined, err
   const seen = new Set<string>();
   for (const origin of origins) {
     if (!origin.id || !origin.kind) continue;
-    if (seen.has(origin.id)) errors.push(`brief.subject.origins: duplicate origin id '${origin.id}'`);
+    if (seen.has(origin.id)) {
+      errors.push(`brief.subject.origins: duplicate origin id '${origin.id}'`);
+      continue;
+    }
     seen.add(origin.id);
     idsByKind.set(origin.kind, [...(idsByKind.get(origin.kind) ?? []), origin.id]);
   }

--- a/plugins-cc/agentkit/skills/product-intelligence/scripts/validate.ts
+++ b/plugins-cc/agentkit/skills/product-intelligence/scripts/validate.ts
@@ -177,6 +177,7 @@ export function validateBriefDoc(doc: Json, ledger?: Json): string[] {
       errors.push(`brief.site_inventory[${i}]: a disposition requires a rationale`);
     }
   }
+  checkOrigins(brief, ledger, errors);
   if (ledger !== undefined) {
     const known = new Set(
       (((ledger as Record<string, Json>).claims ?? []) as Claim[]).map((c) => c.id).filter(Boolean),
@@ -186,6 +187,61 @@ export function validateBriefDoc(doc: Json, ledger?: Json): string[] {
     }
   }
   return errors;
+}
+
+// One brief may span several repos/sites; a locator like 'repo:README.md'
+// cannot say which. Qualification is demanded exactly when it is ambiguous:
+// two origins of one kind make every locator of that kind name its origin.
+const KIND_SCHEMES: Record<string, string[]> = { site: ['site'], repo: ['repo', 'gh'], docset: ['doc'] };
+
+interface Origin {
+  id?: string;
+  kind?: string;
+}
+
+function checkOrigins(brief: Record<string, Json>, ledger: Json | undefined, errors: string[]): void {
+  const origins = ((brief.subject as Record<string, Json> | undefined)?.origins ?? []) as Origin[];
+  if (origins.length === 0) return;
+
+  const idsByKind = new Map<string, string[]>();
+  const seen = new Set<string>();
+  for (const origin of origins) {
+    if (!origin.id || !origin.kind) continue;
+    if (seen.has(origin.id)) errors.push(`brief.subject.origins: duplicate origin id '${origin.id}'`);
+    seen.add(origin.id);
+    idsByKind.set(origin.kind, [...(idsByKind.get(origin.kind) ?? []), origin.id]);
+  }
+
+  const ambiguous = new Map<string, string[]>();
+  for (const [kind, ids] of idsByKind) {
+    if (ids.length < 2) continue;
+    for (const scheme of KIND_SCHEMES[kind] ?? []) ambiguous.set(scheme, ids);
+  }
+  if (ambiguous.size === 0) return;
+
+  for (const { path, locator } of collectLocators(brief, ledger)) {
+    const [scheme, second] = locator.split(':');
+    const ids = ambiguous.get(scheme);
+    if (ids && !ids.includes(second ?? '')) {
+      errors.push(`${path}: locator '${locator}' must name its origin — ${scheme}:<${ids.join('|')}>:…`);
+    }
+  }
+}
+
+function collectLocators(brief: Record<string, Json>, ledger: Json | undefined): { path: string; locator: string }[] {
+  const out: { path: string; locator: string }[] = [];
+  for (const [i, page] of (((brief.site_inventory ?? []) as Record<string, Json>[])).entries()) {
+    if (typeof page.locator === 'string') out.push({ path: `brief.site_inventory[${i}]`, locator: page.locator });
+  }
+  const claims = (((ledger as Record<string, Json> | undefined)?.claims ?? []) as Claim[]);
+  for (const [i, claim] of claims.entries()) {
+    for (const [j, source] of ((claim.sources ?? []) as Record<string, Json>[]).entries()) {
+      if (typeof source.locator === 'string') {
+        out.push({ path: `ledger claim ${claim.id ?? i}: sources[${j}]`, locator: source.locator });
+      }
+    }
+  }
+  return out;
 }
 
 function collectClaimRefs(node: Json, path: string): { path: string; ref: string }[] {

--- a/skills/product-intelligence/SKILL.md
+++ b/skills/product-intelligence/SKILL.md
@@ -173,6 +173,22 @@ earn their place, and do not fabricate technical moats. Inline claim ids
 to its evidence. Render contradictions and `cannot_verify` in the brief
 proper — they are results, not footnotes.
 
+## Multi-source subjects
+
+A product is not a repository — one subject may span several repos, a
+marketing site, docs, and supplied documents. It still gets **one brief and
+one ledger**: acquire each source into the same output directory (the
+`acquisition` list accumulates), then declare the sources as
+`subject.origins` — `{id, kind: site|repo|docset, target}`.
+
+The moment two origins share a kind, locators of that kind must name their
+origin — `repo:server:README.md:12`, `gh:cli:releases/v2.3.0`,
+`site:docs:/quickstart` — and the validator rejects plain ones as ambiguous.
+With at most one origin per kind, plain locators stay valid, so
+single-source briefs are unaffected. Cross-origin contradictions (the site
+promising what no repo implements) are exactly what the single shared
+ledger exists to surface.
+
 ## Refresh mode
 
 Re-running against the same subject keeps the section order stable and diffs

--- a/skills/product-intelligence/SKILL.md
+++ b/skills/product-intelligence/SKILL.md
@@ -183,9 +183,10 @@ one ledger**: acquire each source into the same output directory (the
 
 The moment two origins share a kind, locators of that kind must name their
 origin — `repo:server:README.md:12`, `gh:cli:releases/v2.3.0`,
-`site:docs:/quickstart` — and the validator rejects plain ones as ambiguous.
-With at most one origin per kind, plain locators stay valid, so
-single-source briefs are unaffected. Cross-origin contradictions (the site
+`site:docs:/quickstart`, `doc:contracts:msa.pdf#p3` — and the validator
+rejects plain ones as ambiguous. With at most one origin per kind, plain
+locators stay valid, so single-source briefs are unaffected. Origin ids are
+one namespace across kinds: a handle names exactly one source. Cross-origin contradictions (the site
 promising what no repo implements) are exactly what the single shared
 ledger exists to surface.
 

--- a/skills/product-intelligence/schemas/brief.schema.json
+++ b/skills/product-intelligence/schemas/brief.schema.json
@@ -36,6 +36,28 @@
           "description": "What the product is in one sentence, from a user's point of view — not the architecture.",
           "type": "string",
           "minLength": 1
+        },
+        "origins": {
+          "description": "Every source the product spans, for subjects wider than one repo and one site. Once two origins share a kind, locators of that kind must name their origin: 'repo:<id>:README.md:12', 'site:<id>:/pricing', 'gh:<id>:releases/v1.0'. With at most one origin per kind, plain locators stay valid.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["id", "kind", "target"],
+            "additionalProperties": false,
+            "properties": {
+              "id": {
+                "description": "Short handle used inside locators.",
+                "type": "string",
+                "pattern": "^[a-z0-9][a-z0-9-]*$"
+              },
+              "kind": { "enum": ["site", "repo", "docset"] },
+              "target": {
+                "description": "What was acquired: a URL, owner/repo, or document set name.",
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
         }
       }
     },

--- a/skills/product-intelligence/schemas/fixtures/invalid/brief-multi-origin-unqualified.yaml
+++ b/skills/product-intelligence/schemas/fixtures/invalid/brief-multi-origin-unqualified.yaml
@@ -1,0 +1,12 @@
+brief_version: "1.0"
+subject:
+  name: acme-platform
+  origins:
+    - id: server
+      kind: repo
+      target: acme/server
+    - id: cli
+      kind: repo
+      target: acme/cli
+evidence:
+  ledger: ../valid/ledger.yaml

--- a/skills/product-intelligence/schemas/fixtures/invalid/brief-origin-duplicate-id.yaml
+++ b/skills/product-intelligence/schemas/fixtures/invalid/brief-origin-duplicate-id.yaml
@@ -1,0 +1,12 @@
+brief_version: "1.0"
+subject:
+  name: acme-platform
+  origins:
+    - id: server
+      kind: repo
+      target: acme/server
+    - id: server
+      kind: repo
+      target: acme/server-v2
+evidence:
+  ledger: ../valid/ledger.yaml

--- a/skills/product-intelligence/schemas/fixtures/valid/brief-multi.yaml
+++ b/skills/product-intelligence/schemas/fixtures/valid/brief-multi.yaml
@@ -1,0 +1,39 @@
+brief_version: "1.0"
+subject:
+  name: acme-platform
+  homepage: https://acme.example
+  one_liner: Server plus CLI sold and documented as one product.
+  origins:
+    - id: server
+      kind: repo
+      target: acme/server
+    - id: cli
+      kind: repo
+      target: acme/cli
+    - id: www
+      kind: site
+      target: https://acme.example
+evidence:
+  ledger: ledger-multi.yaml
+  acquired_at: "2026-07-28"
+  acquisition:
+    - tool: repomix --remote
+      target: acme/server
+      retrieved_at: "2026-07-28"
+    - tool: repomix --remote
+      target: acme/cli
+      retrieved_at: "2026-07-28"
+    - tool: advertools
+      target: https://acme.example
+      retrieved_at: "2026-07-28"
+positioning:
+  target_customer: platform teams
+  need: one product surface across server and CLI
+  category: developer platform
+  claims: [C-003]
+site_inventory:
+  - locator: "site:/pricing"
+    page_type: pricing
+    disposition: keep
+    rationale: states the single-license model plainly
+    claims: [C-003]

--- a/skills/product-intelligence/schemas/fixtures/valid/ledger-multi.yaml
+++ b/skills/product-intelligence/schemas/fixtures/valid/ledger-multi.yaml
@@ -1,0 +1,31 @@
+ledger_version: "1.0"
+generated_by: product-intelligence
+generated_at: "2026-07-28T09:00:00Z"
+claims:
+  - id: C-001
+    statement: The server exposes a REST API documented in its README.
+    class: observed
+    confidence: high
+    sources:
+      - locator: "repo:server:README.md:8-14"
+        quote: "Every endpoint is available over REST at /api/v1."
+        stance: supports
+        as_of: "2026-07-28"
+  - id: C-002
+    statement: The CLI ships prebuilt binaries with each release.
+    class: observed
+    confidence: high
+    sources:
+      - locator: "gh:cli:releases/v2.3.0"
+        quote: "Assets: acme-linux-amd64, acme-darwin-arm64"
+        stance: supports
+        as_of: "2026-07-28"
+  - id: C-003
+    statement: The pricing page sells the server and CLI as one product.
+    class: observed
+    confidence: high
+    sources:
+      - locator: "site:/pricing"
+        quote: "One license covers the server and the CLI."
+        stance: supports
+        as_of: "2026-07-28"

--- a/skills/product-intelligence/scripts/validate.ts
+++ b/skills/product-intelligence/scripts/validate.ts
@@ -207,7 +207,10 @@ function checkOrigins(brief: Record<string, Json>, ledger: Json | undefined, err
   const seen = new Set<string>();
   for (const origin of origins) {
     if (!origin.id || !origin.kind) continue;
-    if (seen.has(origin.id)) errors.push(`brief.subject.origins: duplicate origin id '${origin.id}'`);
+    if (seen.has(origin.id)) {
+      errors.push(`brief.subject.origins: duplicate origin id '${origin.id}'`);
+      continue;
+    }
     seen.add(origin.id);
     idsByKind.set(origin.kind, [...(idsByKind.get(origin.kind) ?? []), origin.id]);
   }

--- a/skills/product-intelligence/scripts/validate.ts
+++ b/skills/product-intelligence/scripts/validate.ts
@@ -177,6 +177,7 @@ export function validateBriefDoc(doc: Json, ledger?: Json): string[] {
       errors.push(`brief.site_inventory[${i}]: a disposition requires a rationale`);
     }
   }
+  checkOrigins(brief, ledger, errors);
   if (ledger !== undefined) {
     const known = new Set(
       (((ledger as Record<string, Json>).claims ?? []) as Claim[]).map((c) => c.id).filter(Boolean),
@@ -186,6 +187,61 @@ export function validateBriefDoc(doc: Json, ledger?: Json): string[] {
     }
   }
   return errors;
+}
+
+// One brief may span several repos/sites; a locator like 'repo:README.md'
+// cannot say which. Qualification is demanded exactly when it is ambiguous:
+// two origins of one kind make every locator of that kind name its origin.
+const KIND_SCHEMES: Record<string, string[]> = { site: ['site'], repo: ['repo', 'gh'], docset: ['doc'] };
+
+interface Origin {
+  id?: string;
+  kind?: string;
+}
+
+function checkOrigins(brief: Record<string, Json>, ledger: Json | undefined, errors: string[]): void {
+  const origins = ((brief.subject as Record<string, Json> | undefined)?.origins ?? []) as Origin[];
+  if (origins.length === 0) return;
+
+  const idsByKind = new Map<string, string[]>();
+  const seen = new Set<string>();
+  for (const origin of origins) {
+    if (!origin.id || !origin.kind) continue;
+    if (seen.has(origin.id)) errors.push(`brief.subject.origins: duplicate origin id '${origin.id}'`);
+    seen.add(origin.id);
+    idsByKind.set(origin.kind, [...(idsByKind.get(origin.kind) ?? []), origin.id]);
+  }
+
+  const ambiguous = new Map<string, string[]>();
+  for (const [kind, ids] of idsByKind) {
+    if (ids.length < 2) continue;
+    for (const scheme of KIND_SCHEMES[kind] ?? []) ambiguous.set(scheme, ids);
+  }
+  if (ambiguous.size === 0) return;
+
+  for (const { path, locator } of collectLocators(brief, ledger)) {
+    const [scheme, second] = locator.split(':');
+    const ids = ambiguous.get(scheme);
+    if (ids && !ids.includes(second ?? '')) {
+      errors.push(`${path}: locator '${locator}' must name its origin — ${scheme}:<${ids.join('|')}>:…`);
+    }
+  }
+}
+
+function collectLocators(brief: Record<string, Json>, ledger: Json | undefined): { path: string; locator: string }[] {
+  const out: { path: string; locator: string }[] = [];
+  for (const [i, page] of (((brief.site_inventory ?? []) as Record<string, Json>[])).entries()) {
+    if (typeof page.locator === 'string') out.push({ path: `brief.site_inventory[${i}]`, locator: page.locator });
+  }
+  const claims = (((ledger as Record<string, Json> | undefined)?.claims ?? []) as Claim[]);
+  for (const [i, claim] of claims.entries()) {
+    for (const [j, source] of ((claim.sources ?? []) as Record<string, Json>[]).entries()) {
+      if (typeof source.locator === 'string') {
+        out.push({ path: `ledger claim ${claim.id ?? i}: sources[${j}]`, locator: source.locator });
+      }
+    }
+  }
+  return out;
 }
 
 function collectClaimRefs(node: Json, path: string): { path: string; ref: string }[] {

--- a/tests/product-intelligence/schemas.test.ts
+++ b/tests/product-intelligence/schemas.test.ts
@@ -30,6 +30,8 @@ const expectedFailures: Record<string, string> = {
   'brief-disposition-without-rationale.yaml': 'requires a rationale',
   'brief-missing-subject-name.yaml': "missing required field 'name'",
   'brief-dangling-ledger.yaml': 'not found',
+  'brief-multi-origin-unqualified.yaml': 'must name its origin',
+  'brief-origin-duplicate-id.yaml': 'duplicate origin id',
 };
 
 describe('product-intelligence schemas', () => {

--- a/tests/product-intelligence/schemas.test.ts
+++ b/tests/product-intelligence/schemas.test.ts
@@ -48,7 +48,9 @@ describe('product-intelligence schemas', () => {
   for (const [name, message] of Object.entries(expectedFailures)) {
     test(`rejects ${name} for the right reason`, () => {
       const errors = validateFile(invalid(name));
-      expect(errors.length, errors.join('\n')).toBeGreaterThan(0);
+      // Exactly one: a second error means the fixture breaks two rules and
+      // the pinned message could pass for the wrong one.
+      expect(errors, errors.join('\n')).toHaveLength(1);
       expect(errors.join('\n')).toContain(message);
     });
   }


### PR DESCRIPTION
Closes #130.

A product spanning several repos + a site + documents gets one brief and one ledger. `subject.origins[]` declares the sources; the moment two origins share a kind, every locator of that kind must name its origin (`repo:server:README.md:12`, `gh:cli:releases/v2.3.0`) — the validator rejects plain ones as ambiguous. With ≤1 origin per kind nothing changes, so all existing briefs/fixtures/examples stay valid.

- Schema: `subject.origins` items {id, kind: site|repo|docset, target}, id pattern `[a-z0-9-]`
- Validator: qualification check across brief `site_inventory` + ledger sources; duplicate origin ids rejected; `gh:` scheme belongs to repo kind
- Fixtures: valid two-repo+site set with qualified locators; invalid unqualified + duplicate-id; SKILL.md section

Verify: `scripts/product-command default -- bun test` — 601 pass, 0 fail.