### PR TITLE
feat(install): curl-pipe bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,9 @@ curl -fsSL https://raw.githubusercontent.com/developerinlondon/agentkit/main/boo
 # with options:  … | bash -s -- --with product
 ```
 
+Piped stdin is not a terminal, so the optional-group question is skipped —
+the curl path installs core only unless you pass `--with <group>`.
+
 Or clone first and read before running:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -150,6 +150,16 @@ This installs SKILL.md files for your AI agent (Claude Code, OpenCode, Cursor, e
 
 ### Option 2: Install globally (all projects)
 
+One line — clones to `~/.agentkit-src` (override: `AGENTKIT_SRC`) and runs the
+global install; re-running updates in place:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/developerinlondon/agentkit/main/bootstrap.sh | bash
+# with options:  … | bash -s -- --with product
+```
+
+Or clone first and read before running:
+
 ```bash
 git clone git@github.com:developerinlondon/agentkit.git
 ./agentkit/install.sh --global

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -14,7 +14,7 @@ main() {
 
 	if [[ -d "$src_dir/.git" ]]; then
 		[[ -z "$(git -C "$src_dir" status --porcelain -uno)" ]] \
-			|| die "$src_dir has local changes — commit or stash them, or point AGENTKIT_SRC at a clean dir"
+			|| die "$src_dir has local changes — stash or move them aside, or point AGENTKIT_SRC at a clean dir"
 		echo "[bootstrap] Updating $src_dir"
 		git -C "$src_dir" fetch --depth 1 origin || die "fetch failed — check network and $src_dir"
 		git -C "$src_dir" reset --hard origin/HEAD >/dev/null \

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# One-line installer: curl -fsSL …/bootstrap.sh | bash
+# Clones (or updates) the kit into a persistent source dir, then hands off to
+# install.sh --global. Arguments pass through: … | bash -s -- --with product
+
+REPO_URL="${AGENTKIT_REPO_URL:-https://github.com/developerinlondon/agentkit.git}"
+SRC_DIR="${AGENTKIT_SRC:-$HOME/.agentkit-src}"
+
+die() { echo "bootstrap: $*" >&2; exit 1; }
+
+command -v git >/dev/null || die "git is required"
+command -v bash >/dev/null || die "bash is required"
+
+if [[ -d "$SRC_DIR/.git" ]]; then
+	echo "[bootstrap] Updating $SRC_DIR"
+	git -C "$SRC_DIR" fetch --depth 1 origin || die "fetch failed — check network and $SRC_DIR"
+	git -C "$SRC_DIR" reset --hard origin/HEAD >/dev/null
+elif [[ -e "$SRC_DIR" ]]; then
+	die "$SRC_DIR exists but is not a git clone — move it aside or set AGENTKIT_SRC"
+else
+	echo "[bootstrap] Cloning agentkit into $SRC_DIR"
+	git clone --depth 1 "$REPO_URL" "$SRC_DIR" || die "clone failed"
+fi
+
+exec bash "$SRC_DIR/install.sh" --global "$@"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,27 +1,34 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# One-line installer: curl -fsSL …/bootstrap.sh | bash
-# Clones (or updates) the kit into a persistent source dir, then hands off to
-# install.sh --global. Arguments pass through: … | bash -s -- --with product
+# One-line installer: curl -fsSL …/bootstrap.sh | bash [-s -- --with product]
+# Piped stdin is not a tty, so the optional-group question never fires here —
+# pass --with <group> explicitly.
+# Everything runs from main so a truncated download is a syntax error, never a
+# partial install.
+main() {
+	local repo_url="${AGENTKIT_REPO_URL:-https://github.com/developerinlondon/agentkit.git}"
+	local src_dir="${AGENTKIT_SRC:-$HOME/.agentkit-src}"
 
-REPO_URL="${AGENTKIT_REPO_URL:-https://github.com/developerinlondon/agentkit.git}"
-SRC_DIR="${AGENTKIT_SRC:-$HOME/.agentkit-src}"
+	command -v git >/dev/null || die "git is required"
+
+	if [[ -d "$src_dir/.git" ]]; then
+		[[ -z "$(git -C "$src_dir" status --porcelain -uno)" ]] \
+			|| die "$src_dir has local changes — commit or stash them, or point AGENTKIT_SRC at a clean dir"
+		echo "[bootstrap] Updating $src_dir"
+		git -C "$src_dir" fetch --depth 1 origin || die "fetch failed — check network and $src_dir"
+		git -C "$src_dir" reset --hard origin/HEAD >/dev/null \
+			|| die "update failed — origin/HEAD is unresolvable in $src_dir; re-clone or fix the remote"
+	elif [[ -e "$src_dir" ]]; then
+		die "$src_dir exists but is not a git clone — move it aside or set AGENTKIT_SRC"
+	else
+		echo "[bootstrap] Cloning agentkit into $src_dir"
+		git clone --depth 1 "$repo_url" "$src_dir" || die "clone failed"
+	fi
+
+	exec bash "$src_dir/install.sh" --global "$@"
+}
 
 die() { echo "bootstrap: $*" >&2; exit 1; }
 
-command -v git >/dev/null || die "git is required"
-command -v bash >/dev/null || die "bash is required"
-
-if [[ -d "$SRC_DIR/.git" ]]; then
-	echo "[bootstrap] Updating $SRC_DIR"
-	git -C "$SRC_DIR" fetch --depth 1 origin || die "fetch failed — check network and $SRC_DIR"
-	git -C "$SRC_DIR" reset --hard origin/HEAD >/dev/null
-elif [[ -e "$SRC_DIR" ]]; then
-	die "$SRC_DIR exists but is not a git clone — move it aside or set AGENTKIT_SRC"
-else
-	echo "[bootstrap] Cloning agentkit into $SRC_DIR"
-	git clone --depth 1 "$REPO_URL" "$SRC_DIR" || die "clone failed"
-fi
-
-exec bash "$SRC_DIR/install.sh" --global "$@"
+main "$@"

--- a/moon.yml
+++ b/moon.yml
@@ -92,6 +92,7 @@ fileGroups:
 
   installInputs:
     - "config.example.yaml"
+    - "bootstrap.sh"
     - "hooks/**/*"
     - "install.sh"
     - "instructions/**/*"

--- a/scripts/check-test-slices.ts
+++ b/scripts/check-test-slices.ts
@@ -34,6 +34,7 @@ export const TEST_SLICES = {
     'tests/install-prompt.test.ts',
     'tests/install-shared-root.test.ts',
     'tests/install-tools.test.ts',
+    'tests/install/bootstrap.test.ts',
     'tests/install/manifest-readers.test.ts',
     'tests/install/plugin-scripts.test.ts',
     'tests/install/skill-groups.test.ts',

--- a/tests/install/bootstrap.test.ts
+++ b/tests/install/bootstrap.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const repoRoot = dirname(dirname(import.meta.dir));
+const bootstrap = join(repoRoot, "bootstrap.sh");
+const timeoutMs = 120_000;
+
+function runBootstrap(home: string, extraEnv: Record<string, string> = {}) {
+  return spawnSync("bash", [bootstrap, "--no-session-scope", "--no-prompt"], {
+    cwd: tmpdir(),
+    env: {
+      ...process.env,
+      HOME: home,
+      XDG_CONFIG_HOME: join(home, ".config"),
+      AGENTKIT_HOME: join(home, ".agentkit"),
+      AGENTKIT_REPO_URL: `file://${repoRoot}`,
+      AGENTKIT_SRC: join(home, ".agentkit-src"),
+      ...extraEnv,
+    },
+    encoding: "utf-8",
+    timeout: timeoutMs,
+  });
+}
+
+describe("curl-pipe bootstrap", () => {
+  test("clones the kit and hands off to a global install; re-run updates", () => {
+    const home = mkdtempSync(join(tmpdir(), "agentkit-bootstrap-"));
+
+    try {
+      const first = runBootstrap(home);
+      expect(first.status, first.stderr + "\n" + first.stdout).toBe(0);
+      expect(first.stdout).toContain("[bootstrap] Cloning");
+      expect(existsSync(join(home, ".agentkit-src", ".git"))).toBe(true);
+      expect(existsSync(join(home, ".agentkit", "skills"))).toBe(true);
+
+      const second = runBootstrap(home);
+      expect(second.status, second.stderr + "\n" + second.stdout).toBe(0);
+      expect(second.stdout).toContain("[bootstrap] Updating");
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  }, timeoutMs);
+
+  test("refuses a source dir that exists but is not a clone", () => {
+    const home = mkdtempSync(join(tmpdir(), "agentkit-bootstrap-"));
+
+    try {
+      mkdirSync(join(home, ".agentkit-src"), { recursive: true });
+      writeFileSync(join(home, ".agentkit-src", "somefile"), "not a clone\n");
+
+      const result = runBootstrap(home);
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("not a git clone");
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  }, timeoutMs);
+});

--- a/tests/install/bootstrap.test.ts
+++ b/tests/install/bootstrap.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { afterAll, describe, expect, test } from "bun:test";
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -7,6 +7,47 @@ import { spawnSync } from "node:child_process";
 const repoRoot = dirname(dirname(import.meta.dir));
 const bootstrap = join(repoRoot, "bootstrap.sh");
 const timeoutMs = 120_000;
+const gitIdentity = {
+  GIT_AUTHOR_NAME: "t",
+  GIT_AUTHOR_EMAIL: "t@t",
+  GIT_COMMITTER_NAME: "t",
+  GIT_COMMITTER_EMAIL: "t@t",
+};
+
+function git(args: string[], opts: Record<string, unknown> = {}) {
+  const result = spawnSync("git", args, {
+    encoding: "utf-8",
+    timeout: timeoutMs,
+    env: { ...process.env, ...gitIdentity },
+    maxBuffer: 64 * 1024 * 1024,
+    ...opts,
+  });
+  expect(result.status, `git ${args.join(" ")}: ${result.stderr}`).toBe(0);
+  return result;
+}
+
+// CI checks out a partial (promisor) clone that cannot serve full clones of
+// itself, so the tests build one self-contained origin from the tracked files
+// and bootstrap from that.
+let originDir: string | null = null;
+function sharedOrigin(): string {
+  if (originDir) return originDir;
+  const dir = mkdtempSync(join(tmpdir(), "agentkit-bootstrap-origin-"));
+  const files = git(["-C", repoRoot, "ls-files", "-z"]).stdout.split("\0").filter(Boolean);
+  for (const file of files) {
+    const dst = join(dir, file);
+    mkdirSync(dirname(dst), { recursive: true });
+    cpSync(join(repoRoot, file), dst);
+  }
+  git(["init", "-q", "-b", "main", dir]);
+  git(["-C", dir, "add", "-A"]);
+  git(["-C", dir, "commit", "-q", "--no-verify", "-m", "synthetic origin"]);
+  originDir = dir;
+  return dir;
+}
+afterAll(() => {
+  if (originDir) rmSync(originDir, { recursive: true, force: true });
+});
 
 function runBootstrap(home: string, extraEnv: Record<string, string> = {}, extraArgs: string[] = []) {
   return spawnSync("bash", [bootstrap, "--no-session-scope", "--no-prompt", ...extraArgs], {
@@ -16,7 +57,7 @@ function runBootstrap(home: string, extraEnv: Record<string, string> = {}, extra
       HOME: home,
       XDG_CONFIG_HOME: join(home, ".config"),
       AGENTKIT_HOME: join(home, ".agentkit"),
-      AGENTKIT_REPO_URL: `file://${repoRoot}`,
+      AGENTKIT_REPO_URL: `file://${sharedOrigin()}`,
       AGENTKIT_SRC: join(home, ".agentkit-src"),
       ...extraEnv,
     },
@@ -66,23 +107,14 @@ describe("curl-pipe bootstrap", () => {
 
     try {
       const origin = join(home, "origin");
-      const clone = spawnSync("git", ["clone", "--no-local", repoRoot, origin], {
-        encoding: "utf-8",
-        timeout: timeoutMs,
-      });
-      expect(clone.status, clone.stderr).toBe(0);
+      git(["clone", "-q", "--no-local", sharedOrigin(), origin]);
 
       const first = runBootstrap(home, { AGENTKIT_REPO_URL: `file://${origin}` });
       expect(first.status, first.stderr + "\n" + first.stdout).toBe(0);
 
       writeFileSync(join(origin, "UPSTREAM_MARKER"), "new\n");
-      const env = { GIT_AUTHOR_NAME: "t", GIT_AUTHOR_EMAIL: "t@t", GIT_COMMITTER_NAME: "t", GIT_COMMITTER_EMAIL: "t@t" };
-      spawnSync("git", ["-C", origin, "add", "UPSTREAM_MARKER"], { encoding: "utf-8" });
-      const commit = spawnSync("git", ["-C", origin, "commit", "--no-verify", "-m", "upstream marker"], {
-        encoding: "utf-8",
-        env: { ...process.env, ...env },
-      });
-      expect(commit.status, commit.stderr).toBe(0);
+      git(["-C", origin, "add", "UPSTREAM_MARKER"]);
+      git(["-C", origin, "commit", "-q", "--no-verify", "-m", "upstream marker"]);
 
       const second = runBootstrap(home, { AGENTKIT_REPO_URL: `file://${origin}` });
       expect(second.status, second.stderr + "\n" + second.stdout).toBe(0);

--- a/tests/install/bootstrap.test.ts
+++ b/tests/install/bootstrap.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -8,8 +8,8 @@ const repoRoot = dirname(dirname(import.meta.dir));
 const bootstrap = join(repoRoot, "bootstrap.sh");
 const timeoutMs = 120_000;
 
-function runBootstrap(home: string, extraEnv: Record<string, string> = {}) {
-  return spawnSync("bash", [bootstrap, "--no-session-scope", "--no-prompt"], {
+function runBootstrap(home: string, extraEnv: Record<string, string> = {}, extraArgs: string[] = []) {
+  return spawnSync("bash", [bootstrap, "--no-session-scope", "--no-prompt", ...extraArgs], {
     cwd: tmpdir(),
     env: {
       ...process.env,
@@ -39,6 +39,66 @@ describe("curl-pipe bootstrap", () => {
       const second = runBootstrap(home);
       expect(second.status, second.stderr + "\n" + second.stdout).toBe(0);
       expect(second.stdout).toContain("[bootstrap] Updating");
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  }, timeoutMs);
+
+  test("refuses to update a clone with local modifications", () => {
+    const home = mkdtempSync(join(tmpdir(), "agentkit-bootstrap-"));
+
+    try {
+      const first = runBootstrap(home);
+      expect(first.status, first.stderr + "\n" + first.stdout).toBe(0);
+
+      writeFileSync(join(home, ".agentkit-src", "README.md"), "local edit\n");
+      const second = runBootstrap(home);
+      expect(second.status).not.toBe(0);
+      expect(second.stderr).toContain("local changes");
+      expect(readFileSync(join(home, ".agentkit-src", "README.md"), "utf-8")).toBe("local edit\n");
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  }, timeoutMs);
+
+  test("re-run pulls new upstream commits into the source dir", () => {
+    const home = mkdtempSync(join(tmpdir(), "agentkit-bootstrap-"));
+
+    try {
+      const origin = join(home, "origin");
+      const clone = spawnSync("git", ["clone", "--no-local", repoRoot, origin], {
+        encoding: "utf-8",
+        timeout: timeoutMs,
+      });
+      expect(clone.status, clone.stderr).toBe(0);
+
+      const first = runBootstrap(home, { AGENTKIT_REPO_URL: `file://${origin}` });
+      expect(first.status, first.stderr + "\n" + first.stdout).toBe(0);
+
+      writeFileSync(join(origin, "UPSTREAM_MARKER"), "new\n");
+      const env = { GIT_AUTHOR_NAME: "t", GIT_AUTHOR_EMAIL: "t@t", GIT_COMMITTER_NAME: "t", GIT_COMMITTER_EMAIL: "t@t" };
+      spawnSync("git", ["-C", origin, "add", "UPSTREAM_MARKER"], { encoding: "utf-8" });
+      const commit = spawnSync("git", ["-C", origin, "commit", "--no-verify", "-m", "upstream marker"], {
+        encoding: "utf-8",
+        env: { ...process.env, ...env },
+      });
+      expect(commit.status, commit.stderr).toBe(0);
+
+      const second = runBootstrap(home, { AGENTKIT_REPO_URL: `file://${origin}` });
+      expect(second.status, second.stderr + "\n" + second.stdout).toBe(0);
+      expect(existsSync(join(home, ".agentkit-src", "UPSTREAM_MARKER"))).toBe(true);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  }, timeoutMs);
+
+  test("passes arguments through to the installer", () => {
+    const home = mkdtempSync(join(tmpdir(), "agentkit-bootstrap-"));
+
+    try {
+      const result = runBootstrap(home, {}, ["--with", "product"]);
+      expect(result.status, result.stderr + "\n" + result.stdout).toBe(0);
+      expect(existsSync(join(home, ".agentkit", "skills", "product-intelligence"))).toBe(true);
     } finally {
       rmSync(home, { recursive: true, force: true });
     }


### PR DESCRIPTION
One-line install: `curl -fsSL https://raw.githubusercontent.com/developerinlondon/agentkit/main/bootstrap.sh | bash` (args pass through via `bash -s --`). Shallow-clones to `~/.agentkit-src` (`AGENTKIT_SRC` override), re-runs update in place, refuses a non-clone dir, then hands off to `install.sh --global`. Tests cover clone+install+update and the refusal; suite mutation-checked; shellcheck clean. Wanted for the agentkit.sbs quickstart.