### PR TITLE
feat(product-intelligence): persist intelligence artifacts + agentkit's own brief (#135)

### DIFF
--- a/.agentkit/intelligence/agentkit/acquisition.json
+++ b/.agentkit/intelligence/agentkit/acquisition.json
@@ -1,0 +1,12 @@
+[
+  {
+    "tool": "gh api",
+    "target": "developerinlondon/agentkit",
+    "retrieved_at": "2026-07-28"
+  },
+  {
+    "tool": "repomix --remote",
+    "target": "developerinlondon/agentkit",
+    "retrieved_at": "2026-07-28"
+  }
+]

--- a/.agentkit/intelligence/agentkit/acquisition.json
+++ b/.agentkit/intelligence/agentkit/acquisition.json
@@ -8,5 +8,10 @@
     "tool": "repomix --remote",
     "target": "developerinlondon/agentkit",
     "retrieved_at": "2026-07-28"
+  },
+  {
+    "tool": "repomix --remote",
+    "target": "https://gitlab.com/agentkit/agentkit-pages",
+    "retrieved_at": "2026-07-28"
   }
 ]

--- a/.agentkit/intelligence/agentkit/brief.md
+++ b/.agentkit/intelligence/agentkit/brief.md
@@ -8,8 +8,8 @@ multiple AI coding agents — OpenCode, Claude Code, Codex CLI and Grok CLI
 repositories: the kit itself, and a pages store that holds agent-published
 web pages with git as the source of truth [C-009, C-010]. Its bet is that
 agent behavior should be _enforced_, not described: rules like the consent
-protocol ("never act and ask in the same turn") ship as policy hooks
-alongside the code [C-003].
+protocol ("never act and ask in the same turn") ship with police hooks
+that enforce them [C-003, C-011].
 
 ## The Problem
 
@@ -20,11 +20,11 @@ discipline several times, once per harness, and watches the copies drift.
 
 One shared package, installed everywhere [C-001]. Fix a workflow once and
 every agent inherits it; police hooks make skipping the discipline loud
-instead of silent [C-003].
+instead of silent [C-011].
 
 ## What Makes This Different
 
-Enforcement over prose [C-003], and a publishing surface whose serving
+Enforcement over prose [C-003, C-011], and a publishing surface whose serving
 layer is disposable — the pages repository can re-seed it at any time
 [C-010].
 

--- a/.agentkit/intelligence/agentkit/brief.md
+++ b/.agentkit/intelligence/agentkit/brief.md
@@ -1,0 +1,44 @@
+# Product Brief: agentkit
+
+## Executive Summary
+
+agentkit packages reusable skills, rules, plugins, hooks and tools for
+multiple AI coding agents — OpenCode, Claude Code, Codex CLI and Grok CLI
+[C-001] — under an Apache-2.0 license [C-002]. The product spans two
+repositories: the kit itself, and a pages store that holds agent-published
+web pages with git as the source of truth [C-009, C-010]. Its bet is that
+agent behavior should be _enforced_, not described: rules like the consent
+protocol ("never act and ask in the same turn") ship as policy hooks
+alongside the code [C-003].
+
+## The Problem
+
+An operator running several coding agents otherwise maintains the same
+discipline several times, once per harness, and watches the copies drift.
+
+## The Solution
+
+One shared package, installed everywhere [C-001]. Fix a workflow once and
+every agent inherits it; police hooks make skipping the discipline loud
+instead of silent [C-003].
+
+## What Makes This Different
+
+Enforcement over prose [C-003], and a publishing surface whose serving
+layer is disposable — the pages repository can re-seed it at any time
+[C-010].
+
+## Maturity, Honestly
+
+No GitHub releases exist [C-004]; distribution is install-script based
+[C-005], so consumers track a moving main with nothing to pin. Public
+adoption signals are minimal [C-007, C-008]. The kit ships its own
+measuring instrument: this brief was produced by agentkit's
+product-intelligence skill [C-006].
+
+## Not Verified
+
+- The website surface (agentkit.sbs): the site lane's tools are not
+  installed on the authoring host.
+- macOS behavior: only Linux was exercised during acquisition.
+- Adoption or install counts: no public telemetry exists.

