### PR TITLE
feat(product-intelligence): portable file:// site + Pages CI scaffolds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: '17 4 * * 1'
+    - cron: "17 4 * * 1"
   workflow_dispatch:
 
 permissions:
@@ -45,6 +45,9 @@ jobs:
 
       - name: Install dependencies from the lockfile
         run: bun install --frozen-lockfile
+
+      - name: Install publish-page skill dependencies
+        run: bun install --frozen-lockfile --cwd skills/publish-page
 
       - name: Validate test slice coverage
         run: bun run test:slices
@@ -91,6 +94,9 @@ jobs:
 
       - name: Install dependencies from the lockfile
         run: bun install --frozen-lockfile
+
+      - name: Install publish-page skill dependencies
+        run: bun install --frozen-lockfile --cwd skills/publish-page
 
       - name: Run complete suite
         run: moon run agentkit:test-full

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: "17 4 * * 1"
+    - cron: '17 4 * * 1'
   workflow_dispatch:
 
 permissions:

--- a/plugins-cc/agentkit/skills/product-intelligence/SKILL.md
+++ b/plugins-cc/agentkit/skills/product-intelligence/SKILL.md
@@ -238,6 +238,12 @@ output, so a rebuilt page only changes when the evidence does.
 
 One-time on the machine that renders: `cd skills/publish-page && bun install`.
 
+**Findings diagrams: known limitation.** A `` ```mermaid `` fence in
+`findings.md` reaches the page with the analyze pass's escaping applied inside
+the fence, so any diagram using `[`, `]`, `(` or `)` fails to parse — while
+the 3.4 MB mermaid runtime is inlined regardless. Keep diagrams out of
+`findings.md` until that escaping is fence-aware.
+
 ### Rung 2 — Pages CI
 
 Scaffolds in `assets/ci/` — copy one into the repo that owns the brief and set

--- a/plugins-cc/agentkit/skills/product-intelligence/SKILL.md
+++ b/plugins-cc/agentkit/skills/product-intelligence/SKILL.md
@@ -239,7 +239,7 @@ output, so a rebuilt page only changes when the evidence does.
 One-time on the machine that renders: `cd skills/publish-page && bun install`.
 
 **Findings diagrams: known limitation.** A `` ```mermaid `` fence in
-`findings.md` reaches the page with the analyze pass's escaping applied inside
+`findings.md` reaches the page with the findings sanitizer's escaping applied inside
 the fence, so any diagram using `[`, `]`, `(` or `)` fails to parse — while
 the 3.4 MB mermaid runtime is inlined regardless. Keep diagrams out of
 `findings.md` until that escaping is fence-aware.

--- a/plugins-cc/agentkit/skills/product-intelligence/SKILL.md
+++ b/plugins-cc/agentkit/skills/product-intelligence/SKILL.md
@@ -210,3 +210,46 @@ Re-running against the same subject keeps the section order stable and diffs
 against the previous ledger: new claims, changed sources (`as_of` moved),
 claims whose source disappeared. A vanished source downgrades confidence; it
 does not silently delete the claim.
+
+## Hosting ladder
+
+A brief is only useful once someone can read it. Four rungs, cheapest first —
+climb only as far as the situation needs, and never let the reader's access
+depend on a rung they cannot reach.
+
+| Rung             | What it is                             | Use it when                                                                               |
+| ---------------- | -------------------------------------- | ----------------------------------------------------------------------------------------- |
+| 1 Portable file  | One self-contained `index.html`        | Pages is disabled, the repo is private, the reader is offline or gets it as an attachment |
+| 2 Repo Pages CI  | GitHub or GitLab Pages, built on push  | The brief lives in a repo and should re-publish itself when the evidence changes          |
+| 3 AgentKit Pages | `publish-page` → your own pages worker | You want a URL now, with no repo and no CI                                                |
+| 4 Hosted         | `publish-page` at a hosted endpoint    | Same as rung 3, someone else runs the worker (`AGENTKIT_PAGES_ENDPOINT`)                  |
+
+### Rung 1 — portable file
+
+```sh
+bun skills/product-intelligence/scripts/render.ts <dir> --html --out index.html
+```
+
+Writes `<dir>/index.html` without `--out`. The doc theme's CSS and JS are
+inlined, so the page opens by double-click from `file://` with no server and
+makes **no network request of any kind** — the light/dark toggle, the section
+rail and the anchors all work offline. Same inputs render byte-identical
+output, so a rebuilt page only changes when the evidence does.
+
+One-time on the machine that renders: `cd skills/publish-page && bun install`.
+
+### Rung 2 — Pages CI
+
+Scaffolds in `assets/ci/` — copy one into the repo that owns the brief and set
+`INTELLIGENCE_DIR`:
+
+| File                         | Copy to                             |
+| ---------------------------- | ----------------------------------- |
+| `assets/ci/github-pages.yml` | `.github/workflows/brief-pages.yml` |
+| `assets/ci/gitlab-ci.yml`    | `.gitlab-ci.yml`                    |
+
+Both jobs do the same three things: validate `brief.yaml` + `ledger.yaml`,
+render `brief-page.md` and `index.html` into `public/`, publish that directory.
+Validation runs first on purpose — a dangling claim id fails the build instead
+of publishing a brief whose citations go nowhere. Pin `AGENTKIT_REF` to a tag
+so a rebuild cannot change with upstream.

--- a/plugins-cc/agentkit/skills/product-intelligence/assets/ci/github-pages.yml
+++ b/plugins-cc/agentkit/skills/product-intelligence/assets/ci/github-pages.yml
@@ -1,0 +1,71 @@
+# Copy to .github/workflows/brief-pages.yml in the repo that owns the brief.
+# Set INTELLIGENCE_DIR to the directory holding brief.yaml + ledger.yaml, and
+# pin AGENTKIT_REF to a tag so a page rebuild cannot change with upstream.
+# Repository settings → Pages → Source must be set to "GitHub Actions".
+name: Publish brief to Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+  pages: write
+
+# Deployments queue instead of cancelling: a half-published page is worse than
+# a late one.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Render and deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    env:
+      AGENTKIT: ${{ runner.temp }}/agentkit
+      AGENTKIT_REF: main
+      INTELLIGENCE_DIR: intelligence
+    steps:
+      - name: Check out the brief
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+
+      - name: Fetch the agentkit skills
+        run: |
+          git clone --depth 1 --branch "$AGENTKIT_REF" \
+            https://github.com/developerinlondon/agentkit "$AGENTKIT"
+          cd "$AGENTKIT/skills/publish-page" && bun install
+
+      - name: Validate the evidence
+        run: |
+          bun "$AGENTKIT/skills/product-intelligence/scripts/validate.ts" \
+            "$INTELLIGENCE_DIR/brief.yaml" "$INTELLIGENCE_DIR/ledger.yaml"
+
+      - name: Render the page
+        run: |
+          mkdir -p public
+          RENDER="$AGENTKIT/skills/product-intelligence/scripts/render.ts"
+          bun "$RENDER" "$INTELLIGENCE_DIR" --out public/brief-page.md
+          bun "$RENDER" "$INTELLIGENCE_DIR" --html --out public/index.html
+
+      - name: Configure Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
+      - name: Upload the rendered directory
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: public
+
+      - name: Deploy to Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/plugins-cc/agentkit/skills/product-intelligence/assets/ci/gitlab-ci.yml
+++ b/plugins-cc/agentkit/skills/product-intelligence/assets/ci/gitlab-ci.yml
@@ -1,0 +1,28 @@
+# Copy to .gitlab-ci.yml in the repo that owns the brief (or `include:` it).
+# Set INTELLIGENCE_DIR to the directory holding brief.yaml + ledger.yaml, and
+# pin AGENTKIT_REF to a tag so a page rebuild cannot change with upstream.
+#
+# The literal job name `pages` plus an explicit `public/` artifact is the form
+# every GitLab version accepts; `pages: true` on a freely named job needs 17.9+.
+variables:
+  AGENTKIT_REF: main
+  AGENTKIT_REPO: https://github.com/developerinlondon/agentkit
+  INTELLIGENCE_DIR: intelligence
+
+pages:
+  stage: deploy
+  image: oven/bun:1
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+  before_script:
+    - command -v git >/dev/null || (apt-get update && apt-get install -y --no-install-recommends git)
+    - git clone --depth 1 --branch "$AGENTKIT_REF" "$AGENTKIT_REPO" /tmp/agentkit
+    - cd /tmp/agentkit/skills/publish-page && bun install && cd "$CI_PROJECT_DIR"
+  script:
+    - bun /tmp/agentkit/skills/product-intelligence/scripts/validate.ts "$INTELLIGENCE_DIR/brief.yaml" "$INTELLIGENCE_DIR/ledger.yaml"
+    - mkdir -p public
+    - bun /tmp/agentkit/skills/product-intelligence/scripts/render.ts "$INTELLIGENCE_DIR" --out public/brief-page.md
+    - bun /tmp/agentkit/skills/product-intelligence/scripts/render.ts "$INTELLIGENCE_DIR" --html --out public/index.html
+  artifacts:
+    paths:
+      - public

--- a/plugins-cc/agentkit/skills/product-intelligence/scripts/html.ts
+++ b/plugins-cc/agentkit/skills/product-intelligence/scripts/html.ts
@@ -1,0 +1,34 @@
+#!/usr/bin/env bun
+// The hosting ladder's floor: one HTML file that opens by double-click, with no
+// server, no network and no build step — so a brief survives a private GitLab,
+// an air-gapped laptop or an email attachment.
+
+import { join } from 'node:path';
+import { briefTitle, renderBrief } from './render.ts';
+
+const themeSkill = join(import.meta.dir, '..', '..', 'publish-page');
+
+// Deferred so the markdown lane keeps working without the publish-page skill's
+// dependencies, and so a missing install names its own fix.
+async function themeRenderer() {
+  try {
+    return await import('../../publish-page/render-html.ts');
+  } catch (error) {
+    throw new Error(
+      `page renderer unavailable (${(error as Error).message}) — run: cd ${themeSkill} && bun install`,
+    );
+  }
+}
+
+export async function renderBriefHtml(dir: string): Promise<string> {
+  const { bundledThemePath, renderThemed } = await themeRenderer();
+  return renderThemed({
+    source: renderBrief(dir),
+    isMd: true,
+    template: 'doc',
+    title: briefTitle(dir),
+    // The bundled theme, never the agentkit-pages clone publish.ts prefers: a
+    // portable page must render the same bytes where no clone exists.
+    themePath: bundledThemePath('doc'),
+  });
+}

--- a/plugins-cc/agentkit/skills/product-intelligence/scripts/render.ts
+++ b/plugins-cc/agentkit/skills/product-intelligence/scripts/render.ts
@@ -95,6 +95,10 @@ function chip(label: string, value: string): string {
   return `<span class="chip"><strong>${escText(label)}</strong> ${escText(value)}</span>`;
 }
 
