### PR TITLE
fix(review): resolve Codex tool workdir

### DIFF
--- a/hooks/claude/lib/hook-input.sh
+++ b/hooks/claude/lib/hook-input.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # Shared Pre/PostToolUse input helpers for Claude Code and Grok CLI.
 # Source from a police hook:
 #   # shellcheck source=lib/hook-input.sh
@@ -33,6 +34,13 @@ agentkit_tool_name() {
 
 agentkit_command() {
 	agentkit_jq_raw -r '.tool_input.command // .toolInput.command // empty'
+}
+
+agentkit_workdir() {
+	agentkit_jq_raw -r '
+    .tool_input.workdir // .tool_input.cwd //
+    .toolInput.workdir // .toolInput.cwd //
+    .cwd // empty'
 }
 
 agentkit_session_id() {
@@ -78,6 +86,7 @@ agentkit_is_file_write_tool() {
 # Dual-emit Claude (hookSpecificOutput) and Grok ({decision, reason}) deny shapes.
 agentkit_deny_json() {
 	local reason="$1"
+	# shellcheck disable=SC2016 # jq program; dollar-prefixed names are jq variables.
 	_agentkit_jq -n --arg r "$reason" '{
     decision: "deny",
     reason: $r,
@@ -91,6 +100,7 @@ agentkit_deny_json() {
 
 agentkit_advise_json() {
 	local msg="$1"
+	# shellcheck disable=SC2016 # jq program; dollar-prefixed names are jq variables.
 	_agentkit_jq -n --arg m "$msg" '{
     systemMessage: $m,
     hookSpecificOutput: {

--- a/hooks/claude/review-police.sh
+++ b/hooks/claude/review-police.sh
@@ -95,6 +95,7 @@ SESSION=$(agentkit_session_id)
 # fall back to whitespace-splitting with quote characters stripped. Keeping the
 # quotes glued on (`"glab`) makes exact-token matching miss, which fails OPEN —
 # the one direction this must never take.
+# shellcheck disable=SC2016 # Python source is intentionally single-quoted shell data.
 COMMAND=$(printf '%s' "$RAW_COMMAND" | python3 -c '
 import os, shlex, sys
 
@@ -195,8 +196,6 @@ has_basename() {
 }
 # Any token matching a regex (URLs keep their value through tokenisation).
 tok_match() { printf '%s' "$COMMAND" | grep -qiE -- "$1"; }
-# The token following the first occurrence of a given token.
-after() { printf '%s' "$COMMAND" | awk -v k="$1" 'p { print; exit } $0 == k { p = 1 }'; }
 
 # `gh api graphql` can take its request body from a file or stdin. The mutation
 # name then never appears in RAW_COMMAND/COMMAND, and inspecting the current
@@ -535,7 +534,26 @@ fi
 # --- Resolve WHAT is being merged, from the forge ---------------------------
 # Fail CLOSED: if the target cannot be resolved, the gate denies. An
 # unresolvable merge is exactly when a mistake is most likely.
+REQUEST_WORKDIR=$(agentkit_workdir)
 REPO_DIR="$PWD"
+if [[ -n "$REQUEST_WORKDIR" ]]; then
+	if [[ "$REQUEST_WORKDIR" != /* ]]; then
+		deny "BLOCKED: the merge tool working directory must be an absolute Git worktree.
+
+  tool working directory: $REQUEST_WORKDIR"
+	fi
+	REPO_DIR="$REQUEST_WORKDIR"
+fi
+if ! REPO_ROOT=$(git -C "$REPO_DIR" rev-parse --show-toplevel 2>/dev/null) || [[ -z "$REPO_ROOT" ]]; then
+	deny "BLOCKED: the merge tool working directory is not a readable Git worktree.
+
+  tool working directory: ${REQUEST_WORKDIR:-$PWD}
+
+The review record and target policy must be resolved from the repository that
+the forge change will land in. Run the merge with that repository as the tool
+working directory."
+fi
+REPO_DIR="$REPO_ROOT"
 
 forge_json() {
 	if [[ "$CLI" == "gh" ]]; then
@@ -668,7 +686,7 @@ Retry '$CLI $GROUP merge $MR_ID' after adding '$HEAD_FLAG $HEAD_SHA'. The forge 
 then refuse the merge if the source branch changes after this hook checks it."
 fi
 
-SLUG=$(echo "$BRANCH" | sed 's#/#__#g')
+SLUG=${BRANCH//\//__}
 RECORD="$REPO_DIR/.agentkit/reviews/$SLUG.json"
 
 if [[ ! -f "$RECORD" ]]; then
@@ -716,7 +734,7 @@ if ! POLICY_ENTRY=$(git -C "$REPO_DIR" ls-tree "$TARGET_SHA" -- "$POLICY_PATH" 2
 	deny 'BLOCKED: the exact target commit cannot be inspected for review policy.'
 fi
 if [[ -n "$POLICY_ENTRY" ]]; then
-	read -r POLICY_MODE POLICY_TYPE POLICY_BLOB POLICY_NAME <<<"$POLICY_ENTRY"
+	read -r POLICY_MODE POLICY_TYPE _ POLICY_NAME <<<"$POLICY_ENTRY"
 	if [[ "$POLICY_TYPE" != "blob" ||
 		( "$POLICY_MODE" != "100644" && "$POLICY_MODE" != "100755" ) ||
 		"$POLICY_NAME" != "$POLICY_PATH" ]]; then
@@ -728,6 +746,7 @@ if [[ -n "$POLICY_ENTRY" ]]; then
 		rm -f "$POLICY_TMP"
 		deny 'BLOCKED: cannot allocate a temporary file for changed-path validation.'
 	}
+	# shellcheck disable=SC2329 # invoked by the EXIT trap below.
 	cleanup_review_gate_files() {
 		rm -f "$POLICY_TMP" "$PATHS_TMP"
 	}

--- a/hooks/claude/review-police.sh
+++ b/hooks/claude/review-police.sh
@@ -535,25 +535,30 @@ fi
 # Fail CLOSED: if the target cannot be resolved, the gate denies. An
 # unresolvable merge is exactly when a mistake is most likely.
 REQUEST_WORKDIR=$(agentkit_workdir)
-REPO_DIR="$PWD"
-if [[ -n "$REQUEST_WORKDIR" ]]; then
-	if [[ "$REQUEST_WORKDIR" != /* ]]; then
-		deny "BLOCKED: the merge tool working directory must be an absolute Git worktree.
+SEARCH_DIR=${REQUEST_WORKDIR:-$PWD}
+if [[ "$SEARCH_DIR" != /* ]]; then
+	deny "BLOCKED: the merge tool working directory must be an absolute path.
 
-  tool working directory: $REQUEST_WORKDIR"
-	fi
-	REPO_DIR="$REQUEST_WORKDIR"
+  tool working directory: $SEARCH_DIR"
 fi
-if ! REPO_ROOT=$(git -C "$REPO_DIR" rev-parse --show-toplevel 2>/dev/null) || [[ -z "$REPO_ROOT" ]]; then
-	deny "BLOCKED: the merge tool working directory is not a readable Git worktree.
+if [[ ! -d "$SEARCH_DIR" ]]; then
+	deny "BLOCKED: the merge tool working directory is not a readable directory.
 
-  tool working directory: ${REQUEST_WORKDIR:-$PWD}
+  tool working directory: $SEARCH_DIR"
+fi
+
+REPO_DIR=""
+if REPO_ROOT=$(git -C "$SEARCH_DIR" rev-parse --show-toplevel 2>/dev/null) && [[ -n "$REPO_ROOT" ]]; then
+	REPO_DIR="$REPO_ROOT"
+elif [[ -z "$REPO_FLAG" ]]; then
+	deny "BLOCKED: the merge tool working directory is not a Git worktree and the command has no explicit repository.
+
+  tool working directory: $SEARCH_DIR
 
 The review record and target policy must be resolved from the repository that
-the forge change will land in. Run the merge with that repository as the tool
-working directory."
+the forge change will land in. Add an explicit --repo owner/name selector, or
+run the agent from the repository itself."
 fi
-REPO_DIR="$REPO_ROOT"
 
 forge_json() {
 	if [[ "$CLI" == "gh" ]]; then
@@ -621,6 +626,84 @@ forge_json() {
 	fi
 }
 
+canonical_repository_url() {
+	# shellcheck disable=SC2016 # Python source is intentionally single-quoted shell data.
+	python3 -c '
+import re, sys
+from urllib.parse import urlsplit
+
+raw = sys.stdin.read().strip()
+if not raw:
+    raise SystemExit(1)
+
+if "://" not in raw:
+    match = re.match(r"^(?:[^@/]+@)?([^:/]+):(.+)$", raw)
+    if not match:
+        raise SystemExit(1)
+    host, path = match.groups()
+else:
+    parsed = urlsplit(raw)
+    host, path = parsed.hostname or "", parsed.path
+
+path = path.strip("/")
+if path.endswith(".git"):
+    path = path[:-4]
+if not host or not path:
+    raise SystemExit(1)
+print(f"{host.lower()}/{path}")
+'
+}
+
+repo_matches_repository() {
+	local repo_root="$1"
+	local expected="$2"
+	local remotes remote url actual
+
+	remotes=$(git -C "$repo_root" remote 2>/dev/null || true)
+	while IFS= read -r remote; do
+		[[ -n "$remote" ]] || continue
+		while IFS= read -r url; do
+			if actual=$(printf '%s' "$url" | canonical_repository_url 2>/dev/null) &&
+				[[ "$actual" == "$expected" ]]; then
+				return 0
+			fi
+		done < <(git -C "$repo_root" remote get-url --all "$remote" 2>/dev/null || true)
+	done <<<"$remotes"
+	return 1
+}
+
+discover_review_repo() {
+	local search_root="$1"
+	local slug="$2"
+	local repository="$3"
+	local expected record reviews_dir agentkit_dir candidate repo_root candidate_real root_real
+	local -a matches=()
+
+	expected=$(printf '%s' "$repository" | canonical_repository_url 2>/dev/null) || return 1
+	while IFS= read -r -d '' record; do
+		[[ "${record##*/}" == "$slug.json" ]] || continue
+		reviews_dir=${record%/*}
+		[[ "${reviews_dir##*/}" == "reviews" ]] || continue
+		agentkit_dir=${reviews_dir%/*}
+		[[ "${agentkit_dir##*/}" == ".agentkit" ]] || continue
+		candidate=${agentkit_dir%/*}
+		repo_root=$(git -C "$candidate" rev-parse --show-toplevel 2>/dev/null) || continue
+		candidate_real=$(cd "$candidate" 2>/dev/null && pwd -P) || continue
+		root_real=$(cd "$repo_root" 2>/dev/null && pwd -P) || continue
+		[[ "$candidate_real" == "$root_real" ]] || continue
+		if repo_matches_repository "$root_real" "$expected"; then
+			matches+=("$root_real")
+		fi
+	done < <(find "$search_root" \
+		-type d \( -name .git -o -name node_modules -o -name target -o -name .cache \
+		-o -name .moon -o -name .turbo -o -name .next -o -name dist -o -name build \
+		-o -name vendor -o -name .venv -o -name venv -o -name .kube -o -name lost+found \) \
+		-prune -o -type f -name '*.json' -path '*/.agentkit/reviews/*' -print0 2>/dev/null)
+
+	[[ ${#matches[@]} -eq 1 ]] || return 1
+	printf '%s\n' "${matches[0]}"
+}
+
 BRANCH=""
 HEAD_SHA=""
 TARGET_BRANCH=""
@@ -631,7 +714,8 @@ REPOSITORY_ID=""
 MERGE_QUEUE=""
 SHA_PATTERN='^[0-9a-f]{40}([0-9a-f]{24})?$'
 if [[ -n "$MR_ID" ]]; then
-	RESOLVED=$(cd "$REPO_DIR" 2>/dev/null && forge_json || true)
+	FORGE_RESOLVE_DIR=${REPO_DIR:-$SEARCH_DIR}
+	RESOLVED=$(cd "$FORGE_RESOLVE_DIR" 2>/dev/null && forge_json || true)
 	BRANCH=$(jq -r '.source_branch // empty' <<<"$RESOLVED" 2>/dev/null || true)
 	HEAD_SHA=$(jq -r '.source_sha // empty' <<<"$RESOLVED" 2>/dev/null || true)
 	TARGET_BRANCH=$(jq -r '.target_branch // empty' <<<"$RESOLVED" 2>/dev/null || true)
@@ -649,13 +733,27 @@ if [[ -z "$BRANCH" || -z "$HEAD_SHA" || -z "$TARGET_BRANCH" || -z "$TARGET_SHA" 
 	! "$TARGET_SHA" =~ $SHA_PATTERN ]]; then
 	deny "BLOCKED: cannot resolve what this merge would land, so it cannot be gated.
 
-  command dir: $REPO_DIR
+  command dir: $SEARCH_DIR
   mr/pr id:    ${MR_ID:-<none found>}
 
 The gate must read the change's source/target branches and exact SHAs from the
 forge — the local checkout alone says nothing about the commit being merged.
 Run the merge from the repo directory with an explicit MR/PR number and an
 authenticated forge CLI."
+fi
+
+SLUG=${BRANCH//\//__}
+if [[ -z "$REPO_DIR" ]]; then
+	if ! REPO_DIR=$(discover_review_repo "$SEARCH_DIR" "$SLUG" "$REPOSITORY"); then
+		deny "BLOCKED: the reviewed repository could not be resolved uniquely below the client working directory.
+
+  client working directory: $SEARCH_DIR
+  forge repository:         $REPOSITORY
+
+Codex can expose its workspace directory instead of the nested command
+directory. Keep exactly one local clone for this forge repository and branch
+review record below that workspace, or run the agent from the repository."
+	fi
 fi
 
 if [[ "$CLI" == "gh" && "$MERGE_QUEUE" == "true" ]]; then
@@ -686,7 +784,6 @@ Retry '$CLI $GROUP merge $MR_ID' after adding '$HEAD_FLAG $HEAD_SHA'. The forge 
 then refuse the merge if the source branch changes after this hook checks it."
 fi
 
-SLUG=${BRANCH//\//__}
 RECORD="$REPO_DIR/.agentkit/reviews/$SLUG.json"
 
 if [[ ! -f "$RECORD" ]]; then

--- a/hooks/claude/review-police.sh
+++ b/hooks/claude/review-police.sh
@@ -636,6 +636,8 @@ raw = sys.stdin.read().strip()
 if not raw:
     raise SystemExit(1)
 
+scheme = "ssh"
+port = None
 if "://" not in raw:
     match = re.match(r"^(?:[^@/]+@)?([^:/]+):(.+)$", raw)
     if not match:
@@ -643,14 +645,26 @@ if "://" not in raw:
     host, path = match.groups()
 else:
     parsed = urlsplit(raw)
+    scheme = parsed.scheme.lower()
     host, path = parsed.hostname or "", parsed.path
+    try:
+        port = parsed.port
+    except ValueError:
+        raise SystemExit(1)
 
 path = path.strip("/")
 if path.endswith(".git"):
     path = path[:-4]
 if not host or not path:
     raise SystemExit(1)
-print(f"{host.lower()}/{path}")
+
+host = host.lower()
+if ":" in host:
+    host = f"[{host}]"
+default_ports = {"http": 80, "https": 443, "ssh": 22, "git": 9418}
+if port is not None and port != default_ports.get(scheme):
+    host = f"{host}:{port}"
+print(f"{host}/{path}")
 '
 }
 

--- a/plugins-cc/agentkit/hooks/lib/hook-input.sh
+++ b/plugins-cc/agentkit/hooks/lib/hook-input.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # Shared Pre/PostToolUse input helpers for Claude Code and Grok CLI.
 # Source from a police hook:
 #   # shellcheck source=lib/hook-input.sh
@@ -33,6 +34,13 @@ agentkit_tool_name() {
 
 agentkit_command() {
 	agentkit_jq_raw -r '.tool_input.command // .toolInput.command // empty'
+}
+
+agentkit_workdir() {
+	agentkit_jq_raw -r '
+    .tool_input.workdir // .tool_input.cwd //
+    .toolInput.workdir // .toolInput.cwd //
+    .cwd // empty'
 }
 
 agentkit_session_id() {
@@ -78,6 +86,7 @@ agentkit_is_file_write_tool() {
 # Dual-emit Claude (hookSpecificOutput) and Grok ({decision, reason}) deny shapes.
 agentkit_deny_json() {
 	local reason="$1"
+	# shellcheck disable=SC2016 # jq program; dollar-prefixed names are jq variables.
 	_agentkit_jq -n --arg r "$reason" '{
     decision: "deny",
     reason: $r,
@@ -91,6 +100,7 @@ agentkit_deny_json() {
 
 agentkit_advise_json() {
 	local msg="$1"
+	# shellcheck disable=SC2016 # jq program; dollar-prefixed names are jq variables.
 	_agentkit_jq -n --arg m "$msg" '{
     systemMessage: $m,
     hookSpecificOutput: {

--- a/plugins-cc/agentkit/hooks/review-police.sh
+++ b/plugins-cc/agentkit/hooks/review-police.sh
@@ -95,6 +95,7 @@ SESSION=$(agentkit_session_id)
 # fall back to whitespace-splitting with quote characters stripped. Keeping the
 # quotes glued on (`"glab`) makes exact-token matching miss, which fails OPEN —
 # the one direction this must never take.
+# shellcheck disable=SC2016 # Python source is intentionally single-quoted shell data.
 COMMAND=$(printf '%s' "$RAW_COMMAND" | python3 -c '
 import os, shlex, sys
 
@@ -195,8 +196,6 @@ has_basename() {
 }
 # Any token matching a regex (URLs keep their value through tokenisation).
 tok_match() { printf '%s' "$COMMAND" | grep -qiE -- "$1"; }
-# The token following the first occurrence of a given token.
-after() { printf '%s' "$COMMAND" | awk -v k="$1" 'p { print; exit } $0 == k { p = 1 }'; }
 
 # `gh api graphql` can take its request body from a file or stdin. The mutation
 # name then never appears in RAW_COMMAND/COMMAND, and inspecting the current
@@ -535,7 +534,26 @@ fi
 # --- Resolve WHAT is being merged, from the forge ---------------------------
 # Fail CLOSED: if the target cannot be resolved, the gate denies. An
 # unresolvable merge is exactly when a mistake is most likely.
+REQUEST_WORKDIR=$(agentkit_workdir)
 REPO_DIR="$PWD"
+if [[ -n "$REQUEST_WORKDIR" ]]; then
+	if [[ "$REQUEST_WORKDIR" != /* ]]; then
+		deny "BLOCKED: the merge tool working directory must be an absolute Git worktree.
+
+  tool working directory: $REQUEST_WORKDIR"
+	fi
+	REPO_DIR="$REQUEST_WORKDIR"
+fi
+if ! REPO_ROOT=$(git -C "$REPO_DIR" rev-parse --show-toplevel 2>/dev/null) || [[ -z "$REPO_ROOT" ]]; then
+	deny "BLOCKED: the merge tool working directory is not a readable Git worktree.
+
+  tool working directory: ${REQUEST_WORKDIR:-$PWD}
+
+The review record and target policy must be resolved from the repository that
+the forge change will land in. Run the merge with that repository as the tool
+working directory."
+fi
+REPO_DIR="$REPO_ROOT"
 
 forge_json() {
 	if [[ "$CLI" == "gh" ]]; then
@@ -668,7 +686,7 @@ Retry '$CLI $GROUP merge $MR_ID' after adding '$HEAD_FLAG $HEAD_SHA'. The forge 
 then refuse the merge if the source branch changes after this hook checks it."
 fi
 
-SLUG=$(echo "$BRANCH" | sed 's#/#__#g')
+SLUG=${BRANCH//\//__}
 RECORD="$REPO_DIR/.agentkit/reviews/$SLUG.json"
 
 if [[ ! -f "$RECORD" ]]; then
@@ -716,7 +734,7 @@ if ! POLICY_ENTRY=$(git -C "$REPO_DIR" ls-tree "$TARGET_SHA" -- "$POLICY_PATH" 2
 	deny 'BLOCKED: the exact target commit cannot be inspected for review policy.'
 fi
 if [[ -n "$POLICY_ENTRY" ]]; then
-	read -r POLICY_MODE POLICY_TYPE POLICY_BLOB POLICY_NAME <<<"$POLICY_ENTRY"
+	read -r POLICY_MODE POLICY_TYPE _ POLICY_NAME <<<"$POLICY_ENTRY"
 	if [[ "$POLICY_TYPE" != "blob" ||
 		( "$POLICY_MODE" != "100644" && "$POLICY_MODE" != "100755" ) ||
 		"$POLICY_NAME" != "$POLICY_PATH" ]]; then
@@ -728,6 +746,7 @@ if [[ -n "$POLICY_ENTRY" ]]; then
 		rm -f "$POLICY_TMP"
 		deny 'BLOCKED: cannot allocate a temporary file for changed-path validation.'
 	}
+	# shellcheck disable=SC2329 # invoked by the EXIT trap below.
 	cleanup_review_gate_files() {
 		rm -f "$POLICY_TMP" "$PATHS_TMP"
 	}

--- a/plugins-cc/agentkit/hooks/review-police.sh
+++ b/plugins-cc/agentkit/hooks/review-police.sh
@@ -535,25 +535,30 @@ fi
 # Fail CLOSED: if the target cannot be resolved, the gate denies. An
 # unresolvable merge is exactly when a mistake is most likely.
 REQUEST_WORKDIR=$(agentkit_workdir)
-REPO_DIR="$PWD"
-if [[ -n "$REQUEST_WORKDIR" ]]; then
-	if [[ "$REQUEST_WORKDIR" != /* ]]; then
-		deny "BLOCKED: the merge tool working directory must be an absolute Git worktree.
+SEARCH_DIR=${REQUEST_WORKDIR:-$PWD}
+if [[ "$SEARCH_DIR" != /* ]]; then
+	deny "BLOCKED: the merge tool working directory must be an absolute path.
 
-  tool working directory: $REQUEST_WORKDIR"
-	fi
-	REPO_DIR="$REQUEST_WORKDIR"
+  tool working directory: $SEARCH_DIR"
 fi
-if ! REPO_ROOT=$(git -C "$REPO_DIR" rev-parse --show-toplevel 2>/dev/null) || [[ -z "$REPO_ROOT" ]]; then
-	deny "BLOCKED: the merge tool working directory is not a readable Git worktree.
+if [[ ! -d "$SEARCH_DIR" ]]; then
+	deny "BLOCKED: the merge tool working directory is not a readable directory.
 
-  tool working directory: ${REQUEST_WORKDIR:-$PWD}
+  tool working directory: $SEARCH_DIR"
+fi
+
+REPO_DIR=""
+if REPO_ROOT=$(git -C "$SEARCH_DIR" rev-parse --show-toplevel 2>/dev/null) && [[ -n "$REPO_ROOT" ]]; then
+	REPO_DIR="$REPO_ROOT"
+elif [[ -z "$REPO_FLAG" ]]; then
+	deny "BLOCKED: the merge tool working directory is not a Git worktree and the command has no explicit repository.
+
+  tool working directory: $SEARCH_DIR
 
 The review record and target policy must be resolved from the repository that
-the forge change will land in. Run the merge with that repository as the tool
-working directory."
+the forge change will land in. Add an explicit --repo owner/name selector, or
+run the agent from the repository itself."
 fi
-REPO_DIR="$REPO_ROOT"
 
 forge_json() {
 	if [[ "$CLI" == "gh" ]]; then
@@ -621,6 +626,84 @@ forge_json() {
 	fi
 }
 
+canonical_repository_url() {
+	# shellcheck disable=SC2016 # Python source is intentionally single-quoted shell data.
+	python3 -c '
+import re, sys
+from urllib.parse import urlsplit
+
+raw = sys.stdin.read().strip()
+if not raw:
+    raise SystemExit(1)
+
+if "://" not in raw:
+    match = re.match(r"^(?:[^@/]+@)?([^:/]+):(.+)$", raw)
+    if not match:
+        raise SystemExit(1)
+    host, path = match.groups()
+else:
+    parsed = urlsplit(raw)
+    host, path = parsed.hostname or "", parsed.path
+
+path = path.strip("/")
+if path.endswith(".git"):
+    path = path[:-4]
+if not host or not path:
+    raise SystemExit(1)
+print(f"{host.lower()}/{path}")
+'
+}
+
+repo_matches_repository() {
+	local repo_root="$1"
+	local expected="$2"
+	local remotes remote url actual
+
+	remotes=$(git -C "$repo_root" remote 2>/dev/null || true)
+	while IFS= read -r remote; do
+		[[ -n "$remote" ]] || continue
+		while IFS= read -r url; do
+			if actual=$(printf '%s' "$url" | canonical_repository_url 2>/dev/null) &&
+				[[ "$actual" == "$expected" ]]; then
+				return 0
+			fi
+		done < <(git -C "$repo_root" remote get-url --all "$remote" 2>/dev/null || true)
+	done <<<"$remotes"
+	return 1
+}
+
+discover_review_repo() {
+	local search_root="$1"
+	local slug="$2"
+	local repository="$3"
+	local expected record reviews_dir agentkit_dir candidate repo_root candidate_real root_real
+	local -a matches=()
+
+	expected=$(printf '%s' "$repository" | canonical_repository_url 2>/dev/null) || return 1
+	while IFS= read -r -d '' record; do
+		[[ "${record##*/}" == "$slug.json" ]] || continue
+		reviews_dir=${record%/*}
+		[[ "${reviews_dir##*/}" == "reviews" ]] || continue
+		agentkit_dir=${reviews_dir%/*}
+		[[ "${agentkit_dir##*/}" == ".agentkit" ]] || continue
+		candidate=${agentkit_dir%/*}
+		repo_root=$(git -C "$candidate" rev-parse --show-toplevel 2>/dev/null) || continue
+		candidate_real=$(cd "$candidate" 2>/dev/null && pwd -P) || continue
+		root_real=$(cd "$repo_root" 2>/dev/null && pwd -P) || continue
+		[[ "$candidate_real" == "$root_real" ]] || continue
+		if repo_matches_repository "$root_real" "$expected"; then
+			matches+=("$root_real")
+		fi
+	done < <(find "$search_root" \
+		-type d \( -name .git -o -name node_modules -o -name target -o -name .cache \
+		-o -name .moon -o -name .turbo -o -name .next -o -name dist -o -name build \
+		-o -name vendor -o -name .venv -o -name venv -o -name .kube -o -name lost+found \) \
+		-prune -o -type f -name '*.json' -path '*/.agentkit/reviews/*' -print0 2>/dev/null)
+
+	[[ ${#matches[@]} -eq 1 ]] || return 1
+	printf '%s\n' "${matches[0]}"
+}
+
 BRANCH=""
 HEAD_SHA=""
 TARGET_BRANCH=""
@@ -631,7 +714,8 @@ REPOSITORY_ID=""
 MERGE_QUEUE=""
 SHA_PATTERN='^[0-9a-f]{40}([0-9a-f]{24})?$'
 if [[ -n "$MR_ID" ]]; then
-	RESOLVED=$(cd "$REPO_DIR" 2>/dev/null && forge_json || true)
+	FORGE_RESOLVE_DIR=${REPO_DIR:-$SEARCH_DIR}
+	RESOLVED=$(cd "$FORGE_RESOLVE_DIR" 2>/dev/null && forge_json || true)
 	BRANCH=$(jq -r '.source_branch // empty' <<<"$RESOLVED" 2>/dev/null || true)
 	HEAD_SHA=$(jq -r '.source_sha // empty' <<<"$RESOLVED" 2>/dev/null || true)
 	TARGET_BRANCH=$(jq -r '.target_branch // empty' <<<"$RESOLVED" 2>/dev/null || true)
@@ -649,13 +733,27 @@ if [[ -z "$BRANCH" || -z "$HEAD_SHA" || -z "$TARGET_BRANCH" || -z "$TARGET_SHA" 
 	! "$TARGET_SHA" =~ $SHA_PATTERN ]]; then
 	deny "BLOCKED: cannot resolve what this merge would land, so it cannot be gated.
 
-  command dir: $REPO_DIR
+  command dir: $SEARCH_DIR
   mr/pr id:    ${MR_ID:-<none found>}
 
 The gate must read the change's source/target branches and exact SHAs from the
 forge — the local checkout alone says nothing about the commit being merged.
 Run the merge from the repo directory with an explicit MR/PR number and an
 authenticated forge CLI."
+fi
+
+SLUG=${BRANCH//\//__}
+if [[ -z "$REPO_DIR" ]]; then
+	if ! REPO_DIR=$(discover_review_repo "$SEARCH_DIR" "$SLUG" "$REPOSITORY"); then
+		deny "BLOCKED: the reviewed repository could not be resolved uniquely below the client working directory.
+
+  client working directory: $SEARCH_DIR
+  forge repository:         $REPOSITORY
+
+Codex can expose its workspace directory instead of the nested command
+directory. Keep exactly one local clone for this forge repository and branch
+review record below that workspace, or run the agent from the repository."
+	fi
 fi
 
 if [[ "$CLI" == "gh" && "$MERGE_QUEUE" == "true" ]]; then
@@ -686,7 +784,6 @@ Retry '$CLI $GROUP merge $MR_ID' after adding '$HEAD_FLAG $HEAD_SHA'. The forge 
 then refuse the merge if the source branch changes after this hook checks it."
 fi
 
-SLUG=${BRANCH//\//__}
 RECORD="$REPO_DIR/.agentkit/reviews/$SLUG.json"
 
 if [[ ! -f "$RECORD" ]]; then

--- a/plugins-cc/agentkit/hooks/review-police.sh
+++ b/plugins-cc/agentkit/hooks/review-police.sh
@@ -636,6 +636,8 @@ raw = sys.stdin.read().strip()
 if not raw:
     raise SystemExit(1)
 
+scheme = "ssh"
+port = None
 if "://" not in raw:
     match = re.match(r"^(?:[^@/]+@)?([^:/]+):(.+)$", raw)
     if not match:
@@ -643,14 +645,26 @@ if "://" not in raw:
     host, path = match.groups()
 else:
     parsed = urlsplit(raw)
+    scheme = parsed.scheme.lower()
     host, path = parsed.hostname or "", parsed.path
+    try:
+        port = parsed.port
+    except ValueError:
+        raise SystemExit(1)
 
 path = path.strip("/")
 if path.endswith(".git"):
     path = path[:-4]
 if not host or not path:
     raise SystemExit(1)
-print(f"{host.lower()}/{path}")
+
+host = host.lower()
+if ":" in host:
+    host = f"[{host}]"
+default_ports = {"http": 80, "https": 443, "ssh": 22, "git": 9418}
+if port is not None and port != default_ports.get(scheme):
+    host = f"{host}:{port}"
+print(f"{host}/{path}")
 '
 }
 

--- a/tests/review-police.test.ts
+++ b/tests/review-police.test.ts
@@ -43,11 +43,18 @@ interface StrictReviewFixture {
 
 function runHook(
   command: string,
-  opts: { tool?: string; cwd?: string; supervised?: boolean } = {},
+  opts: { tool?: string; cwd?: string; supervised?: boolean; toolWorkdir?: string } = {},
 ): string {
+  const toolInput =
+    opts.tool && opts.tool !== 'Bash'
+      ? { pull_number: 12 }
+      : {
+          command,
+          ...(opts.toolWorkdir === undefined ? {} : { workdir: opts.toolWorkdir }),
+        };
   const input = JSON.stringify({
     tool_name: opts.tool ?? 'Bash',
-    tool_input: opts.tool && opts.tool !== 'Bash' ? { pull_number: 12 } : { command },
+    tool_input: toolInput,
     session_id: 'test-session',
   });
   const args = opts.supervised ? [SUPERVISOR, '5', HOOK] : [HOOK];
@@ -410,6 +417,21 @@ describe('review-police: intended semantics', () => {
   test('allows a clean pass for the exact head', () => {
     record(passing);
     expect(runHook(MERGE)).toBe('');
+  });
+
+  test('uses the tool working directory when the hook process starts above the repo', () => {
+    record(passing);
+    expect(runHook(MERGE, { cwd: join(repo, '..'), toolWorkdir: repo })).toBe('');
+  });
+
+  test('rejects a relative tool working directory instead of borrowing the hook cwd', () => {
+    record(passing);
+    expect(runHook(MERGE, { toolWorkdir: '.' })).toContain('working directory');
+  });
+
+  test('rejects a tool working directory that is not a Git worktree', () => {
+    record(passing);
+    expect(runHook(MERGE, { toolWorkdir: home })).toContain('working directory');
   });
 
   test('accepts case-insensitive legacy pass verdicts', () => {

--- a/tests/review-police.test.ts
+++ b/tests/review-police.test.ts
@@ -43,19 +43,30 @@ interface StrictReviewFixture {
 
 function runHook(
   command: string,
-  opts: { tool?: string; cwd?: string; supervised?: boolean; toolWorkdir?: string } = {},
+  opts: {
+    tool?: string;
+    cwd?: string;
+    supervised?: boolean;
+    toolWorkdir?: string;
+    toolWorkdirField?: 'workdir' | 'cwd';
+    camelToolInput?: boolean;
+    payloadCwd?: string;
+  } = {},
 ): string {
   const toolInput =
     opts.tool && opts.tool !== 'Bash'
       ? { pull_number: 12 }
       : {
           command,
-          ...(opts.toolWorkdir === undefined ? {} : { workdir: opts.toolWorkdir }),
+          ...(opts.toolWorkdir === undefined
+            ? {}
+            : { [opts.toolWorkdirField ?? 'workdir']: opts.toolWorkdir }),
         };
   const input = JSON.stringify({
-    tool_name: opts.tool ?? 'Bash',
-    tool_input: toolInput,
-    session_id: 'test-session',
+    ...(opts.camelToolInput
+      ? { toolName: opts.tool ?? 'Bash', toolInput, sessionId: 'test-session' }
+      : { tool_name: opts.tool ?? 'Bash', tool_input: toolInput, session_id: 'test-session' }),
+    ...(opts.payloadCwd === undefined ? {} : { cwd: opts.payloadCwd }),
   });
   const args = opts.supervised ? [SUPERVISOR, '5', HOOK] : [HOOK];
   const res = spawnSync('bash', args, {
@@ -118,6 +129,9 @@ function record(body: unknown, slug = 'feat__thing'): void {
 
 const passing = { head_sha: HEAD, verdict: 'pass', findings: [] };
 const MERGE = `glab mr merge 12 --squash --yes --sha ${HEAD} --auto-merge=false`;
+const MERGE_WITH_REPO = `${MERGE} --repo owner/repo`;
+const GITHUB_MERGE_WITH_REPO =
+  `gh pr merge 12 --squash --delete-branch --match-head-commit ${HEAD} --repo owner/repo`;
 
 function mergeForHead(head: string): string {
   return `glab mr merge 12 --squash --yes --sha ${head} --auto-merge=false`;
@@ -265,7 +279,10 @@ beforeAll(() => {
   execSync('git init -q -b main', { cwd: repo, stdio: 'pipe' });
   execSync('git config user.email agentkit-tests@example.invalid', { cwd: repo, stdio: 'pipe' });
   execSync('git config user.name "AgentKit Tests"', { cwd: repo, stdio: 'pipe' });
-  execSync(`git remote add origin ${REPOSITORY}`, { cwd: repo, stdio: 'pipe' });
+  execSync('git remote add origin git@github.example:owner/repo.git', {
+    cwd: repo,
+    stdio: 'pipe',
+  });
   writeFileSync(join(repo, 'README.md'), 'fixture\n');
   execSync('git add README.md', { cwd: repo, stdio: 'pipe' });
   execSync('git commit -qm "test: base target"', { cwd: repo, stdio: 'pipe' });
@@ -280,6 +297,7 @@ beforeAll(() => {
 afterAll(() => rmSync(join(repo, '..'), { force: true, recursive: true }));
 beforeEach(() => {
   rmSync(join(repo, '.agentkit'), { force: true, recursive: true });
+  rmSync(join(repo, '..', 'duplicate'), { force: true, recursive: true });
   execSync(`git reset --hard ${baseTarget}`, { cwd: repo, stdio: 'pipe' });
   targetSha = baseTarget;
   githubBaseRefSha = baseTarget;
@@ -419,9 +437,72 @@ describe('review-police: intended semantics', () => {
     expect(runHook(MERGE)).toBe('');
   });
 
-  test('uses the tool working directory when the hook process starts above the repo', () => {
+  for (const [label, options] of [
+    ['tool_input.workdir', {}],
+    ['tool_input.cwd', { toolWorkdirField: 'cwd' as const }],
+    ['toolInput.workdir', { camelToolInput: true }],
+    ['toolInput.cwd', { camelToolInput: true, toolWorkdirField: 'cwd' as const }],
+  ] as const) {
+    test(`uses ${label} when the hook process starts above the repo`, () => {
+      record(passing);
+      expect(runHook(MERGE, { cwd: join(repo, '..'), toolWorkdir: repo, ...options })).toBe('');
+    });
+  }
+
+  for (const [forge, command] of [
+    ['GitLab', MERGE_WITH_REPO],
+    ['GitHub', GITHUB_MERGE_WITH_REPO],
+  ] as const) {
+    test(`discovers the reviewed ${forge} repo below the Codex session cwd`, () => {
+      record(passing);
+      const workspace = join(repo, '..');
+      expect(
+        runHook(command, { cwd: workspace, payloadCwd: workspace, supervised: true }),
+      ).toBe('');
+    });
+  }
+
+  test('ignores a same-branch review record in a repo for another forge remote', () => {
     record(passing);
-    expect(runHook(MERGE, { cwd: join(repo, '..'), toolWorkdir: repo })).toBe('');
+    const workspace = join(repo, '..');
+    const duplicate = join(workspace, 'duplicate');
+    mkdirSync(join(duplicate, '.agentkit', 'reviews'), { recursive: true });
+    execSync('git init -q -b main', { cwd: duplicate, stdio: 'pipe' });
+    execSync('git remote add origin https://github.example/other/repo', {
+      cwd: duplicate,
+      stdio: 'pipe',
+    });
+    writeFileSync(
+      join(duplicate, '.agentkit', 'reviews', 'feat__thing.json'),
+      JSON.stringify(passing),
+    );
+
+    expect(runHook(MERGE_WITH_REPO, { cwd: workspace, payloadCwd: workspace })).toBe('');
+  });
+
+  test('rejects two reviewed clones of the same forge repo below the session cwd', () => {
+    record(passing);
+    const workspace = join(repo, '..');
+    const duplicate = join(workspace, 'duplicate');
+    mkdirSync(join(duplicate, '.agentkit', 'reviews'), { recursive: true });
+    execSync('git init -q -b main', { cwd: duplicate, stdio: 'pipe' });
+    execSync(`git remote add origin ${REPOSITORY}`, { cwd: duplicate, stdio: 'pipe' });
+    writeFileSync(
+      join(duplicate, '.agentkit', 'reviews', 'feat__thing.json'),
+      JSON.stringify(passing),
+    );
+
+    expect(runHook(MERGE_WITH_REPO, { cwd: workspace, payloadCwd: workspace })).toContain(
+      'uniquely',
+    );
+  });
+
+  test('requires an explicit forge repo when the client cwd is only a workspace', () => {
+    record(passing);
+    const workspace = join(repo, '..');
+    expect(runHook(MERGE, { cwd: workspace, payloadCwd: workspace })).toContain(
+      'explicit repository',
+    );
   });
 
   test('rejects a relative tool working directory instead of borrowing the hook cwd', () => {

--- a/tests/review-police.test.ts
+++ b/tests/review-police.test.ts
@@ -298,6 +298,10 @@ afterAll(() => rmSync(join(repo, '..'), { force: true, recursive: true }));
 beforeEach(() => {
   rmSync(join(repo, '.agentkit'), { force: true, recursive: true });
   rmSync(join(repo, '..', 'duplicate'), { force: true, recursive: true });
+  execSync('git remote set-url origin git@github.example:owner/repo.git', {
+    cwd: repo,
+    stdio: 'pipe',
+  });
   execSync(`git reset --hard ${baseTarget}`, { cwd: repo, stdio: 'pipe' });
   targetSha = baseTarget;
   githubBaseRefSha = baseTarget;
@@ -479,6 +483,34 @@ describe('review-police: intended semantics', () => {
 
     expect(runHook(MERGE_WITH_REPO, { cwd: workspace, payloadCwd: workspace })).toBe('');
   });
+
+  for (const [transport, remote] of [
+    ['HTTPS', 'https://github.example:8443/owner/repo.git'],
+    ['SSH', 'ssh://git@github.example:2222/owner/repo.git'],
+  ] as const) {
+    test(`does not conflate a non-default ${transport} port with the forge host`, () => {
+      record(passing);
+      execSync(`git remote set-url origin ${remote}`, { cwd: repo, stdio: 'pipe' });
+      const workspace = join(repo, '..');
+
+      expect(runHook(MERGE_WITH_REPO, { cwd: workspace, payloadCwd: workspace })).toContain(
+        'uniquely',
+      );
+    });
+  }
+
+  for (const [transport, remote] of [
+    ['HTTPS', 'https://github.example:443/owner/repo.git'],
+    ['SSH', 'ssh://git@github.example:22/owner/repo.git'],
+  ] as const) {
+    test(`normalizes the explicit default ${transport} port`, () => {
+      record(passing);
+      execSync(`git remote set-url origin ${remote}`, { cwd: repo, stdio: 'pipe' });
+      const workspace = join(repo, '..');
+
+      expect(runHook(MERGE_WITH_REPO, { cwd: workspace, payloadCwd: workspace })).toBe('');
+    });
+  }
 
   test('rejects two reviewed clones of the same forge repo below the session cwd', () => {
     record(passing);


### PR DESCRIPTION
Refs #177

## What changed

- resolve the merge repository from Codex tool input workdir/cwd fields
- require an absolute, readable Git worktree and canonicalize it to the repository root
- retain the hook process directory only when the client supplies no tool workdir
- keep Claude/Grok compatibility and plugin mirror parity

## Why

Codex launches hooks from the session directory even when an exec tool call specifies another working directory. The merge gate therefore searched the wrong repository for its exact-head review record and blocked a valid Neutron merge.

## Verification

- TDD RED: the three new workdir cases failed before the implementation
- focused review-police slice: 107 passed, 0 failed
- hook slice: 272 passed, 0 failed, 1 existing explicit skip
- task-scoped preflight: passed
- full suite: 1,411 passed, 0 failed, 6 explicit platform/systemd skips, 6,299 assertions
- both deployed Neutron health endpoints remained healthy before and after the suite

Product coverage is partial: help/platform/infra-tools surfaces passed, while an isolated full OpenCode cold-install probe hit the canary timeout during repeated diagram bundle construction. Existing installer and OpenCode automated coverage passed. The live Codex merge path will be exercised after exact-head review and installation of the reviewed build.

## Rollback

Revert the squash commit. This restores process-directory repository resolution; no persisted data or schema migration is involved.