--- a/.agentkit/intelligence/agentkit/brief.yaml
+++ b/.agentkit/intelligence/agentkit/brief.yaml
@@ -1,0 +1,39 @@
+brief_version: "1.0"
+subject:
+  name: agentkit
+  repo: github.com/developerinlondon/agentkit
+  one_liner: Reusable skills, rules and police hooks that make several AI coding agents behave like one disciplined team.
+evidence:
+  ledger: ledger.yaml
+  acquired_at: "2026-07-28"
+  acquisition:
+    - tool: gh api
+      target: developerinlondon/agentkit
+      retrieved_at: "2026-07-28"
+    - tool: repomix --remote
+      target: developerinlondon/agentkit
+      retrieved_at: "2026-07-28"
+positioning:
+  target_customer: operators running multiple AI coding agents
+  need: the same working discipline on every harness, not per-tool config drift
+  category: agent skills and policy kit
+  key_benefit: one shared copy of skills, rules and hooks, installed everywhere
+  alternative: hand-maintained per-harness instructions
+  differentiation: behavior is enforced by rules and hooks, not just described in prose
+  claims: [C-001, C-003]
+value_map:
+  - attribute: single package spanning OpenCode, Claude Code, Codex and Grok
+    value: fix a workflow once and every agent inherits it
+    proof: install and confirm the same skill appears in each client
+    claims: [C-001]
+  - attribute: consent and safety rules ship as enforceable policy
+    value: agents cannot silently skip the discipline
+    proof: attempt a forbidden action and watch the hook refuse it
+    claims: [C-003]
+cannot_verify:
+  - what: the website surface (agentkit.sbs)
+    why: the site lane needs advertools/trafilatura, which are not installed on this host
+  - what: behavior on macOS hosts
+    why: only this Linux machine was exercised during acquisition
+  - what: real adoption or install counts
+    why: no public telemetry exists; stars and releases are the only visible signals

--- a/.agentkit/intelligence/agentkit/brief.yaml
+++ b/.agentkit/intelligence/agentkit/brief.yaml
@@ -30,7 +30,7 @@ positioning:
   key_benefit: one shared copy of skills, rules and hooks, installed everywhere
   alternative: hand-maintained per-harness instructions
   differentiation: behavior is enforced by rules and hooks, not just described in prose
-  claims: [C-001, C-003]
+  claims: [C-001, C-003, C-011]
 value_map:
   - attribute: single package spanning OpenCode, Claude Code, Codex and Grok
     value: fix a workflow once and every agent inherits it
@@ -39,7 +39,7 @@ value_map:
   - attribute: consent and safety rules ship as enforceable policy
     value: agents cannot silently skip the discipline
     proof: attempt a forbidden action and watch the hook refuse it
-    claims: [C-003]
+    claims: [C-003, C-011]
   - attribute: agent-published pages with git as the source of truth
     value: agents can ship shareable reports whose history survives the serving layer
     proof: delete the served copy and re-seed it from the pages repository

--- a/.agentkit/intelligence/agentkit/brief.yaml
+++ b/.agentkit/intelligence/agentkit/brief.yaml
@@ -3,6 +3,13 @@ subject:
   name: agentkit
   repo: github.com/developerinlondon/agentkit
   one_liner: Reusable skills, rules and police hooks that make several AI coding agents behave like one disciplined team.
+  origins:
+    - id: kit
+      kind: repo
+      target: developerinlondon/agentkit
+    - id: pages
+      kind: repo
+      target: https://gitlab.com/agentkit/agentkit-pages
 evidence:
   ledger: ledger.yaml
   acquired_at: "2026-07-28"
@@ -12,6 +19,9 @@ evidence:
       retrieved_at: "2026-07-28"
     - tool: repomix --remote
       target: developerinlondon/agentkit
+      retrieved_at: "2026-07-28"
+    - tool: repomix --remote
+      target: https://gitlab.com/agentkit/agentkit-pages
       retrieved_at: "2026-07-28"
 positioning:
   target_customer: operators running multiple AI coding agents
@@ -30,6 +40,10 @@ value_map:
     value: agents cannot silently skip the discipline
     proof: attempt a forbidden action and watch the hook refuse it
     claims: [C-003]
+  - attribute: agent-published pages with git as the source of truth
+    value: agents can ship shareable reports whose history survives the serving layer
+    proof: delete the served copy and re-seed it from the pages repository
+    claims: [C-009, C-010]
 cannot_verify:
   - what: the website surface (agentkit.sbs)
     why: the site lane needs advertools/trafilatura, which are not installed on this host

