### PR TITLE
feat(product-intelligence): composition and part_of schemas

### DIFF
--- a/plugins-cc/agentkit/skills/product-intelligence/SKILL.md
+++ b/plugins-cc/agentkit/skills/product-intelligence/SKILL.md
@@ -204,6 +204,81 @@ one namespace across kinds: a handle names exactly one source. Cross-origin cont
 promising what no repo implements) are exactly what the single shared
 ledger exists to surface.
 
+## Composition: one product, several repos
+
+A product spread across repos gets a **product repo** that declares it — one
+product per product repo, and that repo need not hold code. It carries
+`product.yaml` (`schemas/product.schema.json`): product identity, the parts,
+where the evidence lives, and the published page.
+
+Each part names what it is (`repo`, `site` or `service`), where it lives
+(`target`), and what it does for the product (`role`). Components point back
+with a `part_of` marker, so the composition is discoverable from either end
+rather than only from the middle:
+
+```mermaid
+flowchart LR
+  P["product repo<br/>product.yaml<br/>composition.parts[]"] -->|declares| A[engine repo]
+  P -->|declares| B[console repo]
+  A -->|part_of| P
+  B -->|part_of| P
+```
+
+The marker lives **inside the component's existing `.agentkit/product.yaml`**,
+above the surfaces product-review reads — one committed file per component
+answers both "how do I run this" and "what is this part of". It carries
+`product_repo` and this component's `part` id (plus the product `name`, so a
+reader without access to a private product repo still knows what it belongs
+to). The validator checks that block and leaves the surfaces to product-review.
+
+Validate either document with the same CLI as briefs and ledgers — the
+document kind is detected from its top-level key:
+
+```sh
+bun skills/product-intelligence/scripts/validate.ts product.yaml .agentkit/product.yaml
+```
+
+Beyond the schema it enforces what a schema cannot: part ids are unique, and
+every `evidence` and `site.entry` pointer resolves on disk. A declaration whose
+evidence has moved reads as sourced right up until somebody follows it.
+
+### Derived origins
+
+A multi-repo product's `subject.origins` are **derived from the declaration,
+not retyped** — hand-copying is how a brief ends up citing a repo the product
+no longer contains:
+
+```sh
+bun skills/product-intelligence/scripts/origins.ts product.yaml            # pasteable YAML
+bun skills/product-intelligence/scripts/origins.ts product.yaml --json
+bun skills/product-intelligence/scripts/origins.ts product.yaml --check brief.yaml
+```
+
+One part becomes one origin, keyed by the part id: `repo` and `site` pass
+through, and a `service` part derives a `site` origin — a brief has no kind for
+something that runs, and a service is evidence you acquire by visiting its URL.
+`--check` exits non-zero on drift in either direction: a part with no origin,
+or an origin matching no part.
+
+The declaration carries no self-locator, so the product repo itself is not
+emitted as an origin. When the brief cites the product repo's own documents,
+add that origin by hand.
+
+### Workspace orientation
+
+For an agent landing in a multi-repo workspace, generate the page that says
+what the product is, which parts exist, where each lives, and where the
+evidence sits:
+
+```sh
+bun skills/product-intelligence/scripts/orient.ts product.yaml   # writes ORIENTATION.md
+```
+
+It is derived output — regenerate it rather than editing it, and never orient
+from a declaration that does not validate. A worked example of the whole loop
+(declaration, component marker, derived origins, generated page) is in
+`examples/composition/`.
+
 ## Refresh mode
 
 Re-running against the same subject keeps the section order stable and diffs

--- a/plugins-cc/agentkit/skills/product-intelligence/SKILL.md
+++ b/plugins-cc/agentkit/skills/product-intelligence/SKILL.md
@@ -257,12 +257,20 @@ bun skills/product-intelligence/scripts/origins.ts product.yaml --check brief.ya
 One part becomes one origin, keyed by the part id: `repo` and `site` pass
 through, and a `service` part derives a `site` origin — a brief has no kind for
 something that runs, and a service is evidence you acquire by visiting its URL.
-`--check` exits non-zero on drift in either direction: a part with no origin,
-or an origin matching no part.
 
-The declaration carries no self-locator, so the product repo itself is not
-emitted as an origin. When the brief cites the product repo's own documents,
-add that origin by hand.
+`--check` fails when a declared part has no origin in the brief, or when the
+brief cites that part under a different target. Targets compare canonically, so
+a clone URL and its `owner/repo` short form are the same repository — both
+schemas advertise the two notations as interchangeable, and a checker that
+disagreed would report one repo as missing and unrecognised at once. Two
+different hosts are still two repositories.
+
+The check is deliberately **one-directional**: every part must be cited, but a
+brief may legitimately cite sources that are not parts — the product repo's own
+documents, or a supplied docset. Those are reported as `note:` lines and do not
+fail the check. The declaration carries no self-locator, so the product repo is
+never derived as an origin; cite it in the brief when its documents are
+evidence, and the note is the acknowledgement, not a defect to chase.
 
 ### Workspace orientation
 

--- a/plugins-cc/agentkit/skills/product-intelligence/SKILL.md
+++ b/plugins-cc/agentkit/skills/product-intelligence/SKILL.md
@@ -262,8 +262,13 @@ something that runs, and a service is evidence you acquire by visiting its URL.
 brief cites that part under a different target. Targets compare canonically, so
 a clone URL and its `owner/repo` short form are the same repository — both
 schemas advertise the two notations as interchangeable, and a checker that
-disagreed would report one repo as missing and unrecognised at once. Two
-different hosts are still two repositories.
+disagreed would report one repo as missing and unrecognised at once.
+
+Canonical means the host (case-folded, and two different hosts stay two
+repositories) plus the **whole** remaining path. Subgroups are ordinary
+segments, so `acme/platform/engine` and `other/platform/engine` are different
+repos, and the bare `owner/repo` shorthand matches a hosted path only when that
+path is exactly `owner/repo` — never the tail of a deeper one.
 
 The check is deliberately **one-directional**: every part must be cited, but a
 brief may legitimately cite sources that are not parts — the product repo's own

--- a/plugins-cc/agentkit/skills/product-intelligence/examples/README.md
+++ b/plugins-cc/agentkit/skills/product-intelligence/examples/README.md
@@ -3,11 +3,12 @@
 Each directory is a complete, schema-valid artifact set for one evidence
 situation. The subjects are fictional; the shapes are the contract.
 
-| Example         | Demonstrates                                                                                                                               |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `website-only/` | Site locators only; repo-side facts land in `cannot_verify`, not guesses                                                                   |
-| `repo-only/`    | Repo + release locators; adoption/registry facts are `cannot_verify`                                                                       |
-| `mixed/`        | Both surfaces, an unresolved contradiction rendered in the brief, and the full set: `brief.yaml`, `ledger.yaml`, `brief.md`, `findings.md` |
+| Example         | Demonstrates                                                                                                                                               |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `website-only/` | Site locators only; repo-side facts land in `cannot_verify`, not guesses                                                                                   |
+| `repo-only/`    | Repo + release locators; adoption/registry facts are `cannot_verify`                                                                                       |
+| `mixed/`        | Both surfaces, an unresolved contradiction rendered in the brief, and the full set: `brief.yaml`, `ledger.yaml`, `brief.md`, `findings.md`                 |
+| `composition/`  | A product spread across several repos: the `product.yaml` declaration, a component's `part_of` marker, derived origins, and the generated `ORIENTATION.md` |
 
 Validate any of them:
 

--- a/plugins-cc/agentkit/skills/product-intelligence/examples/composition/ORIENTATION.md
+++ b/plugins-cc/agentkit/skills/product-intelligence/examples/composition/ORIENTATION.md
@@ -32,7 +32,7 @@ Paths are relative to the product declaration.
 
 ## Working here
 
-Each part above is a separate repo or service with its own clone. A component
-names the part it is via `part_of` in its `.agentkit/product.yaml`; that marker
-and this declaration must agree on the id, so `acme-platform` is
-discoverable from either end.
+Each part above is a separate repo or service with its own clone. The
+convention is that a component names the part it is with a `part_of` block in
+its `.agentkit/product.yaml`, reusing the id from this table. A component
+without one is still reachable from here, but does not point back.

--- a/plugins-cc/agentkit/skills/product-intelligence/examples/composition/ORIENTATION.md
+++ b/plugins-cc/agentkit/skills/product-intelligence/examples/composition/ORIENTATION.md
@@ -1,0 +1,38 @@
+# acme-platform — workspace orientation
+
+Rules engine plus operator console, sold and supported as one platform rather than as two tools that happen to share a name.
+
+Homepage: <https://acme.example>
+
+`acme-platform` is one product spread across 3 parts. This file
+is generated from the product declaration — edit that, then regenerate.
+
+## Parts
+
+| Part      | Role              | Kind    | Where                    | Visibility |
+| --------- | ----------------- | ------- | ------------------------ | ---------- |
+| `engine`  | core              | repo    | acme/engine              | public     |
+| `console` | operator UI       | repo    | acme/console             | public     |
+| `cloud`   | hosted deployment | service | https://app.acme.example | private    |
+
+### What each part holds
+
+- **engine** — The rules engine itself, its CLI, and the wire format the console speaks. The part a user installs.
+- **console** — Web console for authoring and inspecting rule sets. Ships separately because it is optional; the engine runs headless.
+- **cloud** — The managed instance. Not a repository — it is where the two repos above are observed running together.
+
+## Evidence and published page
+
+- brief: `brief.yaml`
+- ledger: `ledger.yaml`
+- site entry: `index.md`
+- published at: <https://pages.acme.example/acme-platform>
+
+Paths are relative to the product declaration.
+
+## Working here
+
+Each part above is a separate repo or service with its own clone. A component
+names the part it is via `part_of` in its `.agentkit/product.yaml`; that marker
+and this declaration must agree on the id, so `acme-platform` is
+discoverable from either end.

--- a/plugins-cc/agentkit/skills/product-intelligence/examples/composition/brief.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/examples/composition/brief.yaml
@@ -1,0 +1,23 @@
+brief_version: "1.0"
+subject:
+  name: acme-platform
+  homepage: https://acme.example
+  one_liner: Rules engine plus operator console, sold and supported as one platform.
+  origins:
+    - id: engine
+      kind: repo
+      target: acme/engine
+    - id: console
+      kind: repo
+      target: acme/console
+    - id: cloud
+      kind: site
+      target: https://app.acme.example
+evidence:
+  ledger: ledger.yaml
+  acquired_at: "2026-07-28"
+positioning:
+  target_customer: platform teams
+  need: one supported surface across engine and console
+  category: rules platform
+  claims: [C-001]

--- a/plugins-cc/agentkit/skills/product-intelligence/examples/composition/component-product.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/examples/composition/component-product.yaml
@@ -1,0 +1,22 @@
+# What `acme/engine` commits as its own `.agentkit/product.yaml`. The `part_of`
+# block is the back-pointer; everything below it is the product-review manifest
+# that file already carries, shown here so the two are visibly one file.
+
+part_of:
+  product: acme-platform
+  product_repo: acme/product
+  part: engine
+
+summary: >-
+  Rules engine and CLI. Serves rule sets headless; the operator console is a
+  separate part of the same product.
+
+surfaces:
+  - name: engine
+    kind: cli
+    build: cargo build --release
+    verify: cargo test --workspace
+    run: ./target/release/acme-engine serve --rules examples/basic.yaml
+    expect: |
+      Binds a local port and answers a rule evaluation with a decision rather
+      than an error.

--- a/plugins-cc/agentkit/skills/product-intelligence/examples/composition/index.md
+++ b/plugins-cc/agentkit/skills/product-intelligence/examples/composition/index.md
@@ -1,0 +1,6 @@
+# acme-platform
+
+Rules engine plus operator console, sold and supported as one platform.
+
+The published page is rendered from `brief.yaml` and `ledger.yaml`; this file
+exists so the declaration's `site.entry` pointer resolves to something real.

--- a/plugins-cc/agentkit/skills/product-intelligence/examples/composition/ledger.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/examples/composition/ledger.yaml
@@ -1,0 +1,22 @@
+ledger_version: "1.0"
+generated_by: product-intelligence
+generated_at: "2026-07-28T09:00:00Z"
+claims:
+  - id: C-001
+    statement: The engine runs without the console.
+    class: observed
+    confidence: high
+    sources:
+      - locator: "repo:engine:README.md:8"
+        quote: "The console is optional; acme-engine serves rules headless."
+        stance: supports
+        as_of: "2026-07-28"
+  - id: C-002
+    statement: The console is distributed as a separate repository.
+    class: observed
+    confidence: high
+    sources:
+      - locator: "repo:console:README.md:1"
+        quote: "Operator console for acme-engine."
+        stance: supports
+        as_of: "2026-07-28"

--- a/plugins-cc/agentkit/skills/product-intelligence/examples/composition/product.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/examples/composition/product.yaml
@@ -1,0 +1,45 @@
+product_version: "0.1"
+
+product:
+  name: acme-platform
+  one_liner: >-
+    Rules engine plus operator console, sold and supported as one platform
+    rather than as two tools that happen to share a name.
+  homepage: https://acme.example
+
+composition:
+  parts:
+    - id: engine
+      role: core
+      kind: repo
+      target: acme/engine
+      visibility: public
+      description: >-
+        The rules engine itself, its CLI, and the wire format the console
+        speaks. The part a user installs.
+
+    - id: console
+      role: operator UI
+      kind: repo
+      target: acme/console
+      visibility: public
+      description: >-
+        Web console for authoring and inspecting rule sets. Ships separately
+        because it is optional; the engine runs headless.
+
+    - id: cloud
+      role: hosted deployment
+      kind: service
+      target: https://app.acme.example
+      visibility: private
+      description: >-
+        The managed instance. Not a repository — it is where the two repos
+        above are observed running together.
+
+evidence:
+  brief: brief.yaml
+  ledger: ledger.yaml
+
+site:
+  entry: index.md
+  published_at: https://pages.acme.example/acme-platform

--- a/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/part-of-missing-part.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/part-of-missing-part.yaml
@@ -1,0 +1,4 @@
+part_of:
+  product: acme-platform
+  product_repo: acme/product
+summary: Rules engine and CLI.

--- a/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/part-of-unslugged-id.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/part-of-unslugged-id.yaml
@@ -1,0 +1,4 @@
+part_of:
+  product_repo: acme/product
+  part: Engine Core
+summary: Rules engine and CLI.

--- a/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/product-dangling-evidence.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/product-dangling-evidence.yaml
@@ -1,0 +1,10 @@
+product_version: "0.1"
+product:
+  name: acme-platform
+composition:
+  parts:
+    - id: engine
+      kind: repo
+      target: acme/engine
+evidence:
+  ledger: nowhere/ledger.yaml