+function subjectTitle(brief: Dict): string {
+  return `${collapse(brief.subject?.name ?? 'Untitled product')}: what the evidence says`;
+}
+
 function header(brief: Dict, ledger: Dict): string {
   const subject = brief.subject ?? {};
   const claims = (ledger.claims ?? []) as Dict[];
@@ -119,7 +123,7 @@ function header(brief: Dict, ledger: Dict): string {
   const promise = sourced
     ? 'every observed and inferred claim carries a verbatim quote from an acquired source'
     : 'each claim states its kind and how solid its basis is';
-  const lines = [`# ${mdEsc(subject.name ?? 'Untitled product')}: what the evidence says`, ''];
+  const lines = [`# ${mdEsc(subjectTitle(brief))}`, ''];
   lines.push(`<div class="chips">${chips}</div>`, '');
   if (subject.one_liner) lines.push(`**${mdEsc(subject.one_liner)}**`, '');
   lines.push(
@@ -325,14 +329,26 @@ function evidence(brief: Dict, ledger: Dict): string {
   return `## The evidence, claim by claim\n\n${blocks}\n${provenance}`;
 }
 
-export function renderBrief(dir: string): string {
+function artifacts(dir: string): { brief: Dict; ledger: Dict } {
   const briefPath = join(dir, 'brief.yaml');
   const ledgerPath = join(dir, 'ledger.yaml');
   for (const p of [briefPath, ledgerPath]) {
     if (!existsSync(p)) throw new Error(`missing ${p} — render needs both brief.yaml and ledger.yaml`);
   }
-  const brief = Bun.YAML.parse(readFileSync(briefPath, 'utf-8')) as Dict;
-  const ledger = Bun.YAML.parse(readFileSync(ledgerPath, 'utf-8')) as Dict;
+  return {
+    brief: Bun.YAML.parse(readFileSync(briefPath, 'utf-8')) as Dict,
+    ledger: Bun.YAML.parse(readFileSync(ledgerPath, 'utf-8')) as Dict,
+  };
+}
+
+// The page's own <title>, taken before markdown escaping: the h1 carries
+// backslash escapes that a title bar would show literally.
+export function briefTitle(dir: string): string {
+  return subjectTitle(artifacts(dir).brief);
+}
+
+export function renderBrief(dir: string): string {
+  const { brief, ledger } = artifacts(dir);
   const sections = [
     header(brief, ledger),
     positioning(brief),
@@ -351,14 +367,16 @@ export function renderBrief(dir: string): string {
 }
 
 if (import.meta.main) {
-  const [dir, outFlag, outPath] = process.argv.slice(2);
+  const argv = process.argv.slice(2);
+  const html = argv.includes('--html');
+  const [dir, outFlag, outPath] = argv.filter((a) => a !== '--html');
   if (!dir || (outFlag && (outFlag !== '--out' || !outPath))) {
-    console.error('usage: render.ts <intelligence-dir> [--out <file>]');
+    console.error('usage: render.ts <intelligence-dir> [--html] [--out <file>]');
     process.exit(2);
   }
   try {
-    const page = renderBrief(dir);
-    const target = outPath ?? join(dir, 'brief-page.md');
+    const page = html ? await (await import('./html.ts')).renderBriefHtml(dir) : renderBrief(dir);
+    const target = outPath ?? join(dir, html ? 'index.html' : 'brief-page.md');
     writeFileSync(target, page);
     console.log(target);
   } catch (error) {

--- a/plugins-cc/agentkit/skills/publish-page/bun.lock
+++ b/plugins-cc/agentkit/skills/publish-page/bun.lock
@@ -1,0 +1,249 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "publish-page-skill",
+      "dependencies": {
+        "marked": "^18.0.7",
+        "mermaid": "11.16.0",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.2.19",
+      },
+    },
+  },
+  "packages": {
+    "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
+
+    "@braintree/sanitize-url": ["@braintree/sanitize-url@7.1.2", "", {}, "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA=="],
+
+    "@chevrotain/types": ["@chevrotain/types@11.1.2", "", {}, "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw=="],
+
+    "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
+
+    "@iconify/utils": ["@iconify/utils@3.1.4", "", { "dependencies": { "@antfu/install-pkg": "^1.1.0", "@iconify/types": "^2.0.0", "import-meta-resolve": "^4.2.0" } }, "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw=="],
+
+    "@mermaid-js/parser": ["@mermaid-js/parser@1.2.0", "", { "dependencies": { "@chevrotain/types": "~11.1.2" } }, "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA=="],
+
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/d3": ["@types/d3@7.4.3", "", { "dependencies": { "@types/d3-array": "*", "@types/d3-axis": "*", "@types/d3-brush": "*", "@types/d3-chord": "*", "@types/d3-color": "*", "@types/d3-contour": "*", "@types/d3-delaunay": "*", "@types/d3-dispatch": "*", "@types/d3-drag": "*", "@types/d3-dsv": "*", "@types/d3-ease": "*", "@types/d3-fetch": "*", "@types/d3-force": "*", "@types/d3-format": "*", "@types/d3-geo": "*", "@types/d3-hierarchy": "*", "@types/d3-interpolate": "*", "@types/d3-path": "*", "@types/d3-polygon": "*", "@types/d3-quadtree": "*", "@types/d3-random": "*", "@types/d3-scale": "*", "@types/d3-scale-chromatic": "*", "@types/d3-selection": "*", "@types/d3-shape": "*", "@types/d3-time": "*", "@types/d3-time-format": "*", "@types/d3-timer": "*", "@types/d3-transition": "*", "@types/d3-zoom": "*" } }, "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww=="],
+
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-axis": ["@types/d3-axis@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw=="],
+
+    "@types/d3-brush": ["@types/d3-brush@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A=="],
+
+    "@types/d3-chord": ["@types/d3-chord@3.0.6", "", {}, "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-contour": ["@types/d3-contour@3.0.6", "", { "dependencies": { "@types/d3-array": "*", "@types/geojson": "*" } }, "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg=="],
+
+    "@types/d3-delaunay": ["@types/d3-delaunay@6.0.4", "", {}, "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw=="],
+
+    "@types/d3-dispatch": ["@types/d3-dispatch@3.0.7", "", {}, "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA=="],
+
+    "@types/d3-drag": ["@types/d3-drag@3.0.7", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ=="],
+
+    "@types/d3-dsv": ["@types/d3-dsv@3.0.7", "", {}, "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-fetch": ["@types/d3-fetch@3.0.7", "", { "dependencies": { "@types/d3-dsv": "*" } }, "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA=="],
+
+    "@types/d3-force": ["@types/d3-force@3.0.10", "", {}, "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw=="],
+
+    "@types/d3-format": ["@types/d3-format@3.0.4", "", {}, "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g=="],
+
+    "@types/d3-geo": ["@types/d3-geo@3.1.0", "", { "dependencies": { "@types/geojson": "*" } }, "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ=="],
+
+    "@types/d3-hierarchy": ["@types/d3-hierarchy@3.1.7", "", {}, "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-polygon": ["@types/d3-polygon@3.0.2", "", {}, "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA=="],
+
+    "@types/d3-quadtree": ["@types/d3-quadtree@3.0.6", "", {}, "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg=="],
+
+    "@types/d3-random": ["@types/d3-random@3.0.4", "", {}, "sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-scale-chromatic": ["@types/d3-scale-chromatic@3.1.0", "", {}, "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ=="],
+
+    "@types/d3-selection": ["@types/d3-selection@3.0.11", "", {}, "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-time-format": ["@types/d3-time-format@4.0.3", "", {}, "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
+    "@types/d3-transition": ["@types/d3-transition@3.0.9", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg=="],
+
+    "@types/d3-zoom": ["@types/d3-zoom@3.0.8", "", { "dependencies": { "@types/d3-interpolate": "*", "@types/d3-selection": "*" } }, "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw=="],
+
+    "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
+
+    "@types/node": ["@types/node@26.1.2", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg=="],
+
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
+    "@upsetjs/venn.js": ["@upsetjs/venn.js@2.0.0", "", { "optionalDependencies": { "d3-selection": "^3.0.0", "d3-transition": "^3.0.1" } }, "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
+
+    "cose-base": ["cose-base@1.0.3", "", { "dependencies": { "layout-base": "^1.0.0" } }, "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg=="],
+
+    "cytoscape": ["cytoscape@3.34.0", "", {}, "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg=="],
+
+    "cytoscape-cose-bilkent": ["cytoscape-cose-bilkent@4.1.0", "", { "dependencies": { "cose-base": "^1.0.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ=="],
+
+    "cytoscape-fcose": ["cytoscape-fcose@2.2.0", "", { "dependencies": { "cose-base": "^2.2.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ=="],
+
+    "d3": ["d3@7.9.0", "", { "dependencies": { "d3-array": "3", "d3-axis": "3", "d3-brush": "3", "d3-chord": "3", "d3-color": "3", "d3-contour": "4", "d3-delaunay": "6", "d3-dispatch": "3", "d3-drag": "3", "d3-dsv": "3", "d3-ease": "3", "d3-fetch": "3", "d3-force": "3", "d3-format": "3", "d3-geo": "3", "d3-hierarchy": "3", "d3-interpolate": "3", "d3-path": "3", "d3-polygon": "3", "d3-quadtree": "3", "d3-random": "3", "d3-scale": "4", "d3-scale-chromatic": "3", "d3-selection": "3", "d3-shape": "3", "d3-time": "3", "d3-time-format": "4", "d3-timer": "3", "d3-transition": "3", "d3-zoom": "3" } }, "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA=="],
+
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-axis": ["d3-axis@3.0.0", "", {}, "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw=="],
+
+    "d3-brush": ["d3-brush@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "3", "d3-transition": "3" } }, "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ=="],
+
+    "d3-chord": ["d3-chord@3.0.1", "", { "dependencies": { "d3-path": "1 - 3" } }, "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-contour": ["d3-contour@4.0.2", "", { "dependencies": { "d3-array": "^3.2.0" } }, "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA=="],
+
+    "d3-delaunay": ["d3-delaunay@6.0.4", "", { "dependencies": { "delaunator": "5" } }, "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A=="],
+
+    "d3-dispatch": ["d3-dispatch@3.0.1", "", {}, "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="],
+
+    "d3-drag": ["d3-drag@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-selection": "3" } }, "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg=="],
+
+    "d3-dsv": ["d3-dsv@3.0.1", "", { "dependencies": { "commander": "7", "iconv-lite": "0.6", "rw": "1" }, "bin": { "csv2json": "bin/dsv2json.js", "csv2tsv": "bin/dsv2dsv.js", "dsv2dsv": "bin/dsv2dsv.js", "dsv2json": "bin/dsv2json.js", "json2csv": "bin/json2dsv.js", "json2dsv": "bin/json2dsv.js", "json2tsv": "bin/json2dsv.js", "tsv2csv": "bin/dsv2dsv.js", "tsv2json": "bin/dsv2json.js" } }, "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-fetch": ["d3-fetch@3.0.1", "", { "dependencies": { "d3-dsv": "1 - 3" } }, "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw=="],
+
+    "d3-force": ["d3-force@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-quadtree": "1 - 3", "d3-timer": "1 - 3" } }, "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-geo": ["d3-geo@3.1.1", "", { "dependencies": { "d3-array": "2.5.0 - 3" } }, "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q=="],
+
+    "d3-hierarchy": ["d3-hierarchy@3.1.2", "", {}, "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-polygon": ["d3-polygon@3.0.1", "", {}, "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg=="],
+
+    "d3-quadtree": ["d3-quadtree@3.0.1", "", {}, "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="],
+
+    "d3-random": ["d3-random@3.0.1", "", {}, "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ=="],
+
+    "d3-sankey": ["d3-sankey@0.12.3", "", { "dependencies": { "d3-array": "1 - 2", "d3-shape": "^1.2.0" } }, "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-scale-chromatic": ["d3-scale-chromatic@3.1.0", "", { "dependencies": { "d3-color": "1 - 3", "d3-interpolate": "1 - 3" } }, "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ=="],
+
+    "d3-selection": ["d3-selection@3.0.0", "", {}, "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
+    "d3-transition": ["d3-transition@3.0.1", "", { "dependencies": { "d3-color": "1 - 3", "d3-dispatch": "1 - 3", "d3-ease": "1 - 3", "d3-interpolate": "1 - 3", "d3-timer": "1 - 3" }, "peerDependencies": { "d3-selection": "2 - 3" } }, "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w=="],
+
+    "d3-zoom": ["d3-zoom@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "2 - 3", "d3-transition": "2 - 3" } }, "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw=="],
+
+    "dagre-d3-es": ["dagre-d3-es@7.0.14", "", { "dependencies": { "d3": "^7.9.0", "lodash-es": "^4.17.21" } }, "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg=="],
+
+    "dayjs": ["dayjs@1.11.21", "", {}, "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA=="],
+
+    "delaunator": ["delaunator@5.1.0", "", { "dependencies": { "robust-predicates": "^3.0.2" } }, "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ=="],
+
+    "dompurify": ["dompurify@3.4.12", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg=="],
+
+    "es-toolkit": ["es-toolkit@1.50.0", "", {}, "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w=="],
+
+    "hachure-fill": ["hachure-fill@0.5.2", "", {}, "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg=="],
+
+    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "import-meta-resolve": ["import-meta-resolve@4.2.0", "", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
+
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
+
+    "katex": ["katex@0.16.47", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg=="],
+
+    "khroma": ["khroma@2.1.0", "", {}, "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="],
+
+    "layout-base": ["layout-base@1.0.2", "", {}, "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg=="],
+
+    "lodash-es": ["lodash-es@4.18.1", "", {}, "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="],
+
+    "marked": ["marked@18.0.7", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-iDVQ5ldaiKXn6b2JroX5kgRfmwgqolW7NpaEzTl1k/2Zh1njIEN9yniyLV/mOvWwtsE8OGgkjsCYvijuPk1dtA=="],
+
+    "mermaid": ["mermaid@11.16.0", "", { "dependencies": { "@braintree/sanitize-url": "^7.1.2", "@iconify/utils": "^3.0.2", "@mermaid-js/parser": "^1.2.0", "@types/d3": "^7.4.3", "@upsetjs/venn.js": "^2.0.0", "cytoscape": "^3.33.3", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.2.0", "d3": "^7.9.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.14", "dayjs": "^1.11.20", "dompurify": "^3.3.3", "es-toolkit": "^1.45.1", "katex": "^0.16.45", "khroma": "^2.1.0", "marked": "^16.3.0", "roughjs": "^4.6.6", "stylis": "^4.3.6", "ts-dedent": "^2.2.0", "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0" } }, "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA=="],
+
+    "package-manager-detector": ["package-manager-detector@1.8.0", "", {}, "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A=="],
+
+    "path-data-parser": ["path-data-parser@0.1.0", "", {}, "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w=="],
+
+    "points-on-curve": ["points-on-curve@0.2.0", "", {}, "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="],
+
+    "points-on-path": ["points-on-path@0.2.1", "", { "dependencies": { "path-data-parser": "0.1.0", "points-on-curve": "0.2.0" } }, "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g=="],
+
+    "robust-predicates": ["robust-predicates@3.0.3", "", {}, "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA=="],
+
+    "roughjs": ["roughjs@4.6.6", "", { "dependencies": { "hachure-fill": "^0.5.2", "path-data-parser": "^0.1.0", "points-on-curve": "^0.2.0", "points-on-path": "^0.2.1" } }, "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ=="],
+
+    "rw": ["rw@1.3.3", "", {}, "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "stylis": ["stylis@4.4.0", "", {}, "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA=="],
+
+    "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
+
+    "ts-dedent": ["ts-dedent@2.3.0", "", {}, "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "uuid": ["uuid@14.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
+
+    "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
+
+    "d3-dsv/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
+
+    "d3-sankey/d3-array": ["d3-array@2.12.1", "", { "dependencies": { "internmap": "^1.0.0" } }, "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ=="],
+
+    "d3-sankey/d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
+
+    "mermaid/marked": ["marked@16.4.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="],
+
+    "cytoscape-fcose/cose-base/layout-base": ["layout-base@2.0.1", "", {}, "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="],
+
+    "d3-sankey/d3-array/internmap": ["internmap@1.0.1", "", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
+
+    "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
+  }
+}

--- a/plugins-cc/agentkit/skills/publish-page/publish.ts
+++ b/plugins-cc/agentkit/skills/publish-page/publish.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
-import { marked } from "marked";
 import { lintFigures } from "./lint.ts";
+import { bundledThemePath, renderThemed } from "./render-html.ts";
 import { createHmac, randomBytes } from "node:crypto";
 import { existsSync } from "node:fs";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
@@ -19,12 +19,6 @@ function arg(name: string): string | undefined {
   const v = i > 0 ? process.argv[i + 1] : undefined;
   if (v?.startsWith("--")) fail(`--${name} is missing its value (got "${v}")`);
   return v;
-}
-
-function escapeHtml(s: string): string {
-  return s.replace(/[&<>"']/g, (c) =>
-    ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c] as string
-  );
 }
 
 const explicitSlug = arg("slug");
@@ -127,98 +121,25 @@ const title = arg("title")
   ?? source.match(/<title>([^<]+)<\/title>/)?.[1]
   ?? pageLabel;
 
-// Split markdown into slides on `---` lines, ignoring YAML frontmatter and
-// `---` inside fenced code blocks — a naive regex split cuts fences in half.
-function splitSlides(md: string): string[] {
-  let lines = md.split("\n");
-  if (lines[0]?.trim() === "---") {
-    const close = lines.findIndex((l, i) => i > 0 && l.trim() === "---");
-    if (close > 0) lines = lines.slice(close + 1);
-  }
-  const slides: string[][] = [[]];
-  let fence: string | null = null;
-  for (const line of lines) {
-    const open = line.match(/^\s*(```|~~~)/)?.[1];
-    if (open) fence = fence === open ? null : fence ?? open;
-    if (!fence && line.trim() === "---") slides.push([]);
-    else slides[slides.length - 1].push(line);
-  }
-  return slides.map((s) => s.join("\n"));
-}
-
-// Mermaid fences via marked's renderer, not a regex: fence-aware (nesting,
-// splitSlides sees real fences) and escaped (mermaid decodes via textContent).
-marked.use({
-  renderer: {
-    code({ text, lang }: { text: string; lang?: string }) {
-      return lang === "mermaid" ? `<pre class="mermaid">${escapeHtml(text)}</pre>\n` : false;
-    },
-  },
-});
-
-async function mermaidRuntime(): Promise<string> {
-  const dist = join(import.meta.dir, "node_modules/mermaid/dist/mermaid.min.js");
-  if (!existsSync(dist)) fail(`mermaid runtime missing at ${dist} — run: cd ${import.meta.dir} && bun install`);
-  const js = await readFile(dist, "utf8");
-  // Decks render diagrams per-slide (hidden slides have zero width, which breaks
-  // mermaid's measurements) — the deck theme's show() calls mermaid.run on the
-  // active slide; docs render everything immediately.
-  const init = `(() => {
-  const DARK = { darkMode: true, background: "transparent", primaryColor: "#1b1d22", primaryBorderColor: "#3a4150", primaryTextColor: "#eeeeee", secondaryColor: "#16181c", tertiaryColor: "#152438", lineColor: "#6a7280", edgeLabelBackground: "#0a0a0c", nodeBorder: "#3a4150", mainBkg: "#1b1d22", clusterBkg: "#16181c", clusterBorder: "#2a2d34", fontFamily: "ui-monospace, Menlo, monospace", fontSize: "14px", actorBkg: "#1b1d22", actorBorder: "#3a4150", actorTextColor: "#eeeeee", signalColor: "#6a7280", signalTextColor: "#9aa0aa", noteBkgColor: "#152438", noteTextColor: "#eeeeee", noteBorderColor: "#2a2d34" };
-  const LIGHT = { darkMode: false, background: "transparent", primaryColor: "#ffffff", primaryBorderColor: "#c3cbd6", primaryTextColor: "#1a1a1a", secondaryColor: "#f0f3f7", tertiaryColor: "#e3ecf8", lineColor: "#5f6672", edgeLabelBackground: "#eef0f4", nodeBorder: "#c3cbd6", mainBkg: "#ffffff", clusterBkg: "#f0f3f7", clusterBorder: "#d5dae2", fontFamily: "ui-monospace, Menlo, monospace", fontSize: "14px", actorBkg: "#ffffff", actorBorder: "#c3cbd6", actorTextColor: "#1a1a1a", signalColor: "#5f6672", signalTextColor: "#5f6672", noteBkgColor: "#e3ecf8", noteTextColor: "#1a1a1a", noteBorderColor: "#d5dae2" };
-  const srcs = new Map();
-  function renderAll() {
-    const light = document.documentElement.dataset.theme === "light";
-    mermaid.initialize({ startOnLoad: false, theme: "base", themeVariables: light ? LIGHT : DARK, flowchart: { curve: "basis", nodeSpacing: 46, rankSpacing: 56, padding: 12 } });
-    document.querySelectorAll("pre.mermaid").forEach((el) => {
-      if (!srcs.has(el)) srcs.set(el, el.textContent);
-      el.removeAttribute("data-processed");
-      el.replaceChildren();
-      el.textContent = srcs.get(el);
-    });
-    if (document.querySelector(".slide")) mermaid.run({ querySelector: ".slide.active pre.mermaid" });
-    else mermaid.run();
-  }
-  renderAll();
-  addEventListener("agentkit-theme", renderAll);
-})();`;
-  return `\n<script>${js}</script>\n<script>${init}</script>`;
-}
-
 async function render(): Promise<string> {
   if (template === "raw") return source;
   // Canonical themes live in the agentkit-pages repo; the skill bundles a copy
   // so publishing works on machines without the repo clone.
   const repoTheme = join(repo, "themes", `${template}.html`);
-  const bundledTheme = join(import.meta.dir, "themes", `${template}.html`);
+  const bundledTheme = bundledThemePath(template);
   const themePath = existsSync(repoTheme) ? repoTheme : bundledTheme;
   if (!existsSync(themePath)) fail(`theme not found: ${repoTheme} or ${bundledTheme}`);
-  const theme = await readFile(themePath, "utf8");
   if (themePath === repoTheme && existsSync(bundledTheme)) {
-    const bundled = await readFile(bundledTheme, "utf8");
-    if (bundled !== theme) {
+    const [canonical, bundled] = await Promise.all([readFile(repoTheme, "utf8"), readFile(bundledTheme, "utf8")]);
+    if (bundled !== canonical) {
       console.error(`warning: bundled theme drifted from canonical ${repoTheme} — re-sync skills/publish-page/themes/`);
     }
   }
-  let content: string;
-  if (template === "deck") {
-    const parts = isMd
-      ? splitSlides(source).map((s) => marked.parse(s) as string)
-      : source.split(/<hr\b[^>]*>/i);
-    content = parts
-      .map((s) => s.trim())
-      .filter(Boolean)
-      .map((s) => `<section class="slide">\n${s}\n</section>`)
-      .join("\n");
-  } else {
-    content = isMd ? (marked.parse(source) as string) : source;
+  try {
+    return await renderThemed({ source, isMd, template, title, themePath });
+  } catch (error) {
+    fail((error as Error).message);
   }
-  if (content.includes('class="mermaid"')) content += await mermaidRuntime();
-  // Function replacers: a plain string replacement expands $&, $`, $' found in
-  // page content and silently corrupts the output.
-  return theme
-    .replaceAll("{{TITLE}}", () => escapeHtml(title))
-    .replaceAll("{{CONTENT}}", () => content);
 }
 
 const html = await render();

--- a/plugins-cc/agentkit/skills/publish-page/render-html.ts
+++ b/plugins-cc/agentkit/skills/publish-page/render-html.ts
@@ -1,0 +1,109 @@
+// Theme wrapping shared by the two ways a page leaves this repo: publish.ts
+// PUTs it to the pages worker, and the product-intelligence --html lane writes
+// it to a file that must open from file://. One implementation, so a portable
+// page and a published page are the same page.
+import { marked } from "marked";
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+export function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) =>
+    ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c] as string
+  );
+}
+
+// Split markdown into slides on `---` lines, ignoring YAML frontmatter and
+// `---` inside fenced code blocks — a naive regex split cuts fences in half.
+export function splitSlides(md: string): string[] {
+  let lines = md.split("\n");
+  if (lines[0]?.trim() === "---") {
+    const close = lines.findIndex((l, i) => i > 0 && l.trim() === "---");
+    if (close > 0) lines = lines.slice(close + 1);
+  }
+  const slides: string[][] = [[]];
+  let fence: string | null = null;
+  for (const line of lines) {
+    const open = line.match(/^\s*(```|~~~)/)?.[1];
+    if (open) fence = fence === open ? null : fence ?? open;
+    if (!fence && line.trim() === "---") slides.push([]);
+    else slides[slides.length - 1].push(line);
+  }
+  return slides.map((s) => s.join("\n"));
+}
+
+export function bundledThemePath(template: string): string {
+  return join(import.meta.dir, "themes", `${template}.html`);
+}
+
+// Mermaid fences via marked's renderer, not a regex: fence-aware (nesting,
+// splitSlides sees real fences) and escaped (mermaid decodes via textContent).
+marked.use({
+  renderer: {
+    code({ text, lang }: { text: string; lang?: string }) {
+      return lang === "mermaid" ? `<pre class="mermaid">${escapeHtml(text)}</pre>\n` : false;
+    },
+  },
+});
+
+export async function mermaidRuntime(): Promise<string> {
+  const dist = join(import.meta.dir, "node_modules/mermaid/dist/mermaid.min.js");
+  if (!existsSync(dist)) {
+    throw new Error(`mermaid runtime missing at ${dist} — run: cd ${import.meta.dir} && bun install`);
+  }
+  const js = await readFile(dist, "utf8");
+  // Decks render diagrams per-slide (hidden slides have zero width, which breaks
+  // mermaid's measurements) — the deck theme's show() calls mermaid.run on the
+  // active slide; docs render everything immediately.
+  const init = `(() => {
+  const DARK = { darkMode: true, background: "transparent", primaryColor: "#1b1d22", primaryBorderColor: "#3a4150", primaryTextColor: "#eeeeee", secondaryColor: "#16181c", tertiaryColor: "#152438", lineColor: "#6a7280", edgeLabelBackground: "#0a0a0c", nodeBorder: "#3a4150", mainBkg: "#1b1d22", clusterBkg: "#16181c", clusterBorder: "#2a2d34", fontFamily: "ui-monospace, Menlo, monospace", fontSize: "14px", actorBkg: "#1b1d22", actorBorder: "#3a4150", actorTextColor: "#eeeeee", signalColor: "#6a7280", signalTextColor: "#9aa0aa", noteBkgColor: "#152438", noteTextColor: "#eeeeee", noteBorderColor: "#2a2d34" };
+  const LIGHT = { darkMode: false, background: "transparent", primaryColor: "#ffffff", primaryBorderColor: "#c3cbd6", primaryTextColor: "#1a1a1a", secondaryColor: "#f0f3f7", tertiaryColor: "#e3ecf8", lineColor: "#5f6672", edgeLabelBackground: "#eef0f4", nodeBorder: "#c3cbd6", mainBkg: "#ffffff", clusterBkg: "#f0f3f7", clusterBorder: "#d5dae2", fontFamily: "ui-monospace, Menlo, monospace", fontSize: "14px", actorBkg: "#ffffff", actorBorder: "#c3cbd6", actorTextColor: "#1a1a1a", signalColor: "#5f6672", signalTextColor: "#5f6672", noteBkgColor: "#e3ecf8", noteTextColor: "#1a1a1a", noteBorderColor: "#d5dae2" };
+  const srcs = new Map();
+  function renderAll() {
+    const light = document.documentElement.dataset.theme === "light";
+    mermaid.initialize({ startOnLoad: false, theme: "base", themeVariables: light ? LIGHT : DARK, flowchart: { curve: "basis", nodeSpacing: 46, rankSpacing: 56, padding: 12 } });
+    document.querySelectorAll("pre.mermaid").forEach((el) => {
+      if (!srcs.has(el)) srcs.set(el, el.textContent);
+      el.removeAttribute("data-processed");
+      el.replaceChildren();
+      el.textContent = srcs.get(el);
+    });
+    if (document.querySelector(".slide")) mermaid.run({ querySelector: ".slide.active pre.mermaid" });
+    else mermaid.run();
+  }
+  renderAll();
+  addEventListener("agentkit-theme", renderAll);
+})();`;
+  return `\n<script>${js}</script>\n<script>${init}</script>`;
+}
+
+export interface ThemedPage {
+  source: string;
+  isMd: boolean;
+  template: string;
+  title: string;
+  themePath: string;
+}
+
+export async function renderThemed(page: ThemedPage): Promise<string> {
+  const theme = await readFile(page.themePath, "utf8");
+  let content: string;
+  if (page.template === "deck") {
+    const parts = page.isMd
+      ? splitSlides(page.source).map((s) => marked.parse(s) as string)
+      : page.source.split(/<hr\b[^>]*>/i);
+    content = parts
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .map((s) => `<section class="slide">\n${s}\n</section>`)
+      .join("\n");
+  } else {
+    content = page.isMd ? (marked.parse(page.source) as string) : page.source;
+  }
+  if (content.includes('class="mermaid"')) content += await mermaidRuntime();
+  // Function replacers: a plain string replacement expands $&, $`, $' found in
+  // page content and silently corrupts the output.
+  return theme
+    .replaceAll("{{TITLE}}", () => escapeHtml(page.title))
+    .replaceAll("{{CONTENT}}", () => content);
+}

--- a/scripts/check-test-slices.ts
+++ b/scripts/check-test-slices.ts
@@ -29,6 +29,7 @@ export const TEST_SLICES = {
   integrations: ['tests/infra-tools-mcp.test.ts', 'tests/test-slices.test.ts'],
   product: [
     'tests/product-intelligence/acquisition.test.ts',
+    'tests/product-intelligence/portable.test.ts',
     'tests/product-intelligence/render.test.ts',
     'tests/product-intelligence/schemas.test.ts',
     'tests/publish-page/lint.test.ts',

--- a/skills/product-intelligence/SKILL.md
+++ b/skills/product-intelligence/SKILL.md
@@ -238,6 +238,12 @@ output, so a rebuilt page only changes when the evidence does.
 
 One-time on the machine that renders: `cd skills/publish-page && bun install`.
 
+**Findings diagrams: known limitation.** A `` ```mermaid `` fence in
+`findings.md` reaches the page with the analyze pass's escaping applied inside
+the fence, so any diagram using `[`, `]`, `(` or `)` fails to parse — while
+the 3.4 MB mermaid runtime is inlined regardless. Keep diagrams out of
+`findings.md` until that escaping is fence-aware.
+
 ### Rung 2 — Pages CI
 
 Scaffolds in `assets/ci/` — copy one into the repo that owns the brief and set

--- a/skills/product-intelligence/SKILL.md
+++ b/skills/product-intelligence/SKILL.md
@@ -239,7 +239,7 @@ output, so a rebuilt page only changes when the evidence does.
 One-time on the machine that renders: `cd skills/publish-page && bun install`.
 
 **Findings diagrams: known limitation.** A `` ```mermaid `` fence in
-`findings.md` reaches the page with the analyze pass's escaping applied inside
+`findings.md` reaches the page with the findings sanitizer's escaping applied inside
 the fence, so any diagram using `[`, `]`, `(` or `)` fails to parse — while
 the 3.4 MB mermaid runtime is inlined regardless. Keep diagrams out of
 `findings.md` until that escaping is fence-aware.

--- a/skills/product-intelligence/SKILL.md
+++ b/skills/product-intelligence/SKILL.md
@@ -210,3 +210,46 @@ Re-running against the same subject keeps the section order stable and diffs
 against the previous ledger: new claims, changed sources (`as_of` moved),
 claims whose source disappeared. A vanished source downgrades confidence; it
 does not silently delete the claim.
+
+## Hosting ladder
+
+A brief is only useful once someone can read it. Four rungs, cheapest first —
+climb only as far as the situation needs, and never let the reader's access
+depend on a rung they cannot reach.
+
+| Rung             | What it is                             | Use it when                                                                               |
+| ---------------- | -------------------------------------- | ----------------------------------------------------------------------------------------- |
+| 1 Portable file  | One self-contained `index.html`        | Pages is disabled, the repo is private, the reader is offline or gets it as an attachment |
+| 2 Repo Pages CI  | GitHub or GitLab Pages, built on push  | The brief lives in a repo and should re-publish itself when the evidence changes          |
+| 3 AgentKit Pages | `publish-page` → your own pages worker | You want a URL now, with no repo and no CI                                                |
+| 4 Hosted         | `publish-page` at a hosted endpoint    | Same as rung 3, someone else runs the worker (`AGENTKIT_PAGES_ENDPOINT`)                  |
+
+### Rung 1 — portable file
+
+```sh
+bun skills/product-intelligence/scripts/render.ts <dir> --html --out index.html
+```
+
+Writes `<dir>/index.html` without `--out`. The doc theme's CSS and JS are
+inlined, so the page opens by double-click from `file://` with no server and
+makes **no network request of any kind** — the light/dark toggle, the section
+rail and the anchors all work offline. Same inputs render byte-identical
+output, so a rebuilt page only changes when the evidence does.
+
+One-time on the machine that renders: `cd skills/publish-page && bun install`.
+
+### Rung 2 — Pages CI
+
+Scaffolds in `assets/ci/` — copy one into the repo that owns the brief and set
+`INTELLIGENCE_DIR`:
+
+| File                         | Copy to                             |
+| ---------------------------- | ----------------------------------- |
+| `assets/ci/github-pages.yml` | `.github/workflows/brief-pages.yml` |
+| `assets/ci/gitlab-ci.yml`    | `.gitlab-ci.yml`                    |
+
+Both jobs do the same three things: validate `brief.yaml` + `ledger.yaml`,
+render `brief-page.md` and `index.html` into `public/`, publish that directory.
+Validation runs first on purpose — a dangling claim id fails the build instead
+of publishing a brief whose citations go nowhere. Pin `AGENTKIT_REF` to a tag
+so a rebuild cannot change with upstream.

--- a/skills/product-intelligence/assets/ci/github-pages.yml
+++ b/skills/product-intelligence/assets/ci/github-pages.yml
@@ -1,0 +1,71 @@
+# Copy to .github/workflows/brief-pages.yml in the repo that owns the brief.
+# Set INTELLIGENCE_DIR to the directory holding brief.yaml + ledger.yaml, and
+# pin AGENTKIT_REF to a tag so a page rebuild cannot change with upstream.
+# Repository settings → Pages → Source must be set to "GitHub Actions".
+name: Publish brief to Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+  pages: write
+
+# Deployments queue instead of cancelling: a half-published page is worse than
+# a late one.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Render and deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    env:
+      AGENTKIT: ${{ runner.temp }}/agentkit
+      AGENTKIT_REF: main
+      INTELLIGENCE_DIR: intelligence
+    steps:
+      - name: Check out the brief
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+
+      - name: Fetch the agentkit skills
+        run: |
+          git clone --depth 1 --branch "$AGENTKIT_REF" \
+            https://github.com/developerinlondon/agentkit "$AGENTKIT"
+          cd "$AGENTKIT/skills/publish-page" && bun install
+
+      - name: Validate the evidence
+        run: |
+          bun "$AGENTKIT/skills/product-intelligence/scripts/validate.ts" \
+            "$INTELLIGENCE_DIR/brief.yaml" "$INTELLIGENCE_DIR/ledger.yaml"
+
+      - name: Render the page
+        run: |
+          mkdir -p public
+          RENDER="$AGENTKIT/skills/product-intelligence/scripts/render.ts"
+          bun "$RENDER" "$INTELLIGENCE_DIR" --out public/brief-page.md
+          bun "$RENDER" "$INTELLIGENCE_DIR" --html --out public/index.html
+
+      - name: Configure Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
+      - name: Upload the rendered directory
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: public
+
+      - name: Deploy to Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/skills/product-intelligence/assets/ci/gitlab-ci.yml
+++ b/skills/product-intelligence/assets/ci/gitlab-ci.yml
@@ -1,0 +1,28 @@
+# Copy to .gitlab-ci.yml in the repo that owns the brief (or `include:` it).
+# Set INTELLIGENCE_DIR to the directory holding brief.yaml + ledger.yaml, and
+# pin AGENTKIT_REF to a tag so a page rebuild cannot change with upstream.
+#
+# The literal job name `pages` plus an explicit `public/` artifact is the form
+# every GitLab version accepts; `pages: true` on a freely named job needs 17.9+.
+variables:
+  AGENTKIT_REF: main
+  AGENTKIT_REPO: https://github.com/developerinlondon/agentkit
+  INTELLIGENCE_DIR: intelligence
+
+pages:
+  stage: deploy
+  image: oven/bun:1
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+  before_script:
+    - command -v git >/dev/null || (apt-get update && apt-get install -y --no-install-recommends git)
+    - git clone --depth 1 --branch "$AGENTKIT_REF" "$AGENTKIT_REPO" /tmp/agentkit
+    - cd /tmp/agentkit/skills/publish-page && bun install && cd "$CI_PROJECT_DIR"
+  script:
+    - bun /tmp/agentkit/skills/product-intelligence/scripts/validate.ts "$INTELLIGENCE_DIR/brief.yaml" "$INTELLIGENCE_DIR/ledger.yaml"
+    - mkdir -p public
+    - bun /tmp/agentkit/skills/product-intelligence/scripts/render.ts "$INTELLIGENCE_DIR" --out public/brief-page.md
+    - bun /tmp/agentkit/skills/product-intelligence/scripts/render.ts "$INTELLIGENCE_DIR" --html --out public/index.html
+  artifacts:
+    paths:
+      - public

--- a/skills/product-intelligence/scripts/html.ts
+++ b/skills/product-intelligence/scripts/html.ts
@@ -1,0 +1,34 @@
+#!/usr/bin/env bun
+// The hosting ladder's floor: one HTML file that opens by double-click, with no
+// server, no network and no build step — so a brief survives a private GitLab,
+// an air-gapped laptop or an email attachment.
+
+import { join } from 'node:path';
+import { briefTitle, renderBrief } from './render.ts';
+
+const themeSkill = join(import.meta.dir, '..', '..', 'publish-page');
+
+// Deferred so the markdown lane keeps working without the publish-page skill's
+// dependencies, and so a missing install names its own fix.
+async function themeRenderer() {
+  try {
+    return await import('../../publish-page/render-html.ts');
+  } catch (error) {
+    throw new Error(
+      `page renderer unavailable (${(error as Error).message}) — run: cd ${themeSkill} && bun install`,
+    );
+  }
+}
+
+export async function renderBriefHtml(dir: string): Promise<string> {
+  const { bundledThemePath, renderThemed } = await themeRenderer();
+  return renderThemed({
+    source: renderBrief(dir),
+    isMd: true,
+    template: 'doc',
+    title: briefTitle(dir),
+    // The bundled theme, never the agentkit-pages clone publish.ts prefers: a
+    // portable page must render the same bytes where no clone exists.
+    themePath: bundledThemePath('doc'),
+  });
+}

--- a/skills/product-intelligence/scripts/render.ts
+++ b/skills/product-intelligence/scripts/render.ts
@@ -95,6 +95,10 @@ function chip(label: string, value: string): string {
   return `<span class="chip"><strong>${escText(label)}</strong> ${escText(value)}</span>`;
 }
 
+function subjectTitle(brief: Dict): string {
+  return `${collapse(brief.subject?.name ?? 'Untitled product')}: what the evidence says`;
+}
+
 function header(brief: Dict, ledger: Dict): string {
   const subject = brief.subject ?? {};
   const claims = (ledger.claims ?? []) as Dict[];
@@ -119,7 +123,7 @@ function header(brief: Dict, ledger: Dict): string {
   const promise = sourced
     ? 'every observed and inferred claim carries a verbatim quote from an acquired source'
     : 'each claim states its kind and how solid its basis is';
-  const lines = [`# ${mdEsc(subject.name ?? 'Untitled product')}: what the evidence says`, ''];
+  const lines = [`# ${mdEsc(subjectTitle(brief))}`, ''];
   lines.push(`<div class="chips">${chips}</div>`, '');
   if (subject.one_liner) lines.push(`**${mdEsc(subject.one_liner)}**`, '');
   lines.push(
@@ -325,14 +329,26 @@ function evidence(brief: Dict, ledger: Dict): string {
   return `## The evidence, claim by claim\n\n${blocks}\n${provenance}`;
 }
 
-export function renderBrief(dir: string): string {
+function artifacts(dir: string): { brief: Dict; ledger: Dict } {
   const briefPath = join(dir, 'brief.yaml');
   const ledgerPath = join(dir, 'ledger.yaml');
   for (const p of [briefPath, ledgerPath]) {
     if (!existsSync(p)) throw new Error(`missing ${p} — render needs both brief.yaml and ledger.yaml`);
   }
-  const brief = Bun.YAML.parse(readFileSync(briefPath, 'utf-8')) as Dict;
-  const ledger = Bun.YAML.parse(readFileSync(ledgerPath, 'utf-8')) as Dict;
+  return {
+    brief: Bun.YAML.parse(readFileSync(briefPath, 'utf-8')) as Dict,
+    ledger: Bun.YAML.parse(readFileSync(ledgerPath, 'utf-8')) as Dict,
+  };
+}
+
+// The page's own <title>, taken before markdown escaping: the h1 carries
+// backslash escapes that a title bar would show literally.
+export function briefTitle(dir: string): string {
+  return subjectTitle(artifacts(dir).brief);
+}
+
+export function renderBrief(dir: string): string {
+  const { brief, ledger } = artifacts(dir);
   const sections = [
     header(brief, ledger),
     positioning(brief),
@@ -351,14 +367,16 @@ export function renderBrief(dir: string): string {
 }
 
 if (import.meta.main) {
-  const [dir, outFlag, outPath] = process.argv.slice(2);
+  const argv = process.argv.slice(2);
+  const html = argv.includes('--html');
+  const [dir, outFlag, outPath] = argv.filter((a) => a !== '--html');
   if (!dir || (outFlag && (outFlag !== '--out' || !outPath))) {
-    console.error('usage: render.ts <intelligence-dir> [--out <file>]');
+    console.error('usage: render.ts <intelligence-dir> [--html] [--out <file>]');
     process.exit(2);
   }
   try {
-    const page = renderBrief(dir);
-    const target = outPath ?? join(dir, 'brief-page.md');
+    const page = html ? await (await import('./html.ts')).renderBriefHtml(dir) : renderBrief(dir);
+    const target = outPath ?? join(dir, html ? 'index.html' : 'brief-page.md');
     writeFileSync(target, page);
     console.log(target);
   } catch (error) {

--- a/skills/publish-page/bun.lock
+++ b/skills/publish-page/bun.lock
@@ -1,0 +1,249 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "publish-page-skill",
+      "dependencies": {
+        "marked": "^18.0.7",
+        "mermaid": "11.16.0",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.2.19",
+      },
+    },
+  },
+  "packages": {
+    "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
+
+    "@braintree/sanitize-url": ["@braintree/sanitize-url@7.1.2", "", {}, "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA=="],
+
+    "@chevrotain/types": ["@chevrotain/types@11.1.2", "", {}, "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw=="],
+
+    "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
+
+    "@iconify/utils": ["@iconify/utils@3.1.4", "", { "dependencies": { "@antfu/install-pkg": "^1.1.0", "@iconify/types": "^2.0.0", "import-meta-resolve": "^4.2.0" } }, "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw=="],
+
+    "@mermaid-js/parser": ["@mermaid-js/parser@1.2.0", "", { "dependencies": { "@chevrotain/types": "~11.1.2" } }, "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA=="],
+
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/d3": ["@types/d3@7.4.3", "", { "dependencies": { "@types/d3-array": "*", "@types/d3-axis": "*", "@types/d3-brush": "*", "@types/d3-chord": "*", "@types/d3-color": "*", "@types/d3-contour": "*", "@types/d3-delaunay": "*", "@types/d3-dispatch": "*", "@types/d3-drag": "*", "@types/d3-dsv": "*", "@types/d3-ease": "*", "@types/d3-fetch": "*", "@types/d3-force": "*", "@types/d3-format": "*", "@types/d3-geo": "*", "@types/d3-hierarchy": "*", "@types/d3-interpolate": "*", "@types/d3-path": "*", "@types/d3-polygon": "*", "@types/d3-quadtree": "*", "@types/d3-random": "*", "@types/d3-scale": "*", "@types/d3-scale-chromatic": "*", "@types/d3-selection": "*", "@types/d3-shape": "*", "@types/d3-time": "*", "@types/d3-time-format": "*", "@types/d3-timer": "*", "@types/d3-transition": "*", "@types/d3-zoom": "*" } }, "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww=="],
+
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-axis": ["@types/d3-axis@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw=="],
+
+    "@types/d3-brush": ["@types/d3-brush@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A=="],
+
+    "@types/d3-chord": ["@types/d3-chord@3.0.6", "", {}, "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-contour": ["@types/d3-contour@3.0.6", "", { "dependencies": { "@types/d3-array": "*", "@types/geojson": "*" } }, "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg=="],
+
+    "@types/d3-delaunay": ["@types/d3-delaunay@6.0.4", "", {}, "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw=="],
+
+    "@types/d3-dispatch": ["@types/d3-dispatch@3.0.7", "", {}, "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA=="],
+
+    "@types/d3-drag": ["@types/d3-drag@3.0.7", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ=="],
+
+    "@types/d3-dsv": ["@types/d3-dsv@3.0.7", "", {}, "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-fetch": ["@types/d3-fetch@3.0.7", "", { "dependencies": { "@types/d3-dsv": "*" } }, "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA=="],
+
+    "@types/d3-force": ["@types/d3-force@3.0.10", "", {}, "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw=="],
+
+    "@types/d3-format": ["@types/d3-format@3.0.4", "", {}, "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g=="],
+
+    "@types/d3-geo": ["@types/d3-geo@3.1.0", "", { "dependencies": { "@types/geojson": "*" } }, "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ=="],
+
+    "@types/d3-hierarchy": ["@types/d3-hierarchy@3.1.7", "", {}, "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-polygon": ["@types/d3-polygon@3.0.2", "", {}, "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA=="],
+
+    "@types/d3-quadtree": ["@types/d3-quadtree@3.0.6", "", {}, "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg=="],
+
+    "@types/d3-random": ["@types/d3-random@3.0.4", "", {}, "sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-scale-chromatic": ["@types/d3-scale-chromatic@3.1.0", "", {}, "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ=="],
+
+    "@types/d3-selection": ["@types/d3-selection@3.0.11", "", {}, "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-time-format": ["@types/d3-time-format@4.0.3", "", {}, "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
+    "@types/d3-transition": ["@types/d3-transition@3.0.9", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg=="],
+
+    "@types/d3-zoom": ["@types/d3-zoom@3.0.8", "", { "dependencies": { "@types/d3-interpolate": "*", "@types/d3-selection": "*" } }, "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw=="],
+
+    "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
+
+    "@types/node": ["@types/node@26.1.2", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg=="],
+
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
+    "@upsetjs/venn.js": ["@upsetjs/venn.js@2.0.0", "", { "optionalDependencies": { "d3-selection": "^3.0.0", "d3-transition": "^3.0.1" } }, "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
+
+    "cose-base": ["cose-base@1.0.3", "", { "dependencies": { "layout-base": "^1.0.0" } }, "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg=="],
+
+    "cytoscape": ["cytoscape@3.34.0", "", {}, "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg=="],
+
+    "cytoscape-cose-bilkent": ["cytoscape-cose-bilkent@4.1.0", "", { "dependencies": { "cose-base": "^1.0.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ=="],
+
+    "cytoscape-fcose": ["cytoscape-fcose@2.2.0", "", { "dependencies": { "cose-base": "^2.2.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ=="],
+
+    "d3": ["d3@7.9.0", "", { "dependencies": { "d3-array": "3", "d3-axis": "3", "d3-brush": "3", "d3-chord": "3", "d3-color": "3", "d3-contour": "4", "d3-delaunay": "6", "d3-dispatch": "3", "d3-drag": "3", "d3-dsv": "3", "d3-ease": "3", "d3-fetch": "3", "d3-force": "3", "d3-format": "3", "d3-geo": "3", "d3-hierarchy": "3", "d3-interpolate": "3", "d3-path": "3", "d3-polygon": "3", "d3-quadtree": "3", "d3-random": "3", "d3-scale": "4", "d3-scale-chromatic": "3", "d3-selection": "3", "d3-shape": "3", "d3-time": "3", "d3-time-format": "4", "d3-timer": "3", "d3-transition": "3", "d3-zoom": "3" } }, "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA=="],
+
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-axis": ["d3-axis@3.0.0", "", {}, "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw=="],
+
+    "d3-brush": ["d3-brush@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "3", "d3-transition": "3" } }, "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ=="],
+
+    "d3-chord": ["d3-chord@3.0.1", "", { "dependencies": { "d3-path": "1 - 3" } }, "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-contour": ["d3-contour@4.0.2", "", { "dependencies": { "d3-array": "^3.2.0" } }, "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA=="],
+
+    "d3-delaunay": ["d3-delaunay@6.0.4", "", { "dependencies": { "delaunator": "5" } }, "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A=="],
+
+    "d3-dispatch": ["d3-dispatch@3.0.1", "", {}, "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="],
+
+    "d3-drag": ["d3-drag@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-selection": "3" } }, "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg=="],
+
+    "d3-dsv": ["d3-dsv@3.0.1", "", { "dependencies": { "commander": "7", "iconv-lite": "0.6", "rw": "1" }, "bin": { "csv2json": "bin/dsv2json.js", "csv2tsv": "bin/dsv2dsv.js", "dsv2dsv": "bin/dsv2dsv.js", "dsv2json": "bin/dsv2json.js", "json2csv": "bin/json2dsv.js", "json2dsv": "bin/json2dsv.js", "json2tsv": "bin/json2dsv.js", "tsv2csv": "bin/dsv2dsv.js", "tsv2json": "bin/dsv2json.js" } }, "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-fetch": ["d3-fetch@3.0.1", "", { "dependencies": { "d3-dsv": "1 - 3" } }, "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw=="],
+
+    "d3-force": ["d3-force@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-quadtree": "1 - 3", "d3-timer": "1 - 3" } }, "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-geo": ["d3-geo@3.1.1", "", { "dependencies": { "d3-array": "2.5.0 - 3" } }, "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q=="],
+
+    "d3-hierarchy": ["d3-hierarchy@3.1.2", "", {}, "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-polygon": ["d3-polygon@3.0.1", "", {}, "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg=="],
+
+    "d3-quadtree": ["d3-quadtree@3.0.1", "", {}, "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="],
+
+    "d3-random": ["d3-random@3.0.1", "", {}, "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ=="],
+
+    "d3-sankey": ["d3-sankey@0.12.3", "", { "dependencies": { "d3-array": "1 - 2", "d3-shape": "^1.2.0" } }, "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-scale-chromatic": ["d3-scale-chromatic@3.1.0", "", { "dependencies": { "d3-color": "1 - 3", "d3-interpolate": "1 - 3" } }, "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ=="],
+
+    "d3-selection": ["d3-selection@3.0.0", "", {}, "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
+    "d3-transition": ["d3-transition@3.0.1", "", { "dependencies": { "d3-color": "1 - 3", "d3-dispatch": "1 - 3", "d3-ease": "1 - 3", "d3-interpolate": "1 - 3", "d3-timer": "1 - 3" }, "peerDependencies": { "d3-selection": "2 - 3" } }, "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w=="],
+
+    "d3-zoom": ["d3-zoom@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "2 - 3", "d3-transition": "2 - 3" } }, "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw=="],
+
+    "dagre-d3-es": ["dagre-d3-es@7.0.14", "", { "dependencies": { "d3": "^7.9.0", "lodash-es": "^4.17.21" } }, "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg=="],
+
+    "dayjs": ["dayjs@1.11.21", "", {}, "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA=="],
+
+    "delaunator": ["delaunator@5.1.0", "", { "dependencies": { "robust-predicates": "^3.0.2" } }, "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ=="],
+
+    "dompurify": ["dompurify@3.4.12", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg=="],
+
+    "es-toolkit": ["es-toolkit@1.50.0", "", {}, "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w=="],
+
+    "hachure-fill": ["hachure-fill@0.5.2", "", {}, "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg=="],
+
+    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "import-meta-resolve": ["import-meta-resolve@4.2.0", "", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
+
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
+
+    "katex": ["katex@0.16.47", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg=="],
+
+    "khroma": ["khroma@2.1.0", "", {}, "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="],
+
+    "layout-base": ["layout-base@1.0.2", "", {}, "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg=="],
+
+    "lodash-es": ["lodash-es@4.18.1", "", {}, "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="],
+
+    "marked": ["marked@18.0.7", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-iDVQ5ldaiKXn6b2JroX5kgRfmwgqolW7NpaEzTl1k/2Zh1njIEN9yniyLV/mOvWwtsE8OGgkjsCYvijuPk1dtA=="],
+
+    "mermaid": ["mermaid@11.16.0", "", { "dependencies": { "@braintree/sanitize-url": "^7.1.2", "@iconify/utils": "^3.0.2", "@mermaid-js/parser": "^1.2.0", "@types/d3": "^7.4.3", "@upsetjs/venn.js": "^2.0.0", "cytoscape": "^3.33.3", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.2.0", "d3": "^7.9.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.14", "dayjs": "^1.11.20", "dompurify": "^3.3.3", "es-toolkit": "^1.45.1", "katex": "^0.16.45", "khroma": "^2.1.0", "marked": "^16.3.0", "roughjs": "^4.6.6", "stylis": "^4.3.6", "ts-dedent": "^2.2.0", "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0" } }, "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA=="],
+
+    "package-manager-detector": ["package-manager-detector@1.8.0", "", {}, "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A=="],
+
+    "path-data-parser": ["path-data-parser@0.1.0", "", {}, "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w=="],
+
+    "points-on-curve": ["points-on-curve@0.2.0", "", {}, "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="],
+
+    "points-on-path": ["points-on-path@0.2.1", "", { "dependencies": { "path-data-parser": "0.1.0", "points-on-curve": "0.2.0" } }, "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g=="],
+
+    "robust-predicates": ["robust-predicates@3.0.3", "", {}, "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA=="],
+
+    "roughjs": ["roughjs@4.6.6", "", { "dependencies": { "hachure-fill": "^0.5.2", "path-data-parser": "^0.1.0", "points-on-curve": "^0.2.0", "points-on-path": "^0.2.1" } }, "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ=="],
+
+    "rw": ["rw@1.3.3", "", {}, "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "stylis": ["stylis@4.4.0", "", {}, "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA=="],
+
+    "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
+
+    "ts-dedent": ["ts-dedent@2.3.0", "", {}, "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "uuid": ["uuid@14.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
+
+    "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
+
+    "d3-dsv/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
+
+    "d3-sankey/d3-array": ["d3-array@2.12.1", "", { "dependencies": { "internmap": "^1.0.0" } }, "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ=="],
+
+    "d3-sankey/d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
+
+    "mermaid/marked": ["marked@16.4.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="],
+
+    "cytoscape-fcose/cose-base/layout-base": ["layout-base@2.0.1", "", {}, "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="],
+
+    "d3-sankey/d3-array/internmap": ["internmap@1.0.1", "", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
+
+    "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
+  }
+}

--- a/skills/publish-page/publish.ts
+++ b/skills/publish-page/publish.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
-import { marked } from "marked";
 import { lintFigures } from "./lint.ts";
+import { bundledThemePath, renderThemed } from "./render-html.ts";
 import { createHmac, randomBytes } from "node:crypto";
 import { existsSync } from "node:fs";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
@@ -19,12 +19,6 @@ function arg(name: string): string | undefined {
   const v = i > 0 ? process.argv[i + 1] : undefined;
   if (v?.startsWith("--")) fail(`--${name} is missing its value (got "${v}")`);
   return v;
-}
-
-function escapeHtml(s: string): string {
-  return s.replace(/[&<>"']/g, (c) =>
-    ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c] as string
-  );
 }
 
 const explicitSlug = arg("slug");
@@ -127,98 +121,25 @@ const title = arg("title")
   ?? source.match(/<title>([^<]+)<\/title>/)?.[1]
   ?? pageLabel;
 
-// Split markdown into slides on `---` lines, ignoring YAML frontmatter and
-// `---` inside fenced code blocks — a naive regex split cuts fences in half.
-function splitSlides(md: string): string[] {
-  let lines = md.split("\n");
-  if (lines[0]?.trim() === "---") {
-    const close = lines.findIndex((l, i) => i > 0 && l.trim() === "---");
-    if (close > 0) lines = lines.slice(close + 1);
-  }
-  const slides: string[][] = [[]];
-  let fence: string | null = null;
-  for (const line of lines) {
-    const open = line.match(/^\s*(```|~~~)/)?.[1];
-    if (open) fence = fence === open ? null : fence ?? open;
-    if (!fence && line.trim() === "---") slides.push([]);
-    else slides[slides.length - 1].push(line);
-  }
-  return slides.map((s) => s.join("\n"));
-}
-
-// Mermaid fences via marked's renderer, not a regex: fence-aware (nesting,
-// splitSlides sees real fences) and escaped (mermaid decodes via textContent).
-marked.use({
-  renderer: {
-    code({ text, lang }: { text: string; lang?: string }) {
-      return lang === "mermaid" ? `<pre class="mermaid">${escapeHtml(text)}</pre>\n` : false;
-    },
-  },
-});
-
-async function mermaidRuntime(): Promise<string> {
-  const dist = join(import.meta.dir, "node_modules/mermaid/dist/mermaid.min.js");
-  if (!existsSync(dist)) fail(`mermaid runtime missing at ${dist} — run: cd ${import.meta.dir} && bun install`);
-  const js = await readFile(dist, "utf8");
-  // Decks render diagrams per-slide (hidden slides have zero width, which breaks
-  // mermaid's measurements) — the deck theme's show() calls mermaid.run on the
-  // active slide; docs render everything immediately.
-  const init = `(() => {
-  const DARK = { darkMode: true, background: "transparent", primaryColor: "#1b1d22", primaryBorderColor: "#3a4150", primaryTextColor: "#eeeeee", secondaryColor: "#16181c", tertiaryColor: "#152438", lineColor: "#6a7280", edgeLabelBackground: "#0a0a0c", nodeBorder: "#3a4150", mainBkg: "#1b1d22", clusterBkg: "#16181c", clusterBorder: "#2a2d34", fontFamily: "ui-monospace, Menlo, monospace", fontSize: "14px", actorBkg: "#1b1d22", actorBorder: "#3a4150", actorTextColor: "#eeeeee", signalColor: "#6a7280", signalTextColor: "#9aa0aa", noteBkgColor: "#152438", noteTextColor: "#eeeeee", noteBorderColor: "#2a2d34" };
-  const LIGHT = { darkMode: false, background: "transparent", primaryColor: "#ffffff", primaryBorderColor: "#c3cbd6", primaryTextColor: "#1a1a1a", secondaryColor: "#f0f3f7", tertiaryColor: "#e3ecf8", lineColor: "#5f6672", edgeLabelBackground: "#eef0f4", nodeBorder: "#c3cbd6", mainBkg: "#ffffff", clusterBkg: "#f0f3f7", clusterBorder: "#d5dae2", fontFamily: "ui-monospace, Menlo, monospace", fontSize: "14px", actorBkg: "#ffffff", actorBorder: "#c3cbd6", actorTextColor: "#1a1a1a", signalColor: "#5f6672", signalTextColor: "#5f6672", noteBkgColor: "#e3ecf8", noteTextColor: "#1a1a1a", noteBorderColor: "#d5dae2" };
-  const srcs = new Map();
-  function renderAll() {
-    const light = document.documentElement.dataset.theme === "light";
-    mermaid.initialize({ startOnLoad: false, theme: "base", themeVariables: light ? LIGHT : DARK, flowchart: { curve: "basis", nodeSpacing: 46, rankSpacing: 56, padding: 12 } });
-    document.querySelectorAll("pre.mermaid").forEach((el) => {
-      if (!srcs.has(el)) srcs.set(el, el.textContent);
-      el.removeAttribute("data-processed");
-      el.replaceChildren();
-      el.textContent = srcs.get(el);
-    });
-    if (document.querySelector(".slide")) mermaid.run({ querySelector: ".slide.active pre.mermaid" });
-    else mermaid.run();
-  }
-  renderAll();
-  addEventListener("agentkit-theme", renderAll);
-})();`;
-  return `\n<script>${js}</script>\n<script>${init}</script>`;
-}
-
 async function render(): Promise<string> {
   if (template === "raw") return source;
   // Canonical themes live in the agentkit-pages repo; the skill bundles a copy
   // so publishing works on machines without the repo clone.
   const repoTheme = join(repo, "themes", `${template}.html`);
-  const bundledTheme = join(import.meta.dir, "themes", `${template}.html`);
+  const bundledTheme = bundledThemePath(template);
   const themePath = existsSync(repoTheme) ? repoTheme : bundledTheme;
   if (!existsSync(themePath)) fail(`theme not found: ${repoTheme} or ${bundledTheme}`);
-  const theme = await readFile(themePath, "utf8");
   if (themePath === repoTheme && existsSync(bundledTheme)) {
-    const bundled = await readFile(bundledTheme, "utf8");
-    if (bundled !== theme) {
+    const [canonical, bundled] = await Promise.all([readFile(repoTheme, "utf8"), readFile(bundledTheme, "utf8")]);
+    if (bundled !== canonical) {
       console.error(`warning: bundled theme drifted from canonical ${repoTheme} — re-sync skills/publish-page/themes/`);
     }
   }
-  let content: string;
-  if (template === "deck") {
-    const parts = isMd
-      ? splitSlides(source).map((s) => marked.parse(s) as string)
-      : source.split(/<hr\b[^>]*>/i);
-    content = parts
-      .map((s) => s.trim())
-      .filter(Boolean)
-      .map((s) => `<section class="slide">\n${s}\n</section>`)
-      .join("\n");
-  } else {
-    content = isMd ? (marked.parse(source) as string) : source;
+  try {
+    return await renderThemed({ source, isMd, template, title, themePath });
+  } catch (error) {
+    fail((error as Error).message);
   }
-  if (content.includes('class="mermaid"')) content += await mermaidRuntime();
-  // Function replacers: a plain string replacement expands $&, $`, $' found in
-  // page content and silently corrupts the output.
-  return theme
-    .replaceAll("{{TITLE}}", () => escapeHtml(title))
-    .replaceAll("{{CONTENT}}", () => content);
 }
 
 const html = await render();

--- a/skills/publish-page/render-html.ts
+++ b/skills/publish-page/render-html.ts
@@ -1,0 +1,109 @@
+// Theme wrapping shared by the two ways a page leaves this repo: publish.ts
+// PUTs it to the pages worker, and the product-intelligence --html lane writes
+// it to a file that must open from file://. One implementation, so a portable
+// page and a published page are the same page.
+import { marked } from "marked";
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+export function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) =>
+    ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c] as string
+  );
+}
+
+// Split markdown into slides on `---` lines, ignoring YAML frontmatter and
+// `---` inside fenced code blocks — a naive regex split cuts fences in half.
+export function splitSlides(md: string): string[] {
+  let lines = md.split("\n");
+  if (lines[0]?.trim() === "---") {
+    const close = lines.findIndex((l, i) => i > 0 && l.trim() === "---");
+    if (close > 0) lines = lines.slice(close + 1);
+  }
+  const slides: string[][] = [[]];
+  let fence: string | null = null;
+  for (const line of lines) {
+    const open = line.match(/^\s*(```|~~~)/)?.[1];
+    if (open) fence = fence === open ? null : fence ?? open;
+    if (!fence && line.trim() === "---") slides.push([]);
+    else slides[slides.length - 1].push(line);
+  }
+  return slides.map((s) => s.join("\n"));
+}
+
+export function bundledThemePath(template: string): string {
+  return join(import.meta.dir, "themes", `${template}.html`);
+}
+
+// Mermaid fences via marked's renderer, not a regex: fence-aware (nesting,
+// splitSlides sees real fences) and escaped (mermaid decodes via textContent).
+marked.use({
+  renderer: {
+    code({ text, lang }: { text: string; lang?: string }) {
+      return lang === "mermaid" ? `<pre class="mermaid">${escapeHtml(text)}</pre>\n` : false;
+    },
+  },
+});
+
+export async function mermaidRuntime(): Promise<string> {
+  const dist = join(import.meta.dir, "node_modules/mermaid/dist/mermaid.min.js");
+  if (!existsSync(dist)) {
+    throw new Error(`mermaid runtime missing at ${dist} — run: cd ${import.meta.dir} && bun install`);
+  }
+  const js = await readFile(dist, "utf8");
+  // Decks render diagrams per-slide (hidden slides have zero width, which breaks
+  // mermaid's measurements) — the deck theme's show() calls mermaid.run on the
+  // active slide; docs render everything immediately.
+  const init = `(() => {
+  const DARK = { darkMode: true, background: "transparent", primaryColor: "#1b1d22", primaryBorderColor: "#3a4150", primaryTextColor: "#eeeeee", secondaryColor: "#16181c", tertiaryColor: "#152438", lineColor: "#6a7280", edgeLabelBackground: "#0a0a0c", nodeBorder: "#3a4150", mainBkg: "#1b1d22", clusterBkg: "#16181c", clusterBorder: "#2a2d34", fontFamily: "ui-monospace, Menlo, monospace", fontSize: "14px", actorBkg: "#1b1d22", actorBorder: "#3a4150", actorTextColor: "#eeeeee", signalColor: "#6a7280", signalTextColor: "#9aa0aa", noteBkgColor: "#152438", noteTextColor: "#eeeeee", noteBorderColor: "#2a2d34" };
+  const LIGHT = { darkMode: false, background: "transparent", primaryColor: "#ffffff", primaryBorderColor: "#c3cbd6", primaryTextColor: "#1a1a1a", secondaryColor: "#f0f3f7", tertiaryColor: "#e3ecf8", lineColor: "#5f6672", edgeLabelBackground: "#eef0f4", nodeBorder: "#c3cbd6", mainBkg: "#ffffff", clusterBkg: "#f0f3f7", clusterBorder: "#d5dae2", fontFamily: "ui-monospace, Menlo, monospace", fontSize: "14px", actorBkg: "#ffffff", actorBorder: "#c3cbd6", actorTextColor: "#1a1a1a", signalColor: "#5f6672", signalTextColor: "#5f6672", noteBkgColor: "#e3ecf8", noteTextColor: "#1a1a1a", noteBorderColor: "#d5dae2" };
+  const srcs = new Map();
+  function renderAll() {
+    const light = document.documentElement.dataset.theme === "light";
+    mermaid.initialize({ startOnLoad: false, theme: "base", themeVariables: light ? LIGHT : DARK, flowchart: { curve: "basis", nodeSpacing: 46, rankSpacing: 56, padding: 12 } });
+    document.querySelectorAll("pre.mermaid").forEach((el) => {
+      if (!srcs.has(el)) srcs.set(el, el.textContent);
+      el.removeAttribute("data-processed");
+      el.replaceChildren();
+      el.textContent = srcs.get(el);
+    });
+    if (document.querySelector(".slide")) mermaid.run({ querySelector: ".slide.active pre.mermaid" });
+    else mermaid.run();
+  }
+  renderAll();
+  addEventListener("agentkit-theme", renderAll);
+})();`;
+  return `\n<script>${js}</script>\n<script>${init}</script>`;
+}
+
+export interface ThemedPage {
+  source: string;
+  isMd: boolean;
+  template: string;
+  title: string;
+  themePath: string;
+}
+
+export async function renderThemed(page: ThemedPage): Promise<string> {
+  const theme = await readFile(page.themePath, "utf8");
+  let content: string;
+  if (page.template === "deck") {
+    const parts = page.isMd
+      ? splitSlides(page.source).map((s) => marked.parse(s) as string)
+      : page.source.split(/<hr\b[^>]*>/i);
+    content = parts
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .map((s) => `<section class="slide">\n${s}\n</section>`)
+      .join("\n");
+  } else {
+    content = page.isMd ? (marked.parse(page.source) as string) : page.source;
+  }
+  if (content.includes('class="mermaid"')) content += await mermaidRuntime();
+  // Function replacers: a plain string replacement expands $&, $`, $' found in
+  // page content and silently corrupts the output.
+  return theme
+    .replaceAll("{{TITLE}}", () => escapeHtml(page.title))
+    .replaceAll("{{CONTENT}}", () => content);
+}

--- a/tests/agentkit-plugin.test.ts
+++ b/tests/agentkit-plugin.test.ts
@@ -171,9 +171,16 @@ describe('agentkit plugin skills', () => {
     expect(readdirSync(join(pluginDir, 'skills')).sort()).toEqual(names);
     // Recursive: some skills carry a references/ subdirectory, and a nested
     // file that drifts is exactly as misleading as a top-level one.
+    // node_modules is gitignored, never reaches the plugin package, and a
+    // skill that documents `bun install` would otherwise fail this walk on
+    // whichever copy the deps landed in.
     const filesUnder = (dir: string, prefix = ''): string[] =>
       readdirSync(join(dir, prefix), { withFileTypes: true }).flatMap((e) =>
-        e.isDirectory() ? filesUnder(dir, join(prefix, e.name)) : [join(prefix, e.name)]
+        e.name === 'node_modules'
+          ? []
+          : e.isDirectory()
+          ? filesUnder(dir, join(prefix, e.name))
+          : [join(prefix, e.name)]
       );
     for (const name of names) {
       const files = filesUnder(join(sourceSkills, name)).sort();

--- a/tests/product-intelligence/portable.test.ts
+++ b/tests/product-intelligence/portable.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { cpSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { renderBriefHtml } from '../../skills/product-intelligence/scripts/html.ts';
+
+const repoRoot = dirname(dirname(import.meta.dir));
+const skillRoot = join(repoRoot, 'skills', 'product-intelligence');
+const mixed = join(skillRoot, 'examples', 'mixed');
+
+let scratch = '';
+beforeEach(() => {
+  scratch = mkdtempSync(join(tmpdir(), 'agentkit-portable-'));
+});
+afterEach(() => {
+  rmSync(scratch, { force: true, recursive: true });
+});
+
+function copyOfMixed(name: string): string {
+  const dir = join(scratch, name);
+  cpSync(mixed, dir, { recursive: true });
+  return dir;
+}
+
+// Attribute values only. A verbatim quote in the evidence may well contain a
+// URL — printing one costs nothing, while an attribute is what actually makes
+// the browser reach for the network.
+function remoteAttributes(html: string): string[] {
+  const hits: string[] = [];
+  for (const tag of html.match(/<[a-zA-Z][^>]*>/g) ?? []) {
+    const element = tag.match(/^<([a-zA-Z0-9]+)/)![1].toLowerCase();
+    for (const [, attr, quoted, bare] of tag.matchAll(/([a-zA-Z:_-]+)\s*=\s*(?:"([^"]*)"|([^\s>]+))/g)) {
+      const value = quoted ?? bare ?? '';
+      if (!/^(?:https?:)?\/\//i.test(value)) continue;
+      if (element === 'a' && attr.toLowerCase() === 'href') continue;
+      hits.push(`${element}[${attr}]=${value}`);
+    }
+  }
+  return hits;
+}
+
+describe('portable brief page', () => {
+  test('fetches nothing: no remote attribute, stylesheet, import or script src', async () => {
+    const html = await renderBriefHtml(mixed);
+    expect(remoteAttributes(html)).toEqual([]);
+    expect(html).not.toMatch(/<script\b[^>]*\bsrc\s*=/i);
+    expect(html).not.toMatch(/<link\b/i);
+    expect(html).not.toMatch(/@import/i);
+    expect(html).not.toMatch(/url\(\s*["']?(?:https?:)?\/\//i);
+    expect(html).not.toMatch(/\b(?:fetch|importScripts|EventSource|XMLHttpRequest|WebSocket)\s*\(/);
+  });
+
+  // Pins the one allowance the check above grants, so a theme that starts
+  // linking a CDN cannot hide behind "it is only an anchor".
+  test('the only outbound link is the theme footer', async () => {
+    const html = await renderBriefHtml(mixed);
+    const outbound = [...html.matchAll(/<a\b[^>]*href="(https?:\/\/[^"]*)"/gi)].map((m) => m[1]);
+    expect(outbound).toEqual(['https://agentkit.sbs']);
+  });
+
+  test('carries the brief, the evidence anchors and the findings', async () => {
+    const html = await renderBriefHtml(mixed);
+    expect(html).toContain('<title>acme-notes: what the evidence says</title>');
+    expect(html).toContain('<strong>For</strong> solo developers');
+    expect(html).toContain('<h2>What the analyze pass flagged</h2>');
+    const ledger = readFileSync(join(mixed, 'ledger.yaml'), 'utf-8');
+    for (const id of new Set(ledger.match(/C-\d{3}/g) ?? [])) {
+      expect(html, id).toContain(`id="${id.toLowerCase()}"`);
+    }
+  });
+
+  test('same inputs render byte-identical output, from any path', async () => {
+    const [first, second] = await Promise.all([renderBriefHtml(mixed), renderBriefHtml(mixed)]);
+    expect(first).toBe(second);
+    // A different directory for the same artifacts: catches a build stamp or a
+    // source path leaking into the page.
+    const elsewhere = await renderBriefHtml(copyOfMixed('copy'));
+    expect(elsewhere).toBe(first);
+  });
+
+  test('a hostile subject name cannot escape the title', async () => {
+    const dir = copyOfMixed('hostile');
+    const brief = readFileSync(join(dir, 'brief.yaml'), 'utf-8')
+      .replace('name: acme-notes', 'name: "</title><script>alert(1)</script>"');
+    writeFileSync(join(dir, 'brief.yaml'), brief);
+    const html = await renderBriefHtml(dir);
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).toContain('&lt;/title&gt;&lt;script&gt;alert(1)&lt;/script&gt;');
+  });
+
+  test('the mermaid runtime is inlined only when the page has a diagram', async () => {
+    const plain = await renderBriefHtml(mixed);
+    expect(plain).not.toContain('class="mermaid"');
+    expect(plain).not.toContain('mermaid.initialize');
+
+    const dir = copyOfMixed('diagram');
+    writeFileSync(join(dir, 'findings.md'), '# Findings\n\n## Gaps\n\n```mermaid\nflowchart LR\n  a --> b\n```\n');
+    const withDiagram = await renderBriefHtml(dir);
+    expect(withDiagram).toContain('class="mermaid"');
+    expect(withDiagram).toContain('mermaid.initialize');
+    expect(withDiagram).not.toMatch(/<script\b[^>]*\bsrc\s*=/i);
+  });
+});

--- a/tests/product-intelligence/portable.test.ts
+++ b/tests/product-intelligence/portable.test.ts
@@ -50,7 +50,13 @@ function skillTree(name: string, options: { deps: boolean; sentinel?: string }):
 
 function renderCli(root: string, args: string[], env: Record<string, string> = {}) {
   const script = join(root, 'skills', 'product-intelligence', 'scripts', 'render.ts');
-  return spawnSync('bun', [script, ...args], { encoding: 'utf-8', env: { ...process.env, ...env } });
+  // --no-install: bun's runtime auto-install can satisfy `marked` from the
+  // global cache when the scratch tree has no node_modules ancestry — which
+  // silently un-simulates the missing-dependencies case on a clean machine.
+  return spawnSync('bun', ['--no-install', script, ...args], {
+    encoding: 'utf-8',
+    env: { ...process.env, ...env },
+  });
 }
 
 // Attribute values only. A verbatim quote in the evidence may well contain a

--- a/tests/product-intelligence/portable.test.ts
+++ b/tests/product-intelligence/portable.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { cpSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { renderBriefHtml } from '../../skills/product-intelligence/scripts/html.ts';
 
 const repoRoot = dirname(dirname(import.meta.dir));
 const skillRoot = join(repoRoot, 'skills', 'product-intelligence');
+const publishSkill = join(repoRoot, 'skills', 'publish-page');
 const mixed = join(skillRoot, 'examples', 'mixed');
 
 let scratch = '';
@@ -20,6 +22,35 @@ function copyOfMixed(name: string): string {
   const dir = join(scratch, name);
   cpSync(mixed, dir, { recursive: true });
   return dir;
+}
+
+// A standalone copy of the two skills, laid out as they sit in the repo. It
+// lets a test decide whether the dependencies are there and mark its own
+// bundled theme, neither of which can be done to the repo's own tree while
+// other work shares it.
+function skillTree(name: string, options: { deps: boolean; sentinel?: string }): string {
+  const root = join(scratch, name);
+  const publishCopy = join(root, 'skills', 'publish-page');
+  cpSync(publishSkill, publishCopy, {
+    recursive: true,
+    filter: (src) => !src.includes('node_modules'),
+  });
+  cpSync(join(skillRoot, 'scripts'), join(root, 'skills', 'product-intelligence', 'scripts'), {
+    recursive: true,
+  });
+  if (options.deps) {
+    symlinkSync(join(publishSkill, 'node_modules'), join(publishCopy, 'node_modules'));
+  }
+  if (options.sentinel) {
+    const theme = join(publishCopy, 'themes', 'doc.html');
+    writeFileSync(theme, readFileSync(theme, 'utf-8').replace('</head>', `<!--${options.sentinel}--></head>`));
+  }
+  return root;
+}
+
+function renderCli(root: string, args: string[], env: Record<string, string> = {}) {
+  const script = join(root, 'skills', 'product-intelligence', 'scripts', 'render.ts');
+  return spawnSync('bun', [script, ...args], { encoding: 'utf-8', env: { ...process.env, ...env } });
 }
 
 // Attribute values only. A verbatim quote in the evidence may well contain a
@@ -88,6 +119,25 @@ describe('portable brief page', () => {
     expect(html).toContain('&lt;/title&gt;&lt;script&gt;alert(1)&lt;/script&gt;');
   });
 
+  // The page must come from the theme shipped beside the script. publish.ts
+  // prefers a canonical clone when one exists, and a portable page that
+  // silently followed it would render differently on every machine.
+  test('renders the bundled theme, not a canonical clone', async () => {
+    const clone = join(scratch, 'pages-clone');
+    mkdirSync(join(clone, 'themes'), { recursive: true });
+    const bundled = readFileSync(join(publishSkill, 'themes', 'doc.html'), 'utf-8');
+    writeFileSync(join(clone, 'themes', 'doc.html'), bundled.replace('</head>', '<!--CLONE-THEME--></head>'));
+
+    const root = skillTree('themed', { deps: true, sentinel: 'BUNDLED-THEME' });
+    const out = join(scratch, 'themed.html');
+    const result = renderCli(root, [mixed, '--html', '--out', out], { AGENTKIT_PAGES_REPO: clone });
+
+    expect(result.status, result.stderr).toBe(0);
+    const html = readFileSync(out, 'utf-8');
+    expect(html).toContain('<!--BUNDLED-THEME-->');
+    expect(html).not.toContain('<!--CLONE-THEME-->');
+  });
+
   test('the mermaid runtime is inlined only when the page has a diagram', async () => {
     const plain = await renderBriefHtml(mixed);
     expect(plain).not.toContain('class="mermaid"');
@@ -99,5 +149,52 @@ describe('portable brief page', () => {
     expect(withDiagram).toContain('class="mermaid"');
     expect(withDiagram).toContain('mermaid.initialize');
     expect(withDiagram).not.toMatch(/<script\b[^>]*\bsrc\s*=/i);
+  });
+});
+
+// The CLI surface both Pages scaffolds invoke.
+describe('render.ts --html', () => {
+  test('writes index.html into the intelligence dir by default', async () => {
+    const dir = copyOfMixed('cli-default');
+    const result = renderCli(skillTree('cli', { deps: true }), [dir, '--html']);
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout.trim()).toBe(join(dir, 'index.html'));
+    expect(readFileSync(join(dir, 'index.html'), 'utf-8')).toBe(await renderBriefHtml(mixed));
+  });
+
+  test('--out writes there, and the flag may lead the directory', () => {
+    const root = skillTree('cli-out', { deps: true });
+    const target = join(scratch, 'public', 'index.html');
+    mkdirSync(dirname(target), { recursive: true });
+    const leading = renderCli(root, ['--html', mixed, '--out', target]);
+    expect(leading.status, leading.stderr).toBe(0);
+    expect(leading.stdout.trim()).toBe(target);
+    expect(readFileSync(target, 'utf-8')).toContain('<title>acme-notes: what the evidence says</title>');
+  });
+
+  test('exits 2 on usage, 1 on unusable input', () => {
+    const root = skillTree('cli-errors', { deps: true });
+    const noDir = renderCli(root, ['--html']);
+    expect(noDir.status).toBe(2);
+    expect(noDir.stderr).toContain('usage:');
+    expect(noDir.stderr).toContain('--html');
+
+    const noOutPath = renderCli(root, [mixed, '--html', '--out']);
+    expect(noOutPath.status).toBe(2);
+
+    const empty = renderCli(root, [join(scratch, 'nothing-here'), '--html']);
+    expect(empty.status).toBe(1);
+    expect(empty.stderr).toContain('missing');
+  });
+
+  test('without the publish-page dependencies it fails naming its own fix', () => {
+    const root = skillTree('cli-nodeps', { deps: false });
+    const result = renderCli(root, [mixed, '--html', '--out', join(scratch, 'never.html')]);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('page renderer unavailable');
+    expect(result.stderr).toContain('bun install');
+    // The markdown lane carries no such dependency and must stay usable.
+    const markdown = renderCli(root, [mixed, '--out', join(scratch, 'brief.md')]);
+    expect(markdown.status, markdown.stderr).toBe(0);
   });
 });


### PR DESCRIPTION
Closes #153

- `render.ts --html`: self-contained index.html (bundled doc theme, inline mermaid only when needed, zero off-file requests from `file://`)
- GitHub + GitLab Pages CI scaffolds, SHA-pinned, invoking the same lane
- publish.ts refactored over the shared renderer — byte-faithful A/B on the live path (16 cases)
- parity walk now skips node_modules (CI-shape blocker); `--html` CLI + bundled-theme pin under test

Review: .agentkit/reviews/feat__portable-site-scaffold.json — pass at f53d2ed (2 fix rounds; suite 856/0 on merged head)