--- a/.agentkit/intelligence/agentkit/findings.md
+++ b/.agentkit/intelligence/agentkit/findings.md
@@ -1,0 +1,29 @@
+# Findings: agentkit
+
+Read-only analyze pass over `brief.yaml` + `ledger.yaml`, 2026-07-28.
+
+## Contradictions
+
+- None recorded. The two acquired surfaces (repo docs, GitHub metadata) do
+  not disagree with each other.
+
+## Gaps
+
+- Only one origin family was acquired: everything cited is the repository
+  or its GitHub metadata — all vendor-controlled. The website
+  (agentkit.sbs) was not crawled, so no independent surface corroborates
+  the README's story.
+- Ulwick workflow coverage and job stories are absent from the brief —
+  the acquired corpus describes what ships [C-001], not how an operator's
+  day changes.
+- Do-not-invent topics with no evidence in either direction: competitors,
+  install counts, roadmap.
+
+## Risks
+
+- Distribution without releases [C-004, C-005] means consumers track a
+  moving main; there is no version to pin or roll back to.
+- Every load-bearing claim traces to the project's own README or repo
+  metadata; nothing in the ledger is third-party.
+- [C-008] (minimal external adoption) is inferred from two weak public
+  signals; a single blog post or fork could move it either way.

--- a/.agentkit/intelligence/agentkit/findings.md
+++ b/.agentkit/intelligence/agentkit/findings.md
@@ -4,18 +4,16 @@ Read-only analyze pass over `brief.yaml` + `ledger.yaml`, 2026-07-28.
 
 ## Contradictions
 
-- None recorded. The two acquired surfaces (repo docs, GitHub metadata) do
-  not disagree with each other.
+- None recorded. The three acquired sources (kit repo, kit GitHub
+  metadata, pages repo) do not disagree with each other.
 
 ## Gaps
 
-- Only one origin family was acquired: everything cited is the repository
-  or its GitHub metadata — all vendor-controlled. The website
-  (agentkit.sbs) was not crawled, so no independent surface corroborates
-  the README's story.
-- Ulwick workflow coverage and job stories are absent from the brief —
-  the acquired corpus describes what ships [C-001], not how an operator's
-  day changes.
+- Both declared origins are repositories controlled by the same author —
+  no independent surface corroborates the story, and the website
+  (agentkit.sbs) was not crawled.
+- Ulwick workflow coverage and job stories are absent — the corpus
+  describes what ships [C-001], not how an operator's day changes.
 - Do-not-invent topics with no evidence in either direction: competitors,
   install counts, roadmap.
 
@@ -23,7 +21,7 @@ Read-only analyze pass over `brief.yaml` + `ledger.yaml`, 2026-07-28.
 
 - Distribution without releases [C-004, C-005] means consumers track a
   moving main; there is no version to pin or roll back to.
-- Every load-bearing claim traces to the project's own README or repo
-  metadata; nothing in the ledger is third-party.
+- Every load-bearing claim traces to the project's own repos or metadata;
+  nothing in the ledger is third-party.
 - [C-008] (minimal external adoption) is inferred from two weak public
   signals; a single blog post or fork could move it either way.

--- a/.agentkit/intelligence/agentkit/ledger.yaml
+++ b/.agentkit/intelligence/agentkit/ledger.yaml
@@ -1,0 +1,78 @@
+ledger_version: "1.0"
+generated_by: product-intelligence
+generated_at: "2026-07-28T07:10:00Z"
+claims:
+  - id: C-001
+    statement: agentkit packages reusable skills, rules, plugins, hooks and tools for multiple AI coding agents.
+    class: observed
+    confidence: high
+    sources:
+      - locator: "repo:README.md:3"
+        quote: "Reusable AI agent skills, rules, plugins, hooks, and tools for OpenCode, Claude Code, Codex CLI, Grok CLI, and other AI coding agents."
+        stance: supports
+        as_of: "2026-07-28"
+  - id: C-002
+    statement: The project is Apache-2.0 licensed.
+    class: observed
+    confidence: high
+    sources:
+      - locator: "gh:repos/developerinlondon/agentkit#license"
+        quote: '"spdx_id": "Apache-2.0"'
+        stance: supports
+        as_of: "2026-07-28"
+  - id: C-003
+    statement: Behavioral rules ship alongside code, including a consent protocol that forbids acting and asking in the same turn.
+    class: observed
+    confidence: high
+    sources:
+      - locator: "repo:README.md:24"
+        quote: "Stop after asking a question -- never act and ask in the same turn"
+        stance: supports
+        as_of: "2026-07-28"
+  - id: C-004
+    statement: No GitHub releases have been published.
+    class: observed
+    confidence: high
+    sources:
+      - locator: "gh:repos/developerinlondon/agentkit/releases"
+        quote: "[]"
+        stance: supports
+        as_of: "2026-07-28"
+  - id: C-005
+    statement: Distribution is install-script based rather than versioned releases.
+    class: inferred
+    confidence: moderate
+    derived_from: [C-004]
+    sources:
+      - locator: "repo:README.md:9"
+        quote: "Skills (SKILL.md -- works everywhere via skills.sh)"
+        stance: supports
+        as_of: "2026-07-28"
+  - id: C-006
+    statement: The skill set includes product-intelligence itself, described as evidence-backed briefs with a claim ledger.
+    class: observed
+    confidence: high
+    sources:
+      - locator: "repo:README.md:18"
+        quote: "Evidence-backed product briefs with a claim-by-claim ledger; hardened acquisition"
+        stance: supports
+        as_of: "2026-07-28"
+  - id: C-007
+    statement: The repository shows one GitHub star.
+    class: observed
+    confidence: high
+    sources:
+      - locator: "gh:repos/developerinlondon/agentkit#stargazers_count"
+        quote: '"stargazers_count": 1'
+        stance: supports
+        as_of: "2026-07-28"
+  - id: C-008
+    statement: External adoption beyond the author is not yet visible in public signals.
+    class: inferred
+    confidence: low
+    derived_from: [C-007, C-004]
+    sources:
+      - locator: "gh:repos/developerinlondon/agentkit#stargazers_count"
+        quote: '"stargazers_count": 1'
+        stance: context
+        as_of: "2026-07-28"

