### PR TITLE
chore(release): v0.4.1 plugin version bump

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "agentkit",
       "source": "./plugins-cc/agentkit",
       "description": "Claude Code bundle with enforcement hooks, skills, tools/bounded-run, and the assay + infra-tools MCP toolchains. Hooks require jq, awk, cat, and python3; MCPs require bun and assay. Linux bounded execution additionally requires cgroup v2, a systemd user manager, and a provisioned agent-work.slice.",
-      "version": "0.3.0"
+      "version": "0.3.1"
     },
     {
       "name": "assay",

--- a/plugins-cc/agentkit/.claude-plugin/plugin.json
+++ b/plugins-cc/agentkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "agentkit",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Claude Code bundle with enforcement hooks, skills, a bounded runner, and the assay + infra-tools MCP toolchains. Hooks require jq, awk, cat, and python3; MCPs require bun and assay. Linux bounded execution additionally requires cgroup v2, a systemd user manager, and a provisioned agent-work.slice.",
   "author": {
     "name": "developerinlondon",

--- a/tests/agentkit-plugin.test.ts
+++ b/tests/agentkit-plugin.test.ts
@@ -132,7 +132,7 @@ describe('agentkit plugin manifest', () => {
   test('plugin.json declares agentkit without duplicating its standard hooks path', () => {
     const plugin = readJson('.claude-plugin', 'plugin.json');
     expect(plugin.name).toBe('agentkit');
-    expect(plugin.version).toBe('0.3.0');
+    expect(plugin.version).toBe('0.3.1');
     // Claude automatically loads hooks/hooks.json. Declaring that same path in
     // the manifest makes a fresh install appear enabled while hook loading
     // fails with "Duplicate hooks file detected".
@@ -421,7 +421,7 @@ describe('marketplace lists the agentkit plugin', () => {
     const agentkit = marketplace.plugins.find((p: { name: string }) => p.name === 'agentkit');
     expect(agentkit.source).toBe('./plugins-cc/agentkit');
     expect(agentkit.version).toBe(readJson('.claude-plugin', 'plugin.json').version);
-    expect(agentkit.version).toBe('0.3.0');
+    expect(agentkit.version).toBe('0.3.1');
     expect(agentkit.description).toContain('bounded-run');
     expect(agentkit.description).toContain('agent-work.slice');
     expect(agentkit.description).toContain('Linux bounded execution additionally requires');


### PR DESCRIPTION
Prepares the v0.4.1 tag: agentkit plugin 0.3.0→0.3.1 (its bundled autonomous-workflow mirror changed in #189). Release notes will cover #184 #185 #188 #189. Trivial-tier.