### PR TITLE
feat(instructions): review-discipline core layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ and OpenCode `resource-police` remain the recursive command-analysis paths.
 | **coding-discipline.md**        | 11-rule behavioral contract for code work (think first, simplicity, surgical changes, fail loud, …) |
 | **collaboration-visibility.md** | Progress updates, checkpoint summaries, and compact ASCII diagrams for multi-step work              |
 | **resource-safety.md**          | Mandatory bounded execution and live-connectivity preservation rules                                |
+| **review-discipline.md**        | Advisory review lane: one non-authoring reviewer pass for substantive changes, merge on approval    |
+| **evidence-gated-review.md**    | Evidence records + merge-gate doctrine (ships only with the explicit `review` group)                |
 
 ### Claude Code plugins (marketplace)
 
@@ -130,7 +132,7 @@ claude plugin install agentkit-review
 
 **Not in the plugin: the always-on rules and instructions.** Claude Code plugins cannot inject
 always-on global context, so the glob-loaded `rules/` and the `instructions/*.md` global prompts
-(anti-glaze, coding-discipline, collaboration-visibility, resource-safety) are **out of scope for the plugin** and
+(anti-glaze, coding-discipline, collaboration-visibility, resource-safety, review-discipline) are **out of scope for the plugin** and
 are still wired into `~/.claude/CLAUDE.md`, Codex, and OpenCode by `install.sh`. Their
 **enforcement**, however, _is_ bundled: the police hooks (`git-police`, `mr-police`,
 `format-police`, `coding-police`, `kubectl-police`, `pkg-police`, `resource-police`) run as

--- a/instructions/review-discipline.md
+++ b/instructions/review-discipline.md
@@ -1,0 +1,24 @@
+<!-- agentkit:review-discipline:start -->
+
+# Review Discipline
+
+The maker never grades its own work. Before merging or declaring substantive work complete, run
+one advisory review pass in a context that did not author the change: a reviewer subagent where
+the harness supports one, a fresh session otherwise. Any capable agent given a reviewer brief
+works — this discipline names no specific toolkit and depends on none.
+
+Review the committed state (`git show`, `git diff <base>...HEAD`), never the working tree — a
+shared checkout can hold abandoned edits that were never proposed. Probe instead of reading: run
+the tests, execute the change, try to break it. When the change adds tests or guards, mutate what
+they claim to cover and confirm they fail — an assertion that cannot fail is not evidence.
+
+Findings come back ranked by severity, each with a concrete failure scenario, and the author fixes
+them rather than arguing them down. After fixes, ask the same reviewer for a delta re-review; full
+re-reviews are for new scope, not fixups. Merge on approval. The pass is advisory — no mechanism
+blocks the merge, so its cost is one review per substantive change, with no re-binding churn.
+
+Trivial changes — typos, labels, comment wording, config value tweaks — are exempt. Repos where a
+bad merge is expensive escalate by opting into the `review` group (`--with review`), which layers
+evidence records and a hard merge gate on top of this discipline.
+
+<!-- agentkit:review-discipline:end -->

--- a/instructions/review-discipline.md
+++ b/instructions/review-discipline.md
@@ -14,8 +14,9 @@ they claim to cover and confirm they fail — an assertion that cannot fail is n
 
 Findings come back ranked by severity, each with a concrete failure scenario, and the author fixes
 them rather than arguing them down. After fixes, ask the same reviewer for a delta re-review; full
-re-reviews are for new scope, not fixups. Merge on approval. The pass is advisory — no mechanism
-blocks the merge, so its cost is one review per substantive change, with no re-binding churn.
+re-reviews are for new scope, not fixups. Merge on approval. Absent the `review` group, the pass
+is advisory — no mechanism blocks the merge — so the cost is one review per substantive change,
+and nothing forces a re-review for every fixup commit.
 
 Trivial changes — typos, labels, comment wording, config value tweaks — are exempt. Repos where a
 bad merge is expensive escalate by opting into the `review` group (`--with review`), which layers

--- a/tests/install-prompt.test.ts
+++ b/tests/install-prompt.test.ts
@@ -93,10 +93,25 @@ describe('global prompt installation', () => {
         'instructions',
         'resource-safety.md',
       );
+      const reviewDiscipline = join(
+        home,
+        '.agentkit',
+        'instructions',
+        'review-discipline.md',
+      );
       expect(existsSync(antiGlaze)).toBe(true);
       expect(existsSync(codingDiscipline)).toBe(true);
       expect(existsSync(collaborationVisibility)).toBe(true);
       expect(existsSync(resourceSafety)).toBe(true);
+      expect(existsSync(reviewDiscipline)).toBe(true);
+      const grokReviewDiscipline = join(home, '.grok', 'rules', 'review-discipline.md');
+      expect(lstatSync(grokReviewDiscipline).isSymbolicLink()).toBe(true);
+      expect(readFileSync(reviewDiscipline, 'utf-8')).toContain(
+        'agentkit:review-discipline:start',
+      );
+      expect(readFileSync(reviewDiscipline, 'utf-8')).toContain(
+        'did not author',
+      );
       const agentsAntiGlaze = join(home, '.agents', 'instructions', 'anti-glaze.md');
       expect(lstatSync(agentsAntiGlaze).isSymbolicLink()).toBe(true);
       expect(readlinkSync(agentsAntiGlaze)).toBe(antiGlaze);

--- a/tests/install-prompt.test.ts
+++ b/tests/install-prompt.test.ts
@@ -165,6 +165,9 @@ describe('global prompt installation', () => {
         'utf-8',
       );
       expect(claudeInstructions).toContain('Keep this line.');
+      expect(
+        countOccurrences(claudeInstructions, 'agentkit:review-discipline:start'),
+      ).toBe(1);
       expect(claudeInstructions).toContain(
         'Anti-Glaze Global Agent Instructions',
       );


### PR DESCRIPTION
Closes #187

Codifies the lightweight advisory-review lane as a CORE instruction wired into all four harnesses (previously only OMC's Claude-Code lines + per-machine memory; Codex/Grok/OpenCode had none). Executor-agnostic — no OMC dependency. evidence-gated-review.md + the mechanical gate remain the explicit review-group escalation tier. Reviewer-verified wiring on all five surfaces, idempotency, and both mutation probes; round-2 commit takes all four non-blocking findings.