--- a/.agentkit/intelligence/agentkit/ledger.yaml
+++ b/.agentkit/intelligence/agentkit/ledger.yaml
@@ -17,7 +17,7 @@ claims:
     confidence: high
     sources:
       - locator: "gh:kit:repos/developerinlondon/agentkit#license"
-        quote: '"spdx_id": "Apache-2.0"'
+        quote: '"spdx_id":"Apache-2.0"'
         stance: supports
         as_of: "2026-07-28"
   - id: C-003
@@ -25,7 +25,7 @@ claims:
     class: observed
     confidence: high
     sources:
-      - locator: "repo:kit:README.md:24"
+      - locator: "repo:kit:README.md:26"
         quote: "Stop after asking a question -- never act and ask in the same turn"
         stance: supports
         as_of: "2026-07-28"
@@ -63,7 +63,7 @@ claims:
     confidence: high
     sources:
       - locator: "gh:kit:repos/developerinlondon/agentkit#stargazers_count"
-        quote: '"stargazers_count": 1'
+        quote: '"stargazers_count":1'
         stance: supports
         as_of: "2026-07-28"
   - id: C-008
@@ -73,7 +73,7 @@ claims:
     derived_from: [C-007, C-004]
     sources:
       - locator: "gh:kit:repos/developerinlondon/agentkit#stargazers_count"
-        quote: '"stargazers_count": 1'
+        quote: '"stargazers_count":1'
         stance: context
         as_of: "2026-07-28"
   - id: C-009
@@ -81,8 +81,8 @@ claims:
     class: observed
     confidence: high
     sources:
-      - locator: "repo:pages:README.md:1-4"
-        quote: "Canonical store for AgentKit Pages — agent-published web pages served at pages.agentkit.sbs."
+      - locator: "repo:pages:README.md:3"
+        quote: "Canonical store for [AgentKit Pages](https://agentkit.sbs) — agent-published web pages"
         stance: supports
         as_of: "2026-07-28"
   - id: C-010
@@ -90,7 +90,16 @@ claims:
     class: observed
     confidence: high
     sources:
-      - locator: "repo:pages:README.md:6-7"
-        quote: "this repo is the source of truth and can re-seed the serving layer at any time."
+      - locator: "repo:pages:README.md:7"
+        quote: "source of truth and can re-seed the serving layer at any time."
+        stance: supports
+        as_of: "2026-07-28"
+  - id: C-011
+    statement: Police hooks run as PreToolUse/PostToolUse enforcement inside the agentkit plugin.
+    class: observed
+    confidence: high
+    sources:
+      - locator: "repo:kit:README.md:115"
+        quote: "**enforcement**, however, _is_ bundled: the police hooks (`git-police`, `mr-police`,"
         stance: supports
         as_of: "2026-07-28"

--- a/.agentkit/intelligence/agentkit/ledger.yaml
+++ b/.agentkit/intelligence/agentkit/ledger.yaml
@@ -1,22 +1,22 @@
 ledger_version: "1.0"
 generated_by: product-intelligence
-generated_at: "2026-07-28T07:10:00Z"
+generated_at: "2026-07-28T07:20:00Z"
 claims:
   - id: C-001
     statement: agentkit packages reusable skills, rules, plugins, hooks and tools for multiple AI coding agents.
     class: observed
     confidence: high
     sources:
-      - locator: "repo:README.md:3"
+      - locator: "repo:kit:README.md:3"
         quote: "Reusable AI agent skills, rules, plugins, hooks, and tools for OpenCode, Claude Code, Codex CLI, Grok CLI, and other AI coding agents."
         stance: supports
         as_of: "2026-07-28"
   - id: C-002
-    statement: The project is Apache-2.0 licensed.
+    statement: The kit is Apache-2.0 licensed.
     class: observed
     confidence: high
     sources:
-      - locator: "gh:repos/developerinlondon/agentkit#license"
+      - locator: "gh:kit:repos/developerinlondon/agentkit#license"
         quote: '"spdx_id": "Apache-2.0"'
         stance: supports
         as_of: "2026-07-28"
@@ -25,16 +25,16 @@ claims:
     class: observed
     confidence: high
     sources:
-      - locator: "repo:README.md:24"
+      - locator: "repo:kit:README.md:24"
         quote: "Stop after asking a question -- never act and ask in the same turn"
         stance: supports
         as_of: "2026-07-28"
   - id: C-004
-    statement: No GitHub releases have been published.
+    statement: No GitHub releases have been published for the kit.
     class: observed
     confidence: high
     sources:
-      - locator: "gh:repos/developerinlondon/agentkit/releases"
+      - locator: "gh:kit:repos/developerinlondon/agentkit/releases"
         quote: "[]"
         stance: supports
         as_of: "2026-07-28"
@@ -44,7 +44,7 @@ claims:
     confidence: moderate
     derived_from: [C-004]
     sources:
-      - locator: "repo:README.md:9"
+      - locator: "repo:kit:README.md:9"
         quote: "Skills (SKILL.md -- works everywhere via skills.sh)"
         stance: supports
         as_of: "2026-07-28"
@@ -53,16 +53,16 @@ claims:
     class: observed
     confidence: high
     sources:
-      - locator: "repo:README.md:18"
+      - locator: "repo:kit:README.md:18"
         quote: "Evidence-backed product briefs with a claim-by-claim ledger; hardened acquisition"
         stance: supports
         as_of: "2026-07-28"
   - id: C-007
-    statement: The repository shows one GitHub star.
+    statement: The kit repository shows one GitHub star.
     class: observed
     confidence: high
     sources:
-      - locator: "gh:repos/developerinlondon/agentkit#stargazers_count"
+      - locator: "gh:kit:repos/developerinlondon/agentkit#stargazers_count"
         quote: '"stargazers_count": 1'
         stance: supports
         as_of: "2026-07-28"
@@ -72,7 +72,25 @@ claims:
     confidence: low
     derived_from: [C-007, C-004]
     sources:
-      - locator: "gh:repos/developerinlondon/agentkit#stargazers_count"
+      - locator: "gh:kit:repos/developerinlondon/agentkit#stargazers_count"
         quote: '"stargazers_count": 1'
         stance: context
+        as_of: "2026-07-28"
+  - id: C-009
+    statement: The product spans a second repository that stores and serves agent-published web pages.
+    class: observed
+    confidence: high
+    sources:
+      - locator: "repo:pages:README.md:1-4"
+        quote: "Canonical store for AgentKit Pages — agent-published web pages served at pages.agentkit.sbs."
+        stance: supports
+        as_of: "2026-07-28"
+  - id: C-010
+    statement: The pages repository can re-seed the serving layer, making git the source of truth for published pages.
+    class: observed
+    confidence: high
+    sources:
+      - locator: "repo:pages:README.md:6-7"
+        quote: "this repo is the source of truth and can re-seed the serving layer at any time."
+        stance: supports
         as_of: "2026-07-28"

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,15 @@ bun.lock
 # reviewer reads in a fresh clone. Ignoring it wholesale meant it was silently
 # untracked and every reviewer refused for want of a file that was there all
 # along.
+
+# Intelligence runs split the same way: the brief/ledger/findings are dated
+# deliverables (refresh mode diffs against the committed previous ledger),
+# while the raw acquired corpus is re-acquirable bulk — and for third-party
+# subjects, someone else's content wholesale. Allowlist, so unknown corpus
+# shapes stay untracked by default.
+.agentkit/intelligence/*/*
+!.agentkit/intelligence/*/ledger.yaml
+!.agentkit/intelligence/*/brief.yaml
+!.agentkit/intelligence/*/brief.md
+!.agentkit/intelligence/*/findings.md
+!.agentkit/intelligence/*/acquisition.json

--- a/plugins-cc/agentkit/skills/product-intelligence/SKILL.md
+++ b/plugins-cc/agentkit/skills/product-intelligence/SKILL.md
@@ -39,6 +39,14 @@ asymmetric contradictions and unsourced observations all fail loudly.
 Worked examples of the full artifact set — website-only, repo-only and
 mixed evidence — live in `examples/`.
 