--- a/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/product-duplicate-part-id.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/product-duplicate-part-id.yaml
@@ -1,0 +1,11 @@
+product_version: "0.1"
+product:
+  name: acme-platform
+composition:
+  parts:
+    - id: engine
+      kind: repo
+      target: acme/engine
+    - id: engine
+      kind: repo
+      target: acme/engine-v2

--- a/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/product-empty-parts.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/product-empty-parts.yaml
@@ -1,0 +1,5 @@
+product_version: "0.1"
+product:
+  name: acme-platform
+composition:
+  parts: []

--- a/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/product-missing-part-target.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/product-missing-part-target.yaml
@@ -1,0 +1,7 @@
+product_version: "0.1"
+product:
+  name: acme-platform
+composition:
+  parts:
+    - id: engine
+      kind: repo

--- a/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/product-unknown-part-kind.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/invalid/product-unknown-part-kind.yaml
@@ -1,0 +1,8 @@
+product_version: "0.1"
+product:
+  name: acme-platform
+composition:
+  parts:
+    - id: engine
+      kind: package
+      target: acme/engine

--- a/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/valid/part-of.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/valid/part-of.yaml
@@ -1,0 +1,9 @@
+part_of:
+  product: acme-platform
+  product_repo: acme/product
+  part: engine
+summary: Rules engine and CLI.
+surfaces:
+  - name: engine
+    kind: cli
+    build: cargo build --release

--- a/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/valid/product.minimal.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/valid/product.minimal.yaml
@@ -1,0 +1,8 @@
+product_version: "0.1"
+product:
+  name: acme-notes
+composition:
+  parts:
+    - id: app
+      kind: repo
+      target: acme/notes

--- a/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/valid/product.yaml
+++ b/plugins-cc/agentkit/skills/product-intelligence/schemas/fixtures/valid/product.yaml
@@ -1,0 +1,26 @@
+product_version: "0.1"
+product:
+  name: acme-platform
+  one_liner: Rules engine plus operator console, sold as one platform.
+  homepage: https://acme.example
+composition:
+  parts:
+    - id: engine
+      role: core
+      kind: repo
+      target: acme/engine
+      visibility: public
+      description: The rules engine and its CLI.
+    - id: docs
+      role: documentation
+      kind: site
+      target: https://docs.acme.example
+      visibility: public
+    - id: cloud
+      role: hosted deployment
+      kind: service
+      target: https://app.acme.example
+      visibility: private
+evidence:
+  brief: brief.yaml
+  ledger: ledger.yaml

--- a/plugins-cc/agentkit/skills/product-intelligence/schemas/part-of.schema.json
+++ b/plugins-cc/agentkit/skills/product-intelligence/schemas/part-of.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agentkit.sbs/schemas/product-intelligence/part-of.schema.json",
+  "title": "Component part-of marker",
+  "description": "The back-pointer a component repo carries to the product it belongs to. It lives as a `part_of` key inside the component's existing `.agentkit/product.yaml`, alongside the surfaces product-review reads; the validator checks this block and leaves the rest of that file to product-review. Deliberately minimal: it names the product repo and this component's part id, and nothing that would drift from the declaration those two resolve to.",
+  "type": "object",
+  "required": ["product_repo", "part"],
+  "additionalProperties": false,
+  "properties": {
+    "product_repo": {
+      "description": "Locator of the product repo holding the product.yaml declaration — a clone URL or owner/repo. Following it is how a reader gets from one component to the whole product.",
+      "type": "string",
+      "minLength": 1
+    },
+    "part": {
+      "description": "This component's id in that declaration's composition.parts[]. The two must agree; a marker naming a part the declaration does not list points at nothing.",
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]*$"
+    },
+    "product": {
+      "description": "Product name, repeated here so a reader offline — or without access to a private product repo — still knows what this is part of. Optional because it is derivable; duplicated because the derivation needs network and permission.",
+      "type": "string",
+      "minLength": 1
+    }
+  }
+}

--- a/plugins-cc/agentkit/skills/product-intelligence/schemas/product.schema.json
+++ b/plugins-cc/agentkit/skills/product-intelligence/schemas/product.schema.json
@@ -42,6 +42,7 @@
       "properties": {
         "parts": {
           "type": "array",
+          "minItems": 1,
           "items": { "$ref": "#/$defs/part" }
         }
       }

