### PR TITLE
feat: make review effort configurable

### DIFF
--- a/.agentkit/product.yaml
+++ b/.agentkit/product.yaml
@@ -4,9 +4,9 @@
 summary: >-
   Cross-platform enforcement hooks (git, MR, package, resource, review,
   formatting and comment discipline), agent skills, two MCP servers, and a
-  portable evidence validator plus a Linux-only memory-and-CPU-bounded command
-  runner. The full installer supports global and project-local use; the Claude
-  Code plugin is a separate bundle.
+  portable evidence validator, configurable review-profile resolver, and a
+  Linux-only memory-and-CPU-bounded command runner. The full installer supports
+  global and project-local use; the Claude Code plugin is a separate bundle.
 
 surfaces:
   - name: test-suite
@@ -51,14 +51,23 @@ surfaces:
       arguments. The validator performs structural and semantic consistency
       checks; it does not claim reviewer identity or evidence truth.
 
+  - name: review-profile
+    kind: cli
+    run: tools/review-profile --help
+    expect: |
+      Exits successfully and documents the fast, balanced, and strict profiles,
+      task risk, release/user-facing context, and repository selection. A normal
+      invocation emits JSON with the selected lanes and check scope. Local
+      configuration cannot weaken target-owned review policy.
+
   - name: codex-review-hook
     kind: cli
     run: codex --version
     expect: |
       A global or project install creates a Codex `PreToolUse` hook manifest
       with Bash and MCP merge routes, preserves unrelated hooks, and packages
-      `review-police`, its fail-closed supervisor, input helper, and
-      `review-gate` under the same `.codex` root. After the user trusts the
+      `review-police`, its fail-closed supervisor, input helper, `review-gate`,
+      and `review-profile` under the same `.codex` root. After the user trusts the
       changed definition with `/hooks`, a direct REST/GraphQL/MCP merge is
       denied and a forge CLI merge must satisfy the same exact-context evidence
       policy as Claude Code.

--- a/.agentkit/review-policy.json
+++ b/.agentkit/review-policy.json
@@ -7,7 +7,7 @@
         "id": "agent-enforcement",
         "tier": "critical",
         "path_regexes": [
-          "^(hooks/.*|policies/.*|tools/review-gate|install\\.sh|lib/install-platform\\.sh|scripts/(product-command|sync-cc-plugin\\.sh)|plugins/.*\\.ts|plugins-cc/agentkit/(\\.claude-plugin/plugin\\.json|hooks/.*|tools/review-gate)|\\.agentkit/(product\\.yaml|review-policy\\.json)|\\.claude-plugin/marketplace\\.json)$"
+          "^(hooks/.*|policies/.*|tools/review-(gate|profile)|install\\.sh|lib/install-platform\\.sh|scripts/(product-command|sync-cc-plugin\\.sh)|plugins/.*\\.ts|plugins-cc/agentkit/(\\.claude-plugin/plugin\\.json|hooks/.*|tools/review-(gate|profile))|\\.agentkit/(config\\.yaml|product\\.yaml|review-policy\\.json)|\\.claude-plugin/marketplace\\.json|config\\.example\\.yaml)$"
         ]
       },
       {
@@ -21,11 +21,11 @@
         "id": "review-governance",
         "tier": "critical",
         "path_regexes": [
-          "^skills/(adversarial-review|autonomous-workflow|product-review)/.*$",
-          "^plugins-cc/agentkit/skills/(adversarial-review|autonomous-workflow|product-review)/.*$",
+          "^skills/(adversarial-review|autonomous-workflow|product-review|test-driven-development)/.*$",
+          "^plugins-cc/agentkit/skills/(adversarial-review|autonomous-workflow|product-review|test-driven-development)/.*$",
           "^instructions/coding-discipline\\.md$",
           "^docs/review-process\\.md$",
-          "^tests/(agentkit-plugin|codex-review-hooks|hook-supervisor|install-claude-plugin|install-tools|review-gate|review-police|review-disciplines)\\.test\\.ts$"
+          "^tests/(agentkit-plugin|codex-review-hooks|hook-supervisor|install-claude-plugin|install-tools|review-gate|review-profile|review-police|review-disciplines)\\.test\\.ts$"
         ]
       }
     ]

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ Hooks, skills, and tools ship as Claude Code plugins (ADR #45 — the generic un
 skills, hook scripts — are the source of truth; plugins are convenience wrappers). Add the
 marketplace once, then install. The **agentkit** plugin is the recommended Claude bundle: a single
 `claude plugin install agentkit` gives you the enforcement hooks, the skills, the portable
-`review-gate`, the Linux-only bounded runner, and **both** MCP toolchains (assay + infra-tools).
+`review-gate`, `review-profile`, the Linux-only bounded runner, and **both** MCP toolchains
+(assay + infra-tools).
 Resource execution additionally requires a
 configured systemd user manager and the host-provisioned `agent-work.slice`. The
 granular **assay** and **infra-tools** plugins remain for à-la-carte installs.
