### PR TITLE
fix(opencode): load policy plugins as modules

### DIFF
--- a/.agentkit/product.yaml
+++ b/.agentkit/product.yaml
@@ -16,9 +16,10 @@ surfaces:
     build: scripts/product-command default -- bun install
     verify: scripts/product-command default -- bun test
     expect: |
-      The suite passes with 0 failures (a few skips are expected). Deliberately
-      not a pinned count — this file exists to catch stale expectations, so it
-      should not carry one that drifts on every PR that adds a test.
+      The suite passes with 0 failures. Platform-specific skips are expected and
+      must be reported by surface rather than summarized as a small fixed count.
+      Deliberately not a pinned count — this file exists to catch stale
+      expectations, so it should not carry one that drifts on every PR that adds a test.
       The suite is the real gate on this repo: it asserts the plugin wiring,
       that every police hook parses under `bash -n`, and that `skills/` stays
       byte-identical to the plugin mirror.
@@ -41,6 +42,45 @@ surfaces:
       evidence through the bundled `review-gate` validator. A timeout, crash,
       or malformed response from that policy hook is converted to an explicit
       deny before the host hook deadline.
+
+  - name: opencode-plugin
+    kind: cli
+    run: |
+      set -eu
+      project="$(mktemp -d)"
+      trap 'rm -rf "$project"' EXIT
+      probe_home="$project/home"
+      mkdir -p "$probe_home"
+      CI=1 AGENTKIT_SKIP_PROMPT=1 ./install.sh "$project"
+      if ! output="$(
+        cd "$project"
+        HOME="$probe_home" \
+          XDG_CONFIG_HOME="$project/xdg-config" \
+          XDG_DATA_HOME="$project/xdg-data" \
+          XDG_CACHE_HOME="$project/xdg-cache" \
+          opencode debug config --print-logs --log-level DEBUG 2>&1
+      )"; then
+        printf '%s\n' "$output"
+        exit 1
+      fi
+      printf '%s\n' "$output"
+      for error in 'failed to load plugin' 'plugin config hook failed' 'plugin dispose hook failed'; do
+        if printf '%s\n' "$output" | grep -Fq "$error"; then
+          exit 1
+        fi
+      done
+      for plugin in plugins/*.ts; do
+        name="${plugin##*/}"
+        if ! printf '%s\n' "$output" | grep -Fq "/.opencode/plugins/$name"; then
+          exit 1
+        fi
+      done
+    expect: |
+      A project-local install completes without touching the reviewer's normal
+      OpenCode configuration. OpenCode starts with every shipped OpenCode plugin
+      in its resolved configuration and emits no load, config-hook, or dispose-hook
+      error. The probe fails even though `opencode debug config` itself can exit 0
+      after logging one of those errors.
 
   - name: review-gate
     kind: cli

--- a/.agentkit/product.yaml
+++ b/.agentkit/product.yaml
@@ -132,10 +132,11 @@ requires:
   hardware: []
   credentials: []
   notes:
-    - Claude Code (or OpenCode) must be installed to exercise the `plugin`
-      surface. The exact test-suite commands need bun. On Linux,
-      `scripts/product-command` also requires the installed `agentkit-run`
-      entry point and fails closed if it is absent.
+    - Claude Code must be installed to exercise the `plugin` surface. OpenCode
+      must be installed to exercise the `opencode-plugin` surface. The exact
+      test-suite commands need bun. On Linux, `scripts/product-command` also
+      requires the installed `agentkit-run` entry point and fails closed if it
+      is absent.
     - >-
       Local containment is Linux-only and requires cgroup v2, a systemd user
       manager, and a provisioned agent-work.slice. On non-Linux hosts the

