### PR TITLE
docs(autonomous-workflow): defer the no-gate case to review-discipline

### DIFF
--- a/plugins-cc/agentkit/skills/autonomous-workflow/SKILL.md
+++ b/plugins-cc/agentkit/skills/autonomous-workflow/SKILL.md
@@ -44,8 +44,9 @@ Exceptions: bug fixes in already-approved work, read-only research, formatting.
 This section and the review-effort resolver below apply when the explicit
 `review` skill group is installed (`install.sh --with review` or the
 `agentkit-review` plugin). Without it there is no merge gate and no
-`review-profile`/`adversarial-review` lane: verify your work with tests and a
-separate code-reviewer pass, then merge.
+`review-profile`/`adversarial-review` lane — the core `review-discipline`
+instruction already covers that case: one advisory reviewer pass from a
+non-authoring context, then merge on approval.
 
 Review is a gate, not a parallel task and not advice. `review-police.sh` allows
 one standalone `gh pr merge` or `glab mr merge` only with a passing record for

--- a/skills/autonomous-workflow/SKILL.md
+++ b/skills/autonomous-workflow/SKILL.md
@@ -44,8 +44,9 @@ Exceptions: bug fixes in already-approved work, read-only research, formatting.
 This section and the review-effort resolver below apply when the explicit
 `review` skill group is installed (`install.sh --with review` or the
 `agentkit-review` plugin). Without it there is no merge gate and no
-`review-profile`/`adversarial-review` lane: verify your work with tests and a
-separate code-reviewer pass, then merge.
+`review-profile`/`adversarial-review` lane — the core `review-discipline`
+instruction already covers that case: one advisory reviewer pass from a
+non-authoring context, then merge on approval.
 
 Review is a gate, not a parallel task and not advice. `review-police.sh` allows
 one standalone `gh pr merge` or `glab mr merge` only with a passing record for


### PR DESCRIPTION
One-paragraph dedup, refs #187: the skill's no-review-group fallback sentence duplicated what the core review-discipline instruction now owns; it becomes a pointer. Mirror copy synced. Trivial-tier per the discipline itself — no reviewer round.