### PR TITLE
fix(build): group-aware preflight mirror and import checks

### DIFF
--- a/scripts/bash-status-check
+++ b/scripts/bash-status-check
@@ -18,8 +18,8 @@ usage() {
 		'usage: bash-status-check FILE...' \
 		'' \
 		'Reports conditional-and compounds that silently drop a failure:' \
-		'  tail-leak  a function or script ending in `cond && action`' \
-		'  soft-gate  `cmd && echo ...` — a check whose failure branch is nothing' \
+		'  tail-leak  a function or script ending in: cond && action' \
+		'  soft-gate  cmd && echo ... — a check whose failure branch is nothing' \
 		'' \
 		'Exits 1 when any leak is found, 0 when the files are clean.' >&2
 	exit "$status"
@@ -32,6 +32,7 @@ if [[ $# -eq 0 ]]; then
 	usage 2
 fi
 
+# shellcheck disable=SC2016  # awk program: $1 and $2 are awk fields, not shell.
 SCAN='
 function trim(s) {
 	sub(/^[ \t]+/, "", s)

--- a/scripts/bash-status-check
+++ b/scripts/bash-status-check
@@ -45,6 +45,10 @@ function bare(s,   t) {
 	t = s
 	gsub(/\$\([^)]*\)/, "", t)
 	gsub(/`[^`]*`/, "", t)
+	# A single-quoted span is one argument, not shell syntax: an awk or sed
+	# program carrying && is data the shell never evaluates. Erasing only the
+	# contents keeps a real operator outside the quotes visible.
+	gsub(/\047[^\047]*\047/, " ", t)
 	return t
 }
 
@@ -53,6 +57,10 @@ function tail_leak(s,   t) {
 	if (t !~ /&&/) return 0
 	if (t ~ /\|\|/) return 0
 	if (t ~ /^(if|elif|while|until|return|exit|case)([ \t]|$)/) return 0
+	# A tail that is wholly one test is a predicate, not a guarded action: it has
+	# no second command whose failure could be swallowed, and callers consume it
+	# with if/!/||. The leak needs `cond && action`.
+	if (t ~ /^(\[\[.*\]\]|\[.*\]|test[ \t].*)[ \t]*$/) return 0
 	return 1
 }
 

--- a/scripts/bash-status-check
+++ b/scripts/bash-status-check
@@ -45,9 +45,11 @@ function bare(s,   t) {
 	t = s
 	gsub(/\$\([^)]*\)/, "", t)
 	gsub(/`[^`]*`/, "", t)
-	# A single-quoted span is one argument, not shell syntax: an awk or sed
-	# program carrying && is data the shell never evaluates. Erasing only the
-	# contents keeps a real operator outside the quotes visible.
+	# A quoted span is one argument, not shell syntax: an awk or sed program
+	# carrying && is data the shell never evaluates. Double-quoted spans go first,
+	# because an apostrophe inside one would otherwise open a single-quote span
+	# that runs to the next apostrophe, swallowing a real operator between them.
+	gsub(/"[^"]*"/, " ", t)
 	gsub(/\047[^\047]*\047/, " ", t)
 	return t
 }

--- a/scripts/lib/test-verdict.sh
+++ b/scripts/lib/test-verdict.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash disable=SC2034  # sourced: TEST_VERDICT_* are the caller's.
 # Judge a bun test run by its printed pass/fail counts, never by its exit code.
 # A runner that dies before executing anything — a lock it cannot take, a
 # scrubbed environment variable — prints no marker at all, and a caller reading

--- a/scripts/preflight
+++ b/scripts/preflight
@@ -126,12 +126,20 @@ check_bash_status() {
 	return 0
 }
 
+# Runs at shellcheck's default severity, info included, deliberately: SC2016 and
+# SC1091 are info-level and both name real mistakes — a variable that will not
+# expand, and a sourced file whose contents were never analysed. Raising the
+# threshold to warning would buy a quieter gate by not looking.
+#
+# SCRIPTDIR resolves each `# shellcheck source=` directive against the file being
+# checked rather than the caller's working directory, so the sourced libraries
+# are followed instead of reported as unreadable.
 check_shellcheck() {
 	if ! command -v shellcheck >/dev/null 2>&1; then
 		skip "shellcheck not installed — bash-status-check still covers the status-leak class"
 		return 0
 	fi
-	if ! shellcheck -x "$@"; then
+	if ! shellcheck -x --source-path=SCRIPTDIR "$@"; then
 		bad "shellcheck reported findings"
 		return 0
 	fi
@@ -176,14 +184,14 @@ groups_readable() {
 # plugins-cc also holds plugins that are not group mirrors of skills/ at all, so
 # only a declared group's plugin maps back to a source skill.
 is_group_plugin() {
-	local plugin="$1" group
-	for group in $(
+	local plugin="$1" declared
+	for declared in $(
 		SKILL_GROUPS_FILE="$REPO/skills/GROUPS"
 		# shellcheck source=../lib/skill-groups.sh
 		source "$REPO/lib/skill-groups.sh"
 		declared_groups
 	); do
-		if [[ "$plugin" == "$(plugin_for_group "$group")" ]]; then
+		if [[ "$plugin" == "$(plugin_for_group "$declared")" ]]; then
 			return 0
 		fi
 	done
@@ -332,7 +340,7 @@ check_format() {
 	for path in "$@"; do
 		case "$path" in
 		*.md | *.json | *.toml | *.yaml | *.yml)
-			formattable[$count]="$path"
+			formattable[count]="$path"
 			count=$((count + 1))
 			;;
 		esac
@@ -497,6 +505,7 @@ check_restore_by_checkout() {
 		discard="$discard"'|git[[:space:]]+restore[[:space:]]+[^-[:space:]]'
 		discard="$discard"'|git[[:space:]]+(stash|clean)([[:space:]]|$)'
 		exec_verb='(^|[^A-Za-z])(execSync|execFileSync|execFile|spawnSync|spawn|exec|system)[[:space:]]*\('
+		# shellcheck disable=SC2016  # regex literal: $ is an anchor, not expansion.
 		exec_verb="$exec_verb"'|Bun\.\$|(^|[[:space:]])\$([[:space:]]|$)|(sh|bash)[[:space:]]+-c'
 		if is_shell_file "$REPO/$path"; then
 			hits="$(printf '%s\n' "$flat" | grep -E "$discard" || true)"
@@ -545,7 +554,7 @@ check_negative_path() {
 	local path status=0
 	for path in "$@"; do
 		case "$path" in
-		tests/*.ts | tests/*/*.ts) ;;
+		tests/*.ts) ;;
 		*) continue ;;
 		esac
 		if ! grep -qiE 'cannot find (package|module)' "$REPO/$path"; then
@@ -570,7 +579,7 @@ check_real_home() {
 	local path status=0
 	for path in "$@"; do
 		case "$path" in
-		tests/*.ts | tests/*/*.ts) ;;
+		tests/*.ts) ;;
 		*) continue ;;
 		esac
 		if ! code_lines "$REPO/$path" | grep -qE 'install\.sh|AGENTKIT_HOME'; then
@@ -609,10 +618,10 @@ while IFS= read -r candidate; do
 	if [[ -z "$candidate" || ! -f "$REPO/$candidate" ]]; then
 		continue
 	fi
-	EXISTING[$EXISTING_COUNT]="$candidate"
+	EXISTING[EXISTING_COUNT]="$candidate"
 	EXISTING_COUNT=$((EXISTING_COUNT + 1))
 	if is_shell_file "$REPO/$candidate"; then
-		SHELL_FILES[$SHELL_COUNT]="$REPO/$candidate"
+		SHELL_FILES[SHELL_COUNT]="$REPO/$candidate"
 		SHELL_COUNT=$((SHELL_COUNT + 1))
 	fi
 done <<EOF

--- a/scripts/preflight
+++ b/scripts/preflight
@@ -10,6 +10,7 @@ BASE="origin/main"
 PATHS_FROM=""
 SLICE=""
 FAILED=0
+GROUPS_FAULT=""
 
 # shellcheck source=lib/test-verdict.sh
 source "$SCRIPT_DIR/lib/test-verdict.sh"
@@ -151,10 +152,24 @@ plugin_for_skill() {
 	)
 }
 
+# Present is not the same as parseable: a manifest that exists but is malformed
+# would otherwise fall through to core and surface as a mirror failure, blaming
+# the wrong file. The manifest's own validator decides.
 groups_readable() {
-	if [[ -f "$REPO/lib/skill-groups.sh" && -f "$REPO/skills/GROUPS" ]]; then
+	if [[ ! -f "$REPO/lib/skill-groups.sh" || ! -f "$REPO/skills/GROUPS" ]]; then
+		GROUPS_FAULT="missing lib/skill-groups.sh or skills/GROUPS"
+		return 1
+	fi
+	local complaint
+	if complaint="$(
+		SKILL_GROUPS_FILE="$REPO/skills/GROUPS"
+		# shellcheck source=../lib/skill-groups.sh
+		source "$REPO/lib/skill-groups.sh"
+		validate_skill_groups 2>&1 >/dev/null
+	)"; then
 		return 0
 	fi
+	GROUPS_FAULT="skills/GROUPS does not validate: ${complaint:-unknown fault}"
 	return 1
 }
 
@@ -209,7 +224,7 @@ check_mirror() {
 		for path in "$@"; do
 			case "$path" in
 			skills/*/* | plugins-cc/*/skills/*/*)
-				bad "cannot resolve skill groups (missing lib/skill-groups.sh or skills/GROUPS) — mirror parity unchecked"
+				bad "cannot resolve skill groups ($GROUPS_FAULT) — mirror parity unchecked"
 				return 0
 				;;
 			esac
@@ -397,6 +412,20 @@ normalise_path() {
 # Only static imports are fatal: they resolve at module load, so a missing target
 # kills the plugin outright. A dynamic import() is a runtime branch its author
 # already has to handle, and the sync carries only the statically imported leaf.
+# Relative specifiers that resolve when the module loads, in every spelling that
+# does so: a from-clause, a bare side-effect import, and require, which is
+# synchronous and throws where it sits. A dynamic import() is excluded because it
+# is a runtime branch its caller already has to handle. A type-only import is
+# excluded because it is erased before the code ever runs.
+static_specifiers() {
+	local file="$1"
+	code_lines "$file" |
+		grep -vE "^[0-9]+:[[:space:]]*(import|export)[[:space:]]+type[[:space:]]" |
+		grep -oE "^[0-9]+:[[:space:]]*(import|export)[^;]*[[:space:]]from[[:space:]]*['\"]\.[^'\"]*['\"]|^[0-9]+:[[:space:]]*import[[:space:]]*['\"]\.[^'\"]*['\"]|require[[:space:]]*\([[:space:]]*['\"]\.[^'\"]*['\"]" |
+		grep -oE "['\"]\.[^'\"]*['\"]" | tr -d "\"'" || true
+	return 0
+}
+
 check_cross_skill_import() {
 	local path status=0 skill dir spec target plugin shipped
 	for path in "$@"; do
@@ -426,9 +455,7 @@ check_cross_skill_import() {
 			bad "$path statically imports $spec, which $plugin does not ship at $shipped"
 			status=1
 		done <<EOF
-$(code_lines "$REPO/$path" |
-			grep -oE "^[0-9]+:[[:space:]]*(import|export)[^;]*[[:space:]]from[[:space:]]*['\"]\.[^'\"]*['\"]" |
-			grep -oE "['\"]\.[^'\"]*['\"]" | tr -d "\"'" || true)
+$(static_specifiers "$REPO/$path")
 EOF
 	done
 	if [[ "$status" -eq 0 ]]; then

--- a/scripts/preflight
+++ b/scripts/preflight
@@ -138,17 +138,83 @@ check_shellcheck() {
 	return 0
 }
 
+# Install groups ship as separate plugins, so a skill's mirror lives under its
+# own group's plugin. The manifest readers are shared with the installer and the
+# sync script; a second parser here could disagree with what actually ships.
+plugin_for_skill() {
+	local skill="$1"
+	(
+		SKILL_GROUPS_FILE="$REPO/skills/GROUPS"
+		# shellcheck source=../lib/skill-groups.sh
+		source "$REPO/lib/skill-groups.sh"
+		group_plugin_id "$(skill_group "$skill")"
+	)
+}
+
+groups_readable() {
+	if [[ -f "$REPO/lib/skill-groups.sh" && -f "$REPO/skills/GROUPS" ]]; then
+		return 0
+	fi
+	return 1
+}
+
+# plugins-cc also holds plugins that are not group mirrors of skills/ at all, so
+# only a declared group's plugin maps back to a source skill.
+is_group_plugin() {
+	local plugin="$1" group
+	for group in $(
+		SKILL_GROUPS_FILE="$REPO/skills/GROUPS"
+		# shellcheck source=../lib/skill-groups.sh
+		source "$REPO/lib/skill-groups.sh"
+		declared_groups
+	); do
+		if [[ "$plugin" == "$(plugin_for_group "$group")" ]]; then
+			return 0
+		fi
+	done
+	return 1
+}
+
+plugin_for_group() {
+	(
+		SKILL_GROUPS_FILE="$REPO/skills/GROUPS"
+		# shellcheck source=../lib/skill-groups.sh
+		source "$REPO/lib/skill-groups.sh"
+		group_plugin_id "$1"
+	)
+}
+
 mirror_of() {
-	local path="$1"
+	local path="$1" skill plugin
 	case "$path" in
-	skills/*) printf 'plugins-cc/agentkit/%s' "$path" ;;
-	plugins-cc/agentkit/skills/*) printf '%s' "${path#plugins-cc/agentkit/}" ;;
+	skills/*/*)
+		skill="${path#skills/}"
+		skill="${skill%%/*}"
+		printf 'plugins-cc/%s/%s' "$(plugin_for_skill "$skill")" "$path"
+		;;
+	plugins-cc/*/skills/*/*)
+		plugin="${path#plugins-cc/}"
+		plugin="${plugin%%/*}"
+		if is_group_plugin "$plugin"; then
+			printf 'skills/%s' "${path#plugins-cc/*/skills/}"
+		fi
+		;;
 	*) printf '' ;;
 	esac
 }
 
 check_mirror() {
 	local path mirror checked=0 status=0
+	if ! groups_readable; then
+		for path in "$@"; do
+			case "$path" in
+			skills/*/* | plugins-cc/*/skills/*/*)
+				bad "cannot resolve skill groups (missing lib/skill-groups.sh or skills/GROUPS) — mirror parity unchecked"
+				return 0
+				;;
+			esac
+		done
+	fi
 	for path in "$@"; do
 		mirror="$(mirror_of "$path")"
 		if [[ -z "$mirror" ]]; then
@@ -320,13 +386,19 @@ normalise_path() {
 	return 0
 }
 
-# A skill is the unit that ships, and install groups can put two skills in
-# different plugins. An import reaching out of its own skill therefore survives
-# every same-repo check and dangles only in the artifact a user installs — and a
-# byte-parity mirror check copies it faithfully, because parity is sameness, not
-# loadability.
+# A skill is the unit that ships, and install groups put skills in different
+# plugins. An import reaching out of its own skill survives every same-repo check
+# and dangles only in the artifact a user installs — byte parity copies it
+# faithfully, because parity is sameness, not loadability. The shipped tree is
+# therefore the only authority: the sync deliberately carries a consumed module
+# into the consumer's plugin, so an escaping import is fine exactly when the
+# importing skill's own plugin contains the target.
+#
+# Only static imports are fatal: they resolve at module load, so a missing target
+# kills the plugin outright. A dynamic import() is a runtime branch its author
+# already has to handle, and the sync carries only the statically imported leaf.
 check_cross_skill_import() {
-	local path status=0 skill dir spec target
+	local path status=0 skill dir spec target plugin shipped
 	for path in "$@"; do
 		case "$path" in
 		skills/*/*.ts | skills/*/*.js | skills/*/*.mjs) ;;
@@ -335,21 +407,27 @@ check_cross_skill_import() {
 		skill="${path#skills/}"
 		skill="skills/${skill%%/*}"
 		dir="$(dirname "$path")"
+		plugin=""
 		while IFS= read -r spec; do
 			if [[ -z "$spec" ]]; then
 				continue
 			fi
 			target="$(normalise_path "$dir" "$spec")"
 			case "$target" in
-			"$skill"/*) ;;
-			*)
-				bad "$path imports $spec, outside $skill — it dangles wherever the skills ship apart"
-				status=1
-				;;
+			"$skill"/*) continue ;;
 			esac
+			if [[ -z "$plugin" ]]; then
+				plugin="$(plugin_for_skill "${skill#skills/}")"
+			fi
+			shipped="plugins-cc/$plugin/$target"
+			if [[ -f "$REPO/$shipped" ]]; then
+				continue
+			fi
+			bad "$path statically imports $spec, which $plugin does not ship at $shipped"
+			status=1
 		done <<EOF
 $(code_lines "$REPO/$path" |
-			grep -oE "(from|import|require)[[:space:]]*\(?[[:space:]]*['\"]\.[^'\"]*['\"]" |
+			grep -oE "^[0-9]+:[[:space:]]*(import|export)[^;]*[[:space:]]from[[:space:]]*['\"]\.[^'\"]*['\"]" |
 			grep -oE "['\"]\.[^'\"]*['\"]" | tr -d "\"'" || true)
 EOF
 	done

--- a/tests/build/preflight.test.ts
+++ b/tests/build/preflight.test.ts
@@ -136,6 +136,32 @@ describe('conditional-and status leaks', () => {
     expect(result.status).toBe(1);
   });
 
+  test('a && inside a single-quoted program is data, not shell syntax', () => {
+    const clean = statusCheck(
+      'f() {',
+      "\tawk '$1 == \"group\" && NF >= 2 { print $2 }' \"$FILE\"",
+      '}',
+      'f',
+    );
+    // The same operator outside the quotes must still fire, or this proves nothing.
+    const dirty = statusCheck('f() {', "\tgrep -q 'x' \"$FILE\" && printf ok", '}', 'f');
+
+    expect(clean.stdout).toBe('');
+    expect(clean.status).toBe(0);
+    expect(dirty.stdout).toContain('[tail-leak]');
+    expect(dirty.status).toBe(1);
+  });
+
+  test('a tail that is wholly one test is a predicate, not a guarded action', () => {
+    const predicate = statusCheck('f() {', '\t[[ -f "$A" && -f "$B" ]]', '}', 'if f; then printf y; fi');
+    const guarded = statusCheck('f() {', '\t[[ -f "$A" ]] && printf ok', '}', 'f');
+
+    expect(predicate.stdout).toBe('');
+    expect(predicate.status).toBe(0);
+    expect(guarded.stdout).toContain('[tail-leak]');
+    expect(guarded.status).toBe(1);
+  });
+
   test('a && inside a command substitution is not a statement-level gate', () => {
     const result = statusCheck('captured() {', '\tlocal v', '\tv="$(a && b)"', '}', 'captured');
 
@@ -220,66 +246,143 @@ describe('conditional-and status leaks', () => {
   });
 });
 
-describe('plugin mirror parity', () => {
-  test('drift between a skill and its plugin mirror fails', () => {
-    write('skills/demo/SKILL.md', '# demo\n');
-    write('plugins-cc/agentkit/skills/demo/SKILL.md', '# demo drifted\n');
+// A repo shaped like agentkit's: the real group readers, one core skill and one
+// skill in a second group, which ships as its own plugin.
+function groupedRepo(): void {
+  cpSync(join(REPO, 'lib', 'skill-groups.sh'), write('lib/skill-groups.sh', ''));
+  write(
+    'skills/GROUPS',
+    ['group core Core skills', 'group product Product skills', '', 'beta product', ''].join('\n'),
+  );
+}
 
-    const result = preflight(['skills/demo/SKILL.md']);
+describe('plugin mirror parity', () => {
+  test('a core skill mirrors into the core plugin', () => {
+    groupedRepo();
+    write('skills/alpha/SKILL.md', '# alpha\n');
+    write('plugins-cc/agentkit/skills/alpha/SKILL.md', '# alpha\n');
+
+    const result = preflight(['skills/alpha/SKILL.md']);
+
+    expect(result.stdout).toContain('plugin mirror byte-identical');
+    expect(result.status).toBe(0);
+  });
+
+  test('a grouped skill mirrors into its own group plugin, not the core one', () => {
+    groupedRepo();
+    write('skills/beta/SKILL.md', '# beta\n');
+    write('plugins-cc/agentkit-product/skills/beta/SKILL.md', '# beta\n');
+    // Present in the core plugin too, so passing cannot come from looking there.
+    write('plugins-cc/agentkit/skills/beta/SKILL.md', '# beta drifted\n');
+
+    const result = preflight(['skills/beta/SKILL.md']);
+
+    expect(result.stdout).toContain('plugin mirror byte-identical');
+    expect(result.status).toBe(0);
+  });
+
+  test('a grouped skill missing from its group plugin fails, naming that plugin', () => {
+    groupedRepo();
+    write('skills/beta/SKILL.md', '# beta\n');
+
+    const result = preflight(['skills/beta/SKILL.md']);
+
+    expect(result.stdout).toContain('mirror missing: plugins-cc/agentkit-product/skills/beta/SKILL.md');
+    expect(result.status).toBe(1);
+  });
+
+  test('drift between a grouped skill and its group mirror fails', () => {
+    groupedRepo();
+    write('skills/beta/SKILL.md', '# beta\n');
+    write('plugins-cc/agentkit-product/skills/beta/SKILL.md', '# beta drifted\n');
+
+    const result = preflight(['skills/beta/SKILL.md']);
 
     expect(result.stdout).toContain('mirror drift');
     expect(result.stdout).toContain('sync-cc-plugin.sh');
     expect(result.status).toBe(1);
   });
 
-  test('a missing mirror fails', () => {
-    write('skills/demo/SKILL.md', '# demo\n');
+  test('a plugin that is not a declared group maps to no source skill', () => {
+    groupedRepo();
+    write('plugins-cc/infra-tools/skills/infra-tools/SKILL.md', '# standalone\n');
 
-    const result = preflight(['skills/demo/SKILL.md']);
+    const result = preflight(['plugins-cc/infra-tools/skills/infra-tools/SKILL.md']);
 
-    expect(result.stdout).toContain('mirror missing');
-    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('no skill files touched');
+    expect(result.status).toBe(0);
   });
 
-  test('byte-identical mirrors pass', () => {
-    write('skills/demo/SKILL.md', '# demo\n');
-    write('plugins-cc/agentkit/skills/demo/SKILL.md', '# demo\n');
+  test('an unresolvable group manifest fails rather than assuming the core plugin', () => {
+    write('skills/beta/SKILL.md', '# beta\n');
+    write('plugins-cc/agentkit/skills/beta/SKILL.md', '# beta\n');
 
-    const result = preflight(['skills/demo/SKILL.md']);
+    const result = preflight(['skills/beta/SKILL.md']);
 
-    expect(result.stdout).toContain('plugin mirror byte-identical');
-    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('cannot resolve skill groups');
+    expect(result.status).toBe(1);
   });
 });
 
 describe('cross-skill imports', () => {
-  function skillPair(spec: string): ReturnType<typeof spawnSync> {
-    const body = `import { render } from '${spec}';\nexport const x = render;\n`;
-    write('skills/alpha/scripts/render.ts', body);
-    write('plugins-cc/agentkit/skills/alpha/scripts/render.ts', body);
-    write('skills/beta/slides.ts', 'export const render = 1;\n');
-    return preflight(['skills/alpha/scripts/render.ts']);
+  // beta (product plugin) importing from alpha (core): legitimate exactly when
+  // the sync has carried alpha's module into beta's plugin.
+  function crossImport(options: { carried: boolean }): ReturnType<typeof spawnSync> {
+    groupedRepo();
+    const body = "import { render } from '../../alpha/slides.ts';\nexport const x = render;\n";
+    write('skills/alpha/slides.ts', 'export const render = 1;\n');
+    write('skills/beta/scripts/r.ts', body);
+    write('plugins-cc/agentkit-product/skills/beta/scripts/r.ts', body);
+    if (options.carried) {
+      write('plugins-cc/agentkit-product/skills/alpha/slides.ts', 'export const render = 1;\n');
+    }
+    return preflight(['skills/beta/scripts/r.ts']);
   }
 
-  test('an import reaching into another skill fails', () => {
-    const result = skillPair('../../beta/slides.ts');
-
-    expect(result.stdout).toContain('outside skills/alpha');
-    expect(result.status).toBe(1);
-  });
-
-  test('an import inside the same skill passes', () => {
-    const result = skillPair('./slides.ts');
+  test('an escaping import passes when the shipping plugin carries the target', () => {
+    const result = crossImport({ carried: true });
 
     expect(result.stdout).toContain('no skill imports across a skill boundary');
     expect(result.status).toBe(0);
   });
 
-  test('byte parity is satisfied by a faithfully copied broken import', () => {
-    // The mirror is identical either way: parity proves sameness, not loadability,
-    // so it cannot be the check that catches this.
-    expect(skillPair('../../beta/slides.ts').stdout).toContain('plugin mirror byte-identical');
-    expect(skillPair('./slides.ts').stdout).toContain('plugin mirror byte-identical');
+  test('an escaping import fails when the shipping plugin does not carry it', () => {
+    const result = crossImport({ carried: false });
+
+    expect(result.stdout).toContain('does not ship at plugins-cc/agentkit-product/skills/alpha/slides.ts');
+    expect(result.status).toBe(1);
+  });
+
+  test('byte parity is satisfied either way, so it cannot be the check that catches this', () => {
+    expect(crossImport({ carried: false }).stdout).toContain('plugin mirror byte-identical');
+    expect(crossImport({ carried: true }).stdout).toContain('plugin mirror byte-identical');
+  });
+
+  test('an import inside the same skill passes', () => {
+    groupedRepo();
+    const body = "import { render } from './slides.ts';\nexport const x = render;\n";
+    write('skills/beta/slides.ts', 'export const render = 1;\n');
+    write('skills/beta/r.ts', body);
+    write('plugins-cc/agentkit-product/skills/beta/r.ts', body);
+
+    const result = preflight(['skills/beta/r.ts']);
+
+    expect(result.stdout).toContain('no skill imports across a skill boundary');
+    expect(result.status).toBe(0);
+  });
+
+  test('a guarded dynamic import is not the fatal class a static one is', () => {
+    groupedRepo();
+    const body = "async function load() {\n  return await import('../../alpha/optional.ts');\n}\n"
+      + 'export default load;\n';
+    write('skills/alpha/optional.ts', 'export const y = 1;\n');
+    write('skills/beta/scripts/h.ts', body);
+    write('plugins-cc/agentkit-product/skills/beta/scripts/h.ts', body);
+
+    const result = preflight(['skills/beta/scripts/h.ts']);
+
+    expect(result.stdout).toContain('no skill imports across a skill boundary');
+    expect(result.status).toBe(0);
   });
 });
 

--- a/tests/build/preflight.test.ts
+++ b/tests/build/preflight.test.ts
@@ -136,6 +136,13 @@ describe('conditional-and status leaks', () => {
     expect(result.status).toBe(1);
   });
 
+  test('an apostrophe inside a double-quoted string does not open a quoted span', () => {
+    const result = statusCheck('v() {', '\tprintf "it\'s" && printf "won\'t"', '}', 'v');
+
+    expect(result.stdout).toContain('[tail-leak]');
+    expect(result.status).toBe(1);
+  });
+
   test('a && inside a single-quoted program is data, not shell syntax', () => {
     const clean = statusCheck(
       'f() {',
@@ -313,6 +320,20 @@ describe('plugin mirror parity', () => {
     expect(result.status).toBe(0);
   });
 
+  test('a manifest that exists but does not validate is blamed, not the mirror', () => {
+    cpSync(join(REPO, 'lib', 'skill-groups.sh'), write('lib/skill-groups.sh', ''));
+    write('skills/GROUPS', 'group core Core skills\n\nbeta undeclared-group\n');
+    write('skills/beta/SKILL.md', '# beta\n');
+    write('plugins-cc/agentkit/skills/beta/SKILL.md', '# beta\n');
+
+    const result = preflight(['skills/beta/SKILL.md']);
+
+    expect(result.stdout).toContain('skills/GROUPS does not validate');
+    expect(result.stdout).toContain('undeclared-group');
+    expect(result.stdout).not.toContain('mirror missing');
+    expect(result.status).toBe(1);
+  });
+
   test('an unresolvable group manifest fails rather than assuming the core plugin', () => {
     write('skills/beta/SKILL.md', '# beta\n');
     write('plugins-cc/agentkit/skills/beta/SKILL.md', '# beta\n');
@@ -369,6 +390,39 @@ describe('cross-skill imports', () => {
 
     expect(result.stdout).toContain('no skill imports across a skill boundary');
     expect(result.status).toBe(0);
+  });
+
+  test('every spelling that resolves at load time is checked', () => {
+    for (
+      const line of [
+        "import { x } from '../../alpha/gone.ts';",
+        "import '../../alpha/gone.ts';",
+        "const x = require('../../alpha/gone.ts');",
+      ]
+    ) {
+      groupedRepo();
+      write('skills/beta/scripts/a.ts', `${line}\n`);
+      write('plugins-cc/agentkit-product/skills/beta/scripts/a.ts', `${line}\n`);
+      const result = preflight(['skills/beta/scripts/a.ts']);
+      expect(result.stdout, line).toContain('does not ship at');
+      expect(result.status, line).toBe(1);
+    }
+  });
+
+  test('a type-only import is erased before the code runs, so it cannot dangle', () => {
+    for (
+      const line of [
+        "import type { X } from '../../alpha/gone.ts';",
+        "export type { X } from '../../alpha/gone.ts';",
+      ]
+    ) {
+      groupedRepo();
+      write('skills/beta/scripts/a.ts', `${line}\n`);
+      write('plugins-cc/agentkit-product/skills/beta/scripts/a.ts', `${line}\n`);
+      const result = preflight(['skills/beta/scripts/a.ts']);
+      expect(result.stdout, line).toContain('no skill imports across a skill boundary');
+      expect(result.status, line).toBe(0);
+    }
   });
 
   test('a guarded dynamic import is not the fatal class a static one is', () => {


### PR DESCRIPTION
Closes #163

- mirror_of() resolves through lib/skill-groups.sh instead of hardcoding plugins-cc/agentkit
- cross-skill imports judged by what the shipped plugin tree contains; bare side-effect imports caught; `import type` exempt
- unresolvable GROUPS manifest refused with the real cause, never guessed at
- bash-status-check: quote-aware span erasure (double before single); original cond&&action class still caught

Review: .agentkit/reviews/fix__preflight-group-aware.json — approved at 008a6a2 (2 rounds)