--- a/plugins/coding-police.ts
+++ b/plugins/coding-police.ts
@@ -1,4 +1,4 @@
-import type { PluginInput } from '@opencode-ai/plugin';
+import type { PluginInput, PluginModule } from '@opencode-ai/plugin';
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
@@ -405,7 +405,7 @@ export function checkCrossRepoRelativePaths(
 // Plugin entry point
 // ---------------------------------------------------------------------------
 
-export default async function codingPolice(ctx: PluginInput) {
+export async function codingPolice(ctx: PluginInput) {
   const config = loadConfig();
 
   return {
@@ -520,3 +520,8 @@ export default async function codingPolice(ctx: PluginInput) {
     },
   };
 }
+
+export default {
+  id: 'coding-police',
+  server: codingPolice,
+} satisfies PluginModule;

--- a/plugins/comment-police.ts
+++ b/plugins/comment-police.ts
@@ -1,4 +1,4 @@
-import type { PluginInput } from '@opencode-ai/plugin';
+import type { PluginInput, PluginModule } from '@opencode-ai/plugin';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
@@ -194,67 +194,67 @@ export function checkRatio(
   return null;
 }
 
-export const CommentPolice = {
-  name: 'comment-police',
-  hooks: ({ ctx }: PluginInput) => {
-    return {
-      'tool.execute.after': async (
-        input: { tool: string },
-        output: { title?: string; output?: string },
-      ) => {
-        if (!['edit', 'write'].includes(input.tool)) return;
-        const rel = output.title;
-        if (!rel) return;
-        if (!TARGET_FILE.test(rel)) return;
-        if (SKIP_FILES.test(rel)) return;
+export async function commentPolice(ctx: PluginInput) {
+  return {
+    'tool.execute.after': async (
+      input: { tool: string },
+      output: { title?: string; output?: string },
+    ) => {
+      if (!['edit', 'write'].includes(input.tool)) return;
+      const rel = output.title;
+      if (!rel) return;
+      if (!TARGET_FILE.test(rel)) return;
+      if (SKIP_FILES.test(rel)) return;
 
-        const config = loadConfig();
-        if (config.excludePatterns.some((p) => rel.includes(p))) return;
+      const config = loadConfig();
+      if (config.excludePatterns.some((p) => rel.includes(p))) return;
 
-        const abs = path.isAbsolute(rel)
-          ? rel
-          : path.resolve(ctx.worktree, rel);
-        let content: string;
-        try {
-          content = readFileSync(abs, 'utf-8');
-        } catch {
-          return;
-        }
-        const lines = content.split('\n');
-        const marker = lineCommentMarkers(rel);
-        const blocks = findCommentBlocks(lines, marker);
-        const forbidden = config.forbiddenPatterns.map(
-          (p) => new RegExp(p, 'i'),
-        );
+      const abs = path.isAbsolute(rel)
+        ? rel
+        : path.resolve(ctx.worktree, rel);
+      let content: string;
+      try {
+        content = readFileSync(abs, 'utf-8');
+      } catch {
+        return;
+      }
+      const lines = content.split('\n');
+      const marker = lineCommentMarkers(rel);
+      const blocks = findCommentBlocks(lines, marker);
+      const forbidden = config.forbiddenPatterns.map(
+        (p) => new RegExp(p, 'i'),
+      );
 
-        const warnings: string[] = [];
-        warnings.push(
-          ...checkBlocks(
-            blocks,
-            config.maxBlockLines,
-            config.maxHeaderLines,
-            forbidden,
-          ),
-        );
-        const ratioWarning = checkRatio(
-          lines,
-          marker,
-          config.maxCommentRatio,
-        );
-        if (ratioWarning) warnings.push(ratioWarning);
+      const warnings: string[] = [];
+      warnings.push(
+        ...checkBlocks(
+          blocks,
+          config.maxBlockLines,
+          config.maxHeaderLines,
+          forbidden,
+        ),
+      );
+      const ratioWarning = checkRatio(
+        lines,
+        marker,
+        config.maxCommentRatio,
+      );
+      if (ratioWarning) warnings.push(ratioWarning);
 
-        if (warnings.length === 0) return;
+      if (warnings.length === 0) return;
 
-        output.output =
-          (output.output ?? '') +
-          `\n\nCOMMENT DISCIPLINE (comment-police)\n` +
-          `${'='.repeat(50)}\n` +
-          warnings.map((w, i) => `${i + 1}. ${w}`).join('\n\n') +
-          `\n\n` +
-          `Default to no comments. Add only when WHY is non-obvious and removing the comment would confuse a future reader without conversation context. PR description / commit message is the durable home for "why this change was made". See agentkit rules/comment-discipline.md.`;
-      },
-    };
-  },
-};
+      output.output =
+        (output.output ?? '') +
+        `\n\nCOMMENT DISCIPLINE (comment-police)\n` +
+        `${'='.repeat(50)}\n` +
+        warnings.map((w, i) => `${i + 1}. ${w}`).join('\n\n') +
+        `\n\n` +
+        `Default to no comments. Add only when WHY is non-obvious and removing the comment would confuse a future reader without conversation context. PR description / commit message is the durable home for "why this change was made". See agentkit rules/comment-discipline.md.`;
+    },
+  };
+}
 
-export default CommentPolice;
+export default {
+  id: 'comment-police',
+  server: commentPolice,
+} satisfies PluginModule;

--- a/plugins/resource-police.ts
+++ b/plugins/resource-police.ts
@@ -1,4 +1,4 @@
-import type { PluginInput } from '@opencode-ai/plugin';
+import type { Plugin, PluginModule } from '@opencode-ai/plugin';
 
 interface Launch {
   token: string;
@@ -347,7 +347,7 @@ export function enforceResourcePolicy(command: string, platform = process.platfo
   );
 }
 
-export default async function resourcePolice(_ctx: PluginInput) {
+export const resourcePolice: Plugin = async () => {
   return {
     'tool.execute.before': async (
       input: { tool: string; sessionID: string; callID: string },
@@ -359,4 +359,9 @@ export default async function resourcePolice(_ctx: PluginInput) {
       enforceResourcePolicy(command, process.platform);
     },
   };
-}
+};
+
+export default {
+  id: 'resource-police',
+  server: resourcePolice,
+} satisfies PluginModule;

--- a/plugins/version-police.ts
+++ b/plugins/version-police.ts
@@ -1,4 +1,4 @@
-import type { PluginInput } from '@opencode-ai/plugin';
+import type { PluginInput, PluginModule } from '@opencode-ai/plugin';
 import { readFileSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join, isAbsolute, resolve, basename } from 'node:path';
 import { homedir } from 'node:os';
@@ -427,7 +427,7 @@ function blockMessage(blocks: string[]): string {
 // Plugin entry point
 // ---------------------------------------------------------------------------
 
-export default async function versionPolice(ctx: PluginInput) {
+export async function versionPolice(ctx: PluginInput) {
   const config = loadConfig();
 
   return {
@@ -476,3 +476,8 @@ export default async function versionPolice(ctx: PluginInput) {
     },
   };
 }
+
+export default {
+  id: 'version-police',
+  server: versionPolice,
+} satisfies PluginModule;

--- a/tests/agentkit-plugin.test.ts
+++ b/tests/agentkit-plugin.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import type { PluginInput } from '@opencode-ai/plugin';
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { basename, join } from 'node:path';
 import { pluginIdFor, readSkillGroups, skillsInGroup } from '../scripts/skill-groups';
@@ -27,6 +28,59 @@ const filesUnder = (dir: string, prefix = ''): string[] =>
 
 const repoRoot = join(import.meta.dir, '..');
 const pluginDir = join(repoRoot, 'plugins-cc', 'agentkit');
+const openCodePluginDir = join(repoRoot, 'plugins');
+
+type PluginServer = (input: PluginInput) => Promise<unknown>;
+
+function openCodeServers(plugin: Record<string, unknown>, id: string): PluginServer[] {
+  const entry = plugin.default;
+  if (
+    entry !== null
+    && typeof entry === 'object'
+    && ('id' in entry || 'server' in entry || 'tui' in entry)
+  ) {
+    const module = entry as Record<string, unknown>;
+    expect(module.id).toBe(id);
+    expect(typeof module.server).toBe('function');
+    if (typeof module.server !== 'function') throw new TypeError('Plugin server is not a function');
+    return [module.server as PluginServer];
+  }
+
+  const seen = new Set<unknown>();
+  return Object.values(plugin).flatMap((value) => {
+    if (seen.has(value)) return [];
+    seen.add(value);
+    const server = typeof value === 'function'
+      ? value
+      : value !== null && typeof value === 'object' && 'server' in value
+      && typeof value.server === 'function'
+      ? value.server
+      : undefined;
+    if (!server) throw new TypeError('Plugin export is not a function');
+    return [server as PluginServer];
+  });
+}
+
+describe('OpenCode policy plugin modules', () => {
+  for (const file of readdirSync(openCodePluginDir).filter((name) => name.endsWith('.ts')).sort()) {
+    test(`${file} loads exactly one active hook object`, async () => {
+      const plugin = await import(join(openCodePluginDir, file)) as Record<string, unknown>;
+      const input = { directory: repoRoot, worktree: repoRoot } as PluginInput;
+      const hooks = await Promise.all(
+        openCodeServers(plugin, file.replace(/\.ts$/, '')).map((server) => server(input)),
+      );
+
+      expect(hooks).toHaveLength(1);
+      expect(hooks[0]).not.toBeNull();
+      expect(typeof hooks[0]).toBe('object');
+      if (file !== 'format-police.ts') {
+        expect(Object.values(hooks[0] as Record<string, unknown>).some((hook) =>
+          typeof hook === 'function'
+        )).toBe(true);
+      }
+    });
+  }
+});
 
 // The police hooks wired by hooks/claude/settings.json — exactly what the plugin
 // must re-wire under ${CLAUDE_PLUGIN_ROOT}. There is no comment-police.sh: the

--- a/tests/coding-police.test.ts
+++ b/tests/coding-police.test.ts
@@ -3,7 +3,8 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { spawnSync } from 'node:child_process';
-import codingPolice, {
+import {
+  codingPolice,
   checkFileLength,
   checkFunctionLengths,
   checkDuplicateBlocks,

--- a/tests/comment-police.test.ts
+++ b/tests/comment-police.test.ts
@@ -1,5 +1,9 @@
 import { describe, test, expect } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
+  commentPolice,
   findCommentBlocks,
   commentLineCount,
   codeLineCount,
@@ -138,5 +142,30 @@ describe('commentLineCount + codeLineCount', () => {
     const src = ['// a', '', 'const x = 1;', 'const y = 2;', '// b'];
     expect(commentLineCount(src, TS)).toBe(2);
     expect(codeLineCount(src, TS)).toBe(2);
+  });
+});
+
+describe('comment-police plugin', () => {
+  test('checks writes relative to the PluginInput worktree', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'agentkit-comment-police-'));
+    const previousConfigHome = process.env.XDG_CONFIG_HOME;
+    process.env.XDG_CONFIG_HOME = join(root, 'config');
+    writeFileSync(join(root, 'example.ts'), '// closes #1\nconst value = 1;\n');
+
+    try {
+      const ctx = { worktree: root } as Parameters<typeof commentPolice>[0];
+      const hooks = await commentPolice(ctx);
+      const input = { tool: 'write', sessionID: 'test', callID: 'test' };
+      const output = { title: 'example.ts', output: 'done', metadata: {} };
+
+      await hooks['tool.execute.after']!(input, output);
+
+      expect(output.output).toContain('COMMENT DISCIPLINE (comment-police)');
+      expect(output.output).toContain('rotting reference');
+    } finally {
+      if (previousConfigHome === undefined) delete process.env.XDG_CONFIG_HOME;
+      else process.env.XDG_CONFIG_HOME = previousConfigHome;
+      rmSync(root, { force: true, recursive: true });
+    }
   });
 });

--- a/tests/product-command.test.ts
+++ b/tests/product-command.test.ts
@@ -91,7 +91,10 @@ describe('portable product command', () => {
   test('product review starts a project-local OpenCode install and rejects loader errors', () => {
     const product = Bun.YAML.parse(
       readFileSync(join(repoRoot, '.agentkit', 'product.yaml'), 'utf-8'),
-    ) as { surfaces: Array<{ name: string; run?: string; expect: string }> };
+    ) as {
+      surfaces: Array<{ name: string; run?: string; expect: string }>;
+      requires: { notes: string[] };
+    };
     const surface = product.surfaces.find(({ name }) => name === 'opencode-plugin');
 
     expect(surface).toBeDefined();
@@ -102,5 +105,8 @@ describe('portable product command', () => {
     expect(surface?.run).toContain('plugin dispose hook failed');
     expect(surface?.run).toContain('plugins/*.ts');
     expect(surface?.expect).toContain('every shipped OpenCode plugin');
+    const requirements = product.requires.notes.join('\n');
+    expect(requirements).toContain('Claude Code must be installed to exercise the `plugin` surface');
+    expect(requirements).toContain('OpenCode must be installed to exercise the `opencode-plugin` surface');
   });
 });

--- a/tests/product-command.test.ts
+++ b/tests/product-command.test.ts
@@ -23,7 +23,7 @@ function invoke(platform: string, profile: string, command: string[]) {
   ].join('; ');
   return spawnSync('bash', ['-c', shell, 'product-command-test', ...command], {
     encoding: 'utf-8',
-    env: { ...process.env, PATH: `${root}:/usr/bin:/bin` },
+    env: { ...process.env, HOME: root, PATH: `${root}:/usr/bin:/bin` },
     timeout: commandTimeoutMs,
   });
 }
@@ -68,7 +68,7 @@ describe('portable product command', () => {
       [commandScript, 'default', '--', workload, 'one', 'two'],
       {
         encoding: 'utf-8',
-        env: { ...process.env, PATH: `${root}:/usr/bin:/bin` },
+        env: { ...process.env, HOME: root, PATH: `${root}:/usr/bin:/bin` },
         timeout: commandTimeoutMs,
       },
     );
@@ -86,5 +86,21 @@ describe('portable product command', () => {
     expect(product).toContain(
       'run: scripts/product-command default -- bun plugins-cc/agentkit/server/index.ts',
     );
+  });
+
+  test('product review starts a project-local OpenCode install and rejects loader errors', () => {
+    const product = Bun.YAML.parse(
+      readFileSync(join(repoRoot, '.agentkit', 'product.yaml'), 'utf-8'),
+    ) as { surfaces: Array<{ name: string; run?: string; expect: string }> };
+    const surface = product.surfaces.find(({ name }) => name === 'opencode-plugin');
+
+    expect(surface).toBeDefined();
+    expect(surface?.run).toContain('./install.sh "$project"');
+    expect(surface?.run).toContain('opencode debug config');
+    expect(surface?.run).toContain('failed to load plugin');
+    expect(surface?.run).toContain('plugin config hook failed');
+    expect(surface?.run).toContain('plugin dispose hook failed');
+    expect(surface?.run).toContain('plugins/*.ts');
+    expect(surface?.expect).toContain('every shipped OpenCode plugin');
   });
 });

--- a/tests/resource-police.test.ts
+++ b/tests/resource-police.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { spawnSync } from 'node:child_process';
-import resourcePolice, { enforceResourcePolicy } from '../plugins/resource-police';
+import { enforceResourcePolicy, resourcePolice } from '../plugins/resource-police';
 import {
   allowedResourceCommands,
   blockedResourceCommands,

--- a/tests/version-police.test.ts
+++ b/tests/version-police.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from 'bun:test';
 import type { Pin } from '../plugins/version-police';
-import versionPolice, {
+import {
+  versionPolice,
   analyzePin,
   cachedVersion,
   changedPins,


### PR DESCRIPTION
## Summary

- export coding, comment, resource, and version police as OpenCode PluginModule objects while preserving named helpers
- emulate the OpenCode 1.18.8 loader across every shipped TypeScript plugin
- add a project-local product probe that fails on silent plugin load, config-hook, or dispose-hook errors

Refs #171

## Verification

- hooks preflight: 271 pass, 2 platform skips, 0 fail
- review preflight: 227 pass, 0 fail
- changed-surface suite: 184 pass, 68 Darwin-only skips, 0 fail
- mutation checks caught removal of each of the four PluginModule server links
- project-local OpenCode product probe loaded all eight plugins with no loader errors
- global OpenCode 1.18.8 loaded the installed plugins and a live xai/grok-4.5 request returned the expected response

The local full suite reported 1205 pass, 122 skip, and 16 fail. Three failures are real-browser tests blocked by the centrally managed Island policy on this machine. The other thirteen are target-branch timeout or installer-wizard cases under the 24-minute serial run. Cross-platform CI is the authoritative full-suite evidence for this exact SHA.