--- a/plugins-cc/agentkit/skills/product-intelligence/schemas/product.schema.json
+++ b/plugins-cc/agentkit/skills/product-intelligence/schemas/product.schema.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agentkit.sbs/schemas/product-intelligence/product.schema.json",
+  "title": "Product declaration",
+  "description": "What a product IS and which repositories, sites and services compose it. One product per product repo; the product repo need not hold code. Components point back with a `part_of` marker, so the composition is discoverable from either end. This file is also the deterministic input for a brief's subject.origins and for a workspace orientation page — hand-typing either is what it exists to prevent.",
+  "type": "object",
+  "required": ["product_version", "product", "composition"],
+  "additionalProperties": false,
+  "properties": {
+    "product_version": {
+      "description": "Semver of the product-declaration schema this document targets. Backward-compatible across minors.",
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+(\\.[0-9]+)?$"
+    },
+    "product": {
+      "type": "object",
+      "required": ["name"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "description": "Product name as its makers use it. Matches the brief's subject.name.",
+          "type": "string",
+          "minLength": 1
+        },
+        "one_liner": {
+          "description": "What the product is in one sentence, from a user's point of view — not the architecture.",
+          "type": "string",
+          "minLength": 1
+        },
+        "homepage": {
+          "description": "Canonical marketing/site URL.",
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "composition": {
+      "description": "The parts the product is made of. A single-repo product declares one part; nothing here assumes several.",
+      "type": "object",
+      "required": ["parts"],
+      "additionalProperties": false,
+      "properties": {
+        "parts": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/part" }
+        }
+      }
+    },
+    "evidence": {
+      "description": "Where the evidence about this product lives, as paths relative to this file. The validator resolves them: a pointer that no longer resolves is a rotted pointer, not a warning.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "brief": { "type": "string", "minLength": 1 },
+        "ledger": { "type": "string", "minLength": 1 },
+        "findings": { "type": "string", "minLength": 1 },
+        "acquisition": { "type": "string", "minLength": 1 }
+      }
+    },
+    "site": {
+      "description": "The product's published page, derived from the evidence rather than hand-edited.",
+      "type": "object",
+      "required": ["entry"],
+      "additionalProperties": false,
+      "properties": {
+        "entry": {
+          "description": "Page source, relative to this file.",
+          "type": "string",
+          "minLength": 1
+        },
+        "published_at": {
+          "description": "URL the entry is published to.",
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  },
+  "$defs": {
+    "part": {
+      "type": "object",
+      "required": ["id", "kind", "target"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "description": "Short handle for this part. It is the id a component repeats in its `part_of` marker, and the origin id derived for a brief, so it must stay stable once published.",
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9-]*$"
+        },
+        "kind": {
+          "description": "What the part physically is: a repository, a published site, or a running service.",
+          "enum": ["repo", "site", "service"]
+        },
+        "target": {
+          "description": "Where the part lives: a clone URL, owner/repo, or service URL. Named `target` to match the brief's origin field it derives into.",
+          "type": "string",
+          "minLength": 1
+        },
+        "role": {
+          "description": "What this part does for the product, in one line. Free text on purpose — a fixed vocabulary would force every product into one shape.",
+          "type": "string",
+          "minLength": 1
+        },
+        "visibility": {
+          "description": "Whether someone outside the team can reach the target. A private part is why a reader cannot verify it, not an omission.",
+          "enum": ["public", "private"]
+        },
+        "description": {
+          "description": "What the part contains, for a reader who has not opened it.",
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/plugins-cc/agentkit/skills/product-intelligence/scripts/orient.ts
+++ b/plugins-cc/agentkit/skills/product-intelligence/scripts/orient.ts
@@ -1,0 +1,113 @@
+#!/usr/bin/env bun
+// Generates the page an agent reads on landing in a multi-repo workspace: what
+// the product is, which parts it has, where each one lives, and where the
+// evidence about it sits. Derived from the declaration, never hand-edited.
+
+import { writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { type Part, parseDocument, partsOf, validateFile } from './validate.ts';
+
+type Dict = Record<string, any>;
+
+function collapse(value: unknown): string {
+  return String(value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+// A pipe inside a role or target would split the cell and silently shift every
+// column after it.
+function cell(value: unknown): string {
+  return collapse(value).replace(/\|/g, '\\|') || '—';
+}
+
+function heading(product: Dict): string[] {
+  const name = collapse(product.product?.name);
+  const lines = [`# ${name} — workspace orientation`, ''];
+  if (product.product?.one_liner) lines.push(collapse(product.product.one_liner), '');
+  if (product.product?.homepage) lines.push(`Homepage: <${collapse(product.product.homepage)}>`, '');
+  const count = partsOf(product).length;
+  lines.push(
+    `\`${name}\` is one product spread across ${count} ${count === 1 ? 'part' : 'parts'}. This file`,
+    'is generated from the product declaration — edit that, then regenerate.',
+    '',
+  );
+  return lines;
+}
+
+// Columns are padded to the width dprint would align them to, so the committed
+// example survives a repo-wide format run byte-identical to what this emits.
+function table(rows: string[][]): string[] {
+  const widths = rows[0]?.map((_, i) => Math.max(...rows.map((row) => (row[i] as string).length))) ?? [];
+  const line = (row: string[]) => `| ${row.map((c, i) => c.padEnd(widths[i] as number)).join(' | ')} |`;
+  const [header, ...body] = rows as [string[], ...string[][]];
+  return [line(header), line(widths.map((w) => '-'.repeat(w))), ...body.map(line)];
+}
+
+function partsTable(product: Dict): string[] {
+  const rows = [['Part', 'Role', 'Kind', 'Where', 'Visibility']];
+  for (const part of partsOf(product) as Part[]) {
+    rows.push([`\`${cell(part.id)}\``, cell(part.role), cell(part.kind), cell(part.target), cell(part.visibility)]);
+  }
+  const lines = ['## Parts', '', ...table(rows), ''];
+
+  const described = (partsOf(product) as Part[]).filter((part) => part.description);
+  if (described.length > 0) {
+    lines.push('### What each part holds', '');
+    for (const part of described) lines.push(`- **${cell(part.id)}** — ${collapse(part.description)}`);
+    lines.push('');
+  }
+  return lines;
+}
+
+function evidenceSection(product: Dict): string[] {
+  const evidence = (product.evidence ?? {}) as Dict;
+  const entries = Object.entries(evidence).filter(([, value]) => typeof value === 'string');
+  if (entries.length === 0 && !product.site) return [];
+
+  const lines = ['## Evidence and published page', ''];
+  for (const [field, value] of entries) lines.push(`- ${field}: \`${cell(value)}\``);
+  if (product.site?.entry) lines.push(`- site entry: \`${cell(product.site.entry)}\``);
+  if (product.site?.published_at) lines.push(`- published at: <${collapse(product.site.published_at)}>`);
+  lines.push('', 'Paths are relative to the product declaration.', '');
+  return lines;
+}
+
+function claimingSection(product: Dict): string[] {
+  return [
+    '## Working here',
+    '',
+    'Each part above is a separate repo or service with its own clone. A component',
+    'names the part it is via `part_of` in its `.agentkit/product.yaml`; that marker',
+    `and this declaration must agree on the id, so \`${collapse(product.product?.name)}\` is`,
+    'discoverable from either end.',
+    '',
+  ];
+}
+
+export function renderOrientation(productPath: string): string {
+  const errors = validateFile(productPath);
+  if (errors.length > 0) throw new Error(`invalid declaration:\n${errors.map((e) => `  ${e}`).join('\n')}`);
+  const product = parseDocument(productPath) as Dict;
+  return [
+    ...heading(product),
+    ...partsTable(product),
+    ...evidenceSection(product),
+    ...claimingSection(product),
+  ].join('\n');
+}
+
+if (import.meta.main) {
+  const [productPath, outFlag, outPath] = process.argv.slice(2);
+  if (!productPath || (outFlag && (outFlag !== '--out' || !outPath))) {
+    console.error('usage: orient.ts <product.yaml> [--out <file>]');
+    process.exit(2);
+  }
+  try {
+    const page = renderOrientation(productPath);
+    const target = outPath ?? join(dirname(productPath), 'ORIENTATION.md');
+    writeFileSync(target, page);
+    console.log(target);
+  } catch (error) {
+    console.error(`error: ${(error as Error).message}`);
+    process.exit(1);
+  }
+}

--- a/plugins-cc/agentkit/skills/product-intelligence/scripts/orient.ts
+++ b/plugins-cc/agentkit/skills/product-intelligence/scripts/orient.ts
@@ -71,14 +71,17 @@ function evidenceSection(product: Dict): string[] {
   return lines;
 }
 
-function claimingSection(product: Dict): string[] {
+// States the convention, never that the components currently follow it — this
+// page is generated, and a generated page that reports unverified state as
+// fact is the failure the skill exists to prevent.
+function conventionSection(): string[] {
   return [
     '## Working here',
     '',
-    'Each part above is a separate repo or service with its own clone. A component',
-    'names the part it is via `part_of` in its `.agentkit/product.yaml`; that marker',
-    `and this declaration must agree on the id, so \`${collapse(product.product?.name)}\` is`,
-    'discoverable from either end.',
+    'Each part above is a separate repo or service with its own clone. The',
+    'convention is that a component names the part it is with a `part_of` block in',
+    'its `.agentkit/product.yaml`, reusing the id from this table. A component',
+    'without one is still reachable from here, but does not point back.',
     '',
   ];
 }
@@ -91,7 +94,7 @@ export function renderOrientation(productPath: string): string {
     ...heading(product),
     ...partsTable(product),
     ...evidenceSection(product),
-    ...claimingSection(product),
+    ...conventionSection(),
   ].join('\n');
 }
 

--- a/plugins-cc/agentkit/skills/product-intelligence/scripts/origins.ts
+++ b/plugins-cc/agentkit/skills/product-intelligence/scripts/origins.ts
@@ -40,31 +40,27 @@ export interface CanonicalTarget {
 }
 
 // Both schemas advertise a clone URL and `owner/repo` as the same thing, so
-// comparing the raw strings reports one repository as simultaneously missing
-// and unrecognised. Reduce to owner/repo, keeping the host when it is stated:
-// two hosts that disagree are two repositories, not one written two ways.
-export function canonicalTarget(kind: string, target: string): CanonicalTarget {
+// raw string comparison reports one repo as missing and unrecognised at once.
+// The path after the host is kept WHOLE: a GitLab subgroup is an ordinary
+// segment, and reducing to the last two would make acme/platform/engine and
+// other/platform/engine one repository.
+export function canonicalTarget(target: string): CanonicalTarget {
   const trimmed = target.trim().replace(/\/+$/, '');
   const scp = /^(?:[\w.-]+@)?([\w.-]+\.[a-z]{2,}):(.+)$/i.exec(trimmed);
   const hostPath = scp
     ? `${scp[1]}/${scp[2]}`
     : trimmed.replace(/^[a-z][a-z0-9+.-]*:\/\//i, '').replace(/^[\w.-]+@/, '');
-  const bare = hostPath.replace(/\.git$/, '');
-  const segments = bare.split('/').filter(Boolean);
-  const host = (segments[0] ?? '').includes('.') ? (segments[0] as string).toLowerCase() : undefined;
+  const segments = hostPath.replace(/\.git$/, '').split('/').filter(Boolean);
 
   // Hostnames are case-insensitive by DNS; the path after them is not, on any
   // forge or web server, so only the host is folded.
-  if (kind !== 'repo') {
-    return host === undefined ? { path: bare } : { host, path: segments.slice(1).join('/') };
-  }
-  if (segments.length <= 2) return { path: segments.join('/') };
-  return { host, path: segments.slice(-2).join('/') };
+  if (!(segments[0] ?? '').includes('.')) return { path: segments.join('/') };
+  return { host: (segments[0] as string).toLowerCase(), path: segments.slice(1).join('/') };
 }
 
 export function sameTarget(a: Origin, b: Origin): boolean {
-  const left = canonicalTarget(a.kind, a.target);
-  const right = canonicalTarget(b.kind, b.target);
+  const left = canonicalTarget(a.target);
+  const right = canonicalTarget(b.target);
   if (left.path !== right.path) return false;
   return left.host === undefined || right.host === undefined || left.host === right.host;
 }

--- a/plugins-cc/agentkit/skills/product-intelligence/scripts/origins.ts
+++ b/plugins-cc/agentkit/skills/product-intelligence/scripts/origins.ts
@@ -34,28 +34,74 @@ export function formatOrigins(origins: Origin[]): string {
   return `${lines.join('\n')}\n`;
 }
 
-function key(origin: Origin): string {
-  return `${origin.id}|${origin.kind}|${origin.target}`;
+export interface CanonicalTarget {
+  host?: string;
+  path: string;
 }
 
-export function checkOrigins(derived: Origin[], brief: unknown): string[] {
+// Both schemas advertise a clone URL and `owner/repo` as the same thing, so
+// comparing the raw strings reports one repository as simultaneously missing
+// and unrecognised. Reduce to owner/repo, keeping the host when it is stated:
+// two hosts that disagree are two repositories, not one written two ways.
+export function canonicalTarget(kind: string, target: string): CanonicalTarget {
+  const trimmed = target.trim().replace(/\/+$/, '');
+  const scp = /^(?:[\w.-]+@)?([\w.-]+\.[a-z]{2,}):(.+)$/i.exec(trimmed);
+  const hostPath = scp
+    ? `${scp[1]}/${scp[2]}`
+    : trimmed.replace(/^[a-z][a-z0-9+.-]*:\/\//i, '').replace(/^[\w.-]+@/, '');
+  const bare = hostPath.replace(/\.git$/, '');
+  const segments = bare.split('/').filter(Boolean);
+  const host = (segments[0] ?? '').includes('.') ? (segments[0] as string).toLowerCase() : undefined;
+
+  // Hostnames are case-insensitive by DNS; the path after them is not, on any
+  // forge or web server, so only the host is folded.
+  if (kind !== 'repo') {
+    return host === undefined ? { path: bare } : { host, path: segments.slice(1).join('/') };
+  }
+  if (segments.length <= 2) return { path: segments.join('/') };
+  return { host, path: segments.slice(-2).join('/') };
+}
+
+export function sameTarget(a: Origin, b: Origin): boolean {
+  const left = canonicalTarget(a.kind, a.target);
+  const right = canonicalTarget(b.kind, b.target);
+  if (left.path !== right.path) return false;
+  return left.host === undefined || right.host === undefined || left.host === right.host;
+}
+
+export interface OriginCheck {
+  errors: string[];
+  notes: string[];
+}
+
+// One-directional on purpose: every part must be cited, but a brief may cite
+// sources that are not parts — the product repo's own documents, a supplied
+// docset — so an unmatched origin is reported without failing the check.
+export function checkOrigins(derived: Origin[], brief: unknown): OriginCheck {
   const declared = (((brief as Record<string, unknown>).subject as Record<string, unknown> | undefined)
     ?.origins ?? []) as Origin[];
   const errors: string[] = [];
-  const declaredKeys = new Set(declared.map(key));
-  const derivedKeys = new Set(derived.map(key));
+  const notes: string[] = [];
+  const byId = new Map(declared.map((origin) => [origin.id, origin]));
 
-  for (const origin of derived) {
-    if (!declaredKeys.has(key(origin))) {
-      errors.push(`missing origin for part '${origin.id}': ${origin.kind} ${origin.target}`);
+  for (const part of derived) {
+    const cited = byId.get(part.id);
+    if (!cited) {
+      errors.push(`missing origin for part '${part.id}': ${part.kind} ${part.target}`);
+    } else if (cited.kind !== part.kind || !sameTarget(part, cited)) {
+      errors.push(
+        `origin '${part.id}' cites ${cited.kind} ${cited.target}, but the part declares ${part.kind} ${part.target}`,
+      );
     }
   }
+
+  const partIds = new Set(derived.map((origin) => origin.id));
   for (const origin of declared) {
-    if (!derivedKeys.has(key(origin))) {
-      errors.push(`origin '${origin.id}' is not derived from any part: ${origin.kind} ${origin.target}`);
+    if (!partIds.has(origin.id)) {
+      notes.push(`origin '${origin.id}' is not a declared part: ${origin.kind} ${origin.target}`);
     }
   }
-  return errors;
+  return { errors, notes };
 }
 
 function load(path: string): unknown {
@@ -76,10 +122,14 @@ if (import.meta.main) {
   }
   const origins = deriveOrigins(load(productPath));
   if (flag === '--check') {
-    const drift = checkOrigins(origins, Bun.YAML.parse(readFileSync(briefPath as string, 'utf-8')));
-    for (const error of drift) console.error(`error: ${briefPath}: ${error}`);
-    if (drift.length > 0) process.exit(1);
-    console.log(`ok: ${briefPath} origins match ${productPath}`);
+    const { errors, notes } = checkOrigins(origins, Bun.YAML.parse(readFileSync(briefPath as string, 'utf-8')));
+    for (const note of notes) console.log(`note: ${briefPath}: ${note}`);
+    for (const error of errors) console.error(`error: ${briefPath}: ${error}`);
+    if (errors.length > 0) {
+      console.error(`hint: run '${process.argv[1]} ${productPath}' to print the origins the declaration derives`);
+      process.exit(1);
+    }
+    console.log(`ok: ${briefPath} cites every part declared by ${productPath}`);
   } else if (flag === '--json') {
     console.log(JSON.stringify(origins, null, 2));
   } else {

--- a/plugins-cc/agentkit/skills/product-intelligence/scripts/origins.ts
+++ b/plugins-cc/agentkit/skills/product-intelligence/scripts/origins.ts
@@ -1,0 +1,88 @@
+#!/usr/bin/env bun
+// Derives a brief's subject.origins[] from a product declaration's parts, so a
+// multi-repo product's evidence sources come from the composition rather than
+// from someone retyping them into the brief and drifting.
+
+import { readFileSync } from 'node:fs';
+import { type Part, parseDocument, partsOf, validateFile } from './validate.ts';
+
+export interface Origin {
+  id: string;
+  kind: string;
+  target: string;
+}
+
+// A service is evidence you acquire by visiting its URL, which is the `site`
+// lane; the brief has no separate kind for something that runs.
+const ORIGIN_KIND: Record<string, string> = { repo: 'repo', site: 'site', service: 'site' };
+
+export function deriveOrigins(product: unknown): Origin[] {
+  return partsOf(product).map((part: Part) => ({
+    id: part.id as string,
+    kind: ORIGIN_KIND[part.kind as string] as string,
+    target: part.target as string,
+  }));
+}
+
+export function formatOrigins(origins: Origin[]): string {
+  const lines = ['subject:', '  origins:'];
+  for (const origin of origins) {
+    lines.push(`    - id: ${origin.id}`);
+    lines.push(`      kind: ${origin.kind}`);
+    lines.push(`      target: ${JSON.stringify(origin.target)}`);
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+function key(origin: Origin): string {
+  return `${origin.id}|${origin.kind}|${origin.target}`;
+}
+
+export function checkOrigins(derived: Origin[], brief: unknown): string[] {
+  const declared = (((brief as Record<string, unknown>).subject as Record<string, unknown> | undefined)
+    ?.origins ?? []) as Origin[];
+  const errors: string[] = [];
+  const declaredKeys = new Set(declared.map(key));
+  const derivedKeys = new Set(derived.map(key));
+
+  for (const origin of derived) {
+    if (!declaredKeys.has(key(origin))) {
+      errors.push(`missing origin for part '${origin.id}': ${origin.kind} ${origin.target}`);
+    }
+  }
+  for (const origin of declared) {
+    if (!derivedKeys.has(key(origin))) {
+      errors.push(`origin '${origin.id}' is not derived from any part: ${origin.kind} ${origin.target}`);
+    }
+  }
+  return errors;
+}
+
+function load(path: string): unknown {
+  const errors = validateFile(path);
+  if (errors.length > 0) {
+    for (const error of errors) console.error(`error: ${error}`);
+    process.exit(1);
+  }
+  return parseDocument(path);
+}
+
+if (import.meta.main) {
+  const [productPath, flag, briefPath] = process.argv.slice(2);
+  const badFlag = flag !== undefined && (flag !== '--json' && flag !== '--check');
+  if (!productPath || badFlag || (flag === '--check' && !briefPath)) {
+    console.error('usage: origins.ts <product.yaml> [--json | --check <brief.yaml>]');
+    process.exit(2);
+  }
+  const origins = deriveOrigins(load(productPath));
+  if (flag === '--check') {
+    const drift = checkOrigins(origins, Bun.YAML.parse(readFileSync(briefPath as string, 'utf-8')));
+    for (const error of drift) console.error(`error: ${briefPath}: ${error}`);
+    if (drift.length > 0) process.exit(1);
+    console.log(`ok: ${briefPath} origins match ${productPath}`);
+  } else if (flag === '--json') {
+    console.log(JSON.stringify(origins, null, 2));
+  } else {
+    process.stdout.write(formatOrigins(origins));
+  }
+}

--- a/plugins-cc/agentkit/skills/product-intelligence/scripts/validate.ts
+++ b/plugins-cc/agentkit/skills/product-intelligence/scripts/validate.ts
@@ -71,9 +71,16 @@ export function checkSchema(value: Json, schema: Schema, root: Schema, path: str
   }
   if (schema.type === 'string') checkString(value as string, schema, path, errors);
   if (schema.type === 'object') checkObject(value as Record<string, Json>, schema, root, path, errors);
-  if (schema.type === 'array' && schema.items) {
-    (value as Json[]).forEach((item, i) => checkSchema(item, schema.items as Schema, root, `${path}[${i}]`, errors));
+  if (schema.type === 'array') checkArray(value as Json[], schema, root, path, errors);
+}
+
+function checkArray(value: Json[], schema: Schema, root: Schema, path: string, errors: string[]): void {
+  if (typeof schema.minItems === 'number' && value.length < schema.minItems) {
+    errors.push(`${path}: must have at least ${schema.minItems} item(s)`);
+    return;
   }
+  if (!schema.items) return;
+  value.forEach((item, i) => checkSchema(item, schema.items as Schema, root, `${path}[${i}]`, errors));
 }
 
 function checkString(value: string, schema: Schema, path: string, errors: string[]): void {
@@ -365,7 +372,7 @@ function validateBriefFile(doc: Json, path: string): string[] {
 if (import.meta.main) {
   const files = process.argv.slice(2);
   if (files.length === 0) {
-    console.error('usage: validate.ts <ledger-or-brief>...');
+    console.error('usage: validate.ts <ledger|brief|product-declaration|part-of-marker>...');
     process.exit(2);
   }
   let failed = false;

--- a/plugins-cc/agentkit/skills/product-intelligence/scripts/validate.ts
+++ b/plugins-cc/agentkit/skills/product-intelligence/scripts/validate.ts
@@ -1,9 +1,7 @@
 #!/usr/bin/env bun
-// Self-contained validator for product-intelligence ledgers and briefs.
-// The JSON Schema files are the source of truth for structure; this file
-// implements only the schema subset they use, plus the cross-field rules a
-// schema cannot express (class/source coupling, contradiction symmetry,
-// cross-document claim references).
+// Self-contained validator for product-intelligence documents. The JSON Schema
+// files are the source of truth for structure; this file implements only the
+// schema subset they use, plus the cross-field rules a schema cannot express.
 
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
@@ -14,6 +12,8 @@ type Schema = Record<string, Json>;
 const schemasDir = join(import.meta.dir, '..', 'schemas');
 export const ledgerSchema = loadSchema('ledger.schema.json');
 export const briefSchema = loadSchema('brief.schema.json');
+export const productSchema = loadSchema('product.schema.json');
+export const partOfSchema = loadSchema('part-of.schema.json');
 
 function loadSchema(name: string): Schema {
   return JSON.parse(readFileSync(join(schemasDir, name), 'utf-8'));
@@ -265,6 +265,63 @@ function collectClaimRefs(node: Json, path: string): { path: string; ref: string
   return refs;
 }
 
+export interface Part {
+  id?: string;
+  kind?: string;
+  target?: string;
+  role?: string;
+  visibility?: string;
+  description?: string;
+}
+
+export function partsOf(doc: Json): Part[] {
+  const composition = (doc as Record<string, Json>).composition as Record<string, Json> | undefined;
+  return (composition?.parts ?? []) as Part[];
+}
+
+export function validateProductDoc(doc: Json): string[] {
+  const errors: string[] = [];
+  checkSchema(doc, productSchema, productSchema, 'product', errors);
+  if (errors.length > 0) return errors;
+
+  const seen = new Set<string>();
+  for (const part of partsOf(doc)) {
+    if (!part.id) continue;
+    if (seen.has(part.id)) errors.push(`product.composition.parts: duplicate part id '${part.id}'`);
+    seen.add(part.id);
+  }
+  return errors;
+}
+
+// The marker rides inside the component's product-review manifest, so validate
+// that one key and leave the sibling surfaces/requires blocks to product-review.
+export function validatePartOfDoc(doc: Json): string[] {
+  const errors: string[] = [];
+  checkSchema((doc as Record<string, Json>).part_of, partOfSchema, partOfSchema, 'part_of', errors);
+  return errors;
+}
+
+// A declaration whose evidence has moved is worse than one that never had any:
+// it reads as sourced right up until somebody follows the pointer.
+function validateProductFile(doc: Json, path: string): string[] {
+  const errors = validateProductDoc(doc);
+  if (errors.length > 0) return errors;
+
+  const root = doc as Record<string, Json>;
+  const pointers: [string, Json][] = Object.entries((root.evidence ?? {}) as Record<string, Json>)
+    .map(([key, value]) => [`evidence.${key}`, value] as [string, Json]);
+  const entry = (root.site as Record<string, Json> | undefined)?.entry;
+  if (entry !== undefined) pointers.push(['site.entry', entry]);
+
+  for (const [field, value] of pointers) {
+    if (typeof value !== 'string') continue;
+    if (!existsSync(resolve(dirname(path), value))) {
+      errors.push(`product.${field}: '${value}' not found relative to the declaration`);
+    }
+  }
+  return errors;
+}
+
 export function parseDocument(path: string): Json {
   const text = readFileSync(path, 'utf-8');
   return path.endsWith('.json') ? JSON.parse(text) : Bun.YAML.parse(text);
@@ -281,7 +338,11 @@ export function validateFile(path: string): string[] {
   const root = doc as Record<string, Json>;
   if (root.ledger_version !== undefined) return validateLedgerDoc(doc);
   if (root.brief_version !== undefined) return validateBriefFile(doc, path);
-  return [`${path}: neither a ledger (ledger_version) nor a brief (brief_version)`];
+  if (root.product_version !== undefined) return validateProductFile(doc, path);
+  if (root.part_of !== undefined) return validatePartOfDoc(doc);
+  return [
+    `${path}: not a recognised document — expected ledger_version, brief_version, product_version or part_of`,
+  ];
 }
 
 function validateBriefFile(doc: Json, path: string): string[] {

--- a/scripts/check-test-slices.ts
+++ b/scripts/check-test-slices.ts
@@ -29,6 +29,7 @@ export const TEST_SLICES = {
   integrations: ['tests/infra-tools-mcp.test.ts', 'tests/test-slices.test.ts'],
   product: [
     'tests/product-intelligence/acquisition.test.ts',
+    'tests/product-intelligence/composition.test.ts',
     'tests/product-intelligence/render.test.ts',
     'tests/product-intelligence/schemas.test.ts',
     'tests/publish-page/lint.test.ts',

--- a/skills/product-intelligence/SKILL.md
+++ b/skills/product-intelligence/SKILL.md
@@ -204,6 +204,81 @@ one namespace across kinds: a handle names exactly one source. Cross-origin cont
 promising what no repo implements) are exactly what the single shared
 ledger exists to surface.
 
+## Composition: one product, several repos
+
+A product spread across repos gets a **product repo** that declares it — one
+product per product repo, and that repo need not hold code. It carries
+`product.yaml` (`schemas/product.schema.json`): product identity, the parts,
+where the evidence lives, and the published page.
+
+Each part names what it is (`repo`, `site` or `service`), where it lives
+(`target`), and what it does for the product (`role`). Components point back
+with a `part_of` marker, so the composition is discoverable from either end
+rather than only from the middle:
+
+```mermaid
+flowchart LR
+  P["product repo<br/>product.yaml<br/>composition.parts[]"] -->|declares| A[engine repo]
+  P -->|declares| B[console repo]
+  A -->|part_of| P
+  B -->|part_of| P
+```
+
+The marker lives **inside the component's existing `.agentkit/product.yaml`**,
+above the surfaces product-review reads — one committed file per component
+answers both "how do I run this" and "what is this part of". It carries
+`product_repo` and this component's `part` id (plus the product `name`, so a
+reader without access to a private product repo still knows what it belongs
+to). The validator checks that block and leaves the surfaces to product-review.
+
+Validate either document with the same CLI as briefs and ledgers — the
+document kind is detected from its top-level key:
+
+```sh
+bun skills/product-intelligence/scripts/validate.ts product.yaml .agentkit/product.yaml
+```
+
+Beyond the schema it enforces what a schema cannot: part ids are unique, and
+every `evidence` and `site.entry` pointer resolves on disk. A declaration whose
+evidence has moved reads as sourced right up until somebody follows it.
+
+### Derived origins
+
+A multi-repo product's `subject.origins` are **derived from the declaration,
+not retyped** — hand-copying is how a brief ends up citing a repo the product
+no longer contains:
+
+```sh
+bun skills/product-intelligence/scripts/origins.ts product.yaml            # pasteable YAML
+bun skills/product-intelligence/scripts/origins.ts product.yaml --json
+bun skills/product-intelligence/scripts/origins.ts product.yaml --check brief.yaml
+```
+
+One part becomes one origin, keyed by the part id: `repo` and `site` pass
+through, and a `service` part derives a `site` origin — a brief has no kind for
+something that runs, and a service is evidence you acquire by visiting its URL.
+`--check` exits non-zero on drift in either direction: a part with no origin,
+or an origin matching no part.
+
+The declaration carries no self-locator, so the product repo itself is not
+emitted as an origin. When the brief cites the product repo's own documents,
+add that origin by hand.
+
+### Workspace orientation
+
+For an agent landing in a multi-repo workspace, generate the page that says
+what the product is, which parts exist, where each lives, and where the
+evidence sits:
+
+```sh
+bun skills/product-intelligence/scripts/orient.ts product.yaml   # writes ORIENTATION.md
+```
+
+It is derived output — regenerate it rather than editing it, and never orient
+from a declaration that does not validate. A worked example of the whole loop
+(declaration, component marker, derived origins, generated page) is in
+`examples/composition/`.
+
 ## Refresh mode
 
 Re-running against the same subject keeps the section order stable and diffs

--- a/skills/product-intelligence/SKILL.md
+++ b/skills/product-intelligence/SKILL.md
@@ -257,12 +257,20 @@ bun skills/product-intelligence/scripts/origins.ts product.yaml --check brief.ya
 One part becomes one origin, keyed by the part id: `repo` and `site` pass
 through, and a `service` part derives a `site` origin — a brief has no kind for
 something that runs, and a service is evidence you acquire by visiting its URL.
-`--check` exits non-zero on drift in either direction: a part with no origin,
-or an origin matching no part.
 
-The declaration carries no self-locator, so the product repo itself is not
-emitted as an origin. When the brief cites the product repo's own documents,
-add that origin by hand.
+`--check` fails when a declared part has no origin in the brief, or when the
+brief cites that part under a different target. Targets compare canonically, so
+a clone URL and its `owner/repo` short form are the same repository — both
+schemas advertise the two notations as interchangeable, and a checker that
+disagreed would report one repo as missing and unrecognised at once. Two
+different hosts are still two repositories.
+
+The check is deliberately **one-directional**: every part must be cited, but a
+brief may legitimately cite sources that are not parts — the product repo's own
+documents, or a supplied docset. Those are reported as `note:` lines and do not
+fail the check. The declaration carries no self-locator, so the product repo is
+never derived as an origin; cite it in the brief when its documents are
+evidence, and the note is the acknowledgement, not a defect to chase.
 
 ### Workspace orientation
 

--- a/skills/product-intelligence/SKILL.md
+++ b/skills/product-intelligence/SKILL.md
@@ -262,8 +262,13 @@ something that runs, and a service is evidence you acquire by visiting its URL.
 brief cites that part under a different target. Targets compare canonically, so
 a clone URL and its `owner/repo` short form are the same repository — both
 schemas advertise the two notations as interchangeable, and a checker that
-disagreed would report one repo as missing and unrecognised at once. Two
-different hosts are still two repositories.
+disagreed would report one repo as missing and unrecognised at once.
+
+Canonical means the host (case-folded, and two different hosts stay two
+repositories) plus the **whole** remaining path. Subgroups are ordinary
+segments, so `acme/platform/engine` and `other/platform/engine` are different
+repos, and the bare `owner/repo` shorthand matches a hosted path only when that
+path is exactly `owner/repo` — never the tail of a deeper one.
 
 The check is deliberately **one-directional**: every part must be cited, but a
 brief may legitimately cite sources that are not parts — the product repo's own

--- a/skills/product-intelligence/examples/README.md
+++ b/skills/product-intelligence/examples/README.md
@@ -3,11 +3,12 @@
 Each directory is a complete, schema-valid artifact set for one evidence
 situation. The subjects are fictional; the shapes are the contract.
 
-| Example         | Demonstrates                                                                                                                               |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `website-only/` | Site locators only; repo-side facts land in `cannot_verify`, not guesses                                                                   |
-| `repo-only/`    | Repo + release locators; adoption/registry facts are `cannot_verify`                                                                       |
-| `mixed/`        | Both surfaces, an unresolved contradiction rendered in the brief, and the full set: `brief.yaml`, `ledger.yaml`, `brief.md`, `findings.md` |
+| Example         | Demonstrates                                                                                                                                               |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `website-only/` | Site locators only; repo-side facts land in `cannot_verify`, not guesses                                                                                   |
+| `repo-only/`    | Repo + release locators; adoption/registry facts are `cannot_verify`                                                                                       |
+| `mixed/`        | Both surfaces, an unresolved contradiction rendered in the brief, and the full set: `brief.yaml`, `ledger.yaml`, `brief.md`, `findings.md`                 |
+| `composition/`  | A product spread across several repos: the `product.yaml` declaration, a component's `part_of` marker, derived origins, and the generated `ORIENTATION.md` |
 
 Validate any of them:
 

--- a/skills/product-intelligence/examples/composition/ORIENTATION.md
+++ b/skills/product-intelligence/examples/composition/ORIENTATION.md
@@ -32,7 +32,7 @@ Paths are relative to the product declaration.
 
 ## Working here
 
-Each part above is a separate repo or service with its own clone. A component
-names the part it is via `part_of` in its `.agentkit/product.yaml`; that marker
-and this declaration must agree on the id, so `acme-platform` is
-discoverable from either end.
+Each part above is a separate repo or service with its own clone. The
+convention is that a component names the part it is with a `part_of` block in
+its `.agentkit/product.yaml`, reusing the id from this table. A component
+without one is still reachable from here, but does not point back.

--- a/skills/product-intelligence/examples/composition/ORIENTATION.md
+++ b/skills/product-intelligence/examples/composition/ORIENTATION.md
@@ -1,0 +1,38 @@
+# acme-platform — workspace orientation
+
+Rules engine plus operator console, sold and supported as one platform rather than as two tools that happen to share a name.
+
+Homepage: <https://acme.example>
+
+`acme-platform` is one product spread across 3 parts. This file
+is generated from the product declaration — edit that, then regenerate.
+
+## Parts
+
+| Part      | Role              | Kind    | Where                    | Visibility |
+| --------- | ----------------- | ------- | ------------------------ | ---------- |
+| `engine`  | core              | repo    | acme/engine              | public     |
+| `console` | operator UI       | repo    | acme/console             | public     |
+| `cloud`   | hosted deployment | service | https://app.acme.example | private    |
+
+### What each part holds
+
+- **engine** — The rules engine itself, its CLI, and the wire format the console speaks. The part a user installs.
+- **console** — Web console for authoring and inspecting rule sets. Ships separately because it is optional; the engine runs headless.
+- **cloud** — The managed instance. Not a repository — it is where the two repos above are observed running together.
+
+## Evidence and published page
+
+- brief: `brief.yaml`
+- ledger: `ledger.yaml`
+- site entry: `index.md`
+- published at: <https://pages.acme.example/acme-platform>
+
+Paths are relative to the product declaration.
+
+## Working here
+
+Each part above is a separate repo or service with its own clone. A component
+names the part it is via `part_of` in its `.agentkit/product.yaml`; that marker
+and this declaration must agree on the id, so `acme-platform` is
+discoverable from either end.

--- a/skills/product-intelligence/examples/composition/brief.yaml
+++ b/skills/product-intelligence/examples/composition/brief.yaml
@@ -1,0 +1,23 @@
+brief_version: "1.0"
+subject:
+  name: acme-platform
+  homepage: https://acme.example
+  one_liner: Rules engine plus operator console, sold and supported as one platform.
+  origins:
+    - id: engine
+      kind: repo
+      target: acme/engine
+    - id: console
+      kind: repo
+      target: acme/console
+    - id: cloud
+      kind: site
+      target: https://app.acme.example
+evidence:
+  ledger: ledger.yaml
+  acquired_at: "2026-07-28"
+positioning:
+  target_customer: platform teams
+  need: one supported surface across engine and console
+  category: rules platform
+  claims: [C-001]

--- a/skills/product-intelligence/examples/composition/component-product.yaml
+++ b/skills/product-intelligence/examples/composition/component-product.yaml
@@ -1,0 +1,22 @@
+# What `acme/engine` commits as its own `.agentkit/product.yaml`. The `part_of`
+# block is the back-pointer; everything below it is the product-review manifest
+# that file already carries, shown here so the two are visibly one file.
+
+part_of:
+  product: acme-platform
+  product_repo: acme/product
+  part: engine
+
+summary: >-
+  Rules engine and CLI. Serves rule sets headless; the operator console is a
+  separate part of the same product.
+
+surfaces:
+  - name: engine
+    kind: cli
+    build: cargo build --release
+    verify: cargo test --workspace
+    run: ./target/release/acme-engine serve --rules examples/basic.yaml
+    expect: |
+      Binds a local port and answers a rule evaluation with a decision rather
+      than an error.

--- a/skills/product-intelligence/examples/composition/index.md
+++ b/skills/product-intelligence/examples/composition/index.md
@@ -1,0 +1,6 @@
+# acme-platform
+
+Rules engine plus operator console, sold and supported as one platform.
+
+The published page is rendered from `brief.yaml` and `ledger.yaml`; this file
+exists so the declaration's `site.entry` pointer resolves to something real.

--- a/skills/product-intelligence/examples/composition/ledger.yaml
+++ b/skills/product-intelligence/examples/composition/ledger.yaml
@@ -1,0 +1,22 @@
+ledger_version: "1.0"
+generated_by: product-intelligence
+generated_at: "2026-07-28T09:00:00Z"
+claims:
+  - id: C-001
+    statement: The engine runs without the console.
+    class: observed
+    confidence: high
+    sources:
+      - locator: "repo:engine:README.md:8"
+        quote: "The console is optional; acme-engine serves rules headless."
+        stance: supports
+        as_of: "2026-07-28"
+  - id: C-002
+    statement: The console is distributed as a separate repository.
+    class: observed
+    confidence: high
+    sources:
+      - locator: "repo:console:README.md:1"
+        quote: "Operator console for acme-engine."
+        stance: supports
+        as_of: "2026-07-28"

--- a/skills/product-intelligence/examples/composition/product.yaml
+++ b/skills/product-intelligence/examples/composition/product.yaml
@@ -1,0 +1,45 @@
+product_version: "0.1"
+
+product:
+  name: acme-platform
+  one_liner: >-
+    Rules engine plus operator console, sold and supported as one platform
+    rather than as two tools that happen to share a name.
+  homepage: https://acme.example
+
+composition:
+  parts:
+    - id: engine
+      role: core
+      kind: repo
+      target: acme/engine
+      visibility: public
+      description: >-
+        The rules engine itself, its CLI, and the wire format the console
+        speaks. The part a user installs.
+
+    - id: console
+      role: operator UI
+      kind: repo
+      target: acme/console
+      visibility: public
+      description: >-
+        Web console for authoring and inspecting rule sets. Ships separately
+        because it is optional; the engine runs headless.
+
+    - id: cloud
+      role: hosted deployment
+      kind: service
+      target: https://app.acme.example
+      visibility: private
+      description: >-
+        The managed instance. Not a repository — it is where the two repos
+        above are observed running together.
+
+evidence:
+  brief: brief.yaml
+  ledger: ledger.yaml
+
+site:
+  entry: index.md
+  published_at: https://pages.acme.example/acme-platform

--- a/skills/product-intelligence/schemas/fixtures/invalid/part-of-missing-part.yaml
+++ b/skills/product-intelligence/schemas/fixtures/invalid/part-of-missing-part.yaml
@@ -1,0 +1,4 @@
+part_of:
+  product: acme-platform
+  product_repo: acme/product
+summary: Rules engine and CLI.

--- a/skills/product-intelligence/schemas/fixtures/invalid/part-of-unslugged-id.yaml
+++ b/skills/product-intelligence/schemas/fixtures/invalid/part-of-unslugged-id.yaml
@@ -1,0 +1,4 @@
+part_of:
+  product_repo: acme/product
+  part: Engine Core
+summary: Rules engine and CLI.

--- a/skills/product-intelligence/schemas/fixtures/invalid/product-dangling-evidence.yaml
+++ b/skills/product-intelligence/schemas/fixtures/invalid/product-dangling-evidence.yaml
@@ -1,0 +1,10 @@
+product_version: "0.1"
+product:
+  name: acme-platform
+composition:
+  parts:
+    - id: engine
+      kind: repo
+      target: acme/engine
+evidence:
+  ledger: nowhere/ledger.yaml

--- a/skills/product-intelligence/schemas/fixtures/invalid/product-duplicate-part-id.yaml
+++ b/skills/product-intelligence/schemas/fixtures/invalid/product-duplicate-part-id.yaml
@@ -1,0 +1,11 @@
+product_version: "0.1"
+product:
+  name: acme-platform
+composition:
+  parts:
+    - id: engine
+      kind: repo
+      target: acme/engine
+    - id: engine
+      kind: repo
+      target: acme/engine-v2

--- a/skills/product-intelligence/schemas/fixtures/invalid/product-empty-parts.yaml
+++ b/skills/product-intelligence/schemas/fixtures/invalid/product-empty-parts.yaml
@@ -1,0 +1,5 @@
+product_version: "0.1"
+product:
+  name: acme-platform
+composition:
+  parts: []

--- a/skills/product-intelligence/schemas/fixtures/invalid/product-missing-part-target.yaml
+++ b/skills/product-intelligence/schemas/fixtures/invalid/product-missing-part-target.yaml
@@ -1,0 +1,7 @@
+product_version: "0.1"
+product:
+  name: acme-platform
+composition:
+  parts:
+    - id: engine
+      kind: repo

--- a/skills/product-intelligence/schemas/fixtures/invalid/product-unknown-part-kind.yaml
+++ b/skills/product-intelligence/schemas/fixtures/invalid/product-unknown-part-kind.yaml
@@ -1,0 +1,8 @@
+product_version: "0.1"
+product:
+  name: acme-platform
+composition:
+  parts:
+    - id: engine
+      kind: package
+      target: acme/engine

--- a/skills/product-intelligence/schemas/fixtures/valid/part-of.yaml
+++ b/skills/product-intelligence/schemas/fixtures/valid/part-of.yaml
@@ -1,0 +1,9 @@
+part_of:
+  product: acme-platform
+  product_repo: acme/product
+  part: engine
+summary: Rules engine and CLI.
+surfaces:
+  - name: engine
+    kind: cli
+    build: cargo build --release

--- a/skills/product-intelligence/schemas/fixtures/valid/product.minimal.yaml
+++ b/skills/product-intelligence/schemas/fixtures/valid/product.minimal.yaml
@@ -1,0 +1,8 @@
+product_version: "0.1"
+product:
+  name: acme-notes
+composition:
+  parts:
+    - id: app
+      kind: repo
+      target: acme/notes

--- a/skills/product-intelligence/schemas/fixtures/valid/product.yaml
+++ b/skills/product-intelligence/schemas/fixtures/valid/product.yaml
@@ -1,0 +1,26 @@
+product_version: "0.1"
+product:
+  name: acme-platform
+  one_liner: Rules engine plus operator console, sold as one platform.
+  homepage: https://acme.example
+composition:
+  parts:
+    - id: engine
+      role: core
+      kind: repo
+      target: acme/engine
+      visibility: public
+      description: The rules engine and its CLI.
+    - id: docs
+      role: documentation
+      kind: site
+      target: https://docs.acme.example
+      visibility: public
+    - id: cloud
+      role: hosted deployment
+      kind: service
+      target: https://app.acme.example
+      visibility: private
+evidence:
+  brief: brief.yaml
+  ledger: ledger.yaml

--- a/skills/product-intelligence/schemas/part-of.schema.json
+++ b/skills/product-intelligence/schemas/part-of.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agentkit.sbs/schemas/product-intelligence/part-of.schema.json",
+  "title": "Component part-of marker",
+  "description": "The back-pointer a component repo carries to the product it belongs to. It lives as a `part_of` key inside the component's existing `.agentkit/product.yaml`, alongside the surfaces product-review reads; the validator checks this block and leaves the rest of that file to product-review. Deliberately minimal: it names the product repo and this component's part id, and nothing that would drift from the declaration those two resolve to.",
+  "type": "object",
+  "required": ["product_repo", "part"],
+  "additionalProperties": false,
+  "properties": {
+    "product_repo": {
+      "description": "Locator of the product repo holding the product.yaml declaration — a clone URL or owner/repo. Following it is how a reader gets from one component to the whole product.",
+      "type": "string",
+      "minLength": 1
+    },
+    "part": {
+      "description": "This component's id in that declaration's composition.parts[]. The two must agree; a marker naming a part the declaration does not list points at nothing.",
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]*$"
+    },
+    "product": {
+      "description": "Product name, repeated here so a reader offline — or without access to a private product repo — still knows what this is part of. Optional because it is derivable; duplicated because the derivation needs network and permission.",
+      "type": "string",
+      "minLength": 1
+    }
+  }
+}

--- a/skills/product-intelligence/schemas/product.schema.json
+++ b/skills/product-intelligence/schemas/product.schema.json
@@ -42,6 +42,7 @@
       "properties": {
         "parts": {
           "type": "array",
+          "minItems": 1,
           "items": { "$ref": "#/$defs/part" }
         }
       }

--- a/skills/product-intelligence/schemas/product.schema.json
+++ b/skills/product-intelligence/schemas/product.schema.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agentkit.sbs/schemas/product-intelligence/product.schema.json",
+  "title": "Product declaration",
+  "description": "What a product IS and which repositories, sites and services compose it. One product per product repo; the product repo need not hold code. Components point back with a `part_of` marker, so the composition is discoverable from either end. This file is also the deterministic input for a brief's subject.origins and for a workspace orientation page — hand-typing either is what it exists to prevent.",
+  "type": "object",
+  "required": ["product_version", "product", "composition"],
+  "additionalProperties": false,
+  "properties": {
+    "product_version": {
+      "description": "Semver of the product-declaration schema this document targets. Backward-compatible across minors.",
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+(\\.[0-9]+)?$"
+    },
+    "product": {
+      "type": "object",
+      "required": ["name"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "description": "Product name as its makers use it. Matches the brief's subject.name.",
+          "type": "string",
+          "minLength": 1
+        },
+        "one_liner": {
+          "description": "What the product is in one sentence, from a user's point of view — not the architecture.",
+          "type": "string",
+          "minLength": 1
+        },
+        "homepage": {
+          "description": "Canonical marketing/site URL.",
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "composition": {
+      "description": "The parts the product is made of. A single-repo product declares one part; nothing here assumes several.",
+      "type": "object",
+      "required": ["parts"],
+      "additionalProperties": false,
+      "properties": {
+        "parts": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/part" }
+        }
+      }
+    },
+    "evidence": {
+      "description": "Where the evidence about this product lives, as paths relative to this file. The validator resolves them: a pointer that no longer resolves is a rotted pointer, not a warning.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "brief": { "type": "string", "minLength": 1 },
+        "ledger": { "type": "string", "minLength": 1 },
+        "findings": { "type": "string", "minLength": 1 },
+        "acquisition": { "type": "string", "minLength": 1 }
+      }
+    },
+    "site": {
+      "description": "The product's published page, derived from the evidence rather than hand-edited.",
+      "type": "object",
+      "required": ["entry"],
+      "additionalProperties": false,
+      "properties": {
+        "entry": {
+          "description": "Page source, relative to this file.",
+          "type": "string",
+          "minLength": 1
+        },
+        "published_at": {
+          "description": "URL the entry is published to.",
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  },
+  "$defs": {
+    "part": {
+      "type": "object",
+      "required": ["id", "kind", "target"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "description": "Short handle for this part. It is the id a component repeats in its `part_of` marker, and the origin id derived for a brief, so it must stay stable once published.",
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9-]*$"
+        },
+        "kind": {
+          "description": "What the part physically is: a repository, a published site, or a running service.",
+          "enum": ["repo", "site", "service"]
+        },
+        "target": {
+          "description": "Where the part lives: a clone URL, owner/repo, or service URL. Named `target` to match the brief's origin field it derives into.",
+          "type": "string",
+          "minLength": 1
+        },
+        "role": {
+          "description": "What this part does for the product, in one line. Free text on purpose — a fixed vocabulary would force every product into one shape.",
+          "type": "string",
+          "minLength": 1
+        },
+        "visibility": {
+          "description": "Whether someone outside the team can reach the target. A private part is why a reader cannot verify it, not an omission.",
+          "enum": ["public", "private"]
+        },
+        "description": {
+          "description": "What the part contains, for a reader who has not opened it.",
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/skills/product-intelligence/scripts/orient.ts
+++ b/skills/product-intelligence/scripts/orient.ts
@@ -1,0 +1,113 @@
+#!/usr/bin/env bun
+// Generates the page an agent reads on landing in a multi-repo workspace: what
+// the product is, which parts it has, where each one lives, and where the
+// evidence about it sits. Derived from the declaration, never hand-edited.
+
+import { writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { type Part, parseDocument, partsOf, validateFile } from './validate.ts';
+
+type Dict = Record<string, any>;
+
+function collapse(value: unknown): string {
+  return String(value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+// A pipe inside a role or target would split the cell and silently shift every
+// column after it.
+function cell(value: unknown): string {
+  return collapse(value).replace(/\|/g, '\\|') || '—';
+}
+
+function heading(product: Dict): string[] {
+  const name = collapse(product.product?.name);
+  const lines = [`# ${name} — workspace orientation`, ''];
+  if (product.product?.one_liner) lines.push(collapse(product.product.one_liner), '');
+  if (product.product?.homepage) lines.push(`Homepage: <${collapse(product.product.homepage)}>`, '');
+  const count = partsOf(product).length;
+  lines.push(
+    `\`${name}\` is one product spread across ${count} ${count === 1 ? 'part' : 'parts'}. This file`,
+    'is generated from the product declaration — edit that, then regenerate.',
+    '',
+  );
+  return lines;
+}
+
+// Columns are padded to the width dprint would align them to, so the committed
+// example survives a repo-wide format run byte-identical to what this emits.
+function table(rows: string[][]): string[] {
+  const widths = rows[0]?.map((_, i) => Math.max(...rows.map((row) => (row[i] as string).length))) ?? [];
+  const line = (row: string[]) => `| ${row.map((c, i) => c.padEnd(widths[i] as number)).join(' | ')} |`;
+  const [header, ...body] = rows as [string[], ...string[][]];
+  return [line(header), line(widths.map((w) => '-'.repeat(w))), ...body.map(line)];
+}
+
+function partsTable(product: Dict): string[] {
+  const rows = [['Part', 'Role', 'Kind', 'Where', 'Visibility']];
+  for (const part of partsOf(product) as Part[]) {
+    rows.push([`\`${cell(part.id)}\``, cell(part.role), cell(part.kind), cell(part.target), cell(part.visibility)]);
+  }
+  const lines = ['## Parts', '', ...table(rows), ''];
+
+  const described = (partsOf(product) as Part[]).filter((part) => part.description);
+  if (described.length > 0) {
+    lines.push('### What each part holds', '');
+    for (const part of described) lines.push(`- **${cell(part.id)}** — ${collapse(part.description)}`);
+    lines.push('');
+  }
+  return lines;
+}
+
+function evidenceSection(product: Dict): string[] {
+  const evidence = (product.evidence ?? {}) as Dict;
+  const entries = Object.entries(evidence).filter(([, value]) => typeof value === 'string');
+  if (entries.length === 0 && !product.site) return [];
+
+  const lines = ['## Evidence and published page', ''];
+  for (const [field, value] of entries) lines.push(`- ${field}: \`${cell(value)}\``);
+  if (product.site?.entry) lines.push(`- site entry: \`${cell(product.site.entry)}\``);
+  if (product.site?.published_at) lines.push(`- published at: <${collapse(product.site.published_at)}>`);
+  lines.push('', 'Paths are relative to the product declaration.', '');
+  return lines;
+}
+
+function claimingSection(product: Dict): string[] {
+  return [
+    '## Working here',
+    '',
+    'Each part above is a separate repo or service with its own clone. A component',
+    'names the part it is via `part_of` in its `.agentkit/product.yaml`; that marker',
+    `and this declaration must agree on the id, so \`${collapse(product.product?.name)}\` is`,
+    'discoverable from either end.',
+    '',
+  ];
+}
+
+export function renderOrientation(productPath: string): string {
+  const errors = validateFile(productPath);
+  if (errors.length > 0) throw new Error(`invalid declaration:\n${errors.map((e) => `  ${e}`).join('\n')}`);
+  const product = parseDocument(productPath) as Dict;
+  return [
+    ...heading(product),
+    ...partsTable(product),
+    ...evidenceSection(product),
+    ...claimingSection(product),
+  ].join('\n');
+}
+
+if (import.meta.main) {
+  const [productPath, outFlag, outPath] = process.argv.slice(2);
+  if (!productPath || (outFlag && (outFlag !== '--out' || !outPath))) {
+    console.error('usage: orient.ts <product.yaml> [--out <file>]');
+    process.exit(2);
+  }
+  try {
+    const page = renderOrientation(productPath);
+    const target = outPath ?? join(dirname(productPath), 'ORIENTATION.md');
+    writeFileSync(target, page);
+    console.log(target);
+  } catch (error) {
+    console.error(`error: ${(error as Error).message}`);
+    process.exit(1);
+  }
+}

--- a/skills/product-intelligence/scripts/orient.ts
+++ b/skills/product-intelligence/scripts/orient.ts
@@ -71,14 +71,17 @@ function evidenceSection(product: Dict): string[] {
   return lines;
 }
 
-function claimingSection(product: Dict): string[] {
+// States the convention, never that the components currently follow it — this
+// page is generated, and a generated page that reports unverified state as
+// fact is the failure the skill exists to prevent.
+function conventionSection(): string[] {
   return [
     '## Working here',
     '',
-    'Each part above is a separate repo or service with its own clone. A component',
-    'names the part it is via `part_of` in its `.agentkit/product.yaml`; that marker',
-    `and this declaration must agree on the id, so \`${collapse(product.product?.name)}\` is`,
-    'discoverable from either end.',
+    'Each part above is a separate repo or service with its own clone. The',
+    'convention is that a component names the part it is with a `part_of` block in',
+    'its `.agentkit/product.yaml`, reusing the id from this table. A component',
+    'without one is still reachable from here, but does not point back.',
     '',
   ];
 }
@@ -91,7 +94,7 @@ export function renderOrientation(productPath: string): string {
     ...heading(product),
     ...partsTable(product),
     ...evidenceSection(product),
-    ...claimingSection(product),
+    ...conventionSection(),
   ].join('\n');
 }
 

--- a/skills/product-intelligence/scripts/origins.ts
+++ b/skills/product-intelligence/scripts/origins.ts
@@ -40,31 +40,27 @@ export interface CanonicalTarget {
 }
 
 // Both schemas advertise a clone URL and `owner/repo` as the same thing, so
-// comparing the raw strings reports one repository as simultaneously missing
-// and unrecognised. Reduce to owner/repo, keeping the host when it is stated:
-// two hosts that disagree are two repositories, not one written two ways.
-export function canonicalTarget(kind: string, target: string): CanonicalTarget {
+// raw string comparison reports one repo as missing and unrecognised at once.
+// The path after the host is kept WHOLE: a GitLab subgroup is an ordinary
+// segment, and reducing to the last two would make acme/platform/engine and
+// other/platform/engine one repository.
+export function canonicalTarget(target: string): CanonicalTarget {
   const trimmed = target.trim().replace(/\/+$/, '');
   const scp = /^(?:[\w.-]+@)?([\w.-]+\.[a-z]{2,}):(.+)$/i.exec(trimmed);
   const hostPath = scp
     ? `${scp[1]}/${scp[2]}`
     : trimmed.replace(/^[a-z][a-z0-9+.-]*:\/\//i, '').replace(/^[\w.-]+@/, '');
-  const bare = hostPath.replace(/\.git$/, '');
-  const segments = bare.split('/').filter(Boolean);
-  const host = (segments[0] ?? '').includes('.') ? (segments[0] as string).toLowerCase() : undefined;
+  const segments = hostPath.replace(/\.git$/, '').split('/').filter(Boolean);
 
   // Hostnames are case-insensitive by DNS; the path after them is not, on any
   // forge or web server, so only the host is folded.
-  if (kind !== 'repo') {
-    return host === undefined ? { path: bare } : { host, path: segments.slice(1).join('/') };
-  }
-  if (segments.length <= 2) return { path: segments.join('/') };
-  return { host, path: segments.slice(-2).join('/') };
+  if (!(segments[0] ?? '').includes('.')) return { path: segments.join('/') };
+  return { host: (segments[0] as string).toLowerCase(), path: segments.slice(1).join('/') };
 }
 
 export function sameTarget(a: Origin, b: Origin): boolean {
-  const left = canonicalTarget(a.kind, a.target);
-  const right = canonicalTarget(b.kind, b.target);
+  const left = canonicalTarget(a.target);
+  const right = canonicalTarget(b.target);
   if (left.path !== right.path) return false;
   return left.host === undefined || right.host === undefined || left.host === right.host;
 }

--- a/skills/product-intelligence/scripts/origins.ts
+++ b/skills/product-intelligence/scripts/origins.ts
@@ -34,28 +34,74 @@ export function formatOrigins(origins: Origin[]): string {
   return `${lines.join('\n')}\n`;
 }
 
-function key(origin: Origin): string {
-  return `${origin.id}|${origin.kind}|${origin.target}`;
+export interface CanonicalTarget {
+  host?: string;
+  path: string;
 }
 
-export function checkOrigins(derived: Origin[], brief: unknown): string[] {
+// Both schemas advertise a clone URL and `owner/repo` as the same thing, so
+// comparing the raw strings reports one repository as simultaneously missing
+// and unrecognised. Reduce to owner/repo, keeping the host when it is stated:
+// two hosts that disagree are two repositories, not one written two ways.
+export function canonicalTarget(kind: string, target: string): CanonicalTarget {
+  const trimmed = target.trim().replace(/\/+$/, '');
+  const scp = /^(?:[\w.-]+@)?([\w.-]+\.[a-z]{2,}):(.+)$/i.exec(trimmed);
+  const hostPath = scp
+    ? `${scp[1]}/${scp[2]}`
+    : trimmed.replace(/^[a-z][a-z0-9+.-]*:\/\//i, '').replace(/^[\w.-]+@/, '');
+  const bare = hostPath.replace(/\.git$/, '');
+  const segments = bare.split('/').filter(Boolean);
+  const host = (segments[0] ?? '').includes('.') ? (segments[0] as string).toLowerCase() : undefined;
+
+  // Hostnames are case-insensitive by DNS; the path after them is not, on any
+  // forge or web server, so only the host is folded.
+  if (kind !== 'repo') {
+    return host === undefined ? { path: bare } : { host, path: segments.slice(1).join('/') };
+  }
+  if (segments.length <= 2) return { path: segments.join('/') };
+  return { host, path: segments.slice(-2).join('/') };
+}
+
+export function sameTarget(a: Origin, b: Origin): boolean {
+  const left = canonicalTarget(a.kind, a.target);
+  const right = canonicalTarget(b.kind, b.target);
+  if (left.path !== right.path) return false;
+  return left.host === undefined || right.host === undefined || left.host === right.host;
+}
+
+export interface OriginCheck {
+  errors: string[];
+  notes: string[];
+}
+
+// One-directional on purpose: every part must be cited, but a brief may cite
+// sources that are not parts — the product repo's own documents, a supplied
+// docset — so an unmatched origin is reported without failing the check.
+export function checkOrigins(derived: Origin[], brief: unknown): OriginCheck {
   const declared = (((brief as Record<string, unknown>).subject as Record<string, unknown> | undefined)
     ?.origins ?? []) as Origin[];
   const errors: string[] = [];
-  const declaredKeys = new Set(declared.map(key));
-  const derivedKeys = new Set(derived.map(key));
+  const notes: string[] = [];
+  const byId = new Map(declared.map((origin) => [origin.id, origin]));
 
-  for (const origin of derived) {
-    if (!declaredKeys.has(key(origin))) {
-      errors.push(`missing origin for part '${origin.id}': ${origin.kind} ${origin.target}`);
+  for (const part of derived) {
+    const cited = byId.get(part.id);
+    if (!cited) {
+      errors.push(`missing origin for part '${part.id}': ${part.kind} ${part.target}`);
+    } else if (cited.kind !== part.kind || !sameTarget(part, cited)) {
+      errors.push(
+        `origin '${part.id}' cites ${cited.kind} ${cited.target}, but the part declares ${part.kind} ${part.target}`,
+      );
     }
   }
+
+  const partIds = new Set(derived.map((origin) => origin.id));
   for (const origin of declared) {
-    if (!derivedKeys.has(key(origin))) {
-      errors.push(`origin '${origin.id}' is not derived from any part: ${origin.kind} ${origin.target}`);
+    if (!partIds.has(origin.id)) {
+      notes.push(`origin '${origin.id}' is not a declared part: ${origin.kind} ${origin.target}`);
     }
   }
-  return errors;
+  return { errors, notes };
 }
 
 function load(path: string): unknown {
@@ -76,10 +122,14 @@ if (import.meta.main) {
   }
   const origins = deriveOrigins(load(productPath));
   if (flag === '--check') {
-    const drift = checkOrigins(origins, Bun.YAML.parse(readFileSync(briefPath as string, 'utf-8')));
-    for (const error of drift) console.error(`error: ${briefPath}: ${error}`);
-    if (drift.length > 0) process.exit(1);
-    console.log(`ok: ${briefPath} origins match ${productPath}`);
+    const { errors, notes } = checkOrigins(origins, Bun.YAML.parse(readFileSync(briefPath as string, 'utf-8')));
+    for (const note of notes) console.log(`note: ${briefPath}: ${note}`);
+    for (const error of errors) console.error(`error: ${briefPath}: ${error}`);
+    if (errors.length > 0) {
+      console.error(`hint: run '${process.argv[1]} ${productPath}' to print the origins the declaration derives`);
+      process.exit(1);
+    }
+    console.log(`ok: ${briefPath} cites every part declared by ${productPath}`);
   } else if (flag === '--json') {
     console.log(JSON.stringify(origins, null, 2));
   } else {

--- a/skills/product-intelligence/scripts/origins.ts
+++ b/skills/product-intelligence/scripts/origins.ts
@@ -1,0 +1,88 @@
+#!/usr/bin/env bun
+// Derives a brief's subject.origins[] from a product declaration's parts, so a
+// multi-repo product's evidence sources come from the composition rather than
+// from someone retyping them into the brief and drifting.
+
+import { readFileSync } from 'node:fs';
+import { type Part, parseDocument, partsOf, validateFile } from './validate.ts';
+
+export interface Origin {
+  id: string;
+  kind: string;
+  target: string;
+}
+
+// A service is evidence you acquire by visiting its URL, which is the `site`
+// lane; the brief has no separate kind for something that runs.
+const ORIGIN_KIND: Record<string, string> = { repo: 'repo', site: 'site', service: 'site' };
+
+export function deriveOrigins(product: unknown): Origin[] {
+  return partsOf(product).map((part: Part) => ({
+    id: part.id as string,
+    kind: ORIGIN_KIND[part.kind as string] as string,
+    target: part.target as string,
+  }));
+}
+
+export function formatOrigins(origins: Origin[]): string {
+  const lines = ['subject:', '  origins:'];
+  for (const origin of origins) {
+    lines.push(`    - id: ${origin.id}`);
+    lines.push(`      kind: ${origin.kind}`);
+    lines.push(`      target: ${JSON.stringify(origin.target)}`);
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+function key(origin: Origin): string {
+  return `${origin.id}|${origin.kind}|${origin.target}`;
+}
+
+export function checkOrigins(derived: Origin[], brief: unknown): string[] {
+  const declared = (((brief as Record<string, unknown>).subject as Record<string, unknown> | undefined)
+    ?.origins ?? []) as Origin[];
+  const errors: string[] = [];
+  const declaredKeys = new Set(declared.map(key));
+  const derivedKeys = new Set(derived.map(key));
+
+  for (const origin of derived) {
+    if (!declaredKeys.has(key(origin))) {
+      errors.push(`missing origin for part '${origin.id}': ${origin.kind} ${origin.target}`);
+    }
+  }
+  for (const origin of declared) {
+    if (!derivedKeys.has(key(origin))) {
+      errors.push(`origin '${origin.id}' is not derived from any part: ${origin.kind} ${origin.target}`);
+    }
+  }
+  return errors;
+}
+
+function load(path: string): unknown {
+  const errors = validateFile(path);
+  if (errors.length > 0) {
+    for (const error of errors) console.error(`error: ${error}`);
+    process.exit(1);
+  }
+  return parseDocument(path);
+}
+
+if (import.meta.main) {
+  const [productPath, flag, briefPath] = process.argv.slice(2);
+  const badFlag = flag !== undefined && (flag !== '--json' && flag !== '--check');
+  if (!productPath || badFlag || (flag === '--check' && !briefPath)) {
+    console.error('usage: origins.ts <product.yaml> [--json | --check <brief.yaml>]');
+    process.exit(2);
+  }
+  const origins = deriveOrigins(load(productPath));
+  if (flag === '--check') {
+    const drift = checkOrigins(origins, Bun.YAML.parse(readFileSync(briefPath as string, 'utf-8')));
+    for (const error of drift) console.error(`error: ${briefPath}: ${error}`);
+    if (drift.length > 0) process.exit(1);
+    console.log(`ok: ${briefPath} origins match ${productPath}`);
+  } else if (flag === '--json') {
+    console.log(JSON.stringify(origins, null, 2));
+  } else {
+    process.stdout.write(formatOrigins(origins));
+  }
+}

--- a/skills/product-intelligence/scripts/validate.ts
+++ b/skills/product-intelligence/scripts/validate.ts
@@ -71,9 +71,16 @@ export function checkSchema(value: Json, schema: Schema, root: Schema, path: str
   }
   if (schema.type === 'string') checkString(value as string, schema, path, errors);
   if (schema.type === 'object') checkObject(value as Record<string, Json>, schema, root, path, errors);
-  if (schema.type === 'array' && schema.items) {
-    (value as Json[]).forEach((item, i) => checkSchema(item, schema.items as Schema, root, `${path}[${i}]`, errors));
+  if (schema.type === 'array') checkArray(value as Json[], schema, root, path, errors);
+}
+
+function checkArray(value: Json[], schema: Schema, root: Schema, path: string, errors: string[]): void {
+  if (typeof schema.minItems === 'number' && value.length < schema.minItems) {
+    errors.push(`${path}: must have at least ${schema.minItems} item(s)`);
+    return;
   }
+  if (!schema.items) return;
+  value.forEach((item, i) => checkSchema(item, schema.items as Schema, root, `${path}[${i}]`, errors));
 }
 
 function checkString(value: string, schema: Schema, path: string, errors: string[]): void {
@@ -365,7 +372,7 @@ function validateBriefFile(doc: Json, path: string): string[] {
 if (import.meta.main) {
   const files = process.argv.slice(2);
   if (files.length === 0) {
-    console.error('usage: validate.ts <ledger-or-brief>...');
+    console.error('usage: validate.ts <ledger|brief|product-declaration|part-of-marker>...');
     process.exit(2);
   }
   let failed = false;

--- a/skills/product-intelligence/scripts/validate.ts
+++ b/skills/product-intelligence/scripts/validate.ts
@@ -1,9 +1,7 @@
 #!/usr/bin/env bun
-// Self-contained validator for product-intelligence ledgers and briefs.
-// The JSON Schema files are the source of truth for structure; this file
-// implements only the schema subset they use, plus the cross-field rules a
-// schema cannot express (class/source coupling, contradiction symmetry,
-// cross-document claim references).
+// Self-contained validator for product-intelligence documents. The JSON Schema
+// files are the source of truth for structure; this file implements only the
+// schema subset they use, plus the cross-field rules a schema cannot express.
 
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
@@ -14,6 +12,8 @@ type Schema = Record<string, Json>;
 const schemasDir = join(import.meta.dir, '..', 'schemas');
 export const ledgerSchema = loadSchema('ledger.schema.json');
 export const briefSchema = loadSchema('brief.schema.json');
+export const productSchema = loadSchema('product.schema.json');
+export const partOfSchema = loadSchema('part-of.schema.json');
 
 function loadSchema(name: string): Schema {
   return JSON.parse(readFileSync(join(schemasDir, name), 'utf-8'));
@@ -265,6 +265,63 @@ function collectClaimRefs(node: Json, path: string): { path: string; ref: string
   return refs;
 }
 
+export interface Part {
+  id?: string;
+  kind?: string;
+  target?: string;
+  role?: string;
+  visibility?: string;
+  description?: string;
+}
+
+export function partsOf(doc: Json): Part[] {
+  const composition = (doc as Record<string, Json>).composition as Record<string, Json> | undefined;
+  return (composition?.parts ?? []) as Part[];
+}
+
+export function validateProductDoc(doc: Json): string[] {
+  const errors: string[] = [];
+  checkSchema(doc, productSchema, productSchema, 'product', errors);
+  if (errors.length > 0) return errors;
+
+  const seen = new Set<string>();
+  for (const part of partsOf(doc)) {
+    if (!part.id) continue;
+    if (seen.has(part.id)) errors.push(`product.composition.parts: duplicate part id '${part.id}'`);
+    seen.add(part.id);
+  }
+  return errors;
+}
+
+// The marker rides inside the component's product-review manifest, so validate
+// that one key and leave the sibling surfaces/requires blocks to product-review.
+export function validatePartOfDoc(doc: Json): string[] {
+  const errors: string[] = [];
+  checkSchema((doc as Record<string, Json>).part_of, partOfSchema, partOfSchema, 'part_of', errors);
+  return errors;
+}
+
+// A declaration whose evidence has moved is worse than one that never had any:
+// it reads as sourced right up until somebody follows the pointer.
+function validateProductFile(doc: Json, path: string): string[] {
+  const errors = validateProductDoc(doc);
+  if (errors.length > 0) return errors;
+
+  const root = doc as Record<string, Json>;
+  const pointers: [string, Json][] = Object.entries((root.evidence ?? {}) as Record<string, Json>)
+    .map(([key, value]) => [`evidence.${key}`, value] as [string, Json]);
+  const entry = (root.site as Record<string, Json> | undefined)?.entry;
+  if (entry !== undefined) pointers.push(['site.entry', entry]);
+
+  for (const [field, value] of pointers) {
+    if (typeof value !== 'string') continue;
+    if (!existsSync(resolve(dirname(path), value))) {
+      errors.push(`product.${field}: '${value}' not found relative to the declaration`);
+    }
+  }
+  return errors;
+}
+
 export function parseDocument(path: string): Json {
   const text = readFileSync(path, 'utf-8');
   return path.endsWith('.json') ? JSON.parse(text) : Bun.YAML.parse(text);
@@ -281,7 +338,11 @@ export function validateFile(path: string): string[] {
   const root = doc as Record<string, Json>;
   if (root.ledger_version !== undefined) return validateLedgerDoc(doc);
   if (root.brief_version !== undefined) return validateBriefFile(doc, path);
-  return [`${path}: neither a ledger (ledger_version) nor a brief (brief_version)`];
+  if (root.product_version !== undefined) return validateProductFile(doc, path);
+  if (root.part_of !== undefined) return validatePartOfDoc(doc);
+  return [
+    `${path}: not a recognised document — expected ledger_version, brief_version, product_version or part_of`,
+  ];
 }
 
 function validateBriefFile(doc: Json, path: string): string[] {

--- a/tests/product-intelligence/composition.test.ts
+++ b/tests/product-intelligence/composition.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { validateFile } from '../../skills/product-intelligence/scripts/validate.ts';
+import { checkOrigins, deriveOrigins } from '../../skills/product-intelligence/scripts/origins.ts';
+import { renderOrientation } from '../../skills/product-intelligence/scripts/orient.ts';
+
+const repoRoot = dirname(dirname(import.meta.dir));
+const skillRoot = join(repoRoot, 'skills', 'product-intelligence');
+const scripts = join(skillRoot, 'scripts');
+const example = join(skillRoot, 'examples', 'composition');
+const declaration = join(example, 'product.yaml');
+
+const parse = (path: string) => Bun.YAML.parse(readFileSync(path, 'utf-8')) as Record<string, any>;
+
+function tempDeclaration(body: string): string {
+  const dir = mkdtempSync(join(tmpdir(), 'agentkit-composition-'));
+  const path = join(dir, 'product.yaml');
+  writeFileSync(path, body);
+  return path;
+}
+
+describe('derived origins', () => {
+  test('every part becomes one origin, keyed by the part id', () => {
+    const origins = deriveOrigins(parse(declaration));
+    expect(origins.map((o) => o.id)).toEqual(['engine', 'console', 'cloud']);
+    expect(origins.map((o) => o.target)).toEqual([
+      'acme/engine',
+      'acme/console',
+      'https://app.acme.example',
+    ]);
+  });
+
+  // A brief has no origin kind for something that runs; a service is evidence
+  // you acquire by visiting its URL, which is the site lane.
+  test('a service part derives a site origin, repo and site pass through', () => {
+    expect(deriveOrigins(parse(declaration)).map((o) => o.kind)).toEqual(['repo', 'repo', 'site']);
+  });
+
+  test("the example brief's origins are exactly what the declaration derives", () => {
+    expect(checkOrigins(deriveOrigins(parse(declaration)), parse(join(example, 'brief.yaml')))).toEqual([]);
+  });
+
+  test('a part with no origin in the brief is reported', () => {
+    const brief = parse(join(example, 'brief.yaml'));
+    brief.subject.origins = brief.subject.origins.filter((o: { id: string }) => o.id !== 'console');
+    expect(checkOrigins(deriveOrigins(parse(declaration)), brief).join('\n')).toContain(
+      "missing origin for part 'console'",
+    );
+  });
+
+  // Drift in this direction is the one hand-typing produces: an origin nobody
+  // declared as a part, which no `part_of` marker will ever point back from.
+  test('an origin matching no part is reported', () => {
+    const brief = parse(join(example, 'brief.yaml'));
+    brief.subject.origins.push({ id: 'ghost', kind: 'repo', target: 'acme/ghost' });
+    expect(checkOrigins(deriveOrigins(parse(declaration)), brief).join('\n')).toContain(
+      "origin 'ghost' is not derived from any part",
+    );
+  });
+
+  test('a retargeted part is drift, not a match on id alone', () => {
+    const brief = parse(join(example, 'brief.yaml'));
+    brief.subject.origins[0].target = 'acme/engine-fork';
+    const errors = checkOrigins(deriveOrigins(parse(declaration)), brief);
+    expect(errors.join('\n')).toContain('missing origin for part \'engine\'');
+    expect(errors).toHaveLength(2);
+  });
+});
+
+describe('workspace orientation', () => {
+  test('names the product, every part, and where each one lives', () => {
+    const page = renderOrientation(declaration);
+    expect(page).toContain('acme-platform — workspace orientation');
+    for (const part of ['engine', 'console', 'cloud']) expect(page, part).toContain(`\`${part}\``);
+    expect(page).toContain('acme/engine');
+    expect(page).toContain('https://app.acme.example');
+  });
+
+  test('points at the evidence and the published page', () => {
+    const page = renderOrientation(declaration);
+    expect(page).toContain('`brief.yaml`');
+    expect(page).toContain('`ledger.yaml`');
+    expect(page).toContain('https://pages.acme.example/acme-platform');
+  });
+
+  // An unescaped pipe silently shifts every column after it, so the table would
+  // still render — wrongly — and nobody would notice.
+  test('a pipe in a declared field cannot split a table cell', () => {
+    const path = tempDeclaration(
+      'product_version: "0.1"\nproduct:\n  name: acme\ncomposition:\n  parts:\n    - id: engine\n'
+        + '      kind: repo\n      target: acme/engine\n      role: "core | api"\n',
+    );
+    const row = renderOrientation(path).split('\n').find((line) => line.includes('`engine`')) as string;
+    expect(row.split(/(?<!\\)\|/)).toHaveLength(7);
+    expect(row).toContain('core \\| api');
+  });
+
+  // A literal block, not a folded one: YAML folds `>-` into a single line by
+  // itself, so a folded fixture would pass without collapse() doing anything.
+  test('a multi-line description collapses instead of breaking the list', () => {
+    const path = tempDeclaration(
+      'product_version: "0.1"\nproduct:\n  name: acme\ncomposition:\n  parts:\n    - id: engine\n'
+        + '      kind: repo\n      target: acme/engine\n      description: |-\n        first line\n        second line\n',
+    );
+    const page = renderOrientation(path);
+    expect(page).toContain('- **engine** — first line second line');
+    expect(page.split('\n').filter((l) => l.includes('second line'))).toHaveLength(1);
+  });
+
+  test('refuses to render an invalid declaration rather than orienting from a guess', () => {
+    const path = tempDeclaration('product_version: "0.1"\nproduct:\n  name: acme\n');
+    expect(() => renderOrientation(path)).toThrow(/composition/);
+  });
+
+  // The checked-in example is documentation only while it matches its own
+  // generator; a stale one teaches a shape the tool no longer produces.
+  test('the committed example is what the generator produces today', () => {
+    expect(readFileSync(join(example, 'ORIENTATION.md'), 'utf-8')).toBe(renderOrientation(declaration));
+  });
+});
+
+describe('component part-of marker', () => {
+  test('the example component manifest carries a valid marker beside its surfaces', () => {
+    const path = join(example, 'component-product.yaml');
+    expect(validateFile(path)).toEqual([]);
+    const manifest = parse(path);
+    expect(manifest.part_of.part).toBe('engine');
+    expect(manifest.surfaces).toBeDefined();
+  });
+
+  // The marker is only worth carrying if it resolves: its part id must name a
+  // part the product declaration actually lists.
+  test('the marker names a part the declaration declares', () => {
+    const marker = parse(join(example, 'component-product.yaml')).part_of;
+    expect(deriveOrigins(parse(declaration)).map((o) => o.id)).toContain(marker.part);
+  });
+});
+
+describe('composition CLIs', () => {
+  const run = (script: string, ...args: string[]) =>
+    spawnSync('bun', [join(scripts, script), ...args], { encoding: 'utf-8' });
+
+  test('origins.ts prints a pasteable subject.origins block', () => {
+    const result = run('origins.ts', declaration);
+    expect(result.status, result.stderr).toBe(0);
+    expect(Bun.YAML.parse(result.stdout)).toEqual({
+      subject: { origins: deriveOrigins(parse(declaration)) },
+    });
+  });
+
+  test('origins.ts --json emits the same origins as data', () => {
+    const result = run('origins.ts', declaration, '--json');
+    expect(result.status, result.stderr).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual(deriveOrigins(parse(declaration)));
+  });
+
+  test('origins.ts --check exits 0 when the brief matches', () => {
+    const result = run('origins.ts', declaration, '--check', join(example, 'brief.yaml'));
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('origins match');
+  });
+
+  test('origins.ts --check exits 1 and names the drift', () => {
+    const result = run('origins.ts', declaration, '--check', join(example, '..', 'mixed', 'brief.yaml'));
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("missing origin for part 'engine'");
+  });
+
+  test('origins.ts refuses an invalid declaration instead of deriving from it', () => {
+    const path = tempDeclaration('product_version: "0.1"\nproduct:\n  name: acme\n');
+    const result = run('origins.ts', path);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("missing required field 'composition'");
+  });
+
+  test('origins.ts exits 2 with usage on a bad invocation', () => {
+    expect(run('origins.ts').status).toBe(2);
+    expect(run('origins.ts', declaration, '--check').status).toBe(2);
+    expect(run('origins.ts', declaration, '--nope').stderr).toContain('usage');
+  });
+
+  test('orient.ts writes ORIENTATION.md beside the declaration and prints the path', () => {
+    const path = tempDeclaration(readFileSync(declaration, 'utf-8'));
+    const out = join(dirname(path), 'ORIENTATION.md');
+    // The copy has no evidence files beside it, so only the parts survive.
+    const result = run('orient.ts', path);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('not found relative to the declaration');
+    expect(run('orient.ts', declaration, '--out', out).status, out).toBe(0);
+    expect(readFileSync(out, 'utf-8')).toBe(renderOrientation(declaration));
+  });
+
+  test('orient.ts exits 2 with usage on a bad invocation', () => {
+    expect(run('orient.ts').status).toBe(2);
+    expect(run('orient.ts', declaration, '--out').stderr).toContain('usage');
+  });
+});

--- a/tests/product-intelligence/composition.test.ts
+++ b/tests/product-intelligence/composition.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { validateFile } from '../../skills/product-intelligence/scripts/validate.ts';
-import { checkOrigins, deriveOrigins } from '../../skills/product-intelligence/scripts/origins.ts';
+import { canonicalTarget, checkOrigins, deriveOrigins } from '../../skills/product-intelligence/scripts/origins.ts';
 import { renderOrientation } from '../../skills/product-intelligence/scripts/orient.ts';
 
 const repoRoot = dirname(dirname(import.meta.dir));
@@ -19,6 +19,14 @@ function tempDeclaration(body: string): string {
   const dir = mkdtempSync(join(tmpdir(), 'agentkit-composition-'));
   const path = join(dir, 'product.yaml');
   writeFileSync(path, body);
+  return path;
+}
+
+// YAML is a superset of JSON, so the parser reads this back unchanged.
+function tempBrief(origins: unknown[]): string {
+  const dir = mkdtempSync(join(tmpdir(), 'agentkit-composition-'));
+  const path = join(dir, 'brief.yaml');
+  writeFileSync(path, JSON.stringify({ subject: { origins } }));
   return path;
 }
 
@@ -40,33 +48,126 @@ describe('derived origins', () => {
   });
 
   test("the example brief's origins are exactly what the declaration derives", () => {
-    expect(checkOrigins(deriveOrigins(parse(declaration)), parse(join(example, 'brief.yaml')))).toEqual([]);
+    const check = checkOrigins(deriveOrigins(parse(declaration)), parse(join(example, 'brief.yaml')));
+    expect(check.errors).toEqual([]);
+    expect(check.notes).toEqual([]);
   });
 
-  test('a part with no origin in the brief is reported', () => {
+  test('a part with no origin in the brief is an error', () => {
     const brief = parse(join(example, 'brief.yaml'));
     brief.subject.origins = brief.subject.origins.filter((o: { id: string }) => o.id !== 'console');
-    expect(checkOrigins(deriveOrigins(parse(declaration)), brief).join('\n')).toContain(
+    expect(checkOrigins(deriveOrigins(parse(declaration)), brief).errors.join('\n')).toContain(
       "missing origin for part 'console'",
     );
   });
 
-  // Drift in this direction is the one hand-typing produces: an origin nobody
-  // declared as a part, which no `part_of` marker will ever point back from.
-  test('an origin matching no part is reported', () => {
+  // The skill tells you to cite the product repo's own documents, which are not
+  // a part; failing on that would make the documented workflow permanently red.
+  test('an origin that is not a declared part is a note, not a failure', () => {
     const brief = parse(join(example, 'brief.yaml'));
-    brief.subject.origins.push({ id: 'ghost', kind: 'repo', target: 'acme/ghost' });
-    expect(checkOrigins(deriveOrigins(parse(declaration)), brief).join('\n')).toContain(
-      "origin 'ghost' is not derived from any part",
-    );
+    brief.subject.origins.push({ id: 'product', kind: 'repo', target: 'acme/product' });
+    const check = checkOrigins(deriveOrigins(parse(declaration)), brief);
+    expect(check.errors).toEqual([]);
+    expect(check.notes.join('\n')).toContain("origin 'product' is not a declared part");
   });
 
-  test('a retargeted part is drift, not a match on id alone', () => {
+  test('a retargeted part is drift, and says what each side claims', () => {
     const brief = parse(join(example, 'brief.yaml'));
     brief.subject.origins[0].target = 'acme/engine-fork';
-    const errors = checkOrigins(deriveOrigins(parse(declaration)), brief);
-    expect(errors.join('\n')).toContain('missing origin for part \'engine\'');
-    expect(errors).toHaveLength(2);
+    const check = checkOrigins(deriveOrigins(parse(declaration)), brief);
+    expect(check.errors).toHaveLength(1);
+    expect(check.errors[0]).toContain("origin 'engine' cites repo acme/engine-fork");
+    expect(check.errors[0]).toContain('the part declares repo acme/engine');
+    expect(check.notes).toEqual([]);
+  });
+});
+
+describe('target notation', () => {
+  const briefCiting = (target: string) => {
+    const brief = parse(join(example, 'brief.yaml'));
+    brief.subject.origins[0].target = target;
+    return brief;
+  };
+  const errorsFor = (target: string) =>
+    checkOrigins(deriveOrigins(parse(declaration)), briefCiting(target)).errors;
+
+  // Both schemas advertise these as the same repository, so a comparator that
+  // disagreed would report one repo as missing and unrecognised at once.
+  for (
+    const notation of [
+      'https://github.com/acme/engine',
+      'http://github.com/acme/engine',
+      'https://github.com/acme/engine.git',
+      'https://github.com/acme/engine/',
+      'git@github.com:acme/engine.git',
+      'https://GITHUB.com/acme/engine',
+    ]
+  ) {
+    test(`the declaration's 'acme/engine' matches a brief citing '${notation}'`, () => {
+      expect(errorsFor(notation)).toEqual([]);
+    });
+  }
+
+  test('the same equivalence holds when the declaration carries the URL form', () => {
+    const path = tempDeclaration(
+      'product_version: "0.1"\nproduct:\n  name: acme\ncomposition:\n  parts:\n    - id: engine\n'
+        + '      kind: repo\n      target: https://github.com/acme/engine.git\n',
+    );
+    const brief = { subject: { origins: [{ id: 'engine', kind: 'repo', target: 'acme/engine' }] } };
+    expect(checkOrigins(deriveOrigins(parse(path)), brief).errors).toEqual([]);
+  });
+
+  // Normalising must not go so far that two repos become one.
+  test('the same owner/repo on two hosts stays two repositories', () => {
+    const path = tempDeclaration(
+      'product_version: "0.1"\nproduct:\n  name: acme\ncomposition:\n  parts:\n    - id: engine\n'
+        + '      kind: repo\n      target: https://github.com/acme/engine\n',
+    );
+    const brief = {
+      subject: { origins: [{ id: 'engine', kind: 'repo', target: 'https://gitlab.com/acme/engine' }] },
+    };
+    expect(checkOrigins(deriveOrigins(parse(path)), brief).errors.join('\n')).toContain('gitlab.com');
+  });
+
+  test('a different repo under the same host is still drift', () => {
+    expect(errorsFor('https://github.com/acme/engine-fork').join('\n')).toContain('engine-fork');
+  });
+
+  // Only exercises host folding when BOTH sides state a host: with one side
+  // bare, the comparison short-circuits and any casing would pass.
+  test('two spellings of one host are the same host', () => {
+    const path = tempDeclaration(
+      'product_version: "0.1"\nproduct:\n  name: acme\ncomposition:\n  parts:\n    - id: engine\n'
+        + '      kind: repo\n      target: https://GitHub.COM/acme/engine\n',
+    );
+    const brief = { subject: { origins: [{ id: 'engine', kind: 'repo', target: 'https://github.com/acme/engine' }] } };
+    expect(checkOrigins(deriveOrigins(parse(path)), brief).errors).toEqual([]);
+  });
+
+  test('a matching target under the wrong kind is drift', () => {
+    const brief = parse(join(example, 'brief.yaml'));
+    brief.subject.origins[0].kind = 'site';
+    const errors = checkOrigins(deriveOrigins(parse(declaration)), brief).errors;
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('cites site acme/engine');
+  });
+
+  // filter(Boolean) hides a trailing slash on any hosted target, so the strip
+  // is only load-bearing where there is no host to split on.
+  test('a trailing slash is not part of a bare target', () => {
+    expect(canonicalTarget('docset', 'contracts/')).toEqual(canonicalTarget('docset', 'contracts'));
+  });
+
+  test('a service URL matches with or without scheme and trailing slash', () => {
+    const brief = parse(join(example, 'brief.yaml'));
+    brief.subject.origins[2].target = 'app.acme.example/';
+    expect(checkOrigins(deriveOrigins(parse(declaration)), brief).errors).toEqual([]);
+  });
+
+  test('a differing URL path is not folded away', () => {
+    const brief = parse(join(example, 'brief.yaml'));
+    brief.subject.origins[2].target = 'https://app.acme.example/status';
+    expect(checkOrigins(deriveOrigins(parse(declaration)), brief).errors).toHaveLength(1);
   });
 });
 
@@ -108,6 +209,15 @@ describe('workspace orientation', () => {
     const page = renderOrientation(path);
     expect(page).toContain('- **engine** — first line second line');
     expect(page.split('\n').filter((l) => l.includes('second line'))).toHaveLength(1);
+  });
+
+  // The generator cannot see whether components carry markers — this branch is
+  // what makes them possible — so the page states the convention rather than
+  // reporting unverified state as fact.
+  test('states the part_of convention without claiming components already follow it', () => {
+    const page = renderOrientation(declaration);
+    expect(page).toContain('convention is that a component names the part it is');
+    expect(page).not.toContain('must agree on the id');
   });
 
   test('refuses to render an invalid declaration rather than orienting from a guess', () => {
@@ -160,7 +270,25 @@ describe('composition CLIs', () => {
   test('origins.ts --check exits 0 when the brief matches', () => {
     const result = run('origins.ts', declaration, '--check', join(example, 'brief.yaml'));
     expect(result.status, result.stderr).toBe(0);
-    expect(result.stdout).toContain('origins match');
+    expect(result.stdout).toContain('cites every part declared by');
+  });
+
+  test('origins.ts --check accepts a brief citing a source that is not a part', () => {
+    const brief = tempBrief([
+      ...deriveOrigins(parse(declaration)),
+      { id: 'product', kind: 'repo', target: 'acme/product' },
+    ]);
+    const result = run('origins.ts', declaration, '--check', brief);
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("note: ");
+    expect(result.stdout).toContain("origin 'product' is not a declared part");
+  });
+
+  test('origins.ts --check points at the remedy when a part is uncited', () => {
+    const result = run('origins.ts', declaration, '--check', tempBrief([]));
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('hint:');
+    expect(result.stderr).toContain('origins the declaration derives');
   });
 
   test('origins.ts --check exits 1 and names the drift', () => {

--- a/tests/product-intelligence/composition.test.ts
+++ b/tests/product-intelligence/composition.test.ts
@@ -152,10 +152,57 @@ describe('target notation', () => {
     expect(errors[0]).toContain('cites site acme/engine');
   });
 
-  // filter(Boolean) hides a trailing slash on any hosted target, so the strip
-  // is only load-bearing where there is no host to split on.
-  test('a trailing slash is not part of a bare target', () => {
-    expect(canonicalTarget('docset', 'contracts/')).toEqual(canonicalTarget('docset', 'contracts'));
+  // The trailing slash has to go before the .git suffix is stripped, or the
+  // suffix is no longer at the end and survives into the compared path.
+  test('a trailing slash does not hide the .git suffix', () => {
+    expect(errorsFor('https://github.com/acme/engine.git/')).toEqual([]);
+  });
+});
+
+// A GitLab group and subgroup are ordinary path segments, so a comparator that
+// keeps only the last two silently equates repos under different groups.
+describe('subgroup paths', () => {
+  const declaring = (target: string) =>
+    tempDeclaration(
+      'product_version: "0.1"\nproduct:\n  name: acme\ncomposition:\n  parts:\n    - id: engine\n'
+        + `      kind: repo\n      target: ${target}\n`,
+    );
+  const citing = (target: string) => ({ subject: { origins: [{ id: 'engine', kind: 'repo', target }] } });
+  const errorsBetween = (declared: string, cited: string) =>
+    checkOrigins(deriveOrigins(parse(declaring(declared))), citing(cited)).errors;
+
+  test('identical subgroup paths match', () => {
+    expect(errorsBetween('https://gitlab.com/acme/platform/engine', 'acme/platform/engine')).toEqual([]);
+  });
+
+  test('the same subgroup tail under a different group is drift', () => {
+    const errors = errorsBetween(
+      'https://gitlab.com/acme/platform/engine',
+      'https://gitlab.com/other/platform/engine',
+    );
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('other/platform/engine');
+  });
+
+  test('a two-segment shorthand does not match the tail of a deeper path', () => {
+    expect(errorsBetween('https://gitlab.com/acme/platform/engine', 'platform/engine')).toHaveLength(1);
+  });
+
+  test('a shorthand still matches a hosted path that is exactly owner/repo', () => {
+    expect(errorsBetween('https://gitlab.com/acme/engine', 'acme/engine')).toEqual([]);
+  });
+
+  // The host-less spelling of a subgroup path keeps every segment too, or the
+  // two spellings of one repo stop matching.
+  test('a host-less subgroup path matches its hosted spelling', () => {
+    expect(errorsBetween('acme/platform/engine', 'https://gitlab.com/acme/platform/engine')).toEqual([]);
+  });
+
+  test('canonicalTarget keeps every segment after the host', () => {
+    expect(canonicalTarget('https://gitlab.com/acme/platform/engine')).toEqual({
+      host: 'gitlab.com',
+      path: 'acme/platform/engine',
+    });
   });
 
   test('a service URL matches with or without scheme and trailing slash', () => {

--- a/tests/product-intelligence/schemas.test.ts
+++ b/tests/product-intelligence/schemas.test.ts
@@ -32,6 +32,12 @@ const expectedFailures: Record<string, string> = {
   'brief-dangling-ledger.yaml': 'not found',
   'brief-multi-origin-unqualified.yaml': 'must name its origin',
   'brief-origin-duplicate-id.yaml': 'duplicate origin id',
+  'product-duplicate-part-id.yaml': "duplicate part id 'engine'",
+  'product-unknown-part-kind.yaml': 'must be one of',
+  'product-missing-part-target.yaml': "missing required field 'target'",
+  'product-dangling-evidence.yaml': 'not found relative to the declaration',
+  'part-of-missing-part.yaml': "missing required field 'part'",
+  'part-of-unslugged-id.yaml': 'does not match pattern',
 };
 
 describe('product-intelligence schemas', () => {
@@ -61,8 +67,8 @@ describe('worked examples', () => {
   const dirs = () =>
     readdirSync(examples, { withFileTypes: true }).filter((e) => e.isDirectory()).map((e) => e.name);
 
-  test('ships the three evidence situations, each schema-valid', () => {
-    expect(dirs().sort()).toEqual(['mixed', 'repo-only', 'website-only']);
+  test('ships the three evidence situations plus the composition example, each schema-valid', () => {
+    expect(dirs().sort()).toEqual(['composition', 'mixed', 'repo-only', 'website-only']);
     for (const name of dirs()) {
       expect(validateFile(join(examples, name, 'brief.yaml')), name).toEqual([]);
     }

--- a/tests/product-intelligence/schemas.test.ts
+++ b/tests/product-intelligence/schemas.test.ts
@@ -36,6 +36,7 @@ const expectedFailures: Record<string, string> = {
   'product-unknown-part-kind.yaml': 'must be one of',
   'product-missing-part-target.yaml': "missing required field 'target'",
   'product-dangling-evidence.yaml': 'not found relative to the declaration',
+  'product-empty-parts.yaml': 'must have at least 1 item',
   'part-of-missing-part.yaml': "missing required field 'part'",
   'part-of-unslugged-id.yaml': 'does not match pattern',
 };
@@ -103,9 +104,14 @@ describe('validate.ts CLI', () => {
     expect(result.stderr).toContain('not symmetric');
   });
 
-  test('exits 2 with usage when given no files', () => {
+  // The one message a first-time user is guaranteed to see, so it has to name
+  // every kind the dispatch actually accepts.
+  test('exits 2 with usage naming all four document kinds', () => {
     const result = run();
     expect(result.status).toBe(2);
     expect(result.stderr).toContain('usage');
+    for (const kind of ['ledger', 'brief', 'product', 'part-of']) {
+      expect(result.stderr, kind).toContain(kind);
+    }
   });
 });


### PR DESCRIPTION
Closes #150.

- product.schema.json validates the real agentkit/product declaration unchanged; part_of block in the component's .agentkit/product.yaml
- validate.ts: four document kinds; origins.ts derived origins + --check drift gate (canonical targets, subgroup-safe); orient.ts ORIENTATION.md generator (dprint-stable output)
- fixtures valid+invalid, 186-test slice, 25 mutations caught
- review: 3 rounds, record at .agentkit/reviews/feat__product-composition-schema.json (pass @ head)