@@ -113,11 +114,11 @@ claude plugin install assay
 claude plugin install infra-tools
 ```
 
-| Plugin          | Provides                                                                                                                                                                                                                                                                                                                           | Source                                                                                        |
-| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| **agentkit**    | Claude bundle: enforcement police hooks, skills, portable `tools/review-gate`, Linux-only `tools/bounded-run`, and both MCP toolchains. Hooks need `jq`, `git`, `awk`, and `cat`; MCPs need `bun` and `assay`. Linux bounded execution additionally needs cgroup v2, a systemd user manager, and a provisioned `agent-work.slice`. | local `plugins-cc/agentkit/`                                                                  |
-| **assay**       | Gated Lua infra toolkit (`assay_run` + `assay_context`) — Kubernetes, ArgoCD, Vault, Prometheus, GitLab, AWS, … through one read-only/approval-gated tool. Requires the `assay` binary on PATH.                                                                                                                                    | vendored from [developerinlondon/assay](https://github.com/developerinlondon/assay) `plugin/` |
-| **infra-tools** | Read-only helm / tofu / git tools (`helm_template`/`helm_list`/`helm_get_values`, `tofu_plan`/`tofu_show`/`tofu_state_list`, `git_log`/`git_diff`/`git_status`/`git_clone_ro`) as a typed MCP server — render charts, preview plans, read git history. Never applies or mutates. Requires `bun` on PATH.                           | local `plugins-cc/infra-tools/`                                                               |
+| Plugin          | Provides                                                                                                                                                                                                                                                                                                                                     | Source                                                                                        |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| **agentkit**    | Claude bundle: enforcement police hooks, skills, portable review tools, Linux-only `tools/bounded-run`, and both MCP toolchains. Hooks and review tools need `jq`, `git`, `awk`, and `cat`; MCPs need `bun` and `assay`. Linux bounded execution additionally needs cgroup v2, a systemd user manager, and a provisioned `agent-work.slice`. | local `plugins-cc/agentkit/`                                                                  |
+| **assay**       | Gated Lua infra toolkit (`assay_run` + `assay_context`) — Kubernetes, ArgoCD, Vault, Prometheus, GitLab, AWS, … through one read-only/approval-gated tool. Requires the `assay` binary on PATH.                                                                                                                                              | vendored from [developerinlondon/assay](https://github.com/developerinlondon/assay) `plugin/` |
+| **infra-tools** | Read-only helm / tofu / git tools (`helm_template`/`helm_list`/`helm_get_values`, `tofu_plan`/`tofu_show`/`tofu_state_list`, `git_log`/`git_diff`/`git_status`/`git_clone_ro`) as a typed MCP server — render charts, preview plans, read git history. Never applies or mutates. Requires `bun` on PATH.                                     | local `plugins-cc/infra-tools/`                                                               |
 
 **Not in the plugin: the always-on rules and instructions.** Claude Code plugins cannot inject
 always-on global context, so the glob-loaded `rules/` and the `instructions/*.md` global prompts
@@ -150,12 +151,12 @@ git clone git@github.com:developerinlondon/agentkit.git
 `~/.agentkit/{skills,rules,instructions,hooks,tools}`. Each client then gets **per-name**
 symlinks into that root (never a second full copy):
 
-| Client      | Adapter                                                                                          |
-| ----------- | ------------------------------------------------------------------------------------------------ |
-| OpenCode    | `~/.agents/skills\|rules\|instructions` → `~/.agentkit/…`                                        |
-| Claude Code | `~/.claude/skills\|hooks\|tools` → `~/.agentkit/…` (settings still point at `~/.claude/hooks`)   |
-| Grok CLI    | `~/.grok/skills\|rules` → `~/.agentkit/…`; instructions also as `~/.grok/rules/*.md` (always-on) |
-| Codex CLI   | policies, prompts, review hooks, and validator under `$CODEX_HOME` or `~/.codex/`               |
+| Client      | Adapter                                                                                             |
+| ----------- | --------------------------------------------------------------------------------------------------- |
+| OpenCode    | `~/.agents/skills\|rules\|instructions` → `~/.agentkit/…`                                           |
+| Claude Code | `~/.claude/skills\|hooks\|tools` → `~/.agentkit/…` (settings still point at `~/.claude/hooks`)      |
+| Grok CLI    | `~/.grok/skills\|rules` → `~/.agentkit/…`; instructions also as `~/.grok/rules/*.md` (always-on)    |
+| Codex CLI   | policies, prompts, review hooks, validator, and profile resolver under `$CODEX_HOME` or `~/.codex/` |
 
 Per-name links mean non-agentkit siblings stay put — OMC skills under `~/.claude/skills/`,
 Grok builtins under `~/.grok/skills/`, etc. OpenCode plugins still install as real files under
@@ -230,6 +231,7 @@ On Linux, global installs place the bounded runner on `~/.local/bin/` and preser
 | ---------------------- | ------------------------------------------------------------------------------------ |
 | **bounded-run**        | Linux-only direct-argv workload runner for the bounded `agent-work.slice` service    |
 | **review-gate**        | Portable strict review-policy and evidence-record validator used by `review-police`  |
+| **review-profile**     | Resolves configurable review lanes and verification effort for the current task      |
 | **fix-ascii-boxes.py** | Fixes ASCII box-drawing alignment in markdown files, handles nested boxes inside-out |
 
 `bounded-run` fails closed unless the aggregate slice matches its expected limits (default
@@ -261,12 +263,54 @@ Agentkit uses a YAML config file at `~/.config/agentkit/config.yaml` (respects `
 The installer creates a default config from `config.example.yaml` on first run.
 
 ```yaml
+review:
+  profile: balanced
+
 git-police:
   branch-protection:
     allowed-repos:
       - brain
       - my-notes
 ```
+
+### review
+
+Run `review-profile --repo . --risk trivial|standard|critical` before final verification and add
+`--release` or `--user-facing` when applicable. It emits the resolved settings and Boolean lane
+decisions as JSON. `AGENTKIT_REVIEW_PROFILE` or `--profile` provides a session/task override.
+
+| Profile    | Primary review      | Specialist review | Product review                    | CI evidence | Local checks |
+| ---------- | ------------------- | ----------------- | --------------------------------- | ----------- | ------------ |
+| `fast`     | non-trivial changes | never             | releases                          | reuse       | affected     |
+| `balanced` | non-trivial changes | critical changes  | critical, release, or user-facing | reuse       | affected     |
+| `strict`   | every change        | every change      | every change                      | rerun       | full         |
+
+The default is `balanced`: one exact-head adversarial review for ordinary code work, with extra
+lanes only when risk or product exposure justifies them. `fast` does not mean unreviewed ordinary
+code; it removes the second specialist lane and narrows product review. `strict` preserves the
+maximal workflow.
+
+Tune any preset with these keys under `review:`:
+
+| Setting             | Values                                    | Meaning                                                            |
+| ------------------- | ----------------------------------------- | ------------------------------------------------------------------ |
+| `primary-review`    | `nontrivial`, `always`                    | When the exact-head diff review runs                               |
+| `specialist-review` | `never`, `critical`, `always`             | When a second independent specialist runs                          |
+| `product-review`    | `never`, `release`, `triggered`, `always` | `triggered` means critical, release, or user-facing                |
+| `ci-evidence`       | `reuse`, `rerun`                          | Reuse passed CI bound to the exact source SHA or repeat it locally |
+| `local-checks`      | `affected`, `full`                        | Final local verification scope                                     |
+| `evidence-note`     | `critical`, `always`                      | When to post a combined durable evidence note                      |
+
+Configuration precedence is command-line profile, `AGENTKIT_REVIEW_PROFILE`, repository profile,
+global profile, then `balanced`. Granular global overrides apply after the preset and repository
+overrides apply last. Put repository overrides in `.agentkit/config.yaml`; put machine defaults in
+`~/.config/agentkit/config.yaml`.
+
+These settings choose workflow effort only. The exact target commit's
+`.agentkit/review-policy.json`, protected CI, and forge approvals remain authoritative and can
+require checks, product coverage, analyses, or evidence that a local profile would otherwise omit.
+Profile activations and merge-gate duration are recorded without repository paths or commands in
+`~/.agentkit/review-audit.log`.
 
 ### git-police.branch-protection.allowed-repos
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -8,6 +8,24 @@
 #   AGENTKIT_SKIP_HOOKS=coding-police
 #   AGENTKIT_SKIP_HOOKS=all
 
+# Review effort controls orchestration, not merge authority. A repository's
+# target-owned .agentkit/review-policy.json can require stricter evidence and
+# cannot be weakened here. Repositories may override this section in
+# .agentkit/config.yaml.
+review:
+  # fast: primary review for non-trivial work; specialist/product only on narrow triggers
+  # balanced: one primary review by default; extra lanes for critical/user-facing/release work
+  # strict: primary + specialist + product lanes, full local checks, and CI reruns
+  profile: balanced
+
+  # Granular overrides. Delete a key to inherit the selected profile.
+  # primary-review: nontrivial
+  # specialist-review: critical
+  # product-review: triggered
+  # ci-evidence: reuse
+  # local-checks: affected
+  # evidence-note: always
+
 git-police:
   branch-protection:
     # Repos where direct commits/pushes to main/master are allowed.

--- a/docs/review-process.md
+++ b/docs/review-process.md
@@ -53,6 +53,38 @@ binding stale.
 Branch slugs replace `/` with `__`. Context fields inside v2 prevent a colliding
 filename from authorising a different repository or change.
 
+## Configurable workflow profiles
+
+`review-profile --repo . --risk trivial|standard|critical` resolves how much
+review work to schedule. Add `--release` or `--user-facing` for those contexts.
+The resolver is orchestration guidance; it cannot lower requirements from the
+exact target commit's policy, protected CI, or forge approvals.
+
+| Profile    | Primary          | Specialist | Product                                | CI evidence | Local checks |
+| ---------- | ---------------- | ---------- | -------------------------------------- | ----------- | ------------ |
+| `fast`     | non-trivial work | never      | releases                               | reuse       | affected     |
+| `balanced` | non-trivial work | critical   | critical, release, or user-facing work | reuse       | affected     |
+| `strict`   | always           | always     | always                                 | rerun       | full         |
+
+The machine default is configured under `review:` in
+`~/.config/agentkit/config.yaml`; a repository may override it in
+`.agentkit/config.yaml`. Profile selection precedence is CLI, the
+`AGENTKIT_REVIEW_PROFILE` environment variable, repository, global, then the
+`balanced` default. Granular global values apply after the preset and granular
+repository values apply last.
+
+Run deterministic preflight before freezing and pushing the final source head.
+After that freeze, start required reviewer lanes and CI concurrently; do not
+merge until all required results pass. Reuse a passed CI result bound to the
+exact source SHA when configured. A source commit invalidates every earlier
+review and CI result. Write one combined redacted evidence packet rather than a
+separate durable note per lane.
+
+Each resolver invocation appends a `PROFILE` row to
+`~/.agentkit/review-audit.log`. Merge decisions append `gate_seconds`, allowing
+profile activation and gate latency to be measured without recording repository
+paths, commands, or source content.
+
 ## Strict v2 record
 
 ```json
@@ -184,30 +216,32 @@ becomes a valid deny response before Claude reaches its fail-open timeout.
 
 Deterministic checks scale with the trusted target policy:
 
-| Minimum tier | Required local check                                | CI behavior                                   |
-| ------------ | --------------------------------------------------- | --------------------------------------------- |
-| Standard     | `scripts/product-command default -- moon ci`         | affected Moon slices on Linux and macOS       |
-| Critical     | `scripts/product-command default -- bun test`        | full suite inside both affected platform jobs |
-| Main/nightly | n/a                                                 | full hosted Linux and macOS matrix             |
+| Minimum tier | Required local check                          | CI behavior                                   |
+| ------------ | --------------------------------------------- | --------------------------------------------- |
+| Standard     | `scripts/product-command default -- moon ci`  | affected Moon slices on Linux and macOS       |
+| Critical     | `scripts/product-command default -- bun test` | full suite inside both affected platform jobs |
+| Main/nightly | n/a                                           | full hosted Linux and macOS matrix            |
 
 Moon derives affected tasks from explicit inputs. A separate routing check mechanically scans
 every `tests/**/*.test.ts` file and fails if any test belongs to zero or multiple slices. Changes
 to the routing, CI, enforcement hooks, or review governance are critical and therefore ratchet
 back to the full suite.
 
-Use the `adversarial-review` skill for plan and implementation refutation. Feed
+Use the `adversarial-review` skill when the resolved profile selects it. Feed
 it primary artifacts and a mechanically complete candidate set, not the
 orchestrator's conclusion or another reviewer's verdict. It traces before
 reading maker narrative and reports only findings backed by concrete failing
 inputs or replayable traces.
 
-For user-facing/installable changes, run `product-review` as a separate lane.
+When selected by the profile or required by target policy, run
+`product-review` as a separate lane.
 Product coverage and verdict are separate: `partial` describes how much was
 exercised; it does not itself mean pass.
 
-Post the redacted claims, checks, analyses, attempted falsifications, findings,
-and remaining uncertainty to the PR/MR. The local record's `evidence_ref` points
-there. Do not include secrets, tokens, or personal data.
+Post one combined packet of redacted claims, checks, analyses, attempted
+falsifications, findings, and remaining uncertainty to the PR/MR. The local
+record's `evidence_ref` points there. Do not include secrets, tokens, or personal
+data.
 
 ## Legacy v1
 

--- a/hooks/claude/review-police.sh
+++ b/hooks/claude/review-police.sh
@@ -25,6 +25,7 @@
 # The gate resolves the change's real source and target from the forge. Strict
 # policy comes only from the target Git object, never the source checkout.
 set -euo pipefail
+SECONDS=0
 
 # A hook that DIES emits no decision, and the harness reads silence as ALLOW —
 # so every abort path here is a fail-open. Two were reachable from the
@@ -158,7 +159,7 @@ audit_timestamp() {
 
 deny() {
 	mkdir -p "$(dirname "$AUDIT")" 2>/dev/null || true
-	printf '%s\tDENY\tsession=%s\t%s\n' "$(audit_timestamp)" "$SESSION" "${1//$'\n'/ }" >>"$AUDIT" 2>/dev/null || true
+	printf '%s\tDENY\tsession=%s\t%s\tgate_seconds=%s\n' "$(audit_timestamp)" "$SESSION" "${1//$'\n'/ }" "$SECONDS" >>"$AUDIT" 2>/dev/null || true
 	agentkit_deny_json "$1"
 	exit 0
 }
@@ -786,8 +787,8 @@ if [[ -n "$POLICY_ENTRY" ]]; then
 		CONSENT_OVERRIDE:*)
 			CONSENT_QUOTE=$(jq -r '.user_consent.quote // empty' "$RECORD")
 			mkdir -p "$(dirname "$AUDIT")" 2>/dev/null || true
-			printf '%s\tCONSENT-OVERRIDE\tsession=%s\tbranch=%s\tsha=%s\tquote=%s\n' \
-				"$(audit_timestamp)" "$SESSION" "$BRANCH" "$HEAD_SHA" "${CONSENT_QUOTE//$'\n'/ }" \
+			printf '%s\tCONSENT-OVERRIDE\tsession=%s\tbranch=%s\tsha=%s\tquote=%s\tgate_seconds=%s\n' \
+				"$(audit_timestamp)" "$SESSION" "$BRANCH" "$HEAD_SHA" "${CONSENT_QUOTE//$'\n'/ }" "$SECONDS" \
 				>>"$AUDIT" 2>/dev/null || true
 			exit 0
 			;;
@@ -798,8 +799,8 @@ if [[ -n "$POLICY_ENTRY" ]]; then
 	fi
 
 	mkdir -p "$(dirname "$AUDIT")" 2>/dev/null || true
-	printf '%s\tPASS-STRICT\tsession=%s\tbranch=%s\tsha=%s\ttarget=%s\n' \
-		"$(audit_timestamp)" "$SESSION" "$BRANCH" "$HEAD_SHA" "$TARGET_SHA" \
+	printf '%s\tPASS-STRICT\tsession=%s\tbranch=%s\tsha=%s\ttarget=%s\tgate_seconds=%s\n' \
+		"$(audit_timestamp)" "$SESSION" "$BRANCH" "$HEAD_SHA" "$TARGET_SHA" "$SECONDS" \
 		>>"$AUDIT" 2>/dev/null || true
 	exit 0
 fi
@@ -827,15 +828,15 @@ BLOCKING=$(jq -r '
     | "  - \(.severity | ascii_upcase): \(.summary // "(no summary)")"
   ] | join("\n")' "$RECORD" 2>/dev/null || true)
 
-VERDICT=$(jq -r '.verdict // "blocked"' "$RECORD" 2>/dev/null || echo blocked)
+VERDICT=$(jq -r '.verdict // "blocked" | ascii_downcase' "$RECORD" 2>/dev/null || echo blocked)
 CONSENT=$(jq -r '.user_consent.granted // false' "$RECORD" 2>/dev/null || echo false)
 CONSENT_QUOTE=$(jq -r '.user_consent.quote // empty' "$RECORD" 2>/dev/null || true)
 
 if [[ -n "$BLOCKING" || "$VERDICT" != "pass" ]]; then
 	if [[ "$CONSENT" == "true" && -n "$CONSENT_QUOTE" ]]; then
 		mkdir -p "$(dirname "$AUDIT")" 2>/dev/null || true
-		printf '%s\tCONSENT-OVERRIDE\tsession=%s\tbranch=%s\tsha=%s\tquote=%s\n' \
-			"$(audit_timestamp)" "$SESSION" "$BRANCH" "$HEAD_SHA" "${CONSENT_QUOTE//$'\n'/ }" \
+		printf '%s\tCONSENT-OVERRIDE\tsession=%s\tbranch=%s\tsha=%s\tquote=%s\tgate_seconds=%s\n' \
+			"$(audit_timestamp)" "$SESSION" "$BRANCH" "$HEAD_SHA" "${CONSENT_QUOTE//$'\n'/ }" "$SECONDS" \
 			>>"$AUDIT" 2>/dev/null || true
 		exit 0
 	fi
@@ -864,6 +865,6 @@ Fabricating that consent is forging the user's approval — don't."
 fi
 
 mkdir -p "$(dirname "$AUDIT")" 2>/dev/null || true
-printf '%s\tPASS\tsession=%s\tbranch=%s\tsha=%s\n' "$(audit_timestamp)" "$SESSION" "$BRANCH" "$HEAD_SHA" \
+printf '%s\tPASS\tsession=%s\tbranch=%s\tsha=%s\tgate_seconds=%s\n' "$(audit_timestamp)" "$SESSION" "$BRANCH" "$HEAD_SHA" "$SECONDS" \
 	>>"$AUDIT" 2>/dev/null || true
 exit 0

--- a/install.sh
+++ b/install.sh
@@ -677,7 +677,7 @@ install_codex_review_hooks() {
 	local codex_dir="$1"
 	local hooks_dir="$codex_dir/hooks"
 	local tools_dir="$codex_dir/tools"
-	local hook_name source
+	local hook_name source tool_name
 
 	if ! command -v jq >/dev/null 2>&1; then
 		echo "[codex] ERROR: jq is required to install the Codex review hook." >&2
@@ -702,12 +702,15 @@ install_codex_review_hooks() {
 		return 1
 	fi
 	cp "$REPO_DIR/hooks/claude/lib/hook-input.sh" "$hooks_dir/lib/hook-input.sh"
-	if [[ ! -f "$REPO_DIR/tools/review-gate" ]]; then
-		echo "[codex] ERROR: missing review-gate validator." >&2
-		return 1
-	fi
-	cp "$REPO_DIR/tools/review-gate" "$tools_dir/review-gate"
-	chmod +x "$tools_dir/review-gate"
+	for tool_name in review-gate review-profile; do
+		source="$REPO_DIR/tools/$tool_name"
+		if [[ ! -f "$source" ]]; then
+			echo "[codex] ERROR: missing review tool: $tool_name" >&2
+			return 1
+		fi
+		cp "$source" "$tools_dir/$tool_name"
+		chmod +x "$tools_dir/$tool_name"
+	done
 
 	merge_codex_hooks "$codex_dir/hooks.json" "$hooks_dir"
 	echo "[codex] Review or re-trust the AgentKit hooks with /hooks in a new Codex session."

--- a/instructions/coding-discipline.md
+++ b/instructions/coding-discipline.md
@@ -80,10 +80,12 @@ Everything else is on the agent to honor.
 
 ## Evidence-Gated Review
 
-For non-trivial work, the maker never grades its own artifact. Use the
-`adversarial-review` skill from a fresh context, feed it primary artifacts, and require a
-concrete failing input or replayable trace for every finding. Run `product-review` separately
-when the change affects something people install, operate, or experience.
+For non-trivial work, the maker never grades its own artifact. Resolve review effort with
+`review-profile`, then use the required `adversarial-review` lane from a fresh context, feed it
+primary artifacts, and require a concrete failing input or replayable trace for every finding.
+The balanced default uses one reviewer; specialist and product lanes are risk-triggered. Finish
+deterministic preflight before freezing the source head, and reuse passed CI evidence bound to that
+exact SHA unless the profile requires a rerun.
 
 When a forge target contains `.agentkit/review-policy.json`, load policy from the exact target
 commit, never the proposed source checkout. Bind the local v2 evidence index to the forge
@@ -91,6 +93,9 @@ repository and change, source/target SHAs, and policy digest. Missing or malform
 evidence fails closed; critical work cannot use a local consent claim. The record is an
 agent-writable consistency gate, not proof of reviewer identity or evidence truth — protected
 forge checks and approvals remain the trust boundary.
+
+Review profiles control orchestration, not authority. Target-owned policy is authoritative and can
+require checks, product coverage, analyses, or evidence omitted by a local profile.
 
 ## Branch Hygiene
 

--- a/moon.yml
+++ b/moon.yml
@@ -11,6 +11,7 @@ fileGroups:
     - 'scripts/check-test-slices.ts'
 
   criticalInputs:
+    - '.agentkit/config.yaml'
     - '.agentkit/product.yaml'
     - '.agentkit/review-policy.json'
     - '.claude-plugin/marketplace.json'
@@ -18,6 +19,7 @@ fileGroups:
     - '.moon/**/*'
     - '.prototools'
     - 'bun.lock'
+    - 'config.example.yaml'
     - 'docs/review-process.md'
     - 'hooks/**/*'
     - 'install.sh'
@@ -31,7 +33,9 @@ fileGroups:
     - 'plugins-cc/agentkit/skills/adversarial-review/**/*'
     - 'plugins-cc/agentkit/skills/autonomous-workflow/**/*'
     - 'plugins-cc/agentkit/skills/product-review/**/*'
+    - 'plugins-cc/agentkit/skills/test-driven-development/**/*'
     - 'plugins-cc/agentkit/tools/review-gate'
+    - 'plugins-cc/agentkit/tools/review-profile'
     - 'policies/**/*'
     - 'scripts/check-test-slices.ts'
     - 'scripts/product-command'
@@ -39,6 +43,7 @@ fileGroups:
     - 'skills/adversarial-review/**/*'
     - 'skills/autonomous-workflow/**/*'
     - 'skills/product-review/**/*'
+    - 'skills/test-driven-development/**/*'
     - 'tests/agentkit-plugin.test.ts'
     - 'tests/codex-review-hooks.test.ts'
     - 'tests/hook-supervisor.test.ts'
@@ -47,8 +52,10 @@ fileGroups:
     - 'tests/review-disciplines.test.ts'
     - 'tests/review-gate.test.ts'
     - 'tests/review-police.test.ts'
+    - 'tests/review-profile.test.ts'
     - 'tests/test-slices.test.ts'
     - 'tools/review-gate'
+    - 'tools/review-profile'
 
   hookInputs:
     - '.claude-plugin/**/*'
@@ -126,7 +133,9 @@ fileGroups:
     - 'tools/bounded-run'
 
   reviewInputs:
+    - '.agentkit/config.yaml'
     - '.agentkit/review-policy.json'
+    - 'config.example.yaml'
     - 'hooks/claude/fail-closed-hook.sh'
     - 'hooks/claude/review-police.sh'
     - 'hooks/codex/**/*'
@@ -136,18 +145,23 @@ fileGroups:
     - 'plugins-cc/agentkit/skills/adversarial-review/**/*'
     - 'plugins-cc/agentkit/skills/autonomous-workflow/**/*'
     - 'plugins-cc/agentkit/skills/product-review/**/*'
+    - 'plugins-cc/agentkit/skills/test-driven-development/**/*'
     - 'plugins-cc/agentkit/tools/review-gate'
+    - 'plugins-cc/agentkit/tools/review-profile'
     - 'scripts/product-command'
     - 'skills/adversarial-review/**/*'
     - 'skills/autonomous-workflow/**/*'
     - 'skills/product-review/**/*'
+    - 'skills/test-driven-development/**/*'
     - 'tests/codex-review-hooks.test.ts'
     - 'tests/probe-cases.txt'
     - 'tests/product-command.test.ts'
     - 'tests/review-disciplines.test.ts'
     - 'tests/review-gate.test.ts'
     - 'tests/review-police.test.ts'
+    - 'tests/review-profile.test.ts'
     - 'tools/review-gate'
+    - 'tools/review-profile'
 
   sessionInputs:
     - 'install.sh'

--- a/plugins-cc/agentkit/hooks/review-police.sh
+++ b/plugins-cc/agentkit/hooks/review-police.sh
@@ -25,6 +25,7 @@
 # The gate resolves the change's real source and target from the forge. Strict
 # policy comes only from the target Git object, never the source checkout.
 set -euo pipefail
+SECONDS=0
 
 # A hook that DIES emits no decision, and the harness reads silence as ALLOW —
 # so every abort path here is a fail-open. Two were reachable from the
@@ -158,7 +159,7 @@ audit_timestamp() {
 
 deny() {
 	mkdir -p "$(dirname "$AUDIT")" 2>/dev/null || true
-	printf '%s\tDENY\tsession=%s\t%s\n' "$(audit_timestamp)" "$SESSION" "${1//$'\n'/ }" >>"$AUDIT" 2>/dev/null || true
+	printf '%s\tDENY\tsession=%s\t%s\tgate_seconds=%s\n' "$(audit_timestamp)" "$SESSION" "${1//$'\n'/ }" "$SECONDS" >>"$AUDIT" 2>/dev/null || true
 	agentkit_deny_json "$1"
 	exit 0
 }
@@ -786,8 +787,8 @@ if [[ -n "$POLICY_ENTRY" ]]; then
 		CONSENT_OVERRIDE:*)
 			CONSENT_QUOTE=$(jq -r '.user_consent.quote // empty' "$RECORD")
 			mkdir -p "$(dirname "$AUDIT")" 2>/dev/null || true
-			printf '%s\tCONSENT-OVERRIDE\tsession=%s\tbranch=%s\tsha=%s\tquote=%s\n' \
-				"$(audit_timestamp)" "$SESSION" "$BRANCH" "$HEAD_SHA" "${CONSENT_QUOTE//$'\n'/ }" \
+			printf '%s\tCONSENT-OVERRIDE\tsession=%s\tbranch=%s\tsha=%s\tquote=%s\tgate_seconds=%s\n' \
+				"$(audit_timestamp)" "$SESSION" "$BRANCH" "$HEAD_SHA" "${CONSENT_QUOTE//$'\n'/ }" "$SECONDS" \
 				>>"$AUDIT" 2>/dev/null || true
 			exit 0
 			;;
@@ -798,8 +799,8 @@ if [[ -n "$POLICY_ENTRY" ]]; then
 	fi
 
 	mkdir -p "$(dirname "$AUDIT")" 2>/dev/null || true
-	printf '%s\tPASS-STRICT\tsession=%s\tbranch=%s\tsha=%s\ttarget=%s\n' \
-		"$(audit_timestamp)" "$SESSION" "$BRANCH" "$HEAD_SHA" "$TARGET_SHA" \
+	printf '%s\tPASS-STRICT\tsession=%s\tbranch=%s\tsha=%s\ttarget=%s\tgate_seconds=%s\n' \
+		"$(audit_timestamp)" "$SESSION" "$BRANCH" "$HEAD_SHA" "$TARGET_SHA" "$SECONDS" \
 		>>"$AUDIT" 2>/dev/null || true
 	exit 0
 fi
@@ -827,15 +828,15 @@ BLOCKING=$(jq -r '
     | "  - \(.severity | ascii_upcase): \(.summary // "(no summary)")"
   ] | join("\n")' "$RECORD" 2>/dev/null || true)
 
-VERDICT=$(jq -r '.verdict // "blocked"' "$RECORD" 2>/dev/null || echo blocked)
+VERDICT=$(jq -r '.verdict // "blocked" | ascii_downcase' "$RECORD" 2>/dev/null || echo blocked)
 CONSENT=$(jq -r '.user_consent.granted // false' "$RECORD" 2>/dev/null || echo false)
 CONSENT_QUOTE=$(jq -r '.user_consent.quote // empty' "$RECORD" 2>/dev/null || true)
 
 if [[ -n "$BLOCKING" || "$VERDICT" != "pass" ]]; then
 	if [[ "$CONSENT" == "true" && -n "$CONSENT_QUOTE" ]]; then
 		mkdir -p "$(dirname "$AUDIT")" 2>/dev/null || true
-		printf '%s\tCONSENT-OVERRIDE\tsession=%s\tbranch=%s\tsha=%s\tquote=%s\n' \
-			"$(audit_timestamp)" "$SESSION" "$BRANCH" "$HEAD_SHA" "${CONSENT_QUOTE//$'\n'/ }" \
+		printf '%s\tCONSENT-OVERRIDE\tsession=%s\tbranch=%s\tsha=%s\tquote=%s\tgate_seconds=%s\n' \
+			"$(audit_timestamp)" "$SESSION" "$BRANCH" "$HEAD_SHA" "${CONSENT_QUOTE//$'\n'/ }" "$SECONDS" \
 			>>"$AUDIT" 2>/dev/null || true
 		exit 0
 	fi
@@ -864,6 +865,6 @@ Fabricating that consent is forging the user's approval — don't."
 fi
 
 mkdir -p "$(dirname "$AUDIT")" 2>/dev/null || true
-printf '%s\tPASS\tsession=%s\tbranch=%s\tsha=%s\n' "$(audit_timestamp)" "$SESSION" "$BRANCH" "$HEAD_SHA" \
+printf '%s\tPASS\tsession=%s\tbranch=%s\tsha=%s\tgate_seconds=%s\n' "$(audit_timestamp)" "$SESSION" "$BRANCH" "$HEAD_SHA" "$SECONDS" \
 	>>"$AUDIT" 2>/dev/null || true
 exit 0

--- a/plugins-cc/agentkit/skills/adversarial-review/SKILL.md
+++ b/plugins-cc/agentkit/skills/adversarial-review/SKILL.md
@@ -38,7 +38,10 @@ executed or computed ground truth is.
    computation, trace, probe, or source reference; otherwise mark it
    `unverified`. An analogy requires an explicit point-of-difference analysis.
 5. Execute the smallest deterministic checks that can kill each hypothesis.
-   Use the project's resource-safe execution boundary for heavy checks.
+   Reuse checks already passed by CI against the exact reviewed source SHA;
+   rerun only when evidence is missing, inconsistent, or the resolved profile
+   requires it. Use the project's resource-safe execution boundary for heavy
+   checks.
 6. Compare the independent trace with the maker's narrative only after the trace
    exists. Record every disagreement.
 

--- a/plugins-cc/agentkit/skills/adversarial-review/references/reviewer-dispatch.md
+++ b/plugins-cc/agentkit/skills/adversarial-review/references/reviewer-dispatch.md
@@ -33,6 +33,9 @@ Do not include:
    decisive checks.
 4. Require a concrete failing input or replayable trace for every finding.
 5. Honor an empty result by listing attempted falsifications and evidence.
+6. Do not rerun exact-SHA CI checks that already passed unless their evidence is
+   missing or inconsistent, or the resolved review profile requires a rerun.
+   Prefer novel checks that can falsify the change.
 
 ## Output format
 

--- a/plugins-cc/agentkit/skills/autonomous-workflow/SKILL.md
+++ b/plugins-cc/agentkit/skills/autonomous-workflow/SKILL.md
@@ -57,6 +57,32 @@ and logs every pass and override to `~/.agentkit/review-audit.log`. Only
 forge-side required approvals actually prevent a merge. Never describe this
 gate as something it is not.
 
+### Resolve review effort before final verification
+
+Run `review-profile --repo . --risk trivial|standard|critical`, adding
+`--release` and `--user-facing` when applicable. The default `balanced` profile
+uses one exact-head adversarial review for ordinary non-trivial work. A second
+specialist is risk-triggered, and product review is triggered by critical risk,
+a release, or a user-facing change. `fast` narrows the optional lanes; `strict`
+preserves the maximal workflow. Follow the resolver's `required` decisions.
+Use the command from `PATH` after a global install. A Claude plugin-only install
+uses `$CLAUDE_PLUGIN_ROOT/tools/review-profile`; a project install can use
+`.claude/tools/review-profile` or `.codex/tools/review-profile`.
+
+Global settings live under `review:` in
+`~/.config/agentkit/config.yaml`; repository overrides live in
+`.agentkit/config.yaml`. `AGENTKIT_REVIEW_PROFILE` and `--profile` are explicit
+session/task overrides. These settings control orchestration only. Target-owned
+review policy is authoritative and may require checks, product coverage,
+analyses, or evidence that the selected profile would otherwise omit.
+
+Complete changelog, formatting, focused tests, typechecks, and other
+deterministic preflight before you freeze the source head. Push that final head,
+then start its required review lanes and CI concurrently. Any later commit
+invalidates every source-head-bound result. If CI passed against that exact SHA
+and the profile selects `ci-evidence: reuse`, cite the exact-SHA CI evidence;
+do not repeat the same suite locally. Novel falsification probes still run.
+
 1. **Review completes before the merge starts.** Never dispatch a reviewer and
    merge while it works — a verdict that lands after the code is on main
    protects nobody.
@@ -124,18 +150,21 @@ Tier can rise during work and never falls.
 - **Maker:** default to one capable worker. Return the diff plus a claims list;
   every behavioral or quantitative claim is computed/probed or explicitly
   `unverified`.
-- **Adversary:** use the `adversarial-review` skill on every non-trivial change.
-  Trace from primary artifacts before reading maker narrative. A finding counts
-  only with a concrete failing input or replayable trace.
-- **Product lane:** when target policy requires product coverage, run
-  `product-review` separately. Diff correctness does not certify installation or
-  operation.
+- **Adversary:** run the primary `adversarial-review` lane when selected by the
+  resolved profile (every non-trivial change by default). Add a separate
+  specialist only when selected by risk or policy. Trace from primary artifacts
+  before reading maker narrative. A finding counts only with a concrete failing
+  input or replayable trace.
+- **Product lane:** run `product-review` separately when selected by the profile
+  or required by target policy. Diff correctness does not certify installation
+  or operation.
 - **Evidence:** explicitly disposition failure trace, analogy differences,
   mechanically enumerated pattern sweep, new assumptions, and artifact lifetime.
   `not_applicable` needs a reason and only satisfies policy where allowed.
-- **Gate:** run deterministic checks and validate the strict record. The stored
-  verdict must equal the result derived from lanes, findings, checks, claims, and
-  analyses.
+- **Gate:** satisfy target-policy checks on the frozen head and validate the
+  strict record. Reuse passed exact-SHA CI evidence unless the profile requests
+  a rerun. The stored verdict must equal the result derived from lanes,
+  findings, checks, claims, and analyses.
 - **External:** critical work still requires authenticated human or
   different-family review plus protected deterministic checks. The local record
   cannot manufacture either property.
@@ -157,8 +186,9 @@ broken-looking install, missing packaging, a setup step that lives only in
 someone's head. Those reach the user untouched no matter how many diff rounds
 you run.
 
-For anything a person installs or operates, run the **product-review** skill as
-a separate pass: build it, run it, use it, from a cold start. It reads
+When the resolved profile selects the product lane—or target policy requires
+it—run the **product-review** skill as a separate pass: build it, run it, use it,
+from a cold start. It reads
 `.agentkit/product.yaml` and refuses rather than guessing when that is absent.
 When the two lenses disagree on severity, the user-facing consequence wins —
 internally correct code that cannot be used is still broken.

--- a/plugins-cc/agentkit/skills/product-review/SKILL.md
+++ b/plugins-cc/agentkit/skills/product-review/SKILL.md
@@ -150,6 +150,7 @@ from being reported as the same thing.
 ## Scope
 
 Product review does NOT replace diff review — it adds the lens diff review
-structurally cannot have. Run both. When they disagree about severity, the
-user-facing consequence wins: code that is internally correct but unusable is
-still broken.
+structurally cannot have. Run it when the resolved review profile selects the
+product lane or target policy requires it. When the lanes disagree about
+severity, the user-facing consequence wins: code that is internally correct
+but unusable is still broken.

--- a/plugins-cc/agentkit/skills/test-driven-development/SKILL.md
+++ b/plugins-cc/agentkit/skills/test-driven-development/SKILL.md
@@ -41,7 +41,7 @@ TDD applies to ALL code changes:
 
 ### Step 2: Verify RED
 
-- Run the test suite
+- Run the narrowest focused test that demonstrates the behavior
 - Confirm the new test FAILS
 - Confirm it fails for the RIGHT REASON (missing function, wrong return value — not a syntax error)
 - If the test passes immediately, it's not testing new behavior — rewrite it
@@ -54,15 +54,28 @@ TDD applies to ALL code changes:
 
 ### Step 4: Verify GREEN
 
-- Run the FULL test suite (not just the new test)
-- ALL tests must pass — new AND existing
+- Run the focused RED test plus the affected regression slice
+- All selected tests must pass — new AND existing
 - If existing tests break, fix the implementation, not the tests
 
 ### Step 5: Refactor
 
 - Clean up duplication, improve names, extract helpers
-- Run tests after EVERY refactor step to ensure nothing breaks
+- Run the focused tests after every refactor step to ensure nothing breaks
 - This is where you improve code quality — not during GREEN
+
+### Final-head verification
+
+RED and GREEN are fast feedback loops, so keep their checks focused. Before
+freezing the source head, resolve review effort with `review-profile`. Run the
+affected suite for `local-checks: affected`, or the full suite for
+`local-checks: full` and whenever target policy requires it.
+
+Run any required full suite once on the final exact head, not after every GREEN
+or refactor. Passed CI bound to that exact SHA is authoritative evidence when
+the profile selects `ci-evidence: reuse`; repeat it locally only when evidence
+is missing or inconsistent, or `ci-evidence: rerun` is selected. A later commit
+invalidates the result and requires final-head verification again.
 
 ## Anti-Patterns (BLOCKING violations)
 

--- a/plugins-cc/agentkit/tools/review-profile
+++ b/plugins-cc/agentkit/tools/review-profile
@@ -1,0 +1,302 @@
+#!/usr/bin/env bash
+# Resolve AgentKit's review workflow for one task. This selects orchestration
+# effort; target-owned .agentkit/review-policy.json remains the merge authority.
+set -euo pipefail
+
+PROFILE_ARG=""
+RISK="standard"
+REPO="."
+RELEASE=false
+USER_FACING=false
+
+fail() {
+	printf 'review-profile: %s\n' "$1" >&2
+	exit 2
+}
+
+usage() {
+	local status="${1:-2}"
+	printf '%s\n' \
+		'usage: review-profile [--profile fast|balanced|strict]' \
+		'  [--risk trivial|standard|critical] [--release] [--user-facing]' \
+		'  [--repo PATH]' >&2
+	exit "$status"
+}
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--profile)
+		[[ $# -ge 2 ]] || usage
+		PROFILE_ARG="$2"
+		shift 2
+		;;
+	--risk)
+		[[ $# -ge 2 ]] || usage
+		RISK="$2"
+		shift 2
+		;;
+	--repo)
+		[[ $# -ge 2 ]] || usage
+		REPO="$2"
+		shift 2
+		;;
+	--release)
+		RELEASE=true
+		shift
+		;;
+	--user-facing)
+		USER_FACING=true
+		shift
+		;;
+	--help)
+		usage 0
+		;;
+	*) usage ;;
+	esac
+done
+
+case "$RISK" in
+trivial | standard | critical) ;;
+*) fail "invalid risk '$RISK' (expected trivial, standard, or critical)" ;;
+esac
+
+command -v jq >/dev/null 2>&1 || fail 'jq is required'
+REPO_ROOT=$(git -C "$REPO" rev-parse --show-toplevel 2>/dev/null || true)
+if [[ -z "$REPO_ROOT" ]]; then
+	REPO_ROOT=$(cd "$REPO" 2>/dev/null && pwd -P) || fail "repository path is unreadable: $REPO"
+fi
+
+GLOBAL_CONFIG=""
+if [[ -n "${XDG_CONFIG_HOME:-}" ]]; then
+	GLOBAL_CONFIG="$XDG_CONFIG_HOME/agentkit/config.yaml"
+elif [[ -n "${HOME:-}" ]]; then
+	GLOBAL_CONFIG="$HOME/.config/agentkit/config.yaml"
+fi
+REPO_CONFIG="$REPO_ROOT/.agentkit/config.yaml"
+
+parse_config() {
+	local file="$1"
+	[[ -f "$file" ]] || return 0
+	awk '
+    function trim(value) {
+      sub(/^[[:space:]]+/, "", value)
+      sub(/[[:space:]]+$/, "", value)
+      return value
+    }
+    /^[[:space:]]*(#.*)?$/ { next }
+    /^[^[:space:]]/ {
+      if ($0 ~ /^review:/ && $0 !~ /^review:[[:space:]]*(#.*)?$/) {
+        print "__ERROR__\tunsupported review section syntax on line " NR
+        in_review = 0
+        next
+      }
+      in_review = ($0 ~ /^review:[[:space:]]*(#.*)?$/)
+      next
+    }
+    in_review {
+      line = $0
+      sub(/^[[:space:]]+/, "", line)
+      if (line !~ /^[a-z][a-z-]*:[[:space:]]*/) {
+        print "__ERROR__\tunsupported syntax on line " NR
+        next
+      }
+      key = line
+      sub(/:.*/, "", key)
+      value = line
+      sub(/^[^:]*:[[:space:]]*/, "", value)
+      sub(/[[:space:]]+#.*$/, "", value)
+      value = trim(value)
+      if ((substr(value, 1, 1) == "\"" && substr(value, length(value), 1) == "\"") ||
+          (substr(value, 1, 1) == "\047" && substr(value, length(value), 1) == "\047")) {
+        value = substr(value, 2, length(value) - 2)
+      }
+      if (value == "") {
+        print "__ERROR__\tempty value for " key " on line " NR
+      } else if (seen[key]++) {
+        print "__ERROR__\tduplicate key " key " on line " NR
+      } else {
+        print key "\t" value
+      }
+    }
+  ' "$file"
+}
+
+GLOBAL_PARSED=""
+REPO_PARSED=""
+if [[ -n "$GLOBAL_CONFIG" ]]; then
+	GLOBAL_PARSED=$(parse_config "$GLOBAL_CONFIG")
+fi
+REPO_PARSED=$(parse_config "$REPO_CONFIG")
+
+check_parse_errors() {
+	local parsed="$1"
+	local label="$2"
+	local message
+	message=$(printf '%s\n' "$parsed" | awk -F '\t' '$1 == "__ERROR__" { print $2; exit }')
+	[[ -z "$message" ]] || fail "$label: $message"
+}
+check_parse_errors "$GLOBAL_PARSED" 'global review config'
+check_parse_errors "$REPO_PARSED" 'repository review config'
+
+profile_from() {
+	printf '%s\n' "$1" | awk -F '\t' '$1 == "profile" { print $2 }'
+}
+
+PROFILE="balanced"
+GLOBAL_PROFILE=$(profile_from "$GLOBAL_PARSED")
+REPO_PROFILE=$(profile_from "$REPO_PARSED")
+[[ -z "$GLOBAL_PROFILE" ]] || PROFILE="$GLOBAL_PROFILE"
+[[ -z "$REPO_PROFILE" ]] || PROFILE="$REPO_PROFILE"
+[[ -z "${AGENTKIT_REVIEW_PROFILE:-}" ]] || PROFILE="$AGENTKIT_REVIEW_PROFILE"
+[[ -z "$PROFILE_ARG" ]] || PROFILE="$PROFILE_ARG"
+
+preset() {
+	case "$PROFILE" in
+	fast)
+		PRIMARY_REVIEW=nontrivial
+		SPECIALIST_REVIEW=never
+		PRODUCT_REVIEW=release
+		CI_EVIDENCE=reuse
+		LOCAL_CHECKS=affected
+		EVIDENCE_NOTE=critical
+		;;
+	balanced)
+		PRIMARY_REVIEW=nontrivial
+		SPECIALIST_REVIEW=critical
+		PRODUCT_REVIEW=triggered
+		CI_EVIDENCE=reuse
+		LOCAL_CHECKS=affected
+		EVIDENCE_NOTE=always
+		;;
+	strict)
+		PRIMARY_REVIEW=always
+		SPECIALIST_REVIEW=always
+		PRODUCT_REVIEW=always
+		CI_EVIDENCE=rerun
+		LOCAL_CHECKS=full
+		EVIDENCE_NOTE=always
+		;;
+	*) fail "invalid profile '$PROFILE' (expected fast, balanced, or strict)" ;;
+	esac
+}
+preset
+
+set_value() {
+	local key="$1"
+	local value="$2"
+	local label="$3"
+	case "$key" in
+	profile)
+		case "$value" in fast | balanced | strict) ;; *) fail "$label profile: invalid value '$value'" ;; esac
+		;;
+	primary-review)
+		case "$value" in nontrivial | always) PRIMARY_REVIEW="$value" ;; *) fail "$label primary-review: invalid value '$value'" ;; esac
+		;;
+	specialist-review)
+		case "$value" in never | critical | always) SPECIALIST_REVIEW="$value" ;; *) fail "$label specialist-review: invalid value '$value'" ;; esac
+		;;
+	product-review)
+		case "$value" in never | release | triggered | always) PRODUCT_REVIEW="$value" ;; *) fail "$label product-review: invalid value '$value'" ;; esac
+		;;
+	ci-evidence)
+		case "$value" in reuse | rerun) CI_EVIDENCE="$value" ;; *) fail "$label ci-evidence: invalid value '$value'" ;; esac
+		;;
+	local-checks)
+		case "$value" in affected | full) LOCAL_CHECKS="$value" ;; *) fail "$label local-checks: invalid value '$value'" ;; esac
+		;;
+	evidence-note)
+		case "$value" in critical | always) EVIDENCE_NOTE="$value" ;; *) fail "$label evidence-note: invalid value '$value'" ;; esac
+		;;
+	__ERROR__ | '') ;;
+	*) fail "$label: unknown review key '$key'" ;;
+	esac
+}
+
+apply_config() {
+	local parsed="$1"
+	local label="$2"
+	local key value
+	while IFS=$'\t' read -r key value; do
+		[[ -z "$key" ]] || set_value "$key" "$value" "$label"
+	done <<<"$parsed"
+}
+apply_config "$GLOBAL_PARSED" 'global review config'
+apply_config "$REPO_PARSED" 'repository review config'
+
+PRIMARY_REQUIRED=false
+SPECIALIST_REQUIRED=false
+PRODUCT_REQUIRED=false
+EVIDENCE_REQUIRED=false
+[[ "$PRIMARY_REVIEW" == "always" || "$RISK" != "trivial" ]] && PRIMARY_REQUIRED=true
+[[ "$SPECIALIST_REVIEW" == "always" || ( "$SPECIALIST_REVIEW" == "critical" && "$RISK" == "critical" ) ]] && SPECIALIST_REQUIRED=true
+if [[ "$PRODUCT_REVIEW" == "always" ||
+	( "$PRODUCT_REVIEW" == "release" && "$RELEASE" == true ) ||
+	( "$PRODUCT_REVIEW" == "triggered" &&
+		( "$RISK" == "critical" || "$RELEASE" == true || "$USER_FACING" == true ) ) ]]; then
+	PRODUCT_REQUIRED=true
+fi
+[[ "$EVIDENCE_NOTE" == "always" || "$RISK" == "critical" ]] && EVIDENCE_REQUIRED=true
+
+RERUN_CI=false
+FULL_LOCAL_CHECKS=false
+[[ "$CI_EVIDENCE" == "rerun" ]] && RERUN_CI=true
+[[ "$LOCAL_CHECKS" == "full" ]] && FULL_LOCAL_CHECKS=true
+WORKTREE_POLICY_PRESENT=false
+[[ -f "$REPO_ROOT/.agentkit/review-policy.json" ]] && WORKTREE_POLICY_PRESENT=true
+
+RESULT=$(jq -cn \
+	--arg profile "$PROFILE" \
+	--arg risk "$RISK" \
+	--argjson release "$RELEASE" \
+	--argjson user_facing "$USER_FACING" \
+	--argjson worktree_policy_present "$WORKTREE_POLICY_PRESENT" \
+	--arg primary "$PRIMARY_REVIEW" \
+	--arg specialist "$SPECIALIST_REVIEW" \
+	--arg product "$PRODUCT_REVIEW" \
+	--arg ci "$CI_EVIDENCE" \
+	--arg local_checks "$LOCAL_CHECKS" \
+	--arg evidence "$EVIDENCE_NOTE" \
+	--argjson primary_required "$PRIMARY_REQUIRED" \
+	--argjson specialist_required "$SPECIALIST_REQUIRED" \
+	--argjson product_required "$PRODUCT_REQUIRED" \
+	--argjson rerun_ci "$RERUN_CI" \
+	--argjson full_local_checks "$FULL_LOCAL_CHECKS" \
+	--argjson evidence_required "$EVIDENCE_REQUIRED" '
+  {
+    schema_version: 1,
+    profile: $profile,
+    context: {
+      risk: $risk,
+      release: $release,
+      user_facing: $user_facing,
+      target_policy_authoritative: true,
+      worktree_policy_present: $worktree_policy_present
+    },
+    settings: {
+      primary_review: $primary,
+      specialist_review: $specialist,
+      product_review: $product,
+      ci_evidence: $ci,
+      local_checks: $local_checks,
+      evidence_note: $evidence
+    },
+    required: {
+      primary_review: $primary_required,
+      specialist_review: $specialist_required,
+      product_review: $product_required,
+      rerun_ci: $rerun_ci,
+      full_local_checks: $full_local_checks,
+      evidence_note: $evidence_required
+    }
+  }
+')
+
+AUDIT="${HOME:-/tmp}/.agentkit/review-audit.log"
+mkdir -p "${AUDIT%/*}" 2>/dev/null || true
+printf '%s\tPROFILE\tprofile=%s\trisk=%s\trelease=%s\tuser_facing=%s\tprimary=%s\tspecialist=%s\tproduct=%s\tci=%s\tlocal=%s\tevidence=%s\tworktree_policy=%s\n' \
+	"$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || printf 'timestamp-unavailable')" \
+	"$PROFILE" "$RISK" "$RELEASE" "$USER_FACING" "$PRIMARY_REQUIRED" "$SPECIALIST_REQUIRED" \
+	"$PRODUCT_REQUIRED" "$CI_EVIDENCE" "$LOCAL_CHECKS" "$EVIDENCE_REQUIRED" "$WORKTREE_POLICY_PRESENT" \
+	>>"$AUDIT" 2>/dev/null || true
+
+printf '%s\n' "$RESULT"

--- a/plugins-cc/agentkit/tools/review-profile
+++ b/plugins-cc/agentkit/tools/review-profile
@@ -19,7 +19,18 @@ usage() {
 	printf '%s\n' \
 		'usage: review-profile [--profile fast|balanced|strict]' \
 		'  [--risk trivial|standard|critical] [--release] [--user-facing]' \
-		'  [--repo PATH]' >&2
+		'  [--repo PATH]' \
+		'' \
+		'profiles:' \
+		'  fast: primary review for nontrivial work; product review at release' \
+		'  balanced: primary review plus risk-triggered specialist and product lanes' \
+		'  strict: all review lanes, full local checks, and a fresh CI run' \
+		'' \
+		'context:' \
+		'  --risk trivial|standard|critical  classify the change risk' \
+		'  --release                         mark release work' \
+		'  --user-facing                     mark a user-visible change' \
+		'  --repo PATH                       read repository review configuration' >&2
 	exit "$status"
 }
 

--- a/scripts/check-test-slices.ts
+++ b/scripts/check-test-slices.ts
@@ -45,6 +45,7 @@ export const TEST_SLICES = {
     'tests/review-disciplines.test.ts',
     'tests/review-gate.test.ts',
     'tests/review-police.test.ts',
+    'tests/review-profile.test.ts',
   ],
   session: ['tests/session/agent-session.test.ts', 'tests/session/install-session-slice.test.ts'],
 } as const;
@@ -67,6 +68,7 @@ const productionRoots = [
   'tools',
 ] as const;
 const productionFiles = new Set([
+  '.agentkit/config.yaml',
   '.agentkit/product.yaml',
   '.agentkit/review-policy.json',
   'config.example.yaml',

--- a/scripts/sync-cc-plugin.sh
+++ b/scripts/sync-cc-plugin.sh
@@ -39,7 +39,7 @@ echo "[sync] skills/* -> plugins-cc/agentkit/skills/"
 
 # Portable tools used by bundled hooks. Keep this allowlist explicit: other
 # top-level tools are not necessarily plugin-facing commands.
-for tool in bounded-run review-gate; do
+for tool in bounded-run review-gate review-profile; do
 	cp "$REPO_DIR/tools/$tool" "$PLUGIN_DIR/tools/$tool"
 	chmod +x "$PLUGIN_DIR/tools/$tool"
 done

--- a/skills/adversarial-review/SKILL.md
+++ b/skills/adversarial-review/SKILL.md
@@ -38,7 +38,10 @@ executed or computed ground truth is.
    computation, trace, probe, or source reference; otherwise mark it
    `unverified`. An analogy requires an explicit point-of-difference analysis.
 5. Execute the smallest deterministic checks that can kill each hypothesis.
-   Use the project's resource-safe execution boundary for heavy checks.
+   Reuse checks already passed by CI against the exact reviewed source SHA;
+   rerun only when evidence is missing, inconsistent, or the resolved profile
+   requires it. Use the project's resource-safe execution boundary for heavy
+   checks.
 6. Compare the independent trace with the maker's narrative only after the trace
    exists. Record every disagreement.
 

--- a/skills/adversarial-review/references/reviewer-dispatch.md
+++ b/skills/adversarial-review/references/reviewer-dispatch.md
@@ -33,6 +33,9 @@ Do not include:
    decisive checks.
 4. Require a concrete failing input or replayable trace for every finding.
 5. Honor an empty result by listing attempted falsifications and evidence.
+6. Do not rerun exact-SHA CI checks that already passed unless their evidence is
+   missing or inconsistent, or the resolved review profile requires a rerun.
+   Prefer novel checks that can falsify the change.
 
 ## Output format
 

--- a/skills/autonomous-workflow/SKILL.md
+++ b/skills/autonomous-workflow/SKILL.md
@@ -57,6 +57,32 @@ and logs every pass and override to `~/.agentkit/review-audit.log`. Only
 forge-side required approvals actually prevent a merge. Never describe this
 gate as something it is not.
 
+### Resolve review effort before final verification
+
+Run `review-profile --repo . --risk trivial|standard|critical`, adding
+`--release` and `--user-facing` when applicable. The default `balanced` profile
+uses one exact-head adversarial review for ordinary non-trivial work. A second
+specialist is risk-triggered, and product review is triggered by critical risk,
+a release, or a user-facing change. `fast` narrows the optional lanes; `strict`
+preserves the maximal workflow. Follow the resolver's `required` decisions.
+Use the command from `PATH` after a global install. A Claude plugin-only install
+uses `$CLAUDE_PLUGIN_ROOT/tools/review-profile`; a project install can use
+`.claude/tools/review-profile` or `.codex/tools/review-profile`.
+
+Global settings live under `review:` in
+`~/.config/agentkit/config.yaml`; repository overrides live in
+`.agentkit/config.yaml`. `AGENTKIT_REVIEW_PROFILE` and `--profile` are explicit
+session/task overrides. These settings control orchestration only. Target-owned
+review policy is authoritative and may require checks, product coverage,
+analyses, or evidence that the selected profile would otherwise omit.
+
+Complete changelog, formatting, focused tests, typechecks, and other
+deterministic preflight before you freeze the source head. Push that final head,
+then start its required review lanes and CI concurrently. Any later commit
+invalidates every source-head-bound result. If CI passed against that exact SHA
+and the profile selects `ci-evidence: reuse`, cite the exact-SHA CI evidence;
+do not repeat the same suite locally. Novel falsification probes still run.
+
 1. **Review completes before the merge starts.** Never dispatch a reviewer and
    merge while it works — a verdict that lands after the code is on main
    protects nobody.
@@ -124,18 +150,21 @@ Tier can rise during work and never falls.
 - **Maker:** default to one capable worker. Return the diff plus a claims list;
   every behavioral or quantitative claim is computed/probed or explicitly
   `unverified`.
-- **Adversary:** use the `adversarial-review` skill on every non-trivial change.
-  Trace from primary artifacts before reading maker narrative. A finding counts
-  only with a concrete failing input or replayable trace.
-- **Product lane:** when target policy requires product coverage, run
-  `product-review` separately. Diff correctness does not certify installation or
-  operation.
+- **Adversary:** run the primary `adversarial-review` lane when selected by the
+  resolved profile (every non-trivial change by default). Add a separate
+  specialist only when selected by risk or policy. Trace from primary artifacts
+  before reading maker narrative. A finding counts only with a concrete failing
+  input or replayable trace.
+- **Product lane:** run `product-review` separately when selected by the profile
+  or required by target policy. Diff correctness does not certify installation
+  or operation.
 - **Evidence:** explicitly disposition failure trace, analogy differences,
   mechanically enumerated pattern sweep, new assumptions, and artifact lifetime.
   `not_applicable` needs a reason and only satisfies policy where allowed.
-- **Gate:** run deterministic checks and validate the strict record. The stored
-  verdict must equal the result derived from lanes, findings, checks, claims, and
-  analyses.
+- **Gate:** satisfy target-policy checks on the frozen head and validate the
+  strict record. Reuse passed exact-SHA CI evidence unless the profile requests
+  a rerun. The stored verdict must equal the result derived from lanes,
+  findings, checks, claims, and analyses.
 - **External:** critical work still requires authenticated human or
   different-family review plus protected deterministic checks. The local record
   cannot manufacture either property.
@@ -157,8 +186,9 @@ broken-looking install, missing packaging, a setup step that lives only in
 someone's head. Those reach the user untouched no matter how many diff rounds
 you run.
 
-For anything a person installs or operates, run the **product-review** skill as
-a separate pass: build it, run it, use it, from a cold start. It reads
+When the resolved profile selects the product lane—or target policy requires
+it—run the **product-review** skill as a separate pass: build it, run it, use it,
+from a cold start. It reads
 `.agentkit/product.yaml` and refuses rather than guessing when that is absent.
 When the two lenses disagree on severity, the user-facing consequence wins —
 internally correct code that cannot be used is still broken.

--- a/skills/product-review/SKILL.md
+++ b/skills/product-review/SKILL.md
@@ -150,6 +150,7 @@ from being reported as the same thing.
 ## Scope
 
 Product review does NOT replace diff review — it adds the lens diff review
-structurally cannot have. Run both. When they disagree about severity, the
-user-facing consequence wins: code that is internally correct but unusable is
-still broken.
+structurally cannot have. Run it when the resolved review profile selects the
+product lane or target policy requires it. When the lanes disagree about
+severity, the user-facing consequence wins: code that is internally correct
+but unusable is still broken.

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -41,7 +41,7 @@ TDD applies to ALL code changes:
 
 ### Step 2: Verify RED
 
-- Run the test suite
+- Run the narrowest focused test that demonstrates the behavior
 - Confirm the new test FAILS
 - Confirm it fails for the RIGHT REASON (missing function, wrong return value — not a syntax error)
 - If the test passes immediately, it's not testing new behavior — rewrite it
@@ -54,15 +54,28 @@ TDD applies to ALL code changes:
 
 ### Step 4: Verify GREEN
 
-- Run the FULL test suite (not just the new test)
-- ALL tests must pass — new AND existing
+- Run the focused RED test plus the affected regression slice
+- All selected tests must pass — new AND existing
 - If existing tests break, fix the implementation, not the tests
 
 ### Step 5: Refactor
 
 - Clean up duplication, improve names, extract helpers
-- Run tests after EVERY refactor step to ensure nothing breaks
+- Run the focused tests after every refactor step to ensure nothing breaks
 - This is where you improve code quality — not during GREEN
+
+### Final-head verification
+
+RED and GREEN are fast feedback loops, so keep their checks focused. Before
+freezing the source head, resolve review effort with `review-profile`. Run the
+affected suite for `local-checks: affected`, or the full suite for
+`local-checks: full` and whenever target policy requires it.
+
+Run any required full suite once on the final exact head, not after every GREEN
+or refactor. Passed CI bound to that exact SHA is authoritative evidence when
+the profile selects `ci-evidence: reuse`; repeat it locally only when evidence
+is missing or inconsistent, or `ci-evidence: rerun` is selected. A later commit
+invalidates the result and requires final-head verification again.
 
 ## Anti-Patterns (BLOCKING violations)
 

--- a/tests/agentkit-plugin.test.ts
+++ b/tests/agentkit-plugin.test.ts
@@ -191,7 +191,7 @@ describe('agentkit plugin skills', () => {
 
 describe('agentkit plugin tools', () => {
   test('bundles the portable tools and keeps them executable', () => {
-    for (const tool of ['bounded-run', 'review-gate']) {
+    for (const tool of ['bounded-run', 'review-gate', 'review-profile']) {
       const bundled = join(pluginDir, 'tools', tool);
       expect(readFileSync(bundled, 'utf-8')).toBe(
         readFileSync(join(repoRoot, 'tools', tool), 'utf-8'),

--- a/tests/install-hooks.test.ts
+++ b/tests/install-hooks.test.ts
@@ -101,6 +101,7 @@ describe('Claude Code and Codex hook wiring', () => {
         join(codexDir, 'hooks', 'fail-closed-hook.sh'),
         join(codexDir, 'hooks', 'review-police.sh'),
         join(codexDir, 'tools', 'review-gate'),
+        join(codexDir, 'tools', 'review-profile'),
       ]) {
         expect(existsSync(path), path).toBe(true);
         expect(statSync(path).mode & 0o111, path).not.toBe(0);
@@ -190,6 +191,7 @@ describe('Claude Code and Codex hook wiring', () => {
       expect(existsSync(join(codexHome, 'hooks.json'))).toBe(true);
       expect(existsSync(join(codexHome, 'config.toml'))).toBe(true);
       expect(existsSync(join(codexHome, 'hooks', 'review-police.sh'))).toBe(true);
+      expect(existsSync(join(codexHome, 'tools', 'review-profile'))).toBe(true);
       expect(existsSync(join(home, '.codex', 'hooks.json'))).toBe(false);
       expect(existsSync(join(home, '.codex', 'config.toml'))).toBe(false);
     } finally {

--- a/tests/install-platform.test.ts
+++ b/tests/install-platform.test.ts
@@ -69,6 +69,7 @@ function createFixture(): Fixture {
     true,
   );
   writeFixtureFile(join(repo, 'tools', 'review-gate'), '#!/usr/bin/env bash\n', true);
+  writeFixtureFile(join(repo, 'tools', 'review-profile'), '#!/usr/bin/env bash\n', true);
   writeFixtureFile(
     join(repo, 'policies', 'codex', 'resource-police.rules'),
     '# agentkit:platform linux # local cgroup containment\n',
@@ -140,6 +141,7 @@ describe('platform-aware artifact installation', () => {
         expect(existsSync(join(codex, 'hooks', 'fail-closed-hook.sh'))).toBe(true);
         expect(existsSync(join(codex, 'hooks', 'lib', 'hook-input.sh'))).toBe(true);
         expect(existsSync(join(codex, 'tools', 'review-gate'))).toBe(true);
+        expect(existsSync(join(codex, 'tools', 'review-profile'))).toBe(true);
         expect(readFileSync(join(codex, 'hooks.json'), 'utf-8')).not.toContain(
           '__AGENTKIT_CODEX_HOOKS_ROOT__',
         );
@@ -176,6 +178,7 @@ describe('platform-aware artifact installation', () => {
         expect(existsSync(join(policies, 'delegation-police.rules'))).toBe(true);
         expect(existsSync(join(codex, 'hooks', 'review-police.sh'))).toBe(true);
         expect(existsSync(join(codex, 'tools', 'review-gate'))).toBe(true);
+        expect(existsSync(join(codex, 'tools', 'review-profile'))).toBe(true);
         if (global) {
           for (const base of [
             join(fixture.home, '.agentkit', 'tools'),

--- a/tests/install-tools.test.ts
+++ b/tests/install-tools.test.ts
@@ -40,6 +40,13 @@ describe('standalone tool installation', () => {
       expect(readFileSync(pathReviewGate, 'utf-8')).toBe(readFileSync(claudeReviewGate, 'utf-8'));
       expect(statSync(pathReviewGate).mode & 0o111).not.toBe(0);
       expect(statSync(claudeReviewGate).mode & 0o111).not.toBe(0);
+      const pathReviewProfile = join(home, '.local', 'bin', 'review-profile');
+      const claudeReviewProfile = join(home, '.claude', 'tools', 'review-profile');
+      expect(readFileSync(pathReviewProfile, 'utf-8')).toBe(
+        readFileSync(claudeReviewProfile, 'utf-8'),
+      );
+      expect(statSync(pathReviewProfile).mode & 0o111).not.toBe(0);
+      expect(statSync(claudeReviewProfile).mode & 0o111).not.toBe(0);
       expect(result.stdout).toContain(`PATH tools:      ${join(home, '.local', 'bin')}/`);
       expect(existsSync(join(home, '.config', 'opencode', 'plugins', 'resource-police.ts'))).toBe(
         true,
@@ -59,6 +66,13 @@ describe('standalone tool installation', () => {
   test('ships the evidence validator inside the one-shot Claude plugin', () => {
     const source = readFileSync(join(repoRoot, 'tools', 'review-gate'), 'utf-8');
     const bundled = join(repoRoot, 'plugins-cc', 'agentkit', 'tools', 'review-gate');
+    expect(readFileSync(bundled, 'utf-8')).toBe(source);
+    expect(statSync(bundled).mode & 0o111).not.toBe(0);
+  });
+
+  test('ships the review profile resolver inside the one-shot Claude plugin', () => {
+    const source = readFileSync(join(repoRoot, 'tools', 'review-profile'), 'utf-8');
+    const bundled = join(repoRoot, 'plugins-cc', 'agentkit', 'tools', 'review-profile');
     expect(readFileSync(bundled, 'utf-8')).toBe(source);
     expect(statSync(bundled).mode & 0o111).not.toBe(0);
   });

--- a/tests/product-command.test.ts
+++ b/tests/product-command.test.ts
@@ -81,6 +81,7 @@ describe('portable product command', () => {
     const product = readFileSync(join(repoRoot, '.agentkit', 'product.yaml'), 'utf-8');
     expect(product).toContain('build: scripts/product-command default -- bun install');
     expect(product).toContain('verify: scripts/product-command default -- bun test');
+    expect(product).toContain('run: tools/review-profile --help');
     expect(product).toContain('run: scripts/product-command default -- echo ok');
     expect(product).toContain(
       'run: scripts/product-command default -- bun plugins-cc/agentkit/server/index.ts',

--- a/tests/resource-police.test.ts
+++ b/tests/resource-police.test.ts
@@ -414,5 +414,5 @@ describe('Codex resource policies', () => {
     );
     expect(wrapped.status, wrapped.stderr).toBe(0);
     expect(JSON.parse(wrapped.stdout).decision).toBeUndefined();
-  });
+  }, 30_000);
 });

--- a/tests/review-disciplines.test.ts
+++ b/tests/review-disciplines.test.ts
@@ -16,6 +16,10 @@ const resourceSafeExecution = readFileSync(
   'utf-8',
 );
 const codingDiscipline = readFileSync(join(instructionsDir, 'coding-discipline.md'), 'utf-8');
+const testDrivenDevelopment = readFileSync(
+  join(skillsDir, 'test-driven-development', 'SKILL.md'),
+  'utf-8',
+);
 
 describe('review disciplines', () => {
   test('keeps evidence checks in the review workflow', () => {
@@ -67,5 +71,20 @@ describe('review disciplines', () => {
     expect(codingDiscipline).toContain('temporary, task-owned worktree');
     expect(codingDiscipline).toMatch(/do not keep a permanent worktrees directory/i);
     expect(codingDiscipline).not.toContain('code that no longer exists anywhere else');
+  });
+
+  test('resolves configurable review effort without weakening target policy', () => {
+    expect(autonomousWorkflow).toContain('review-profile');
+    expect(autonomousWorkflow).toContain('$CLAUDE_PLUGIN_ROOT/tools/review-profile');
+    expect(autonomousWorkflow).toMatch(/target-owned\s+review policy is authoritative/i);
+    expect(autonomousWorkflow).toMatch(/freeze.*source head/i);
+    expect(autonomousWorkflow).toMatch(/exact-SHA CI evidence/i);
+    expect(reviewerDispatch).toMatch(/do not rerun.*exact-SHA CI/i);
+  });
+
+  test('uses focused TDD checks during iteration and one authoritative final run', () => {
+    expect(testDrivenDevelopment).toMatch(/focused.*RED.*GREEN/is);
+    expect(testDrivenDevelopment).toMatch(/full.*exact.*head/is);
+    expect(testDrivenDevelopment).not.toContain('Run the FULL test suite (not just the new test)');
   });
 });

--- a/tests/review-gate.test.ts
+++ b/tests/review-gate.test.ts
@@ -271,6 +271,7 @@ describe('review-gate strict evidence validation', () => {
     }).trim();
 
     for (const path of [
+      '.agentkit/config.yaml',
       '.agentkit/product.yaml',
       '.github/workflows/ci.yml',
       '.moon/workspace.yml',
@@ -280,9 +281,11 @@ describe('review-gate strict evidence validation', () => {
       'package.json',
       'bun.lock',
       'plugins-cc/agentkit/.claude-plugin/plugin.json',
+      'plugins-cc/agentkit/tools/review-profile',
       'skills/adversarial-review/SKILL.md',
       'skills/autonomous-workflow/SKILL.md',
       'skills/product-review/SKILL.md',
+      'skills/test-driven-development/SKILL.md',
       'instructions/coding-discipline.md',
       'docs/review-process.md',
       'tests/review-gate.test.ts',
@@ -296,6 +299,8 @@ describe('review-gate strict evidence validation', () => {
       'tests/test-slices.test.ts',
       'scripts/check-test-slices.ts',
       'scripts/product-command',
+      'tools/review-profile',
+      'config.example.yaml',
     ]) {
       writePaths([path]);
       const body = criticalRecord();

--- a/tests/review-police.test.ts
+++ b/tests/review-police.test.ts
@@ -357,7 +357,7 @@ describe('review-police: the hook itself cannot fail open', () => {
     expect(res.status, res.stderr).toBe(0);
     expect(res.stderr).toBe('');
     expect(readFileSync(audit, 'utf-8')).toMatch(
-      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\tPASS\t/,
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\tPASS\t.*\tgate_seconds=\d+$/m,
     );
   });
 
@@ -409,6 +409,11 @@ describe('review-police: intended semantics', () => {
 
   test('allows a clean pass for the exact head', () => {
     record(passing);
+    expect(runHook(MERGE)).toBe('');
+  });
+
+  test('accepts case-insensitive legacy pass verdicts', () => {
+    record({ ...passing, verdict: 'PASS' });
     expect(runHook(MERGE)).toBe('');
   });
 

--- a/tests/review-profile.test.ts
+++ b/tests/review-profile.test.ts
@@ -59,6 +59,19 @@ afterEach(() => {
 });
 
 describe('review-profile', () => {
+  test('documents profiles, task context, and repository selection in help', () => {
+    const result = resolve(['--help']);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain('fast:');
+    expect(result.stderr).toContain('balanced:');
+    expect(result.stderr).toContain('strict:');
+    expect(result.stderr).toContain('--risk trivial|standard|critical');
+    expect(result.stderr).toContain('--release');
+    expect(result.stderr).toContain('--user-facing');
+    expect(result.stderr).toContain('--repo PATH');
+  });
+
   test('defaults to one exact-head review and reuses exact-SHA CI evidence', () => {
     const result = output(['--risk', 'standard']);
 

--- a/tests/review-profile.test.ts
+++ b/tests/review-profile.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const TOOL = join(import.meta.dir, '..', 'tools', 'review-profile');
+
+let home: string;
+let repo: string;
+
+interface Resolution {
+  profile: string;
+  context: {
+    risk: string;
+    release: boolean;
+    user_facing: boolean;
+    target_policy_authoritative: boolean;
+    worktree_policy_present: boolean;
+  };
+  settings: Record<string, string>;
+  required: Record<string, boolean>;
+}
+
+function resolve(
+  args: string[] = [],
+  env: Record<string, string | undefined> = {},
+): ReturnType<typeof spawnSync> {
+  return spawnSync('bash', [TOOL, '--repo', repo, ...args], {
+    encoding: 'utf-8',
+    env: {
+      ...process.env,
+      HOME: home,
+      XDG_CONFIG_HOME: join(home, '.config'),
+      ...env,
+    },
+  });
+}
+
+function output(args: string[] = [], env: Record<string, string | undefined> = {}): Resolution {
+  const result = resolve(args, env);
+  expect(result.status, result.stderr).toBe(0);
+  return JSON.parse(result.stdout) as Resolution;
+}
+
+function config(path: string, body: string): void {
+  mkdirSync(path, { recursive: true });
+  writeFileSync(join(path, 'config.yaml'), body);
+}
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'agentkit-review-profile-home-'));
+  repo = mkdtempSync(join(tmpdir(), 'agentkit-review-profile-repo-'));
+});
+
+afterEach(() => {
+  rmSync(home, { force: true, recursive: true });
+  rmSync(repo, { force: true, recursive: true });
+});
+
+describe('review-profile', () => {
+  test('defaults to one exact-head review and reuses exact-SHA CI evidence', () => {
+    const result = output(['--risk', 'standard']);
+
+    expect(result.profile).toBe('balanced');
+    expect(result.settings).toEqual({
+      primary_review: 'nontrivial',
+      specialist_review: 'critical',
+      product_review: 'triggered',
+      ci_evidence: 'reuse',
+      local_checks: 'affected',
+      evidence_note: 'always',
+    });
+    expect(result.required).toEqual({
+      primary_review: true,
+      specialist_review: false,
+      product_review: false,
+      rerun_ci: false,
+      full_local_checks: false,
+      evidence_note: true,
+    });
+  });
+
+  test('activates risk and product lanes from task context', () => {
+    const result = output(['--risk', 'critical', '--user-facing']);
+
+    expect(result.context).toMatchObject({ risk: 'critical', user_facing: true });
+    expect(result.required.specialist_review).toBe(true);
+    expect(result.required.product_review).toBe(true);
+  });
+
+  test('applies global and repository overrides after the selected preset', () => {
+    config(
+      join(home, '.config', 'agentkit'),
+      `review:
+  profile: fast
+  specialist-review: never
+  evidence-note: critical
+`,
+    );
+    config(
+      join(repo, '.agentkit'),
+      `review:
+  profile: balanced
+  specialist-review: always
+  local-checks: full
+`,
+    );
+
+    const result = output(['--risk', 'standard']);
+
+    expect(result.profile).toBe('balanced');
+    expect(result.settings.specialist_review).toBe('always');
+    expect(result.settings.local_checks).toBe('full');
+    expect(result.settings.evidence_note).toBe('critical');
+    expect(result.required.specialist_review).toBe(true);
+    expect(result.required.full_local_checks).toBe(true);
+    expect(result.required.evidence_note).toBe(false);
+  });
+
+  test('lets an explicit profile override config and environment selection', () => {
+    config(join(home, '.config', 'agentkit'), 'review:\n  profile: fast\n');
+
+    expect(output([], { AGENTKIT_REVIEW_PROFILE: 'strict' }).profile).toBe('strict');
+    expect(
+      output(['--profile', 'balanced'], { AGENTKIT_REVIEW_PROFILE: 'strict' }).profile,
+    ).toBe('balanced');
+  });
+
+  test('reports target policy authority without pretending the profile can lower it', () => {
+    mkdirSync(join(repo, '.agentkit'), { recursive: true });
+    writeFileSync(join(repo, '.agentkit', 'review-policy.json'), '{}\n');
+
+    const result = output(['--profile', 'fast', '--risk', 'trivial']);
+
+    expect(result.context.target_policy_authoritative).toBe(true);
+    expect(result.context.worktree_policy_present).toBe(true);
+    expect(result.required.primary_review).toBe(false);
+  });
+
+  test('fails loudly on invalid review configuration', () => {
+    config(
+      join(home, '.config', 'agentkit'),
+      'review:\n  specialist-review: sometimes\n',
+    );
+
+    const result = resolve();
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('specialist-review');
+    expect(result.stderr).toContain('sometimes');
+  });
+
+  test('rejects unsupported inline review YAML instead of silently using defaults', () => {
+    config(join(home, '.config', 'agentkit'), 'review: { profile: fast }\n');
+
+    const result = resolve();
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('unsupported review section syntax');
+  });
+
+  test('records profile activation telemetry without sensitive command data', () => {
+    output(['--risk', 'critical', '--release']);
+
+    const audit = readFileSync(join(home, '.agentkit', 'review-audit.log'), 'utf-8');
+    expect(audit).toMatch(/\tPROFILE\tprofile=balanced\trisk=critical\t/);
+    expect(audit).toContain('release=true');
+    expect(audit).toContain('specialist=true');
+    expect(audit).not.toContain(repo);
+  });
+});

--- a/tests/test-slices.test.ts
+++ b/tests/test-slices.test.ts
@@ -76,6 +76,7 @@ describe('test slice routing', () => {
   test('discovers installed runtime roots and executable entrypoints', () => {
     const root = mkdtempSync(join(tmpdir(), 'agentkit-production-discovery-'));
     const runtimeFiles = [
+      '.agentkit/config.yaml',
       '.agentkit/review-policy.json',
       '.claude-plugin/marketplace.json',
       'config.example.yaml',

--- a/tools/review-profile
+++ b/tools/review-profile
@@ -1,0 +1,302 @@
+#!/usr/bin/env bash
+# Resolve AgentKit's review workflow for one task. This selects orchestration
+# effort; target-owned .agentkit/review-policy.json remains the merge authority.
+set -euo pipefail
+
+PROFILE_ARG=""
+RISK="standard"
+REPO="."
+RELEASE=false
+USER_FACING=false
+
+fail() {
+	printf 'review-profile: %s\n' "$1" >&2
+	exit 2
+}
+
+usage() {
+	local status="${1:-2}"
+	printf '%s\n' \
+		'usage: review-profile [--profile fast|balanced|strict]' \
+		'  [--risk trivial|standard|critical] [--release] [--user-facing]' \
+		'  [--repo PATH]' >&2
+	exit "$status"
+}
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--profile)
+		[[ $# -ge 2 ]] || usage
+		PROFILE_ARG="$2"
+		shift 2
+		;;
+	--risk)
+		[[ $# -ge 2 ]] || usage
+		RISK="$2"
+		shift 2
+		;;
+	--repo)
+		[[ $# -ge 2 ]] || usage
+		REPO="$2"
+		shift 2
+		;;
+	--release)
+		RELEASE=true
+		shift
+		;;
+	--user-facing)
+		USER_FACING=true
+		shift
+		;;
+	--help)
+		usage 0
+		;;
+	*) usage ;;
+	esac
+done
+
+case "$RISK" in
+trivial | standard | critical) ;;
+*) fail "invalid risk '$RISK' (expected trivial, standard, or critical)" ;;
+esac
+
+command -v jq >/dev/null 2>&1 || fail 'jq is required'
+REPO_ROOT=$(git -C "$REPO" rev-parse --show-toplevel 2>/dev/null || true)
+if [[ -z "$REPO_ROOT" ]]; then
+	REPO_ROOT=$(cd "$REPO" 2>/dev/null && pwd -P) || fail "repository path is unreadable: $REPO"
+fi
+
+GLOBAL_CONFIG=""
+if [[ -n "${XDG_CONFIG_HOME:-}" ]]; then
+	GLOBAL_CONFIG="$XDG_CONFIG_HOME/agentkit/config.yaml"
+elif [[ -n "${HOME:-}" ]]; then
+	GLOBAL_CONFIG="$HOME/.config/agentkit/config.yaml"
+fi
+REPO_CONFIG="$REPO_ROOT/.agentkit/config.yaml"
+
+parse_config() {
+	local file="$1"
+	[[ -f "$file" ]] || return 0
+	awk '
+    function trim(value) {
+      sub(/^[[:space:]]+/, "", value)
+      sub(/[[:space:]]+$/, "", value)
+      return value
+    }
+    /^[[:space:]]*(#.*)?$/ { next }
+    /^[^[:space:]]/ {
+      if ($0 ~ /^review:/ && $0 !~ /^review:[[:space:]]*(#.*)?$/) {
+        print "__ERROR__\tunsupported review section syntax on line " NR
+        in_review = 0
+        next
+      }
+      in_review = ($0 ~ /^review:[[:space:]]*(#.*)?$/)
+      next
+    }
+    in_review {
+      line = $0
+      sub(/^[[:space:]]+/, "", line)
+      if (line !~ /^[a-z][a-z-]*:[[:space:]]*/) {
+        print "__ERROR__\tunsupported syntax on line " NR
+        next
+      }
+      key = line
+      sub(/:.*/, "", key)
+      value = line
+      sub(/^[^:]*:[[:space:]]*/, "", value)
+      sub(/[[:space:]]+#.*$/, "", value)
+      value = trim(value)
+      if ((substr(value, 1, 1) == "\"" && substr(value, length(value), 1) == "\"") ||
+          (substr(value, 1, 1) == "\047" && substr(value, length(value), 1) == "\047")) {
+        value = substr(value, 2, length(value) - 2)
+      }
+      if (value == "") {
+        print "__ERROR__\tempty value for " key " on line " NR
+      } else if (seen[key]++) {
+        print "__ERROR__\tduplicate key " key " on line " NR
+      } else {
+        print key "\t" value
+      }
+    }
+  ' "$file"
+}
+
+GLOBAL_PARSED=""
+REPO_PARSED=""
+if [[ -n "$GLOBAL_CONFIG" ]]; then
+	GLOBAL_PARSED=$(parse_config "$GLOBAL_CONFIG")
+fi
+REPO_PARSED=$(parse_config "$REPO_CONFIG")
+
+check_parse_errors() {
+	local parsed="$1"
+	local label="$2"
+	local message
+	message=$(printf '%s\n' "$parsed" | awk -F '\t' '$1 == "__ERROR__" { print $2; exit }')
+	[[ -z "$message" ]] || fail "$label: $message"
+}
+check_parse_errors "$GLOBAL_PARSED" 'global review config'
+check_parse_errors "$REPO_PARSED" 'repository review config'
+
+profile_from() {
+	printf '%s\n' "$1" | awk -F '\t' '$1 == "profile" { print $2 }'
+}
+
+PROFILE="balanced"
+GLOBAL_PROFILE=$(profile_from "$GLOBAL_PARSED")
+REPO_PROFILE=$(profile_from "$REPO_PARSED")
+[[ -z "$GLOBAL_PROFILE" ]] || PROFILE="$GLOBAL_PROFILE"
+[[ -z "$REPO_PROFILE" ]] || PROFILE="$REPO_PROFILE"
+[[ -z "${AGENTKIT_REVIEW_PROFILE:-}" ]] || PROFILE="$AGENTKIT_REVIEW_PROFILE"
+[[ -z "$PROFILE_ARG" ]] || PROFILE="$PROFILE_ARG"
+
+preset() {
+	case "$PROFILE" in
+	fast)
+		PRIMARY_REVIEW=nontrivial
+		SPECIALIST_REVIEW=never
+		PRODUCT_REVIEW=release
+		CI_EVIDENCE=reuse
+		LOCAL_CHECKS=affected
+		EVIDENCE_NOTE=critical
+		;;
+	balanced)
+		PRIMARY_REVIEW=nontrivial
+		SPECIALIST_REVIEW=critical
+		PRODUCT_REVIEW=triggered
+		CI_EVIDENCE=reuse
+		LOCAL_CHECKS=affected
+		EVIDENCE_NOTE=always
+		;;
+	strict)
+		PRIMARY_REVIEW=always
+		SPECIALIST_REVIEW=always
+		PRODUCT_REVIEW=always
+		CI_EVIDENCE=rerun
+		LOCAL_CHECKS=full
+		EVIDENCE_NOTE=always
+		;;
+	*) fail "invalid profile '$PROFILE' (expected fast, balanced, or strict)" ;;
+	esac
+}
+preset
+
+set_value() {
+	local key="$1"
+	local value="$2"
+	local label="$3"
+	case "$key" in
+	profile)
+		case "$value" in fast | balanced | strict) ;; *) fail "$label profile: invalid value '$value'" ;; esac
+		;;
+	primary-review)
+		case "$value" in nontrivial | always) PRIMARY_REVIEW="$value" ;; *) fail "$label primary-review: invalid value '$value'" ;; esac
+		;;
+	specialist-review)
+		case "$value" in never | critical | always) SPECIALIST_REVIEW="$value" ;; *) fail "$label specialist-review: invalid value '$value'" ;; esac
+		;;
+	product-review)
+		case "$value" in never | release | triggered | always) PRODUCT_REVIEW="$value" ;; *) fail "$label product-review: invalid value '$value'" ;; esac
+		;;
+	ci-evidence)
+		case "$value" in reuse | rerun) CI_EVIDENCE="$value" ;; *) fail "$label ci-evidence: invalid value '$value'" ;; esac
+		;;
+	local-checks)
+		case "$value" in affected | full) LOCAL_CHECKS="$value" ;; *) fail "$label local-checks: invalid value '$value'" ;; esac
+		;;
+	evidence-note)
+		case "$value" in critical | always) EVIDENCE_NOTE="$value" ;; *) fail "$label evidence-note: invalid value '$value'" ;; esac
+		;;
+	__ERROR__ | '') ;;
+	*) fail "$label: unknown review key '$key'" ;;
+	esac
+}
+
+apply_config() {
+	local parsed="$1"
+	local label="$2"
+	local key value
+	while IFS=$'\t' read -r key value; do
+		[[ -z "$key" ]] || set_value "$key" "$value" "$label"
+	done <<<"$parsed"
+}
+apply_config "$GLOBAL_PARSED" 'global review config'
+apply_config "$REPO_PARSED" 'repository review config'
+
+PRIMARY_REQUIRED=false
+SPECIALIST_REQUIRED=false
+PRODUCT_REQUIRED=false
+EVIDENCE_REQUIRED=false
+[[ "$PRIMARY_REVIEW" == "always" || "$RISK" != "trivial" ]] && PRIMARY_REQUIRED=true
+[[ "$SPECIALIST_REVIEW" == "always" || ( "$SPECIALIST_REVIEW" == "critical" && "$RISK" == "critical" ) ]] && SPECIALIST_REQUIRED=true
+if [[ "$PRODUCT_REVIEW" == "always" ||
+	( "$PRODUCT_REVIEW" == "release" && "$RELEASE" == true ) ||
+	( "$PRODUCT_REVIEW" == "triggered" &&
+		( "$RISK" == "critical" || "$RELEASE" == true || "$USER_FACING" == true ) ) ]]; then
+	PRODUCT_REQUIRED=true
+fi
+[[ "$EVIDENCE_NOTE" == "always" || "$RISK" == "critical" ]] && EVIDENCE_REQUIRED=true
+
+RERUN_CI=false
+FULL_LOCAL_CHECKS=false
+[[ "$CI_EVIDENCE" == "rerun" ]] && RERUN_CI=true
+[[ "$LOCAL_CHECKS" == "full" ]] && FULL_LOCAL_CHECKS=true
+WORKTREE_POLICY_PRESENT=false
+[[ -f "$REPO_ROOT/.agentkit/review-policy.json" ]] && WORKTREE_POLICY_PRESENT=true
+
+RESULT=$(jq -cn \
+	--arg profile "$PROFILE" \
+	--arg risk "$RISK" \
+	--argjson release "$RELEASE" \
+	--argjson user_facing "$USER_FACING" \
+	--argjson worktree_policy_present "$WORKTREE_POLICY_PRESENT" \
+	--arg primary "$PRIMARY_REVIEW" \
+	--arg specialist "$SPECIALIST_REVIEW" \
+	--arg product "$PRODUCT_REVIEW" \
+	--arg ci "$CI_EVIDENCE" \
+	--arg local_checks "$LOCAL_CHECKS" \
+	--arg evidence "$EVIDENCE_NOTE" \
+	--argjson primary_required "$PRIMARY_REQUIRED" \
+	--argjson specialist_required "$SPECIALIST_REQUIRED" \
+	--argjson product_required "$PRODUCT_REQUIRED" \
+	--argjson rerun_ci "$RERUN_CI" \
+	--argjson full_local_checks "$FULL_LOCAL_CHECKS" \
+	--argjson evidence_required "$EVIDENCE_REQUIRED" '
+  {
+    schema_version: 1,
+    profile: $profile,
+    context: {
+      risk: $risk,
+      release: $release,
+      user_facing: $user_facing,
+      target_policy_authoritative: true,
+      worktree_policy_present: $worktree_policy_present
+    },
+    settings: {
+      primary_review: $primary,
+      specialist_review: $specialist,
+      product_review: $product,
+      ci_evidence: $ci,
+      local_checks: $local_checks,
+      evidence_note: $evidence
+    },
+    required: {
+      primary_review: $primary_required,
+      specialist_review: $specialist_required,
+      product_review: $product_required,
+      rerun_ci: $rerun_ci,
+      full_local_checks: $full_local_checks,
+      evidence_note: $evidence_required
+    }
+  }
+')
+
+AUDIT="${HOME:-/tmp}/.agentkit/review-audit.log"
+mkdir -p "${AUDIT%/*}" 2>/dev/null || true
+printf '%s\tPROFILE\tprofile=%s\trisk=%s\trelease=%s\tuser_facing=%s\tprimary=%s\tspecialist=%s\tproduct=%s\tci=%s\tlocal=%s\tevidence=%s\tworktree_policy=%s\n' \
+	"$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || printf 'timestamp-unavailable')" \
+	"$PROFILE" "$RISK" "$RELEASE" "$USER_FACING" "$PRIMARY_REQUIRED" "$SPECIALIST_REQUIRED" \
+	"$PRODUCT_REQUIRED" "$CI_EVIDENCE" "$LOCAL_CHECKS" "$EVIDENCE_REQUIRED" "$WORKTREE_POLICY_PRESENT" \
+	>>"$AUDIT" 2>/dev/null || true
+
+printf '%s\n' "$RESULT"

--- a/tools/review-profile
+++ b/tools/review-profile
@@ -19,7 +19,18 @@ usage() {
 	printf '%s\n' \
 		'usage: review-profile [--profile fast|balanced|strict]' \
 		'  [--risk trivial|standard|critical] [--release] [--user-facing]' \
-		'  [--repo PATH]' >&2
+		'  [--repo PATH]' \
+		'' \
+		'profiles:' \
+		'  fast: primary review for nontrivial work; product review at release' \
+		'  balanced: primary review plus risk-triggered specialist and product lanes' \
+		'  strict: all review lanes, full local checks, and a fresh CI run' \
+		'' \
+		'context:' \
+		'  --risk trivial|standard|critical  classify the change risk' \
+		'  --release                         mark release work' \
+		'  --user-facing                     mark a user-visible change' \
+		'  --repo PATH                       read repository review configuration' >&2
 	exit "$status"
 }
 


### PR DESCRIPTION
## Summary

- add portable `fast`, `balanced`, and `strict` review profiles with global, repository, environment, and CLI selection
- make specialist, product, CI, local-check, and evidence requirements risk-aware while preserving target-owned policy authority
- normalize legacy PASS verdict casing, record profile/gate timing telemetry, and install the resolver across supported clients
- freeze deterministic preflight before exact-head CI/review dispatch and reuse exact-SHA CI evidence when configured

## Verification

- Exact head: `ca374cd11f6cad44bb3a966fc543696925afa668`
- Full Linux product suite: 736 passed, 6 environment-skipped, 0 failed
- Focused Codex policy matrix: 1 passed, 0 failed
- Plugin mirrors, install routing, review policy classification, and product manifest are covered by the full suite

## Risk and rollout

- This changes review governance and is therefore classified as critical by AgentKit target policy.
- `balanced` remains the default; `strict` preserves unconditional review lanes.
- Repository target policy remains authoritative and cannot be weakened by a local profile.
- Install machine-wide only after exact-head CI and mandatory review lanes pass.

Related to #74.
