### PR TITLE
feat(pages): serve a real multi-page site on the apex host

### DIFF
--- a/pages/worker/src/worker.js
+++ b/pages/worker/src/worker.js
@@ -2,8 +2,12 @@ const SLUG_RE = /^[a-z0-9][a-z0-9-]{0,63}(\/[a-z0-9][a-z0-9-]{0,63}){0,3}$/;
 const MAX_PAGE_BYTES = 5 * 1024 * 1024;
 
 // Slugs the site deploy flow may write, gated by SITE_TOKEN instead of
-// PUBLISH_TOKEN so a leaked page-publish token cannot deface the site.
+// PUBLISH_TOKEN so a leaked page-publish token cannot deface the site. Sub-page
+// writes address `_site/<path>`; the two keyspaces cannot cross, because
+// SLUG_RE's alphabet has no leading underscore for a PUBLISH_TOKEN slug to
+// reach `_site/*` with, and every site key is rooted at `_site/`.
 const SITE_SLUGS = { "_site": "_site/index.html", "_pages-index": "_site/pages-index.html" };
+const SITE_PREFIX = "_site/";
 
 const BASE_HEADERS = {
   "content-type": "text/html; charset=utf-8",
@@ -31,21 +35,39 @@ async function servePage(env, key, headers) {
   return html(200, obj.body, headers);
 }
 
+// null when the slug is not site-space at all. An empty string keeps a
+// malformed sub-path inside site-space, so it is still SITE_TOKEN that must
+// authenticate before the 400 tells anyone the path was rejected.
+function siteKey(slug) {
+  if (Object.hasOwn(SITE_SLUGS, slug)) return SITE_SLUGS[slug];
+  if (!slug.startsWith(SITE_PREFIX)) return null;
+  const path = slug.slice(SITE_PREFIX.length);
+  return SLUG_RE.test(path) ? `_site/${path}/index.html` : "";
+}
+
 // Shared write-path gate: bearer auth (site slugs need SITE_TOKEN, pages need
 // PUBLISH_TOKEN, both fail closed when unset) + slug validation + R2 key.
 // Returns a Response on rejection, else { isSite, key }.
 function authorizeWrite(request, env, slug) {
   const auth = request.headers.get("authorization") ?? "";
   const token = auth.replace(/^Bearer\s+/i, "");
-  const isSite = Object.hasOwn(SITE_SLUGS, slug);
+  const site = siteKey(slug);
+  const isSite = site !== null;
   const expected = isSite ? env.SITE_TOKEN : env.PUBLISH_TOKEN;
   if (!expected || token !== expected) {
     return new Response("unauthorized\n", { status: 401 });
   }
-  if (!isSite && !SLUG_RE.test(slug)) {
+  if (isSite ? site === "" : !SLUG_RE.test(slug)) {
     return new Response("invalid slug\n", { status: 400 });
   }
-  return { isSite, key: isSite ? SITE_SLUGS[slug] : `pages/${slug}/index.html` };
+  return { isSite, key: isSite ? site : `pages/${slug}/index.html` };
+}
+
+function publishedUrl(slug, isSite) {
+  if (!isSite) return `https://pages.agentkit.sbs/${slug}`;
+  if (slug === "_pages-index") return "https://pages.agentkit.sbs/";
+  if (slug === "_site") return "https://agentkit.sbs/";
+  return `https://agentkit.sbs/${slug.slice(SITE_PREFIX.length)}`;
 }
 
 async function handlePublish(request, env, slug) {
@@ -62,12 +84,7 @@ async function handlePublish(request, env, slug) {
   await env.PAGES.put(gate.key, body, {
     httpMetadata: { contentType: "text/html; charset=utf-8" },
   });
-  const url = slug === "_site"
-    ? "https://agentkit.sbs/"
-    : slug === "_pages-index"
-    ? "https://pages.agentkit.sbs/"
-    : `https://pages.agentkit.sbs/${slug}`;
-  return Response.json({ ok: true, slug, url });
+  return Response.json({ ok: true, slug, url: publishedUrl(slug, gate.isSite) });
 }
 
 async function handleDelete(request, env, slug) {
@@ -96,8 +113,9 @@ export default {
     }
 
     if (host === "agentkit.sbs" || host === "www.agentkit.sbs") {
-      if (path !== "") return html(404, NOT_FOUND);
-      return servePage(env, "_site/index.html", BASE_HEADERS);
+      if (path === "") return servePage(env, "_site/index.html", BASE_HEADERS);
+      if (!SLUG_RE.test(path)) return html(404, NOT_FOUND);
+      return servePage(env, `_site/${path}/index.html`, BASE_HEADERS);
     }
     if (path === "") {
       return servePage(env, "_site/pages-index.html", PAGE_HEADERS);

--- a/scripts/check-test-slices.ts
+++ b/scripts/check-test-slices.ts
@@ -51,6 +51,7 @@ export const TEST_SLICES = {
     'tests/publish-page/lint.test.ts',
     'tests/publish-page/mermaid-runtime.test.ts',
     'tests/publish-page/pages-police.test.ts',
+    'tests/publish-page/worker.test.ts',
   ],
   resources: [
     'tests/resource-police.test.ts',

--- a/tests/publish-page/worker.test.ts
+++ b/tests/publish-page/worker.test.ts
@@ -45,6 +45,11 @@ function env(PAGES: Bucket, overrides: Record<string, string | undefined> = {}) 
   return { PAGES, SITE_TOKEN, PUBLISH_TOKEN, ...overrides };
 }
 
+const SEEDED: Record<string, string> = {
+  '_site/docs/index.html': '<h1>seeded site</h1>',
+  'pages/deadbeef/index.html': '<h1>seeded page</h1>',
+};
+
 function get(url: string) {
   return new Request(url);
 }
@@ -288,14 +293,90 @@ describe('token separation', () => {
     expect(store.writes.get('pages/deadbeef/index.html')?.body).toBe('<h1>page</h1>');
   });
 
-  test.each([
-    ['_site/docs', 'SITE_TOKEN'],
-    ['deadbeef', 'PUBLISH_TOKEN'],
-  ])('%s fails closed when %s is unset', (slug, unset) =>
-    expectWriteRejected(slug, '', { [unset]: undefined }));
-
   test('an unauthenticated site write is rejected', () =>
     expectWriteRejected('_site/docs', null));
+
+  // `constructor` is the only Object.prototype member SLUG_RE admits, so it is
+  // the one slug that can tell an own-property reserved-slug lookup apart from
+  // a prototype-walking one.
+  test('a page slug named after an Object.prototype member is publishable', async () => {
+    const store = bucket();
+    const res = await worker.fetch(
+      write('https://agentkit.sbs/api/pages/constructor', PUBLISH_TOKEN, '<h1>ctor</h1>'),
+      env(store),
+    );
+
+    expect(res.status).toBe(200);
+    expect([...store.writes.keys()]).toEqual(['pages/constructor/index.html']);
+    expect(store.writes.get('pages/constructor/index.html')?.body).toBe('<h1>ctor</h1>');
+  });
+
+  test('SITE_TOKEN cannot write the Object.prototype slug either', () =>
+    expectWriteRejected('constructor', SITE_TOKEN));
+
+  // Site-space membership is anchored at position 0. A slug that merely
+  // contains the prefix is a page slug; treating it as site-space would slice
+  // it at the wrong offset and land the write on an unrelated key.
+  test.each(['a/_site/b', 'docs/_site/install'])(
+    'the slug %s only contains the site prefix, so it is not site-space',
+    (slug) => expectWriteRejected(slug, SITE_TOKEN),
+  );
+});
+
+// An unset secret is already rejected by the equality check, because no token
+// equals undefined. An empty secret is the state that check cannot judge —
+// `'' !== ''` is false — so the emptiness guard is the only thing standing
+// between an empty binding and anonymous writes to either keyspace.
+const ABSENT_SECRET = [['unset', undefined], ['empty', '']] as const;
+const WRITE_TARGETS = [
+  ['_site/docs', '_site/docs/index.html', 'SITE_TOKEN'],
+  ['deadbeef', 'pages/deadbeef/index.html', 'PUBLISH_TOKEN'],
+] as const;
+const ANONYMOUS_CASES = WRITE_TARGETS.flatMap(([slug, key, secret]) =>
+  ABSENT_SECRET.flatMap(([state, value]) =>
+    (['PUT', 'DELETE'] as const).map(
+      (method) =>
+        [`${method} ${slug} with ${secret} ${state}`, method, slug, key, secret, value] as const,
+    ),
+  ),
+);
+
+describe('writes fail closed when the secret is missing', () => {
+  test.each(ANONYMOUS_CASES)(
+    'an anonymous %s is refused and leaves the object untouched',
+    async (_label, method, slug, key, secret, value) => {
+      const store = bucket(SEEDED);
+      const res = await worker.fetch(
+        new Request(`https://agentkit.sbs/api/pages/${slug}`, {
+          method,
+          ...(method === 'PUT' ? { body: '<h1>anonymous</h1>' } : {}),
+        }),
+        env(store, { [secret]: value }),
+      );
+
+      expect(res.status).toBe(401);
+      expect(store.writes.get(key)?.body).toBe(SEEDED[key]);
+    },
+  );
+});
+
+describe('method allowlist', () => {
+  test.each([
+    ['POST', 'https://agentkit.sbs/'],
+    ['POST', 'https://agentkit.sbs/docs'],
+    ['PATCH', 'https://agentkit.sbs/docs'],
+    ['OPTIONS', 'https://agentkit.sbs/docs'],
+    ['POST', 'https://pages.agentkit.sbs/deadbeef'],
+    ['PATCH', 'https://agentkit.sbs/api/pages/_site/docs'],
+    ['POST', 'https://agentkit.sbs/api/pages/deadbeef'],
+  ])('%s %s is refused without touching R2', async (method, url) => {
+    const store = bucket(SEEDED);
+    const res = await worker.fetch(new Request(url, { method }), env(store));
+
+    expect(res.status).toBe(405);
+    expect(store.reads).toEqual([]);
+    expect([...store.writes.keys()].sort()).toEqual(Object.keys(SEEDED).sort());
+  });
 });
 
 describe('size limits', () => {

--- a/tests/publish-page/worker.test.ts
+++ b/tests/publish-page/worker.test.ts
@@ -1,0 +1,347 @@
+import { describe, expect, test } from 'bun:test';
+import worker from '../../pages/worker/src/worker.js';
+
+const SITE_TOKEN = 'site-secret';
+const PUBLISH_TOKEN = 'publish-secret';
+const MAX_PAGE_BYTES = 5 * 1024 * 1024;
+
+interface Bucket {
+  reads: string[];
+  writes: Map<string, { body: string; contentType: string }>;
+  get(key: string): Promise<{ body: string } | null>;
+  put(key: string, body: ArrayBuffer, options: { httpMetadata: { contentType: string } }): Promise<void>;
+  head(key: string): Promise<Record<string, never> | null>;
+  delete(key: string): Promise<void>;
+}
+
+function bucket(seed: Record<string, string> = {}): Bucket {
+  const writes = new Map(
+    Object.entries(seed).map(([key, body]) => [key, { body, contentType: 'seed' }]),
+  );
+  return {
+    reads: [],
+    writes,
+    async get(key) {
+      this.reads.push(key);
+      const stored = writes.get(key);
+      return stored ? { body: stored.body } : null;
+    },
+    async put(key, body, options) {
+      writes.set(key, {
+        body: new TextDecoder().decode(body),
+        contentType: options.httpMetadata.contentType,
+      });
+    },
+    async head(key) {
+      return writes.has(key) ? {} : null;
+    },
+    async delete(key) {
+      writes.delete(key);
+    },
+  };
+}
+
+function env(PAGES: Bucket, overrides: Record<string, string | undefined> = {}) {
+  return { PAGES, SITE_TOKEN, PUBLISH_TOKEN, ...overrides };
+}
+
+function get(url: string) {
+  return new Request(url);
+}
+
+function write(url: string, token: string | null, body = '<!doctype html>hi', headers: Record<string, string> = {}) {
+  return new Request(url, {
+    method: 'PUT',
+    body,
+    headers: token === null ? headers : { authorization: `Bearer ${token}`, ...headers },
+  });
+}
+
+describe('apex site routing', () => {
+  test('root serves the site index, indexable', async () => {
+    const store = bucket({ '_site/index.html': '<h1>home</h1>' });
+    const res = await worker.fetch(get('https://agentkit.sbs/'), env(store));
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('<h1>home</h1>');
+    expect(res.headers.get('x-robots-tag')).toBeNull();
+    expect(res.headers.get('content-type')).toBe('text/html; charset=utf-8');
+    expect(res.headers.get('content-security-policy')).toContain("default-src 'none'");
+  });
+
+  test('www root serves the same key', async () => {
+    const store = bucket({ '_site/index.html': '<h1>home</h1>' });
+    const res = await worker.fetch(get('https://www.agentkit.sbs/'), env(store));
+
+    expect(res.status).toBe(200);
+    expect(store.reads).toEqual(['_site/index.html']);
+  });
+
+  test.each([
+    ['https://agentkit.sbs/docs', '_site/docs/index.html'],
+    ['https://agentkit.sbs/docs/install', '_site/docs/install/index.html'],
+    ['https://agentkit.sbs/docs/install/', '_site/docs/install/index.html'],
+    ['https://www.agentkit.sbs/guides/a-b-c', '_site/guides/a-b-c/index.html'],
+  ])('%s serves %s with no noindex', async (url, key) => {
+    const store = bucket({ [key]: '<h1>page</h1>' });
+    const res = await worker.fetch(get(url), env(store));
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('<h1>page</h1>');
+    expect(res.headers.get('x-robots-tag')).toBeNull();
+    expect(store.reads).toEqual([key]);
+  });
+
+  test('absent sub-path 404s with the site 404 page', async () => {
+    const store = bucket({ '_site/index.html': '<h1>home</h1>' });
+    const res = await worker.fetch(get('https://agentkit.sbs/docs/missing'), env(store));
+
+    expect(res.status).toBe(404);
+    expect(await res.text()).toContain('No page lives at this address');
+    expect(res.headers.get('x-robots-tag')).toBeNull();
+  });
+
+  test.each([
+    'https://agentkit.sbs/Docs',
+    'https://agentkit.sbs/-docs',
+    'https://agentkit.sbs/docs//install',
+    'https://agentkit.sbs/a/b/c/d/e',
+    'https://agentkit.sbs/index.html',
+    'https://agentkit.sbs/pages-index.html',
+    'https://agentkit.sbs/docs%2Finstall',
+  ])('%s never reaches R2', async (url) => {
+    const store = bucket();
+    const res = await worker.fetch(get(url), env(store));
+
+    expect(res.status).toBe(404);
+    expect(store.reads).toEqual([]);
+  });
+
+  // The URL parser decodes and collapses dot segments before the worker sees a
+  // path, so traversal cannot survive to the key — it resolves within the site.
+  test.each([
+    ['https://agentkit.sbs/docs/%2e%2e/secret', '_site/secret/index.html'],
+    ['https://agentkit.sbs/docs/../secret', '_site/secret/index.html'],
+    ['https://agentkit.sbs/../../pages/evil', '_site/pages/evil/index.html'],
+  ])('%s stays inside the site keyspace', async (url, key) => {
+    const store = bucket();
+    await worker.fetch(get(url), env(store));
+
+    expect(store.reads).toEqual([key]);
+  });
+});
+
+describe('published pages stay noindex', () => {
+  test('a page slug serves with noindex', async () => {
+    const store = bucket({ 'pages/deadbeef/index.html': '<h1>artifact</h1>' });
+    const res = await worker.fetch(get('https://pages.agentkit.sbs/deadbeef'), env(store));
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('<h1>artifact</h1>');
+    expect(res.headers.get('x-robots-tag')).toBe('noindex, nofollow');
+  });
+
+  test('the pages index serves with noindex', async () => {
+    const store = bucket({ '_site/pages-index.html': '<h1>index</h1>' });
+    const res = await worker.fetch(get('https://pages.agentkit.sbs/'), env(store));
+
+    expect(res.status).toBe(200);
+    expect(store.reads).toEqual(['_site/pages-index.html']);
+    expect(res.headers.get('x-robots-tag')).toBe('noindex, nofollow');
+  });
+});
+
+describe('site writes', () => {
+  test.each([
+    ['_site', '_site/index.html', 'https://agentkit.sbs/'],
+    ['_pages-index', '_site/pages-index.html', 'https://pages.agentkit.sbs/'],
+    ['_site/docs', '_site/docs/index.html', 'https://agentkit.sbs/docs'],
+    ['_site/docs/install', '_site/docs/install/index.html', 'https://agentkit.sbs/docs/install'],
+  ])('SITE_TOKEN writes %s to %s', async (slug, key, url) => {
+    const store = bucket();
+    const res = await worker.fetch(
+      write(`https://agentkit.sbs/api/pages/${slug}`, SITE_TOKEN, '<h1>new</h1>'),
+      env(store),
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, slug, url });
+    expect(store.writes.get(key)?.body).toBe('<h1>new</h1>');
+    expect(store.writes.get(key)?.contentType).toBe('text/html; charset=utf-8');
+  });
+
+  test('a site write is served back from the apex host', async () => {
+    const store = bucket();
+    await worker.fetch(
+      write('https://agentkit.sbs/api/pages/_site/docs/install', SITE_TOKEN, '<h1>install</h1>'),
+      env(store),
+    );
+    const res = await worker.fetch(get('https://agentkit.sbs/docs/install'), env(store));
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('<h1>install</h1>');
+    expect(res.headers.get('x-robots-tag')).toBeNull();
+  });
+
+  test('SITE_TOKEN deletes a site sub-path', async () => {
+    const store = bucket({ '_site/docs/index.html': '<h1>docs</h1>' });
+    const res = await worker.fetch(
+      new Request('https://agentkit.sbs/api/pages/_site/docs', {
+        method: 'DELETE',
+        headers: { authorization: `Bearer ${SITE_TOKEN}` },
+      }),
+      env(store),
+    );
+
+    expect(res.status).toBe(200);
+    expect(store.writes.has('_site/docs/index.html')).toBe(false);
+  });
+
+  test.each([
+    '_site/Docs',
+    '_site/-docs',
+    '_site/_site',
+    '_site/docs//install',
+    '_site/docs%2Finstall',
+    '_site/a/b/c/d/e',
+    `_site/${'a'.repeat(65)}`,
+    '_site/docs/index.html',
+  ])('rejects the malformed site path %s', async (slug) => {
+    const store = bucket();
+    const res = await worker.fetch(
+      write(`https://agentkit.sbs/api/pages/${slug}`, SITE_TOKEN),
+      env(store),
+    );
+
+    expect(res.status).toBe(400);
+    expect([...store.writes.keys()]).toEqual([]);
+  });
+
+  test('a trailing slash still addresses the site index', async () => {
+    const store = bucket();
+    const res = await worker.fetch(
+      write('https://agentkit.sbs/api/pages/_site/', SITE_TOKEN, '<h1>home</h1>'),
+      env(store),
+    );
+
+    expect(res.status).toBe(200);
+    expect(store.writes.get('_site/index.html')?.body).toBe('<h1>home</h1>');
+  });
+});
+
+async function expectWriteRejected(slug: string, token: string | null, overrides = {}) {
+  const store = bucket();
+  const res = await worker.fetch(
+    write(`https://agentkit.sbs/api/pages/${slug}`, token, '<h1>defaced</h1>'),
+    env(store, overrides),
+  );
+
+  expect(res.status).toBe(401);
+  expect([...store.writes.keys()]).toEqual([]);
+}
+
+describe('token separation', () => {
+  test.each(['_site', '_pages-index', '_site/docs', '_site/docs/install'])(
+    'PUBLISH_TOKEN cannot write %s',
+    (slug) => expectWriteRejected(slug, PUBLISH_TOKEN),
+  );
+
+  test('PUBLISH_TOKEN cannot delete site content', async () => {
+    const store = bucket({ '_site/docs/index.html': '<h1>docs</h1>' });
+    const res = await worker.fetch(
+      new Request('https://agentkit.sbs/api/pages/_site/docs', {
+        method: 'DELETE',
+        headers: { authorization: `Bearer ${PUBLISH_TOKEN}` },
+      }),
+      env(store),
+    );
+
+    expect(res.status).toBe(401);
+    expect(store.writes.has('_site/docs/index.html')).toBe(true);
+  });
+
+  test.each(['deadbeef', 'design/agentkit-pages', 'pages/evil'])(
+    'SITE_TOKEN cannot write the page slug %s',
+    (slug) => expectWriteRejected(slug, SITE_TOKEN),
+  );
+
+  // The URL parser collapses the traversal before the worker sees it, leaving a
+  // plain page slug — which SITE_TOKEN must still not be able to write.
+  test.each(['_site/../evil', '_site/%2e%2e/evil', '_site/../pages/evil'])(
+    'the traversal write %s normalises to a page slug SITE_TOKEN cannot reach',
+    (slug) => expectWriteRejected(slug, SITE_TOKEN),
+  );
+
+  test('PUBLISH_TOKEN still writes a page slug', async () => {
+    const store = bucket();
+    const res = await worker.fetch(
+      write('https://agentkit.sbs/api/pages/deadbeef', PUBLISH_TOKEN, '<h1>page</h1>'),
+      env(store),
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      ok: true,
+      slug: 'deadbeef',
+      url: 'https://pages.agentkit.sbs/deadbeef',
+    });
+    expect(store.writes.get('pages/deadbeef/index.html')?.body).toBe('<h1>page</h1>');
+  });
+
+  test.each([
+    ['_site/docs', 'SITE_TOKEN'],
+    ['deadbeef', 'PUBLISH_TOKEN'],
+  ])('%s fails closed when %s is unset', (slug, unset) =>
+    expectWriteRejected(slug, '', { [unset]: undefined }));
+
+  test('an unauthenticated site write is rejected', () =>
+    expectWriteRejected('_site/docs', null));
+});
+
+describe('size limits', () => {
+  test('a declared oversize site write is rejected before the body is read', async () => {
+    const store = bucket();
+    const res = await worker.fetch(
+      write('https://agentkit.sbs/api/pages/_site/docs', SITE_TOKEN, 'small', {
+        'content-length': String(MAX_PAGE_BYTES + 1),
+      }),
+      env(store),
+    );
+
+    expect(res.status).toBe(413);
+    expect([...store.writes.keys()]).toEqual([]);
+  });
+
+  test('an oversize site body is rejected', async () => {
+    const store = bucket();
+    const res = await worker.fetch(
+      write('https://agentkit.sbs/api/pages/_site/docs', SITE_TOKEN, 'a'.repeat(MAX_PAGE_BYTES + 1)),
+      env(store),
+    );
+
+    expect(res.status).toBe(413);
+    expect([...store.writes.keys()]).toEqual([]);
+  });
+
+  test('an empty site body is rejected', async () => {
+    const store = bucket();
+    const res = await worker.fetch(
+      write('https://agentkit.sbs/api/pages/_site/docs', SITE_TOKEN, ''),
+      env(store),
+    );
+
+    expect(res.status).toBe(413);
+    expect([...store.writes.keys()]).toEqual([]);
+  });
+
+  test('a body at the cap is accepted', async () => {
+    const store = bucket();
+    const res = await worker.fetch(
+      write('https://agentkit.sbs/api/pages/_site/docs', SITE_TOKEN, 'a'.repeat(MAX_PAGE_BYTES)),
+      env(store),
+    );
+
+    expect(res.status).toBe(200);
+    expect(store.writes.get('_site/docs/index.html')?.body.length).toBe(MAX_PAGE_BYTES);
+  });
+});


### PR DESCRIPTION
Closes #173

- `agentkit.sbs/<path>` serves `_site/<path>/index.html` with indexable headers; root and 404 behaviour unchanged
- SITE_TOKEN writes extend to `_site/<path>` sub-paths; the two keyspaces cannot cross (page slugs have no leading underscore, every site key is rooted at `_site/`)
- published pages keep `noindex`; CSP, size limits and DELETE gating unchanged
- guards pinned by mutation-tested cases: fail-closed on unset/empty token, prototype-safe reserved lookup, prefix anchoring, method allowlist

Review: .agentkit/reviews/feat__site-multipage.json — pass at 7acf87b (2 rounds; token-separation matrix and hostile-path→key table verified)