### PR TITLE
feat(publish-page): figure-legibility lint + pages-police hook (#131)

### DIFF
--- a/hooks/claude/pages-police.sh
+++ b/hooks/claude/pages-police.sh
@@ -20,8 +20,17 @@ deny() {
 # canonical history. A raw PUT with the bearer token skips all three. Reads
 # (GET/HEAD) stay allowed.
 if echo "$COMMAND" | grep -qE '/api/pages'; then
-  if echo "$COMMAND" | grep -qiE '\b(curl|wget|http|xh)\b' \
-    && echo "$COMMAND" | grep -qiE '(-X[[:space:]]*(PUT|POST|DELETE)|--method[[:space:]=]*(PUT|POST|DELETE)|--upload-file|[[:space:]]-T[[:space:]]|--data|[[:space:]]-d[[:space:]])'; then
+  API_WRITE=0
+  if echo "$COMMAND" | grep -qiE '\b(curl|wget)\b' \
+    && echo "$COMMAND" | grep -qiE '((-X|--request|--method)[[:space:]=]*(PUT|POST|DELETE)|--upload-file|[[:space:]]-T[[:space:]]|--data|--json|--form|[[:space:]]-d[[:space:]])'; then
+    API_WRITE=1
+  fi
+  # httpie/xh take the method as a bare word: `http PUT …/api/pages/x`.
+  if echo "$COMMAND" | grep -qE '(^|[[:space:];&|])(http|xh)[[:space:]]' \
+    && echo "$COMMAND" | grep -qE '\b(PUT|POST|DELETE)\b'; then
+    API_WRITE=1
+  fi
+  if [[ "$API_WRITE" == "1" ]]; then
     deny "BLOCKED: direct write to the Pages API. Publish through skills/publish-page/publish.ts — it enforces the figure lint (illegible-diagram guard), the 5 MB cap, and the canonical git commit; a raw API write bypasses all three. Deletes: publish.ts --delete --name <name>."
   fi
 fi

--- a/hooks/claude/pages-police.sh
+++ b/hooks/claude/pages-police.sh
@@ -26,7 +26,7 @@ if echo "$COMMAND" | grep -qE '/api/pages'; then
     API_WRITE=1
   fi
   # httpie/xh take the method as a bare word: `http PUT …/api/pages/x`.
-  if echo "$COMMAND" | grep -qE '(^|[[:space:];&|])(http|xh)[[:space:]]' \
+  if echo "$COMMAND" | grep -qE '(^|[[:space:];&|"'"'"'])(http|xh)[[:space:]]' \
     && echo "$COMMAND" | grep -qE '\b(PUT|POST|DELETE)\b'; then
     API_WRITE=1
   fi

--- a/hooks/claude/pages-police.sh
+++ b/hooks/claude/pages-police.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# pages-police.sh — Claude Code PreToolUse hook (matcher: Bash)
+# Blocks: direct writes to the AgentKit Pages API (bypasses the publish-time
+# figure lint and canonical git history) and unapproved --allow-bare-svg.
+set -euo pipefail
+
+# shellcheck source=lib/hook-input.sh
+source "${BASH_SOURCE[0]%/*}/lib/hook-input.sh"
+agentkit_slurp_input
+COMMAND=$(agentkit_command)
+
+[[ -z "$COMMAND" ]] && exit 0
+
+deny() {
+  agentkit_deny_json "$1"
+  exit 0
+}
+
+# Writes must go through publish.ts: it lints figures, caps size, and commits
+# canonical history. A raw PUT with the bearer token skips all three. Reads
+# (GET/HEAD) stay allowed.
+if echo "$COMMAND" | grep -qE '/api/pages'; then
+  if echo "$COMMAND" | grep -qiE '\b(curl|wget|http|xh)\b' \
+    && echo "$COMMAND" | grep -qiE '(-X[[:space:]]*(PUT|POST|DELETE)|--method[[:space:]=]*(PUT|POST|DELETE)|--upload-file|[[:space:]]-T[[:space:]]|--data|[[:space:]]-d[[:space:]])'; then
+    deny "BLOCKED: direct write to the Pages API. Publish through skills/publish-page/publish.ts — it enforces the figure lint (illegible-diagram guard), the 5 MB cap, and the canonical git commit; a raw API write bypasses all three. Deletes: publish.ts --delete --name <name>."
+  fi
+fi
+
+# --allow-bare-svg skips the figure lint; that is a user decision, not an
+# agent convenience. Same override convention as AGENTKIT_ALLOW_PKG.
+if echo "$COMMAND" | grep -qE -- '--allow-bare-svg'; then
+  BARE_OK="${AGENTKIT_ALLOW_BARE_SVG:-0}"
+  if echo "$COMMAND" | grep -qE '(^|[[:space:];&|])AGENTKIT_ALLOW_BARE_SVG=1([[:space:];&|]|$)'; then
+    BARE_OK=1
+  fi
+  if [[ "$BARE_OK" != "1" ]]; then
+    deny "BLOCKED: --allow-bare-svg skips the figure-legibility lint. Fix the page instead (wrap the diagram in a .figure island or style its container with var(--diagram-bg)). Only when the USER has approved shipping a bare diagram, prefix with AGENTKIT_ALLOW_BARE_SVG=1."
+  fi
+fi
+
+exit 0

--- a/hooks/claude/settings.json
+++ b/hooks/claude/settings.json
@@ -24,6 +24,12 @@
           },
           {
             "type": "command",
+            "command": "$HOME/.claude/hooks/pages-police.sh",
+            "timeout": 10,
+            "statusMessage": "pages-police: guarding page publishes..."
+          },
+          {
+            "type": "command",
             "command": "$HOME/.claude/hooks/resource-police.sh",
             "timeout": 10,
             "statusMessage": "resource-police: requiring bounded execution..."

--- a/plugins-cc/agentkit/hooks/hooks.json
+++ b/plugins-cc/agentkit/hooks/hooks.json
@@ -24,6 +24,12 @@
           },
           {
             "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/pages-police.sh",
+            "timeout": 10,
+            "statusMessage": "pages-police: guarding page publishes..."
+          },
+          {
+            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/resource-police.sh",
             "timeout": 10,
             "statusMessage": "resource-police: requiring bounded execution..."

--- a/plugins-cc/agentkit/hooks/pages-police.sh
+++ b/plugins-cc/agentkit/hooks/pages-police.sh
@@ -20,8 +20,17 @@ deny() {
 # canonical history. A raw PUT with the bearer token skips all three. Reads
 # (GET/HEAD) stay allowed.
 if echo "$COMMAND" | grep -qE '/api/pages'; then
-  if echo "$COMMAND" | grep -qiE '\b(curl|wget|http|xh)\b' \
-    && echo "$COMMAND" | grep -qiE '(-X[[:space:]]*(PUT|POST|DELETE)|--method[[:space:]=]*(PUT|POST|DELETE)|--upload-file|[[:space:]]-T[[:space:]]|--data|[[:space:]]-d[[:space:]])'; then
+  API_WRITE=0
+  if echo "$COMMAND" | grep -qiE '\b(curl|wget)\b' \
+    && echo "$COMMAND" | grep -qiE '((-X|--request|--method)[[:space:]=]*(PUT|POST|DELETE)|--upload-file|[[:space:]]-T[[:space:]]|--data|--json|--form|[[:space:]]-d[[:space:]])'; then
+    API_WRITE=1
+  fi
+  # httpie/xh take the method as a bare word: `http PUT …/api/pages/x`.
+  if echo "$COMMAND" | grep -qE '(^|[[:space:];&|])(http|xh)[[:space:]]' \
+    && echo "$COMMAND" | grep -qE '\b(PUT|POST|DELETE)\b'; then
+    API_WRITE=1
+  fi
+  if [[ "$API_WRITE" == "1" ]]; then
     deny "BLOCKED: direct write to the Pages API. Publish through skills/publish-page/publish.ts — it enforces the figure lint (illegible-diagram guard), the 5 MB cap, and the canonical git commit; a raw API write bypasses all three. Deletes: publish.ts --delete --name <name>."
   fi
 fi

--- a/plugins-cc/agentkit/hooks/pages-police.sh
+++ b/plugins-cc/agentkit/hooks/pages-police.sh
@@ -26,7 +26,7 @@ if echo "$COMMAND" | grep -qE '/api/pages'; then
     API_WRITE=1
   fi
   # httpie/xh take the method as a bare word: `http PUT …/api/pages/x`.
-  if echo "$COMMAND" | grep -qE '(^|[[:space:];&|])(http|xh)[[:space:]]' \
+  if echo "$COMMAND" | grep -qE '(^|[[:space:];&|"'"'"'])(http|xh)[[:space:]]' \
     && echo "$COMMAND" | grep -qE '\b(PUT|POST|DELETE)\b'; then
     API_WRITE=1
   fi

--- a/plugins-cc/agentkit/hooks/pages-police.sh
+++ b/plugins-cc/agentkit/hooks/pages-police.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# pages-police.sh — Claude Code PreToolUse hook (matcher: Bash)
+# Blocks: direct writes to the AgentKit Pages API (bypasses the publish-time
+# figure lint and canonical git history) and unapproved --allow-bare-svg.
+set -euo pipefail
+
+# shellcheck source=lib/hook-input.sh
+source "${BASH_SOURCE[0]%/*}/lib/hook-input.sh"
+agentkit_slurp_input
+COMMAND=$(agentkit_command)
+
+[[ -z "$COMMAND" ]] && exit 0
+
+deny() {
+  agentkit_deny_json "$1"
+  exit 0
+}
+
+# Writes must go through publish.ts: it lints figures, caps size, and commits
+# canonical history. A raw PUT with the bearer token skips all three. Reads
+# (GET/HEAD) stay allowed.
+if echo "$COMMAND" | grep -qE '/api/pages'; then
+  if echo "$COMMAND" | grep -qiE '\b(curl|wget|http|xh)\b' \
+    && echo "$COMMAND" | grep -qiE '(-X[[:space:]]*(PUT|POST|DELETE)|--method[[:space:]=]*(PUT|POST|DELETE)|--upload-file|[[:space:]]-T[[:space:]]|--data|[[:space:]]-d[[:space:]])'; then
+    deny "BLOCKED: direct write to the Pages API. Publish through skills/publish-page/publish.ts — it enforces the figure lint (illegible-diagram guard), the 5 MB cap, and the canonical git commit; a raw API write bypasses all three. Deletes: publish.ts --delete --name <name>."
+  fi
+fi
+
+# --allow-bare-svg skips the figure lint; that is a user decision, not an
+# agent convenience. Same override convention as AGENTKIT_ALLOW_PKG.
+if echo "$COMMAND" | grep -qE -- '--allow-bare-svg'; then
+  BARE_OK="${AGENTKIT_ALLOW_BARE_SVG:-0}"
+  if echo "$COMMAND" | grep -qE '(^|[[:space:];&|])AGENTKIT_ALLOW_BARE_SVG=1([[:space:];&|]|$)'; then
+    BARE_OK=1
+  fi
+  if [[ "$BARE_OK" != "1" ]]; then
+    deny "BLOCKED: --allow-bare-svg skips the figure-legibility lint. Fix the page instead (wrap the diagram in a .figure island or style its container with var(--diagram-bg)). Only when the USER has approved shipping a bare diagram, prefix with AGENTKIT_ALLOW_BARE_SVG=1."
+  fi
+fi
+
+exit 0

--- a/plugins-cc/agentkit/skills/publish-page/SKILL.md
+++ b/plugins-cc/agentkit/skills/publish-page/SKILL.md
@@ -174,3 +174,7 @@ navy tokens above so pages feel like one product.
   serving CSP blocks every external request. Max 5 MB.
 - Errors are loud; fix and re-run. Do not fall back to pasting the content into
   chat without saying the publish failed.
+- Publish refuses a baked (excalidraw) SVG that is not inside a `.figure`
+  island or a container styled with `var(--diagram-bg)` — a navy-palette
+  diagram on a page-supplied light background is illegible in both themes.
+  `--allow-bare-svg` overrides when a raw page really owns its background.

--- a/plugins-cc/agentkit/skills/publish-page/SKILL.md
+++ b/plugins-cc/agentkit/skills/publish-page/SKILL.md
@@ -177,4 +177,6 @@ navy tokens above so pages feel like one product.
 - Publish refuses a baked (excalidraw) SVG that is not inside a `.figure`
   island or a container styled with `var(--diagram-bg)` — a navy-palette
   diagram on a page-supplied light background is illegible in both themes.
-  `--allow-bare-svg` overrides when a raw page really owns its background.
+  `--allow-bare-svg` overrides when a raw page really owns its background —
+  the pages-police hook blocks that flag unless the user approved it
+  (`AGENTKIT_ALLOW_BARE_SVG=1`), and blocks raw API writes outright.

--- a/plugins-cc/agentkit/skills/publish-page/lint.ts
+++ b/plugins-cc/agentkit/skills/publish-page/lint.ts
@@ -1,0 +1,57 @@
+// Baked excalidraw SVGs carry the navy palette; published outside the theme's
+// .figure island (or an equivalent var(--diagram-bg) container) they land on
+// whatever background the page provides — a white island shipped pale-on-white
+// once, illegible in both themes. Refuse that shape at publish time.
+
+export interface LintResult {
+  errors: string[];
+  warnings: string[];
+}
+
+const EXCALIDRAW_MARK = "svg-source:excalidraw";
+const CONTAINER_RE = /<(?:div|section|figure)\b[^>]*class="([^"]*)"[^>]*>/g;
+const NEARBY = 600;
+
+function styleBlocks(html: string): string {
+  return [...html.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/gi)].map((m) => m[1]).join("\n");
+}
+
+function classHasDiagramBg(cls: string, css: string): boolean {
+  const rule = new RegExp(`\\.${cls}[^{]*\\{[^}]*var\\(--diagram-bg`);
+  return rule.test(css);
+}
+
+export function lintFigures(html: string, allowBareSvg = false): LintResult {
+  const result: LintResult = { errors: [], warnings: [] };
+  const marks = [...html.matchAll(new RegExp(EXCALIDRAW_MARK, "g"))].map((m) => m.index ?? 0);
+  if (marks.length === 0) return result;
+
+  const css = styleBlocks(html);
+  if (/background:\s*(white\b|#fff\b|#ffffff\b)/i.test(css)) {
+    result.warnings.push(
+      "page CSS hardcodes a white background while carrying a baked diagram — "
+        + "if the diagram sits on it, use var(--diagram-bg) so both themes stay legible",
+    );
+  }
+  if (allowBareSvg) return result;
+
+  for (const at of marks) {
+    const before = html.slice(Math.max(0, at - NEARBY * 8), at);
+    const containers = [...before.matchAll(CONTAINER_RE)];
+    const nearest = containers[containers.length - 1];
+    const classes = nearest?.[1]?.split(/\s+/) ?? [];
+    const distance = nearest ? before.length - (nearest.index ?? 0) : Infinity;
+    const wrapped = distance <= NEARBY
+      && (classes.includes("figure")
+        || classes.some((c) => /^[A-Za-z0-9_-]+$/.test(c) && classHasDiagramBg(c, css)));
+    if (!wrapped) {
+      result.errors.push(
+        "excalidraw SVG published outside a .figure island — wrap it in "
+          + '<div class="figure">…<div class="figcaption">…</div></div>, or style its container '
+          + "with background: var(--diagram-bg) so it stays legible in both themes "
+          + "(--allow-bare-svg overrides)",
+      );
+    }
+  }
+  return result;
+}

--- a/plugins-cc/agentkit/skills/publish-page/lint.ts
+++ b/plugins-cc/agentkit/skills/publish-page/lint.ts
@@ -9,16 +9,47 @@ export interface LintResult {
 }
 
 const EXCALIDRAW_MARK = "svg-source:excalidraw";
-const CONTAINER_RE = /<(?:div|section|figure)\b[^>]*class="([^"]*)"[^>]*>/g;
-const NEARBY = 600;
+const CONTAINER_RE = /<(?:div|section|figure)\b[^>]*class\s*=\s*["']([^"']*)["'][^>]*>/gi;
+const TAG_OPEN_RE = /<(?:div|section|figure)\b/gi;
+const TAG_CLOSE_RE = /<\/(?:div|section|figure)>/gi;
+const NEARBY = 900;
 
 function styleBlocks(html: string): string {
   return [...html.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/gi)].map((m) => m[1]).join("\n");
 }
 
 function classHasDiagramBg(cls: string, css: string): boolean {
-  const rule = new RegExp(`\\.${cls}[^{]*\\{[^}]*var\\(--diagram-bg`);
+  // Anchored (`.dia` must not accept `.diagram` rules) and property-bound:
+  // var(--diagram-bg) on a border while background stays white is the defect,
+  // not a pass.
+  const rule = new RegExp(
+    `\\.${cls}(?![A-Za-z0-9_-])[^{]*\\{[^}]*background(?:-color)?:[^;}]*var\\(--diagram-bg`,
+  );
   return rule.test(css);
+}
+
+// The container only covers the mark while it is still open: as many closes
+// as opens after its own tag means the island ended before the diagram began.
+function stillOpen(between: string): boolean {
+  const opens = [...between.matchAll(TAG_OPEN_RE)].length;
+  const closes = [...between.matchAll(TAG_CLOSE_RE)].length;
+  return closes <= opens;
+}
+
+function isWrapped(before: string, css: string): boolean {
+  const containers = [...before.matchAll(CONTAINER_RE)];
+  for (const container of containers.reverse()) {
+    const end = (container.index ?? 0) + container[0].length;
+    if (before.length - end > NEARBY) return false;
+    if (!stillOpen(before.slice(end))) continue;
+    const classes = container[1].split(/\s+/);
+    const qualifies = classes.includes("figure")
+      || classes.some((c) => /^[A-Za-z0-9_-]+$/.test(c) && classHasDiagramBg(c, css));
+    // A still-open container that does not qualify may itself sit inside a
+    // qualifying island — keep walking outward.
+    if (qualifies) return true;
+  }
+  return false;
 }
 
 export function lintFigures(html: string, allowBareSvg = false): LintResult {
@@ -27,7 +58,7 @@ export function lintFigures(html: string, allowBareSvg = false): LintResult {
   if (marks.length === 0) return result;
 
   const css = styleBlocks(html);
-  if (/background:\s*(white\b|#fff\b|#ffffff\b)/i.test(css)) {
+  if (/background(?:-color)?:\s*(white\b|#fff\b|#ffffff\b|rgb\(\s*255\s*,\s*255\s*,\s*255)/i.test(css)) {
     result.warnings.push(
       "page CSS hardcodes a white background while carrying a baked diagram — "
         + "if the diagram sits on it, use var(--diagram-bg) so both themes stay legible",
@@ -36,15 +67,7 @@ export function lintFigures(html: string, allowBareSvg = false): LintResult {
   if (allowBareSvg) return result;
 
   for (const at of marks) {
-    const before = html.slice(Math.max(0, at - NEARBY * 8), at);
-    const containers = [...before.matchAll(CONTAINER_RE)];
-    const nearest = containers[containers.length - 1];
-    const classes = nearest?.[1]?.split(/\s+/) ?? [];
-    const distance = nearest ? before.length - (nearest.index ?? 0) : Infinity;
-    const wrapped = distance <= NEARBY
-      && (classes.includes("figure")
-        || classes.some((c) => /^[A-Za-z0-9_-]+$/.test(c) && classHasDiagramBg(c, css)));
-    if (!wrapped) {
+    if (!isWrapped(html.slice(Math.max(0, at - NEARBY * 8), at), css)) {
       result.errors.push(
         "excalidraw SVG published outside a .figure island — wrap it in "
           + '<div class="figure">…<div class="figcaption">…</div></div>, or style its container '

--- a/plugins-cc/agentkit/skills/publish-page/lint.ts
+++ b/plugins-cc/agentkit/skills/publish-page/lint.ts
@@ -10,8 +10,7 @@ export interface LintResult {
 
 const EXCALIDRAW_MARK = "svg-source:excalidraw";
 const CONTAINER_RE = /<(?:div|section|figure)\b[^>]*class\s*=\s*["']([^"']*)["'][^>]*>/gi;
-const TAG_OPEN_RE = /<(?:div|section|figure)\b/gi;
-const TAG_CLOSE_RE = /<\/(?:div|section|figure)>/gi;
+const TAG_RE = /<(\/?)(?:div|section|figure)\b/gi;
 const NEARBY = 900;
 
 function styleBlocks(html: string): string {
@@ -28,12 +27,16 @@ function classHasDiagramBg(cls: string, css: string): boolean {
   return rule.test(css);
 }
 
-// The container only covers the mark while it is still open: as many closes
-// as opens after its own tag means the island ended before the diagram began.
+// The container only covers the mark while it is still open. Depth must be
+// walked in order — a close followed by a sibling open has equal totals but
+// the island is already over.
 function stillOpen(between: string): boolean {
-  const opens = [...between.matchAll(TAG_OPEN_RE)].length;
-  const closes = [...between.matchAll(TAG_CLOSE_RE)].length;
-  return closes <= opens;
+  let depth = 0;
+  for (const tag of between.matchAll(TAG_RE)) {
+    depth += tag[1] === "/" ? -1 : 1;
+    if (depth < 0) return false;
+  }
+  return true;
 }
 
 function isWrapped(before: string, css: string): boolean {

--- a/plugins-cc/agentkit/skills/publish-page/publish.ts
+++ b/plugins-cc/agentkit/skills/publish-page/publish.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env bun
 import { marked } from "marked";
+import { lintFigures } from "./lint.ts";
 import { createHmac, randomBytes } from "node:crypto";
 import { existsSync } from "node:fs";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
@@ -221,6 +222,9 @@ async function render(): Promise<string> {
 }
 
 const html = await render();
+const lint = lintFigures(html, process.argv.includes("--allow-bare-svg"));
+for (const warning of lint.warnings) console.error(`publish-page: warning: ${warning}`);
+if (lint.errors.length > 0) fail(lint.errors.join("\n"));
 if (Buffer.byteLength(html) > 5 * 1024 * 1024) {
   const hint = html.includes("mermaid.initialize")
     ? " (the inlined mermaid runtime accounts for ~3.4 MB — diagram pages have ~1.4 MB left for content; split the page or drop diagrams)"

--- a/plugins-cc/agentkit/skills/publish-page/tsconfig.json
+++ b/plugins-cc/agentkit/skills/publish-page/tsconfig.json
@@ -4,6 +4,7 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "types": ["bun"],
     "strict": true,
     "noEmit": true

--- a/skills/publish-page/SKILL.md
+++ b/skills/publish-page/SKILL.md
@@ -174,3 +174,7 @@ navy tokens above so pages feel like one product.
   serving CSP blocks every external request. Max 5 MB.
 - Errors are loud; fix and re-run. Do not fall back to pasting the content into
   chat without saying the publish failed.
+- Publish refuses a baked (excalidraw) SVG that is not inside a `.figure`
+  island or a container styled with `var(--diagram-bg)` — a navy-palette
+  diagram on a page-supplied light background is illegible in both themes.
+  `--allow-bare-svg` overrides when a raw page really owns its background.

--- a/skills/publish-page/SKILL.md
+++ b/skills/publish-page/SKILL.md
@@ -177,4 +177,6 @@ navy tokens above so pages feel like one product.
 - Publish refuses a baked (excalidraw) SVG that is not inside a `.figure`
   island or a container styled with `var(--diagram-bg)` — a navy-palette
   diagram on a page-supplied light background is illegible in both themes.
-  `--allow-bare-svg` overrides when a raw page really owns its background.
+  `--allow-bare-svg` overrides when a raw page really owns its background —
+  the pages-police hook blocks that flag unless the user approved it
+  (`AGENTKIT_ALLOW_BARE_SVG=1`), and blocks raw API writes outright.

--- a/skills/publish-page/lint.ts
+++ b/skills/publish-page/lint.ts
@@ -1,0 +1,57 @@
+// Baked excalidraw SVGs carry the navy palette; published outside the theme's
+// .figure island (or an equivalent var(--diagram-bg) container) they land on
+// whatever background the page provides — a white island shipped pale-on-white
+// once, illegible in both themes. Refuse that shape at publish time.
+
+export interface LintResult {
+  errors: string[];
+  warnings: string[];
+}
+
+const EXCALIDRAW_MARK = "svg-source:excalidraw";
+const CONTAINER_RE = /<(?:div|section|figure)\b[^>]*class="([^"]*)"[^>]*>/g;
+const NEARBY = 600;
+
+function styleBlocks(html: string): string {
+  return [...html.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/gi)].map((m) => m[1]).join("\n");
+}
+
+function classHasDiagramBg(cls: string, css: string): boolean {
+  const rule = new RegExp(`\\.${cls}[^{]*\\{[^}]*var\\(--diagram-bg`);
+  return rule.test(css);
+}
+
+export function lintFigures(html: string, allowBareSvg = false): LintResult {
+  const result: LintResult = { errors: [], warnings: [] };
+  const marks = [...html.matchAll(new RegExp(EXCALIDRAW_MARK, "g"))].map((m) => m.index ?? 0);
+  if (marks.length === 0) return result;
+
+  const css = styleBlocks(html);
+  if (/background:\s*(white\b|#fff\b|#ffffff\b)/i.test(css)) {
+    result.warnings.push(
+      "page CSS hardcodes a white background while carrying a baked diagram — "
+        + "if the diagram sits on it, use var(--diagram-bg) so both themes stay legible",
+    );
+  }
+  if (allowBareSvg) return result;
+
+  for (const at of marks) {
+    const before = html.slice(Math.max(0, at - NEARBY * 8), at);
+    const containers = [...before.matchAll(CONTAINER_RE)];
+    const nearest = containers[containers.length - 1];
+    const classes = nearest?.[1]?.split(/\s+/) ?? [];
+    const distance = nearest ? before.length - (nearest.index ?? 0) : Infinity;
+    const wrapped = distance <= NEARBY
+      && (classes.includes("figure")
+        || classes.some((c) => /^[A-Za-z0-9_-]+$/.test(c) && classHasDiagramBg(c, css)));
+    if (!wrapped) {
+      result.errors.push(
+        "excalidraw SVG published outside a .figure island — wrap it in "
+          + '<div class="figure">…<div class="figcaption">…</div></div>, or style its container '
+          + "with background: var(--diagram-bg) so it stays legible in both themes "
+          + "(--allow-bare-svg overrides)",
+      );
+    }
+  }
+  return result;
+}

--- a/skills/publish-page/lint.ts
+++ b/skills/publish-page/lint.ts
@@ -9,16 +9,47 @@ export interface LintResult {
 }
 
 const EXCALIDRAW_MARK = "svg-source:excalidraw";
-const CONTAINER_RE = /<(?:div|section|figure)\b[^>]*class="([^"]*)"[^>]*>/g;
-const NEARBY = 600;
+const CONTAINER_RE = /<(?:div|section|figure)\b[^>]*class\s*=\s*["']([^"']*)["'][^>]*>/gi;
+const TAG_OPEN_RE = /<(?:div|section|figure)\b/gi;
+const TAG_CLOSE_RE = /<\/(?:div|section|figure)>/gi;
+const NEARBY = 900;
 
 function styleBlocks(html: string): string {
   return [...html.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/gi)].map((m) => m[1]).join("\n");
 }
 
 function classHasDiagramBg(cls: string, css: string): boolean {
-  const rule = new RegExp(`\\.${cls}[^{]*\\{[^}]*var\\(--diagram-bg`);
+  // Anchored (`.dia` must not accept `.diagram` rules) and property-bound:
+  // var(--diagram-bg) on a border while background stays white is the defect,
+  // not a pass.
+  const rule = new RegExp(
+    `\\.${cls}(?![A-Za-z0-9_-])[^{]*\\{[^}]*background(?:-color)?:[^;}]*var\\(--diagram-bg`,
+  );
   return rule.test(css);
+}
+
+// The container only covers the mark while it is still open: as many closes
+// as opens after its own tag means the island ended before the diagram began.
+function stillOpen(between: string): boolean {
+  const opens = [...between.matchAll(TAG_OPEN_RE)].length;
+  const closes = [...between.matchAll(TAG_CLOSE_RE)].length;
+  return closes <= opens;
+}
+
+function isWrapped(before: string, css: string): boolean {
+  const containers = [...before.matchAll(CONTAINER_RE)];
+  for (const container of containers.reverse()) {
+    const end = (container.index ?? 0) + container[0].length;
+    if (before.length - end > NEARBY) return false;
+    if (!stillOpen(before.slice(end))) continue;
+    const classes = container[1].split(/\s+/);
+    const qualifies = classes.includes("figure")
+      || classes.some((c) => /^[A-Za-z0-9_-]+$/.test(c) && classHasDiagramBg(c, css));
+    // A still-open container that does not qualify may itself sit inside a
+    // qualifying island — keep walking outward.
+    if (qualifies) return true;
+  }
+  return false;
 }
 
 export function lintFigures(html: string, allowBareSvg = false): LintResult {
@@ -27,7 +58,7 @@ export function lintFigures(html: string, allowBareSvg = false): LintResult {
   if (marks.length === 0) return result;
 
   const css = styleBlocks(html);
-  if (/background:\s*(white\b|#fff\b|#ffffff\b)/i.test(css)) {
+  if (/background(?:-color)?:\s*(white\b|#fff\b|#ffffff\b|rgb\(\s*255\s*,\s*255\s*,\s*255)/i.test(css)) {
     result.warnings.push(
       "page CSS hardcodes a white background while carrying a baked diagram — "
         + "if the diagram sits on it, use var(--diagram-bg) so both themes stay legible",
@@ -36,15 +67,7 @@ export function lintFigures(html: string, allowBareSvg = false): LintResult {
   if (allowBareSvg) return result;
 
   for (const at of marks) {
-    const before = html.slice(Math.max(0, at - NEARBY * 8), at);
-    const containers = [...before.matchAll(CONTAINER_RE)];
-    const nearest = containers[containers.length - 1];
-    const classes = nearest?.[1]?.split(/\s+/) ?? [];
-    const distance = nearest ? before.length - (nearest.index ?? 0) : Infinity;
-    const wrapped = distance <= NEARBY
-      && (classes.includes("figure")
-        || classes.some((c) => /^[A-Za-z0-9_-]+$/.test(c) && classHasDiagramBg(c, css)));
-    if (!wrapped) {
+    if (!isWrapped(html.slice(Math.max(0, at - NEARBY * 8), at), css)) {
       result.errors.push(
         "excalidraw SVG published outside a .figure island — wrap it in "
           + '<div class="figure">…<div class="figcaption">…</div></div>, or style its container '

--- a/skills/publish-page/lint.ts
+++ b/skills/publish-page/lint.ts
@@ -10,8 +10,7 @@ export interface LintResult {
 
 const EXCALIDRAW_MARK = "svg-source:excalidraw";
 const CONTAINER_RE = /<(?:div|section|figure)\b[^>]*class\s*=\s*["']([^"']*)["'][^>]*>/gi;
-const TAG_OPEN_RE = /<(?:div|section|figure)\b/gi;
-const TAG_CLOSE_RE = /<\/(?:div|section|figure)>/gi;
+const TAG_RE = /<(\/?)(?:div|section|figure)\b/gi;
 const NEARBY = 900;
 
 function styleBlocks(html: string): string {
@@ -28,12 +27,16 @@ function classHasDiagramBg(cls: string, css: string): boolean {
   return rule.test(css);
 }
 
-// The container only covers the mark while it is still open: as many closes
-// as opens after its own tag means the island ended before the diagram began.
+// The container only covers the mark while it is still open. Depth must be
+// walked in order — a close followed by a sibling open has equal totals but
+// the island is already over.
 function stillOpen(between: string): boolean {
-  const opens = [...between.matchAll(TAG_OPEN_RE)].length;
-  const closes = [...between.matchAll(TAG_CLOSE_RE)].length;
-  return closes <= opens;
+  let depth = 0;
+  for (const tag of between.matchAll(TAG_RE)) {
+    depth += tag[1] === "/" ? -1 : 1;
+    if (depth < 0) return false;
+  }
+  return true;
 }
 
 function isWrapped(before: string, css: string): boolean {

--- a/skills/publish-page/publish.ts
+++ b/skills/publish-page/publish.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env bun
 import { marked } from "marked";
+import { lintFigures } from "./lint.ts";
 import { createHmac, randomBytes } from "node:crypto";
 import { existsSync } from "node:fs";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
@@ -221,6 +222,9 @@ async function render(): Promise<string> {
 }
 
 const html = await render();
+const lint = lintFigures(html, process.argv.includes("--allow-bare-svg"));
+for (const warning of lint.warnings) console.error(`publish-page: warning: ${warning}`);
+if (lint.errors.length > 0) fail(lint.errors.join("\n"));
 if (Buffer.byteLength(html) > 5 * 1024 * 1024) {
   const hint = html.includes("mermaid.initialize")
     ? " (the inlined mermaid runtime accounts for ~3.4 MB — diagram pages have ~1.4 MB left for content; split the page or drop diagrams)"

--- a/skills/publish-page/tsconfig.json
+++ b/skills/publish-page/tsconfig.json
@@ -4,6 +4,7 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "types": ["bun"],
     "strict": true,
     "noEmit": true

--- a/tests/agentkit-plugin.test.ts
+++ b/tests/agentkit-plugin.test.ts
@@ -21,6 +21,7 @@ const PRE_TOOL_USE_HOOKS = [
   'git-police.sh',
   'kubectl-police.sh',
   'pkg-police.sh',
+  'pages-police.sh',
   'mr-police.sh',
   'resource-police.sh',
   'review-police.sh',

--- a/tests/hook-payload-compat.test.ts
+++ b/tests/hook-payload-compat.test.ts
@@ -85,6 +85,15 @@ describe('hook payload compat (Claude + Grok)', () => {
     expect(stdout).toMatch(/bun/i);
   });
 
+  test('pages-police denies a raw Pages API write on Grok camelCase', () => {
+    const { stdout } = runHook('pages-police.sh', {
+      toolName: 'run_terminal_command',
+      toolInput: { command: 'curl -X PUT --data @p.html https://pages.agentkit.sbs/api/pages/abc' },
+    });
+    expect(isDeny(stdout)).toBe(true);
+    expect(stdout).toMatch(/publish\.ts/);
+  });
+
   const describeResource = canBound ? describe : describe.skip;
   describeResource('resource-police', () => {
     test('denies unbounded cargo build on Grok camelCase', () => {

--- a/tests/publish-page/lint.test.ts
+++ b/tests/publish-page/lint.test.ts
@@ -59,6 +59,13 @@ describe('publish-page figure lint', () => {
     expect(lintFigures(html).errors).toHaveLength(1);
   });
 
+  test('a closed .figure followed by a sibling wrapper div does not cover it either', () => {
+    // Totals-based depth counting read close+open as still-open; the walk
+    // must be ordered.
+    const html = `<div class="figure">old</div><div class="wrap">${SVG}</div>`;
+    expect(lintFigures(html).errors).toHaveLength(1);
+  });
+
   test('an unstyled inner div inside an open .figure still counts as wrapped', () => {
     const html = `<div class="figure"><div class="inner">${SVG}</div></div>`;
     expect(lintFigures(html).errors).toEqual([]);

--- a/tests/publish-page/lint.test.ts
+++ b/tests/publish-page/lint.test.ts
@@ -49,8 +49,36 @@ describe('publish-page figure lint', () => {
   });
 
   test('a distant .figure from an earlier, closed island does not cover a bare svg', () => {
-    const filler = '<p>x</p>'.repeat(120);
+    const filler = '<p>x</p>'.repeat(160);
     const html = `<div class="figure">old</div>${filler}${SVG}`;
     expect(lintFigures(html).errors).toHaveLength(1);
+  });
+
+  test('a CLOSED .figure immediately before a bare svg does not cover it', () => {
+    const html = `<div class="figure">old</div><p>hi</p>${SVG}`;
+    expect(lintFigures(html).errors).toHaveLength(1);
+  });
+
+  test('an unstyled inner div inside an open .figure still counts as wrapped', () => {
+    const html = `<div class="figure"><div class="inner">${SVG}</div></div>`;
+    expect(lintFigures(html).errors).toEqual([]);
+  });
+
+  test('a prefix-named class does not borrow another rule: .diagrams cannot cover .diagram', () => {
+    const html = `<style>.diagrams { background: var(--diagram-bg) } .diagram { background: white }</style>
+<div class="diagram">${SVG}</div>`;
+    expect(lintFigures(html).errors).toHaveLength(1);
+  });
+
+  test('var(--diagram-bg) on a non-background property does not qualify', () => {
+    const html = `<style>.d { border-color: var(--diagram-bg); background: white }</style><div class="d">${SVG}</div>`;
+    expect(lintFigures(html).errors).toHaveLength(1);
+  });
+
+  test('background-color spelling and single-quoted class attributes are understood', () => {
+    const html = `<style>.hero { background-color: white }</style><div class='figure'>${SVG}</div>`;
+    const result = lintFigures(html);
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toHaveLength(1);
   });
 });

--- a/tests/publish-page/lint.test.ts
+++ b/tests/publish-page/lint.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'bun:test';
+import { lintFigures } from '../../skills/publish-page/lint.ts';
+
+const SVG = '<svg version="1.1" width="100%" role="img" aria-label="x"><!-- svg-source:excalidraw --><metadata></metadata></svg>';
+
+describe('publish-page figure lint', () => {
+  test('a .figure-wrapped diagram passes, including a <p> between wrapper and svg', () => {
+    const html = `<div class="figure">\n<p>${SVG}</p>\n<div class="figcaption">c</div></div>`;
+    expect(lintFigures(html)).toEqual({ errors: [], warnings: [] });
+  });
+
+  test('the shipped white-island shape is refused with the fix named', () => {
+    // The exact defect that reached production: custom container, hardcoded
+    // white background, navy-palette SVG — illegible in both themes.
+    const html = `<style>.study .diagram { border-radius: 14px; background: white; overflow: hidden; }</style>
+<div class="study"><div class="diagram">${SVG}</div></div>`;
+    const result = lintFigures(html);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('.figure');
+    expect(result.errors[0]).toContain('var(--diagram-bg)');
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  test('the repaired shape passes: custom container styled with var(--diagram-bg)', () => {
+    const html = `<style>.study .diagram { background: var(--diagram-bg, #071224); overflow: hidden; }</style>
+<div class="study"><div class="diagram">${SVG}</div></div>`;
+    expect(lintFigures(html).errors).toEqual([]);
+  });
+
+  test('a bare svg with no container at all is refused', () => {
+    expect(lintFigures(`<main>${SVG}</main>`).errors).toHaveLength(1);
+  });
+
+  test('--allow-bare-svg suppresses the error but keeps the contrast warning', () => {
+    const html = `<style>.d { background: #fff }</style><div class="d">${SVG}</div>`;
+    const result = lintFigures(html, true);
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  test('pages without a baked diagram are never flagged', () => {
+    const html = '<style>.hero { background: white }</style><div class="hero"><svg viewBox="0 0 24 24"></svg></div>';
+    expect(lintFigures(html)).toEqual({ errors: [], warnings: [] });
+  });
+
+  test('a legitimately tinted background like #fff9ec does not trip the warning', () => {
+    const html = `<style>.status { background: #fff9ec }</style><div class="figure">${SVG}</div>`;
+    expect(lintFigures(html).warnings).toEqual([]);
+  });
+
+  test('a distant .figure from an earlier, closed island does not cover a bare svg', () => {
+    const filler = '<p>x</p>'.repeat(120);
+    const html = `<div class="figure">old</div>${filler}${SVG}`;
+    expect(lintFigures(html).errors).toHaveLength(1);
+  });
+});

--- a/tests/publish-page/pages-police.test.ts
+++ b/tests/publish-page/pages-police.test.ts
@@ -19,7 +19,11 @@ describe('pages-police: direct API writes', () => {
     'curl --upload-file page.html https://pages.agentkit.sbs/api/pages/abc',
     'curl -T page.html https://pages.agentkit.sbs/api/pages/abc',
     'curl -X DELETE https://pages.agentkit.sbs/api/pages/abc',
+    'curl --request DELETE https://pages.agentkit.sbs/api/pages/abc',
+    'curl --request PUT --json @p.html https://pages.agentkit.sbs/api/pages/abc',
     'wget --method=PUT --body-file=p.html http://127.0.0.1:8787/api/pages/abc',
+    'http PUT pages.agentkit.sbs/api/pages/abc < page.html',
+    'xh DELETE pages.agentkit.sbs/api/pages/abc',
   ];
   for (const command of denied) {
     test(`denies: ${command.slice(0, 60)}`, () => {

--- a/tests/publish-page/pages-police.test.ts
+++ b/tests/publish-page/pages-police.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from 'bun:test';
+import { dirname, join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const repoRoot = dirname(dirname(import.meta.dir));
+const hook = join(repoRoot, 'hooks', 'claude', 'pages-police.sh');
+
+function runHook(command: string, env: Record<string, string> = {}): string {
+  return spawnSync('bash', [hook], {
+    input: JSON.stringify({ tool_input: { command } }),
+    encoding: 'utf-8',
+    env: { ...process.env, AGENTKIT_ALLOW_BARE_SVG: '', ...env },
+  }).stdout ?? '';
+}
+
+describe('pages-police: direct API writes', () => {
+  const denied = [
+    'curl -X PUT https://pages.agentkit.sbs/api/pages/abc --data @page.html',
+    'curl --upload-file page.html https://pages.agentkit.sbs/api/pages/abc',
+    'curl -T page.html https://pages.agentkit.sbs/api/pages/abc',
+    'curl -X DELETE https://pages.agentkit.sbs/api/pages/abc',
+    'wget --method=PUT --body-file=p.html http://127.0.0.1:8787/api/pages/abc',
+  ];
+  for (const command of denied) {
+    test(`denies: ${command.slice(0, 60)}`, () => {
+      const out = runHook(command);
+      expect(out).toContain('"permissionDecision": "deny"');
+      expect(out).toContain('publish.ts');
+    });
+  }
+
+  const allowed = [
+    'curl https://pages.agentkit.sbs/api/pages/abc',
+    'curl -I https://pages.agentkit.sbs/api/pages/abc',
+    'bun skills/publish-page/publish.ts --name x --file page.md',
+    'bun skills/publish-page/publish.ts --name x --delete',
+    'curl -X PUT https://other.example/v1/items -d x=1',
+  ];
+  for (const command of allowed) {
+    test(`allows: ${command.slice(0, 60)}`, () => {
+      expect(runHook(command)).not.toContain('deny');
+    });
+  }
+});
+
+describe('pages-police: --allow-bare-svg needs user approval', () => {
+  const publish = 'bun skills/publish-page/publish.ts --name x --file p.md --allow-bare-svg';
+
+  test('denied without the override', () => {
+    const out = runHook(publish);
+    expect(out).toContain('"permissionDecision": "deny"');
+    expect(out).toContain('AGENTKIT_ALLOW_BARE_SVG=1');
+  });
+
+  test('inline override allows it', () => {
+    expect(runHook(`AGENTKIT_ALLOW_BARE_SVG=1 ${publish}`)).not.toContain('deny');
+  });
+
+  test('environment override allows it', () => {
+    expect(runHook(publish, { AGENTKIT_ALLOW_BARE_SVG: '1' })).not.toContain('deny');
+  });
+
+  test('an override token buried in a string does not count', () => {
+    expect(runHook(`echo AGENTKIT_ALLOW_BARE_SVG=1x; ${publish}`)).toContain('deny');
+  });
+});
+
+describe('pages-police: harness compatibility', () => {
+  test('empty and non-bash payloads pass through silently', () => {
+    expect(runHook('')).not.toContain('deny');
+    const out = spawnSync('bash', [hook], { input: '{}', encoding: 'utf-8' }).stdout ?? '';
+    expect(out).not.toContain('deny');
+  });
+});

--- a/tests/publish-page/pages-police.test.ts
+++ b/tests/publish-page/pages-police.test.ts
@@ -24,6 +24,7 @@ describe('pages-police: direct API writes', () => {
     'wget --method=PUT --body-file=p.html http://127.0.0.1:8787/api/pages/abc',
     'http PUT pages.agentkit.sbs/api/pages/abc < page.html',
     'xh DELETE pages.agentkit.sbs/api/pages/abc',
+    'sh -c "http PUT pages.agentkit.sbs/api/pages/abc < page.html"',
   ];
   for (const command of denied) {
     test(`denies: ${command.slice(0, 60)}`, () => {


### PR DESCRIPTION
Closes #131. Follow-through on the illegible-diagram page (pages.agentkit.sbs/290cf7222ad6e1e8d9e9, since repaired): make that page shape impossible to ship silently, and make the bypasses require explicit user approval.

Two layers:
- **Publish-time lint** (`skills/publish-page/lint.ts`, wired into publish.ts): a baked excalidraw SVG must sit in a `.figure` island or a container styled with `var(--diagram-bg)`; otherwise the publish is refused with the fix named. Hardcoded white backgrounds alongside a baked diagram warn. The repaired page's markup passes; its original broken markup is refused (both are test fixtures). All four existing diagram pages lint clean.
- **pages-police hook** (PreToolUse Bash, wired in settings.json + plugin hooks.json): raw `curl`/`wget` writes to `/api/pages` are blocked (they bypass lint, the 5 MB cap, and canonical git history — reads stay allowed), and `--allow-bare-svg` is blocked unless the user-approval convention `AGENTKIT_ALLOW_BARE_SVG=1` is present (same pattern as AGENTKIT_ALLOW_PKG).

Verify: `scripts/product-command default -- bun test` — 625 pass, 0 fail (16 new: lint shapes both directions, hook deny/allow matrices, override-token-in-string negative).