+The four artifacts plus `acquisition.json` are **deliverables — commit
+them**: git history is the brief's version trail, and refresh mode diffs
+against the committed previous ledger. The raw acquired corpus (repo
+packs, crawled pages, `gh-*` responses) stays untracked: it is
+re-acquirable on demand and, for third-party subjects, someone else's
+content wholesale — the ledger's short verbatim quotes are the part that
+belongs in your repo.
+
 ## Workflow
 
 ```mermaid

--- a/plugins-cc/agentkit/skills/product-intelligence/scripts/acquire.ts
+++ b/plugins-cc/agentkit/skills/product-intelligence/scripts/acquire.ts
@@ -93,8 +93,14 @@ async function acquireSite(target: string, outDir: string): Promise<void> {
   stamp(outDir, 'advertools', target, argv);
 }
 
+// Multi-origin subjects acquire several repos into one directory; a fixed
+// filename would let the second pack silently clobber the first.
+function targetSlug(target: string): string {
+  return target.replace(/^https?:\/\//, '').replace(/\.git$/, '').replace(/[^\w.-]+/g, '_');
+}
+
 async function acquireRepo(target: string, outDir: string): Promise<void> {
-  const argv = [...runnerPrefix(), ...repomixArgs(target, join(outDir, 'repo.json'))];
+  const argv = [...runnerPrefix(), ...repomixArgs(target, join(outDir, `repo-${targetSlug(target)}.json`))];
   // owner/repo shorthand resolves to github.com; a full URL names its own
   // host and gets the same SSRF check as every other lane.
   if (target.startsWith('https://')) await assertHostAllowed(new URL(target).hostname);
@@ -105,9 +111,9 @@ async function acquireRepo(target: string, outDir: string): Promise<void> {
 function acquireGh(target: string, outDir: string): void {
   if (!OWNER_REPO.test(target)) throw new Error(`refusing gh target '${target}': expected owner/repo`);
   const lanes: [string, string[]][] = [
-    ['gh-meta.json', ['gh', 'api', `repos/${target}`]],
-    ['gh-releases.json', ['gh', 'api', `repos/${target}/releases?per_page=20`]],
-    ['gh-readme.md', ['gh', 'api', `repos/${target}/readme`, '-H', 'Accept: application/vnd.github.raw']],
+    [`gh-${targetSlug(target)}-meta.json`, ['gh', 'api', `repos/${target}`]],
+    [`gh-${targetSlug(target)}-releases.json`, ['gh', 'api', `repos/${target}/releases?per_page=20`]],
+    [`gh-${targetSlug(target)}-readme.md`, ['gh', 'api', `repos/${target}/readme`, '-H', 'Accept: application/vnd.github.raw']],
   ];
   for (const [file, argv] of lanes) {
     const result = Bun.spawnSync(argv, { stdout: 'pipe', stderr: 'inherit' });

--- a/plugins-cc/agentkit/skills/product-intelligence/scripts/acquire.ts
+++ b/plugins-cc/agentkit/skills/product-intelligence/scripts/acquire.ts
@@ -88,14 +88,14 @@ async function acquireUrl(target: string, outDir: string): Promise<void> {
 
 async function acquireSite(target: string, outDir: string): Promise<void> {
   await assertHostAllowed(new URL(target).hostname);
-  const argv = [...runnerPrefix(), ...advertoolsArgs(target, join(outDir, 'crawl.jl'))];
+  const argv = [...runnerPrefix(), ...advertoolsArgs(target, join(outDir, `crawl-${targetSlug(target)}.jl`))];
   run(argv);
   stamp(outDir, 'advertools', target, argv);
 }
 
 // Multi-origin subjects acquire several repos into one directory; a fixed
 // filename would let the second pack silently clobber the first.
-function targetSlug(target: string): string {
+export function targetSlug(target: string): string {
   return target.replace(/^https?:\/\//, '').replace(/\.git$/, '').replace(/[^\w.-]+/g, '_');
 }
 

--- a/skills/product-intelligence/SKILL.md
+++ b/skills/product-intelligence/SKILL.md
@@ -39,6 +39,14 @@ asymmetric contradictions and unsourced observations all fail loudly.
 Worked examples of the full artifact set — website-only, repo-only and
 mixed evidence — live in `examples/`.
 
+The four artifacts plus `acquisition.json` are **deliverables — commit
+them**: git history is the brief's version trail, and refresh mode diffs
+against the committed previous ledger. The raw acquired corpus (repo
+packs, crawled pages, `gh-*` responses) stays untracked: it is
+re-acquirable on demand and, for third-party subjects, someone else's
+content wholesale — the ledger's short verbatim quotes are the part that
+belongs in your repo.
+
 ## Workflow
 
 ```mermaid

