### PR TITLE
fix(install): stop wiping foreign helpers from the shared hooks lib dir

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -947,9 +947,12 @@ install_claude_hooks() {
 	# link_children below as a *directory* symlink — never re-link files
 	# inside lib/, or path resolution turns into self-symlinks.
 	if [[ -d "$REPO_DIR/hooks/claude/lib" ]]; then
-		# `:?` rather than a bare expansion: an empty install_dir here would make
-		# this `rm -rf /lib`.
-		rm -rf "${install_dir:?}/lib"
+		# Other toolkits (e.g. OMC) install their own helpers into this dir
+		# through the client-dir symlink — copy agentkit's files over, never
+		# wipe the dir. A retired agentkit helper must be removed by name here.
+		if [[ -L "$install_dir/lib" && ! -e "$install_dir/lib" ]]; then
+			rm -f "$install_dir/lib"
+		fi
 		mkdir -p "$install_dir/lib"
 		cp -a "$REPO_DIR"/hooks/claude/lib/. "$install_dir/lib/"
 		echo "[claude] Installed hook lib/ helpers"

--- a/install.sh
+++ b/install.sh
@@ -954,6 +954,17 @@ install_claude_hooks() {
 			rm -f "$install_dir/lib"
 		fi
 		mkdir -p "$install_dir/lib"
+		# Fold a pre-shared-root real client lib/ into canon before
+		# link_children swaps the directory for a symlink and loses it.
+		if [[ "$hooks_dir" != "$install_dir" && -d "$hooks_dir/lib" && ! -L "$hooks_dir/lib" ]]; then
+			cp -a "$hooks_dir/lib/." "$install_dir/lib/"
+			rm -rf "${hooks_dir:?}/lib"
+		fi
+		# rm by name first: a read-only or self-symlinked leftover aborts cp under set -e.
+		local lib_file
+		for lib_file in "$REPO_DIR"/hooks/claude/lib/*; do
+			rm -f "$install_dir/lib/$(basename "$lib_file")"
+		done
 		cp -a "$REPO_DIR"/hooks/claude/lib/. "$install_dir/lib/"
 		echo "[claude] Installed hook lib/ helpers"
 	fi

--- a/tests/install-shared-root.test.ts
+++ b/tests/install-shared-root.test.ts
@@ -125,6 +125,48 @@ describe("shared ~/.agentkit root + client symlinks", () => {
     }
   }, globalInstallTimeoutMs);
 
+  test("re-install preserves foreign helpers in the shared hooks lib dir", () => {
+    const home = mkdtempSync(join(tmpdir(), "agentkit-shared-"));
+
+    try {
+      const env = {
+        ...process.env,
+        HOME: home,
+        XDG_CONFIG_HOME: join(home, ".config"),
+        AGENTKIT_HOME: join(home, ".agentkit"),
+      };
+      const first = spawnSync("bash", [installScript, "--global", "--no-session-scope"], {
+        cwd: repoRoot,
+        env,
+        encoding: "utf-8",
+        timeout: globalInstallTimeoutMs,
+      });
+      expect(first.status, first.stderr + "\n" + first.stdout).toBe(0);
+
+      // Another toolkit (OMC) installs its own helpers via the client path,
+      // which resolves through the directory symlink into canon.
+      const clientLibDir = join(home, ".claude", "hooks", "lib");
+      const foreign = join(clientLibDir, "stdin.mjs");
+      writeFileSync(foreign, "export function readStdin() {}\n");
+
+      const second = spawnSync("bash", [installScript, "--global", "--no-session-scope"], {
+        cwd: repoRoot,
+        env,
+        encoding: "utf-8",
+        timeout: globalInstallTimeoutMs,
+      });
+      expect(second.status, second.stderr + "\n" + second.stdout).toBe(0);
+
+      expect(existsSync(foreign)).toBe(true);
+      expect(readFileSync(foreign, "utf-8")).toContain("readStdin");
+      expect(
+        readFileSync(join(clientLibDir, "hook-input.sh"), "utf-8"),
+      ).toContain("agentkit_command");
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
   test("resolves the Bun executable before entering an installed skill directory", () => {
     const root = mkdtempSync(join(tmpdir(), "agentkit-bun-resolution-"));
     const fixtureRepo = join(root, "repo");

--- a/tests/install-shared-root.test.ts
+++ b/tests/install-shared-root.test.ts
@@ -32,6 +32,36 @@ function writeExecutable(path: string, content: string): void {
   chmodSync(path, 0o755);
 }
 
+function withTempHome(fn: (home: string, clientLibDir: string) => void) {
+  const home = mkdtempSync(join(tmpdir(), "agentkit-shared-"));
+  try {
+    fn(home, join(home, ".claude", "hooks", "lib"));
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+}
+
+function expectSharedLib(clientLibDir: string) {
+  expect(readFileSync(join(clientLibDir, "stdin.mjs"), "utf-8")).toContain("readStdin");
+  expect(
+    readFileSync(join(clientLibDir, "hook-input.sh"), "utf-8"),
+  ).toContain("agentkit_command");
+}
+
+function runGlobalInstall(home: string) {
+  return spawnSync("bash", [installScript, "--global", "--no-session-scope"], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      HOME: home,
+      XDG_CONFIG_HOME: join(home, ".config"),
+      AGENTKIT_HOME: join(home, ".agentkit"),
+    },
+    encoding: "utf-8",
+    timeout: globalInstallTimeoutMs,
+  });
+}
+
 describe("shared ~/.agentkit root + client symlinks", () => {
   test("global install writes one skill tree and links clients by name", () => {
     const home = mkdtempSync(join(tmpdir(), "agentkit-shared-"));
@@ -42,17 +72,7 @@ describe("shared ~/.agentkit root + client symlinks", () => {
       mkdirSync(join(claudeSkills, "omc-only-skill"), { recursive: true });
       writeFileSync(join(claudeSkills, "omc-only-skill", "SKILL.md"), "# omc\n");
 
-      const result = spawnSync("bash", [installScript, "--global", "--no-session-scope"], {
-        cwd: repoRoot,
-        env: {
-          ...process.env,
-          HOME: home,
-          XDG_CONFIG_HOME: join(home, ".config"),
-          AGENTKIT_HOME: join(home, ".agentkit"),
-        },
-        encoding: "utf-8",
-        timeout: globalInstallTimeoutMs,
-      });
+      const result = runGlobalInstall(home);
       expect(result.status, result.stderr + "\n" + result.stdout).toBe(0);
 
       const canon = join(home, ".agentkit", "skills");
@@ -126,46 +146,37 @@ describe("shared ~/.agentkit root + client symlinks", () => {
   }, globalInstallTimeoutMs);
 
   test("re-install preserves foreign helpers in the shared hooks lib dir", () => {
-    const home = mkdtempSync(join(tmpdir(), "agentkit-shared-"));
-
-    try {
-      const env = {
-        ...process.env,
-        HOME: home,
-        XDG_CONFIG_HOME: join(home, ".config"),
-        AGENTKIT_HOME: join(home, ".agentkit"),
-      };
-      const first = spawnSync("bash", [installScript, "--global", "--no-session-scope"], {
-        cwd: repoRoot,
-        env,
-        encoding: "utf-8",
-        timeout: globalInstallTimeoutMs,
-      });
+    withTempHome((home, clientLibDir) => {
+      const first = runGlobalInstall(home);
       expect(first.status, first.stderr + "\n" + first.stdout).toBe(0);
 
       // Another toolkit (OMC) installs its own helpers via the client path,
       // which resolves through the directory symlink into canon.
-      const clientLibDir = join(home, ".claude", "hooks", "lib");
       const foreign = join(clientLibDir, "stdin.mjs");
       writeFileSync(foreign, "export function readStdin() {}\n");
 
-      const second = spawnSync("bash", [installScript, "--global", "--no-session-scope"], {
-        cwd: repoRoot,
-        env,
-        encoding: "utf-8",
-        timeout: globalInstallTimeoutMs,
-      });
+      const second = runGlobalInstall(home);
       expect(second.status, second.stderr + "\n" + second.stdout).toBe(0);
 
       expect(existsSync(foreign)).toBe(true);
-      expect(readFileSync(foreign, "utf-8")).toContain("readStdin");
-      expect(
-        readFileSync(join(clientLibDir, "hook-input.sh"), "utf-8"),
-      ).toContain("agentkit_command");
-    } finally {
-      rmSync(home, { recursive: true, force: true });
-    }
-  });
+      expectSharedLib(clientLibDir);
+    });
+  }, globalInstallTimeoutMs);
+
+  test("first install migrates a pre-existing real client lib dir into canon", () => {
+    withTempHome((home, clientLibDir) => {
+      // OMC-first layout: ~/.claude/hooks/lib is a real directory with
+      // another toolkit's helpers, created before agentkit ever ran.
+      mkdirSync(clientLibDir, { recursive: true });
+      writeFileSync(join(clientLibDir, "stdin.mjs"), "export function readStdin() {}\n");
+
+      const result = runGlobalInstall(home);
+      expect(result.status, result.stderr + "\n" + result.stdout).toBe(0);
+
+      expect(lstatSync(clientLibDir).isSymbolicLink()).toBe(true);
+      expectSharedLib(clientLibDir);
+    });
+  }, globalInstallTimeoutMs);
 
   test("resolves the Bun executable before entering an installed skill directory", () => {
     const root = mkdtempSync(join(tmpdir(), "agentkit-bun-resolution-"));


### PR DESCRIPTION
Closes #183

## Problem
`install_claude_hooks` ran `rm -rf` on the canon `hooks/lib` dir and repopulated it with only agentkit's `hook-input.sh`. `~/.claude/hooks/lib` is a directory symlink into that canon dir, so helpers other toolkits installed through the client path (OMC's `stdin.mjs`, `atomic-write.mjs`, …) were deleted on every installer run — breaking all 7 OMC hooks, surfacing as a `UserPromptSubmit` hook error on every prompt.

## Fix
- Copy agentkit's lib files into the dir; never delete the dir. A retired agentkit helper is removed by name (same pattern as review-hook removal).
- Drop a dangling `lib` symlink before `mkdir -p` so older layouts still install.

## Verification
- New regression test: foreign `stdin.mjs` seeded via the client symlink survives a second `--global` install (RED before fix, GREEN after).
- `bun test` on all 5 install test files: 30 pass / 0 fail.