--- a/skills/product-intelligence/scripts/acquire.ts
+++ b/skills/product-intelligence/scripts/acquire.ts
@@ -93,8 +93,14 @@ async function acquireSite(target: string, outDir: string): Promise<void> {
   stamp(outDir, 'advertools', target, argv);
 }
 
+// Multi-origin subjects acquire several repos into one directory; a fixed
+// filename would let the second pack silently clobber the first.
+function targetSlug(target: string): string {
+  return target.replace(/^https?:\/\//, '').replace(/\.git$/, '').replace(/[^\w.-]+/g, '_');
+}
+
 async function acquireRepo(target: string, outDir: string): Promise<void> {
-  const argv = [...runnerPrefix(), ...repomixArgs(target, join(outDir, 'repo.json'))];
+  const argv = [...runnerPrefix(), ...repomixArgs(target, join(outDir, `repo-${targetSlug(target)}.json`))];
   // owner/repo shorthand resolves to github.com; a full URL names its own
   // host and gets the same SSRF check as every other lane.
   if (target.startsWith('https://')) await assertHostAllowed(new URL(target).hostname);
@@ -105,9 +111,9 @@ async function acquireRepo(target: string, outDir: string): Promise<void> {
 function acquireGh(target: string, outDir: string): void {
   if (!OWNER_REPO.test(target)) throw new Error(`refusing gh target '${target}': expected owner/repo`);
   const lanes: [string, string[]][] = [
-    ['gh-meta.json', ['gh', 'api', `repos/${target}`]],
-    ['gh-releases.json', ['gh', 'api', `repos/${target}/releases?per_page=20`]],
-    ['gh-readme.md', ['gh', 'api', `repos/${target}/readme`, '-H', 'Accept: application/vnd.github.raw']],
+    [`gh-${targetSlug(target)}-meta.json`, ['gh', 'api', `repos/${target}`]],
+    [`gh-${targetSlug(target)}-releases.json`, ['gh', 'api', `repos/${target}/releases?per_page=20`]],
+    [`gh-${targetSlug(target)}-readme.md`, ['gh', 'api', `repos/${target}/readme`, '-H', 'Accept: application/vnd.github.raw']],
   ];
   for (const [file, argv] of lanes) {
     const result = Bun.spawnSync(argv, { stdout: 'pipe', stderr: 'inherit' });

--- a/skills/product-intelligence/scripts/acquire.ts
+++ b/skills/product-intelligence/scripts/acquire.ts
@@ -88,14 +88,14 @@ async function acquireUrl(target: string, outDir: string): Promise<void> {
 
 async function acquireSite(target: string, outDir: string): Promise<void> {
   await assertHostAllowed(new URL(target).hostname);
-  const argv = [...runnerPrefix(), ...advertoolsArgs(target, join(outDir, 'crawl.jl'))];
+  const argv = [...runnerPrefix(), ...advertoolsArgs(target, join(outDir, `crawl-${targetSlug(target)}.jl`))];
   run(argv);
   stamp(outDir, 'advertools', target, argv);
 }
 
 // Multi-origin subjects acquire several repos into one directory; a fixed
 // filename would let the second pack silently clobber the first.
-function targetSlug(target: string): string {
+export function targetSlug(target: string): string {
   return target.replace(/^https?:\/\//, '').replace(/\.git$/, '').replace(/[^\w.-]+/g, '_');
 }
 

--- a/tests/product-intelligence/acquisition.test.ts
+++ b/tests/product-intelligence/acquisition.test.ts
@@ -14,6 +14,7 @@ import {
   advertoolsArgs,
   repomixArgs,
   runnerPrefix,
+  targetSlug,
 } from '../../skills/product-intelligence/scripts/acquire.ts';
 
 const repoRoot = dirname(dirname(import.meta.dir));
@@ -250,8 +251,27 @@ describe('acquire.ts CLI', () => {
     expect(result.code, result.err).toBe(0);
     expect(readFileSync(join(scratch, 'runner-argv'), 'utf-8').trim()).toBe(
       '--profile default -- advertools crawl https://example.com/ '
-        + `${join(outDir, 'crawl.jl')} --follow-links 1 --custom-settings DEPTH_LIMIT=3 CLOSESPIDER_PAGECOUNT=200`,
+        + `${join(outDir, 'crawl-example.com.jl')} --follow-links 1 --custom-settings DEPTH_LIMIT=3 CLOSESPIDER_PAGECOUNT=200`,
     );
+  });
+
+  test('targetSlug strips scheme and .git and keeps targets distinct', () => {
+    expect(targetSlug('owner/repo')).toBe('owner_repo');
+    expect(targetSlug('https://gitlab.com/agentkit/agentkit-pages.git')).toBe('gitlab.com_agentkit_agentkit-pages');
+    expect(targetSlug('https://gitlab.com/a/b')).not.toBe(targetSlug('https://gitlab.com/a/c'));
+  });
+
+  test('two repo origins acquired into one directory keep separate packs', () => {
+    // The bug this pins: a fixed repo.json let the second origin's pack
+    // silently clobber the first during a real multi-origin run.
+    process.env.SAFE_FETCH_ALLOW_HOSTS = 'gitlab.com';
+    fakeExecutable('agentkit-run', `printf '%s\\n' "$*" >> '${scratch}/runner-log'`);
+    const outDir = join(scratch, 'out');
+    expect(runCli('repo', 'owner/repo', '--out', outDir).code).toBe(0);
+    expect(runCli('repo', 'https://gitlab.com/other/pages', '--out', outDir).code).toBe(0);
+    const log = readFileSync(join(scratch, 'runner-log'), 'utf-8');
+    expect(log).toContain('repo-owner_repo.json');
+    expect(log).toContain('repo-gitlab.com_other_pages.json');
   });
 
   test('repo lane refuses a non-public host in URL form', () => {

--- a/tests/product-intelligence/acquisition.test.ts
+++ b/tests/product-intelligence/acquisition.test.ts
@@ -232,7 +232,7 @@ describe('acquire.ts CLI', () => {
     expect(result.code, result.err).toBe(0);
     expect(readFileSync(join(scratch, 'runner-argv'), 'utf-8').trim()).toBe(
       '--profile default -- repomix --remote owner/repo --style json --include '
-        + `README*,readme*,docs/**,doc/**,CHANGELOG*,CHANGES*,*.md -o ${join(outDir, 'repo.json')}`,
+        + `README*,readme*,docs/**,doc/**,CHANGELOG*,CHANGES*,*.md -o ${join(outDir, 'repo-owner_repo.json')}`,
     );
     const entries = JSON.parse(readFileSync(join(outDir, 'acquisition.json'), 'utf-8'));
     expect(entries).toHaveLength(1);
@@ -272,13 +272,13 @@ describe('acquire.ts CLI', () => {
     expect(() => readFileSync(join(scratch, 'runner-ran'))).toThrow();
   });
 
-  test('gh lane writes the three evidence files', () => {
+  test('gh lane writes per-target evidence files so two origins cannot clobber each other', () => {
     fakeExecutable('gh', `printf '{"lane":"%s"}' "$2"`);
     const outDir = join(scratch, 'out');
     const result = runCli('gh', 'owner/repo', '--out', outDir);
     expect(result.code, result.err).toBe(0);
-    expect(readFileSync(join(outDir, 'gh-meta.json'), 'utf-8')).toContain('repos/owner/repo');
-    expect(readFileSync(join(outDir, 'gh-releases.json'), 'utf-8')).toContain('releases');
+    expect(readFileSync(join(outDir, 'gh-owner_repo-meta.json'), 'utf-8')).toContain('repos/owner/repo');
+    expect(readFileSync(join(outDir, 'gh-owner_repo-releases.json'), 'utf-8')).toContain('releases');
     const entries = JSON.parse(readFileSync(join(outDir, 'acquisition.json'), 'utf-8'));
     expect(entries[0].tool).toBe('gh api');
   });


### PR DESCRIPTION
Closes #135.

Intelligence artifacts are deliverables, not scratch — the skill's refresh mode diffs against the committed previous ledger, so throwing them away breaks the design. The raw corpus is the opposite: re-acquirable bulk and, for third-party subjects, someone else's content wholesale.

- Allowlist gitignore under `.agentkit/intelligence/`: `ledger.yaml`, `brief.yaml`, `brief.md`, `findings.md`, `acquisition.json` tracked; everything else (repo packs, `gh-*`, crawled pages) ignored by default — verified in both directions
- SKILL.md persistence paragraph
- **agentkit's own brief**, produced by the skill's first real run (gh + repo lanes on this repo): 8 claims, every quote verbatim from the acquired corpus, provenance stamped, validates clean; findings honestly surface that distribution has no releases to pin and every claim is vendor-controlled

Verify: `scripts/product-command default -- bun test` — 637 pass, 0 fail.