### PR TITLE
feat(pkg-police): configurable package manager, lockfile-inferred by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Reusable AI agent skills, rules, plugins, hooks, and tools for OpenCode, Claude 
 | **git-police.ts**      | Blocks commits to main/master, force push, --no-verify, AI attribution, push to protected branches                       |
 | **coding-police.ts**   | Enforces DRY code, modular files (<1000 lines), short functions, single responsibility, and capped directory file counts |
 | **comment-police.ts**  | Warns on long comment blocks, tutorial-style file headers, PR/plan/closes-#N references, and high comment-to-code ratios |
-| **pkg-police.ts**      | Enforces bun as package manager — blocks npm, npx, yarn, pnpm commands                                                   |
+| **pkg-police.ts**      | Enforces the project's declared package manager — blocks the other managers' commands                                    |
 | **resource-police.ts** | Requires bounded heavy commands on Linux; blocks delegated and undecidable commands everywhere                           |
 
 ### Runtime hooks (Claude Code; review gate is opt-in, also installed for Codex when selected)
@@ -52,7 +52,7 @@ Reusable AI agent skills, rules, plugins, hooks, and tools for OpenCode, Claude 
 | **kubectl-police.sh**  | PreToolUse        | Blocks kubectl create/apply on Kargo CRDs                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | **format-police.sh**   | PostToolUse       | Auto-formats files after edit/write using dprint                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
 | **coding-police.sh**   | PostToolUse       | Enforces DRY code, modular files (<1000 lines), short functions, single responsibility, and capped directory file counts                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| **pkg-police.sh**      | PreToolUse        | Enforces bun as package manager — blocks npm, npx, yarn, pnpm commands                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| **pkg-police.sh**      | PreToolUse        | Enforces the project's declared package manager — blocks the other managers' commands                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | **resource-police.sh** | PreToolUse        | With `jq`, `awk`, and `cat`, requires `bounded-run` for heavy commands on Linux and blocks delegated or undecidable commands on every platform; warns and fails open when a parser dependency is missing                                                                                                                                                                                                                                                                                                                                            |
 | **chime.sh**           | Notification/Stop | Audible nudge when Claude needs you: springy boing on permission prompts/questions, soft ping when a turn finishes. Mute: `touch ~/.claude/.chime-off` or `CLAUDE_CHIME=0`                                                                                                                                                                                                                                                                                                                                                                          |
 | **mr-police.sh**       | PreToolUse        | Blocks opening a new MR while you already have an open MR you authored on the repo — stops unmerged MRs from stacking up                                                                                                                                                                                                                                                                                                                                                                                                                            |
@@ -73,7 +73,7 @@ protections below remain literal command-prefix policies.
 | **git-police.rules**        | Blocks force push, --no-verify, direct push to protected branches                                            |
 | **kubectl-police.rules**    | Blocks kubectl create/apply on Kargo CRDs                                                                    |
 | **coding-police.rules**     | Coding standards guidance + prompts on heredoc/tee writes that may produce oversized files                   |
-| **pkg-police.rules**        | Enforces bun as package manager — blocks npm, npx, yarn, pnpm commands                                       |
+| **pkg-police.rules**        | Enforces bun as package manager — static policy, so it cannot honor the configured manager                   |
 | **delegation-police.rules** | Blocks direct mutating container, service-manager, privilege, and remote prefixes; allows direct diagnostics |
 | **resource-police.rules**   | On Linux, blocks direct heavy commands that do not start with the bounded runner                             |
 
@@ -499,20 +499,28 @@ platforms (OpenCode plugin, Claude Code hook, Codex policy). Checks:
 
 All thresholds are configurable via `coding-police` in your config. See [Configuration](#configuration).
 
-**pkg-police**: Enforces bun as the default JavaScript/TypeScript package manager and runtime.
-Intercepts bash commands before execution and blocks npm, npx, yarn, and pnpm. Available on all
-three platforms (OpenCode plugin, Claude Code hook, Codex policy).
+**pkg-police**: Keeps one JavaScript/TypeScript package manager per project. It intercepts bash
+commands before execution and blocks the managers the project does not use, naming the equivalent
+command in the one it does.
 
-Blocked commands and their bun equivalents:
+By default the enforced manager is inferred from the repository's lockfile, found by walking up
+from the working directory to the git root:
 
-| Blocked             | Use instead             |
-| ------------------- | ----------------------- |
-| `npm install`       | `bun install`           |
-| `npm install <pkg>` | `bun add <pkg>`         |
-| `npm run <script>`  | `bun run <script>`      |
-| `npx <cmd>`         | `bunx <cmd>`            |
-| `npm test`          | `bun test`              |
-| `yarn` / `pnpm`     | `bun` (same subcommand) |
+| Lockfile                     | Enforced manager |
+| ---------------------------- | ---------------- |
+| `bun.lock` / `bun.lockb`     | bun              |
+| `package-lock.json`          | npm              |
+| `pnpm-lock.yaml`             | pnpm             |
+| `yarn.lock`                  | yarn             |
+| none, or several that differ | nothing blocked  |
+
+Set `pkg-police.manager` in your agentkit config to `bun`, `npm`, `pnpm`, or `yarn` to enforce one
+everywhere regardless of the lockfile, `auto` for the lockfile default, or `off` to disable the
+unit. An unrecognized value disables it rather than guessing. (The older `enabled: false` still
+reads as `off`; `manager` wins when both are present.)
+
+Equivalents are mapped across managers, so a blocked `npx tsc` in a pnpm project asks for
+`pnpm dlx tsc`, and a blocked `npm i lodash` in a bun project asks for `bun add`.
 
 | Platform    | File                              | Hook type           |
 | ----------- | --------------------------------- | ------------------- |
@@ -520,8 +528,11 @@ Blocked commands and their bun equivalents:
 | Claude Code | `hooks/claude/pkg-police.sh`      | PreToolUse          |
 | Codex CLI   | `policies/codex/pkg-police.rules` | exec policy         |
 
-Disable per-project by setting `pkg-police.enabled: false` in your agentkit config.
-Override per-command when the user explicitly requests a different package manager.
+Codex exec policies are static and cannot read config or inspect a lockfile, so the Codex unit
+enforces bun unconditionally; only the OpenCode plugin and the Claude Code hook are configurable.
+
+Override a single command with `AGENTKIT_ALLOW_PKG=1` when the user explicitly approves a
+different package manager.
 
 ## Rules
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -67,10 +67,17 @@ coding-police:
   #     - migrations/
 
 pkg-police:
-  # Set to false to disable bun enforcement (allows npm/npx/yarn/pnpm).
-  enabled: true
-  # Example:
-  #   enabled: false
+  # Which JavaScript/TypeScript package manager to enforce.
+  #   auto  — infer it from the repository's lockfile (the default). bun.lock
+  #           or bun.lockb → bun, package-lock.json → npm, pnpm-lock.yaml →
+  #           pnpm, yarn.lock → yarn. No lockfile, or several that disagree,
+  #           means there is no basis to judge and nothing is blocked.
+  #   bun | npm | pnpm | yarn — enforce that one whatever the lockfile says.
+  #   off   — disable the unit entirely.
+  # Commands belonging to any other manager are blocked, with the equivalent
+  # command in the enforced one. AGENTKIT_ALLOW_PKG=1 overrides a single
+  # command regardless of this setting.
+  manager: auto
 
 version-police:
   # Set to false to disable stale-major dependency-pin blocking.

--- a/hooks/claude/pkg-police.sh
+++ b/hooks/claude/pkg-police.sh
@@ -1,8 +1,170 @@
 #!/usr/bin/env bash
 # pkg-police.sh — Claude Code PreToolUse hook (matcher: Bash)
-# Blocks: npm, npx, yarn, pnpm commands — enforces bun as package manager
+# Blocks package-manager commands that disagree with the project's manager
 # Equivalent to: plugins/pkg-police.ts (OpenCode)
 set -euo pipefail
+
+# ── Configuration ───────────────────────────────────────────────────────────
+AGENTKIT_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/agentkit/config.yaml"
+
+CONFIG_MANAGER=""
+CONFIG_ENABLED=""
+
+load_config() {
+  [[ -f "$AGENTKIT_CONFIG" ]] || return 0
+  local key value
+  while IFS='=' read -r key value; do
+    case "$key" in
+      manager) CONFIG_MANAGER="$value" ;;
+      enabled) CONFIG_ENABLED="$value" ;;
+    esac
+  done < <(awk '
+    /^[^[:space:]#]/ {
+      in_section = ($0 ~ /^pkg-police:/)
+      next
+    }
+    in_section {
+      line = $0
+      sub(/^[[:space:]]+/, "", line)
+      if (line !~ /^(manager|enabled):[[:space:]]*[^[:space:]#]+([[:space:]]*#.*)?$/) next
+      key = line
+      sub(/:.*/, "", key)
+      sub(/^[^:]*:[[:space:]]*/, "", line)
+      sub(/[[:space:]#].*$/, "", line)
+      print key "=" tolower(line)
+    }
+  ' "$AGENTKIT_CONFIG")
+}
+
+ENFORCED=""
+REASON=""
+
+# The hook payload carries no reliable cwd, so lockfile detection starts at the
+# shell's own directory and stops at the git root — a lockfile outside the
+# repository says nothing about this project.
+detect_from_lockfile() {
+  local dir="$PWD" entry mgr lock hit lockname parent
+  while :; do
+    hit=""
+    lockname=""
+    for entry in bun:bun.lock bun:bun.lockb npm:package-lock.json \
+      pnpm:pnpm-lock.yaml yarn:yarn.lock; do
+      mgr="${entry%%:*}"
+      lock="${entry#*:}"
+      [[ -e "$dir/$lock" ]] || continue
+      if [[ -z "$hit" ]]; then
+        hit="$mgr"
+        lockname="$lock"
+      elif [[ "$hit" != "$mgr" ]]; then
+        return 1
+      fi
+    done
+    if [[ -n "$hit" ]]; then
+      ENFORCED="$hit"
+      REASON="this project uses $hit ($lockname)"
+      return 0
+    fi
+    [[ -e "$dir/.git" ]] && return 1
+    [[ "$dir" == "/" || -z "$dir" ]] && return 1
+    parent="${dir%/*}"
+    [[ -z "$parent" ]] && parent="/"
+    dir="$parent"
+  done
+}
+
+resolve_manager() {
+  case "$CONFIG_MANAGER" in
+    bun | npm | pnpm | yarn)
+      ENFORCED="$CONFIG_MANAGER"
+      REASON="agentkit config sets pkg-police.manager: $CONFIG_MANAGER"
+      return 0
+      ;;
+    off) return 1 ;;
+    auto | '') ;;
+    *) return 1 ;;
+  esac
+  [[ -z "$CONFIG_MANAGER" && "$CONFIG_ENABLED" == "false" ]] && return 1
+  detect_from_lockfile
+}
+
+# ── Command classification ──────────────────────────────────────────────────
+BOUND='[^[:alnum:]_-]'
+ARG='([[:space:]]+([^-[:space:]][^[:space:]]*))?'
+
+DETECTED_LABEL=""
+DETECTED_ACTION=""
+
+action_for() {
+  local sub="$1" arg="$2"
+  case "$sub" in
+    install | i | ci | '')
+      [[ -n "$arg" ]] && printf 'add' || printf 'install'
+      ;;
+    add) printf 'add' ;;
+    exec | dlx | x) printf 'exec' ;;
+    run | test | init | publish | create) printf '%s' "$sub" ;;
+    *) printf 'run' ;;
+  esac
+}
+
+# npm and bun are runtimes too, so only their package-management subcommands
+# count; pnpm and yarn are package managers whatever the subcommand.
+subcommand_is_managed() {
+  case "$1:$2" in
+    npm:install | npm:i | npm:ci | npm:add | npm:run | npm:test | npm:init | npm:publish | npm:exec | npm:create) return 0 ;;
+    bun:install | bun:i | bun:add | bun:run | bun:test | bun:init | bun:publish | bun:create | bun:x) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+detect_invocation() {
+  local cmd="$1" skip="$2" mgr sub arg exe re
+  for mgr in npm bun; do
+    [[ "$mgr" == "$skip" ]] && continue
+    exe="npx"
+    [[ "$mgr" == bun ]] && exe="bunx"
+    re="(^|$BOUND)${exe}[[:space:]]"
+    if [[ "$cmd" =~ $re ]]; then
+      DETECTED_LABEL="$exe"
+      DETECTED_ACTION="exec"
+      return 0
+    fi
+    re="(^|$BOUND)${mgr}[[:space:]]+([[:alnum:]:@._-]+)$ARG"
+    if [[ "$cmd" =~ $re ]]; then
+      sub="${BASH_REMATCH[2]}"
+      arg="${BASH_REMATCH[4]}"
+      subcommand_is_managed "$mgr" "$sub" || continue
+      DETECTED_LABEL="$mgr $sub"
+      DETECTED_ACTION=$(action_for "$sub" "$arg")
+      return 0
+    fi
+  done
+  for mgr in pnpm yarn; do
+    [[ "$mgr" == "$skip" ]] && continue
+    re="(^|$BOUND)${mgr}([[:space:]]+([[:alnum:]:@._-]+))?$ARG($|$BOUND)"
+    if [[ "$cmd" =~ $re ]]; then
+      sub="${BASH_REMATCH[3]}"
+      arg="${BASH_REMATCH[5]}"
+      DETECTED_LABEL="$mgr${sub:+ $sub}"
+      DETECTED_ACTION=$(action_for "$sub" "$arg")
+      return 0
+    fi
+  done
+  return 1
+}
+
+equivalent() {
+  local mgr="$1" action="$2"
+  if [[ "$action" == "exec" ]]; then
+    case "$mgr" in
+      npm) printf 'npx' ;;
+      bun) printf 'bunx' ;;
+      *) printf '%s dlx' "$mgr" ;;
+    esac
+    return 0
+  fi
+  printf '%s %s' "$mgr" "$action"
+}
 
 # shellcheck source=lib/hook-input.sh
 # Pure bash dirname: external `dirname` is missing when PATH is empty (the
@@ -14,7 +176,7 @@ COMMAND=$(agentkit_command)
 
 [[ -z "$COMMAND" ]] && exit 0
 
-# User-approved escape hatch for tools that only work with npm/yarn/pnpm.
+# User-approved escape hatch for tools that only work with another manager.
 # Works from the environment or inline (`AGENTKIT_ALLOW_PKG=1 npm ci`) —
 # inline assignments never reach the hook process, so honor them from the
 # text (same treatment as AGENTKIT_ALLOW_STALE_PUSH in git-police).
@@ -24,31 +186,10 @@ if echo "$COMMAND" | grep -qE '(^|[[:space:];&|])AGENTKIT_ALLOW_PKG=1([[:space:]
 fi
 [[ "$PKG_OK" == "1" ]] && exit 0
 
-deny() {
-  local reason="$1"
-  agentkit_deny_json "$reason"
-  exit 0
-}
+load_config
+resolve_manager || exit 0
 
-# Check for npm commands (install, run, test, exec, create, init, publish, ci)
-if echo "$COMMAND" | grep -qiE '\bnpm\s+(install|i|ci|run|test|init|publish|exec|create)\b'; then
-  SUBCMD=$(echo "$COMMAND" | grep -oiE '\bnpm\s+\w+' | head -1)
-  deny "BLOCKED: '${SUBCMD}' is not allowed. Use bun instead. Mapping: npm install → bun install, npm run → bun run, npm test → bun test, npm init → bun init, npx → bunx. Override (only when the user approves npm): prefix with AGENTKIT_ALLOW_PKG=1."
-fi
+detect_invocation "$COMMAND" "$ENFORCED" || exit 0
 
-# Check for npx
-if echo "$COMMAND" | grep -qiE '\bnpx\s+'; then
-  deny "BLOCKED: 'npx' is not allowed. Use 'bunx' instead. Example: npx tsc → bunx tsc. Override (only when the user approves npx): prefix with AGENTKIT_ALLOW_PKG=1."
-fi
-
-# Check for yarn
-if echo "$COMMAND" | grep -qiE '\byarn(\s+|$)'; then
-  deny "BLOCKED: 'yarn' is not allowed. Use bun instead. Mapping: yarn → bun install, yarn add → bun add, yarn run → bun run. Override (only when the user approves yarn): prefix with AGENTKIT_ALLOW_PKG=1."
-fi
-
-# Check for pnpm
-if echo "$COMMAND" | grep -qiE '\bpnpm(\s+|$)'; then
-  deny "BLOCKED: 'pnpm' is not allowed. Use bun instead. Mapping: pnpm install → bun install, pnpm add → bun add, pnpm run → bun run. Override (only when the user approves pnpm): prefix with AGENTKIT_ALLOW_PKG=1."
-fi
-
+agentkit_deny_json "BLOCKED: '$DETECTED_LABEL' — $REASON. Use '$(equivalent "$ENFORCED" "$DETECTED_ACTION")'. Override (only when the user approves): prefix with AGENTKIT_ALLOW_PKG=1."
 exit 0

--- a/hooks/claude/settings.json
+++ b/hooks/claude/settings.json
@@ -20,7 +20,7 @@
             "type": "command",
             "command": "$HOME/.claude/hooks/pkg-police.sh",
             "timeout": 10,
-            "statusMessage": "pkg-police: enforcing bun as package manager..."
+            "statusMessage": "pkg-police: checking the project's package manager..."
           },
           {
             "type": "command",

--- a/plugins-cc/agentkit/hooks/hooks.json
+++ b/plugins-cc/agentkit/hooks/hooks.json
@@ -20,7 +20,7 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/pkg-police.sh",
             "timeout": 10,
-            "statusMessage": "pkg-police: enforcing bun as package manager..."
+            "statusMessage": "pkg-police: checking the project's package manager..."
           },
           {
             "type": "command",

--- a/plugins-cc/agentkit/hooks/pkg-police.sh
+++ b/plugins-cc/agentkit/hooks/pkg-police.sh
@@ -1,8 +1,170 @@
 #!/usr/bin/env bash
 # pkg-police.sh — Claude Code PreToolUse hook (matcher: Bash)
-# Blocks: npm, npx, yarn, pnpm commands — enforces bun as package manager
+# Blocks package-manager commands that disagree with the project's manager
 # Equivalent to: plugins/pkg-police.ts (OpenCode)
 set -euo pipefail
+
+# ── Configuration ───────────────────────────────────────────────────────────
+AGENTKIT_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/agentkit/config.yaml"
+
+CONFIG_MANAGER=""
+CONFIG_ENABLED=""
+
+load_config() {
+  [[ -f "$AGENTKIT_CONFIG" ]] || return 0
+  local key value
+  while IFS='=' read -r key value; do
+    case "$key" in
+      manager) CONFIG_MANAGER="$value" ;;
+      enabled) CONFIG_ENABLED="$value" ;;
+    esac
+  done < <(awk '
+    /^[^[:space:]#]/ {
+      in_section = ($0 ~ /^pkg-police:/)
+      next
+    }
+    in_section {
+      line = $0
+      sub(/^[[:space:]]+/, "", line)
+      if (line !~ /^(manager|enabled):[[:space:]]*[^[:space:]#]+([[:space:]]*#.*)?$/) next
+      key = line
+      sub(/:.*/, "", key)
+      sub(/^[^:]*:[[:space:]]*/, "", line)
+      sub(/[[:space:]#].*$/, "", line)
+      print key "=" tolower(line)
+    }
+  ' "$AGENTKIT_CONFIG")
+}
+
+ENFORCED=""
+REASON=""
+
+# The hook payload carries no reliable cwd, so lockfile detection starts at the
+# shell's own directory and stops at the git root — a lockfile outside the
+# repository says nothing about this project.
+detect_from_lockfile() {
+  local dir="$PWD" entry mgr lock hit lockname parent
+  while :; do
+    hit=""
+    lockname=""
+    for entry in bun:bun.lock bun:bun.lockb npm:package-lock.json \
+      pnpm:pnpm-lock.yaml yarn:yarn.lock; do
+      mgr="${entry%%:*}"
+      lock="${entry#*:}"
+      [[ -e "$dir/$lock" ]] || continue
+      if [[ -z "$hit" ]]; then
+        hit="$mgr"
+        lockname="$lock"
+      elif [[ "$hit" != "$mgr" ]]; then
+        return 1
+      fi
+    done
+    if [[ -n "$hit" ]]; then
+      ENFORCED="$hit"
+      REASON="this project uses $hit ($lockname)"
+      return 0
+    fi
+    [[ -e "$dir/.git" ]] && return 1
+    [[ "$dir" == "/" || -z "$dir" ]] && return 1
+    parent="${dir%/*}"
+    [[ -z "$parent" ]] && parent="/"
+    dir="$parent"
+  done
+}
+
+resolve_manager() {
+  case "$CONFIG_MANAGER" in
+    bun | npm | pnpm | yarn)
+      ENFORCED="$CONFIG_MANAGER"
+      REASON="agentkit config sets pkg-police.manager: $CONFIG_MANAGER"
+      return 0
+      ;;
+    off) return 1 ;;
+    auto | '') ;;
+    *) return 1 ;;
+  esac
+  [[ -z "$CONFIG_MANAGER" && "$CONFIG_ENABLED" == "false" ]] && return 1
+  detect_from_lockfile
+}
+
+# ── Command classification ──────────────────────────────────────────────────
+BOUND='[^[:alnum:]_-]'
+ARG='([[:space:]]+([^-[:space:]][^[:space:]]*))?'
+
+DETECTED_LABEL=""
+DETECTED_ACTION=""
+
+action_for() {
+  local sub="$1" arg="$2"
+  case "$sub" in
+    install | i | ci | '')
+      [[ -n "$arg" ]] && printf 'add' || printf 'install'
+      ;;
+    add) printf 'add' ;;
+    exec | dlx | x) printf 'exec' ;;
+    run | test | init | publish | create) printf '%s' "$sub" ;;
+    *) printf 'run' ;;
+  esac
+}
+
+# npm and bun are runtimes too, so only their package-management subcommands
+# count; pnpm and yarn are package managers whatever the subcommand.
+subcommand_is_managed() {
+  case "$1:$2" in
+    npm:install | npm:i | npm:ci | npm:add | npm:run | npm:test | npm:init | npm:publish | npm:exec | npm:create) return 0 ;;
+    bun:install | bun:i | bun:add | bun:run | bun:test | bun:init | bun:publish | bun:create | bun:x) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+detect_invocation() {
+  local cmd="$1" skip="$2" mgr sub arg exe re
+  for mgr in npm bun; do
+    [[ "$mgr" == "$skip" ]] && continue
+    exe="npx"
+    [[ "$mgr" == bun ]] && exe="bunx"
+    re="(^|$BOUND)${exe}[[:space:]]"
+    if [[ "$cmd" =~ $re ]]; then
+      DETECTED_LABEL="$exe"
+      DETECTED_ACTION="exec"
+      return 0
+    fi
+    re="(^|$BOUND)${mgr}[[:space:]]+([[:alnum:]:@._-]+)$ARG"
+    if [[ "$cmd" =~ $re ]]; then
+      sub="${BASH_REMATCH[2]}"
+      arg="${BASH_REMATCH[4]}"
+      subcommand_is_managed "$mgr" "$sub" || continue
+      DETECTED_LABEL="$mgr $sub"
+      DETECTED_ACTION=$(action_for "$sub" "$arg")
+      return 0
+    fi
+  done
+  for mgr in pnpm yarn; do
+    [[ "$mgr" == "$skip" ]] && continue
+    re="(^|$BOUND)${mgr}([[:space:]]+([[:alnum:]:@._-]+))?$ARG($|$BOUND)"
+    if [[ "$cmd" =~ $re ]]; then
+      sub="${BASH_REMATCH[3]}"
+      arg="${BASH_REMATCH[5]}"
+      DETECTED_LABEL="$mgr${sub:+ $sub}"
+      DETECTED_ACTION=$(action_for "$sub" "$arg")
+      return 0
+    fi
+  done
+  return 1
+}
+
+equivalent() {
+  local mgr="$1" action="$2"
+  if [[ "$action" == "exec" ]]; then
+    case "$mgr" in
+      npm) printf 'npx' ;;
+      bun) printf 'bunx' ;;
+      *) printf '%s dlx' "$mgr" ;;
+    esac
+    return 0
+  fi
+  printf '%s %s' "$mgr" "$action"
+}
 
 # shellcheck source=lib/hook-input.sh
 # Pure bash dirname: external `dirname` is missing when PATH is empty (the
@@ -14,7 +176,7 @@ COMMAND=$(agentkit_command)
 
 [[ -z "$COMMAND" ]] && exit 0
 
-# User-approved escape hatch for tools that only work with npm/yarn/pnpm.
+# User-approved escape hatch for tools that only work with another manager.
 # Works from the environment or inline (`AGENTKIT_ALLOW_PKG=1 npm ci`) —
 # inline assignments never reach the hook process, so honor them from the
 # text (same treatment as AGENTKIT_ALLOW_STALE_PUSH in git-police).
@@ -24,31 +186,10 @@ if echo "$COMMAND" | grep -qE '(^|[[:space:];&|])AGENTKIT_ALLOW_PKG=1([[:space:]
 fi
 [[ "$PKG_OK" == "1" ]] && exit 0
 
-deny() {
-  local reason="$1"
-  agentkit_deny_json "$reason"
-  exit 0
-}
+load_config
+resolve_manager || exit 0
 
-# Check for npm commands (install, run, test, exec, create, init, publish, ci)
-if echo "$COMMAND" | grep -qiE '\bnpm\s+(install|i|ci|run|test|init|publish|exec|create)\b'; then
-  SUBCMD=$(echo "$COMMAND" | grep -oiE '\bnpm\s+\w+' | head -1)
-  deny "BLOCKED: '${SUBCMD}' is not allowed. Use bun instead. Mapping: npm install → bun install, npm run → bun run, npm test → bun test, npm init → bun init, npx → bunx. Override (only when the user approves npm): prefix with AGENTKIT_ALLOW_PKG=1."
-fi
+detect_invocation "$COMMAND" "$ENFORCED" || exit 0
 
-# Check for npx
-if echo "$COMMAND" | grep -qiE '\bnpx\s+'; then
-  deny "BLOCKED: 'npx' is not allowed. Use 'bunx' instead. Example: npx tsc → bunx tsc. Override (only when the user approves npx): prefix with AGENTKIT_ALLOW_PKG=1."
-fi
-
-# Check for yarn
-if echo "$COMMAND" | grep -qiE '\byarn(\s+|$)'; then
-  deny "BLOCKED: 'yarn' is not allowed. Use bun instead. Mapping: yarn → bun install, yarn add → bun add, yarn run → bun run. Override (only when the user approves yarn): prefix with AGENTKIT_ALLOW_PKG=1."
-fi
-
-# Check for pnpm
-if echo "$COMMAND" | grep -qiE '\bpnpm(\s+|$)'; then
-  deny "BLOCKED: 'pnpm' is not allowed. Use bun instead. Mapping: pnpm install → bun install, pnpm add → bun add, pnpm run → bun run. Override (only when the user approves pnpm): prefix with AGENTKIT_ALLOW_PKG=1."
-fi
-
+agentkit_deny_json "BLOCKED: '$DETECTED_LABEL' — $REASON. Use '$(equivalent "$ENFORCED" "$DETECTED_ACTION")'. Override (only when the user approves): prefix with AGENTKIT_ALLOW_PKG=1."
 exit 0

--- a/plugins/pkg-police.ts
+++ b/plugins/pkg-police.ts
@@ -1,68 +1,158 @@
 import type { PluginInput } from '@opencode-ai/plugin';
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 import { homedir } from 'node:os';
 
-/**
- * Blocked package manager commands and their bun equivalents.
- *
- * Pattern: regex matching the forbidden command invocation.
- * Replacement: human-readable bun equivalent for the error message.
- */
-const BLOCKED_COMMANDS: Array<{ pattern: RegExp; tool: string; replacement: string }> = [
-  { pattern: /\bnpm\s+install\b/i, tool: 'npm install', replacement: 'bun install' },
-  { pattern: /\bnpm\s+i\b/i, tool: 'npm i', replacement: 'bun install' },
-  { pattern: /\bnpm\s+ci\b/i, tool: 'npm ci', replacement: 'bun install --frozen-lockfile' },
-  { pattern: /\bnpm\s+run\b/i, tool: 'npm run', replacement: 'bun run' },
-  { pattern: /\bnpm\s+test\b/i, tool: 'npm test', replacement: 'bun test' },
-  { pattern: /\bnpm\s+init\b/i, tool: 'npm init', replacement: 'bun init' },
-  { pattern: /\bnpm\s+publish\b/i, tool: 'npm publish', replacement: 'bun publish' },
-  { pattern: /\bnpm\s+exec\b/i, tool: 'npm exec', replacement: 'bunx' },
-  { pattern: /\bnpm\s+create\b/i, tool: 'npm create', replacement: 'bun create' },
-  { pattern: /\bnpx\s+/i, tool: 'npx', replacement: 'bunx' },
-  { pattern: /\byarn\s+/i, tool: 'yarn', replacement: 'bun' },
-  { pattern: /\byarn$/im, tool: 'yarn', replacement: 'bun install' },
-  { pattern: /\bpnpm\s+/i, tool: 'pnpm', replacement: 'bun' },
-  { pattern: /\bpnpm$/im, tool: 'pnpm', replacement: 'bun install' },
+type Manager = 'bun' | 'npm' | 'pnpm' | 'yarn';
+
+const MANAGERS: Manager[] = ['bun', 'npm', 'pnpm', 'yarn'];
+
+const LOCKFILES: Array<[Manager, string]> = [
+  ['bun', 'bun.lock'],
+  ['bun', 'bun.lockb'],
+  ['npm', 'package-lock.json'],
+  ['pnpm', 'pnpm-lock.yaml'],
+  ['yarn', 'yarn.lock'],
 ];
 
-function getAgentkitConfigPath(): string {
+const MANAGED_SUBCOMMANDS: Record<'npm' | 'bun', string[]> = {
+  npm: ['install', 'i', 'ci', 'add', 'run', 'test', 'init', 'publish', 'exec', 'create'],
+  bun: ['install', 'i', 'add', 'run', 'test', 'init', 'publish', 'create', 'x'],
+};
+
+const BOUND = '[^A-Za-z0-9_-]';
+const ARG = '(?:\\s+([^-\\s]\\S*))?';
+
+interface Enforcement {
+  manager: Manager;
+  reason: string;
+}
+
+interface Invocation {
+  label: string;
+  action: string;
+}
+
+function configPath(): string {
   const xdg = process.env.XDG_CONFIG_HOME || join(homedir(), '.config');
   return join(xdg, 'agentkit', 'config.yaml');
 }
 
-function isDisabled(): boolean {
+function readConfigSection(): { manager?: string; enabled?: string } {
+  let content: string;
   try {
-    const content = readFileSync(getAgentkitConfigPath(), 'utf-8');
-    // Simple YAML check: pkg-police:\n  enabled: false
-    if (/pkg-police:\s*\n\s+enabled:\s*false/i.test(content)) return true;
-    return false;
+    content = readFileSync(configPath(), 'utf-8');
   } catch {
-    return false;
+    return {};
+  }
+  const values: Record<string, string> = {};
+  let inSection = false;
+  for (const line of content.split('\n')) {
+    if (/^[^\s#]/.test(line)) {
+      inSection = /^pkg-police:/.test(line);
+      continue;
+    }
+    if (!inSection) continue;
+    const match = /^\s+(manager|enabled):\s*([^\s#]+)/.exec(line);
+    if (match) values[match[1]!] = match[2]!.toLowerCase();
+  }
+  return values;
+}
+
+// The tool payload carries no reliable cwd, so lockfile detection starts at the
+// session directory and stops at the git root — a lockfile outside the
+// repository says nothing about this project.
+function detectFromLockfile(start: string): Enforcement | null {
+  let dir = start;
+  for (;;) {
+    let hit: Manager | null = null;
+    let lockname = '';
+    for (const [manager, lock] of LOCKFILES) {
+      if (!existsSync(join(dir, lock))) continue;
+      if (hit === null) {
+        hit = manager;
+        lockname = lock;
+      } else if (hit !== manager) {
+        return null;
+      }
+    }
+    if (hit) return { manager: hit, reason: `this project uses ${hit} (${lockname})` };
+    if (existsSync(join(dir, '.git'))) return null;
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
   }
 }
 
-function detectBlockedPkgManager(command: string): string | null {
-  for (const { pattern, tool, replacement } of BLOCKED_COMMANDS) {
-    if (pattern.test(command)) {
-      return (
-        `BLOCKED: '${tool}' is not allowed. Use bun instead.\n` +
-        `\n` +
-        `Replace with: ${replacement}\n` +
-        `\n` +
-        `Quick reference:\n` +
-        `  npm install / yarn / pnpm install  →  bun install\n` +
-        `  npm install <pkg>                  →  bun add <pkg>\n` +
-        `  npm run <script>                   →  bun run <script>\n` +
-        `  npx <cmd>                          →  bunx <cmd>\n` +
-        `  npm test                           →  bun test\n` +
-        `\n` +
-        `Override: prefix with AGENTKIT_ALLOW_PKG=1 (only when the user\n` +
-        `approves it), or set pkg-police.enabled: false in agentkit config.`
-      );
+function resolveManager(dir: string): Enforcement | null {
+  const { manager, enabled } = readConfigSection();
+  if (manager && MANAGERS.includes(manager as Manager)) {
+    return {
+      manager: manager as Manager,
+      reason: `agentkit config sets pkg-police.manager: ${manager}`,
+    };
+  }
+  if (manager === 'off') return null;
+  if (manager && manager !== 'auto') return null;
+  if (!manager && enabled === 'false') return null;
+  return detectFromLockfile(dir);
+}
+
+function actionFor(subcommand: string, arg: string | undefined): string {
+  switch (subcommand) {
+    case 'install':
+    case 'i':
+    case 'ci':
+    case '':
+      return arg ? 'add' : 'install';
+    case 'add':
+      return 'add';
+    case 'exec':
+    case 'dlx':
+    case 'x':
+      return 'exec';
+    case 'run':
+    case 'test':
+    case 'init':
+    case 'publish':
+    case 'create':
+      return subcommand;
+    default:
+      return 'run';
+  }
+}
+
+// npm and bun are runtimes too, so only their package-management subcommands
+// count; pnpm and yarn are package managers whatever the subcommand.
+function detectInvocation(command: string, skip: Manager): Invocation | null {
+  for (const manager of ['npm', 'bun'] as const) {
+    if (manager === skip) continue;
+    const exe = manager === 'bun' ? 'bunx' : 'npx';
+    if (new RegExp(`(^|${BOUND})${exe}\\s`, 'i').test(command)) {
+      return { label: exe, action: 'exec' };
     }
+    const match = new RegExp(`(^|${BOUND})${manager}\\s+([\\w:@.-]+)${ARG}`, 'i').exec(command);
+    if (!match) continue;
+    const sub = match[2]!.toLowerCase();
+    if (!MANAGED_SUBCOMMANDS[manager].includes(sub)) continue;
+    return { label: `${manager} ${sub}`, action: actionFor(sub, match[3]) };
+  }
+  for (const manager of ['pnpm', 'yarn'] as const) {
+    if (manager === skip) continue;
+    const pattern = `(^|${BOUND})${manager}(?:\\s+([\\w:@.-]+))?${ARG}($|${BOUND})`;
+    const match = new RegExp(pattern, 'i').exec(command);
+    if (!match) continue;
+    const sub = (match[2] ?? '').toLowerCase();
+    return { label: sub ? `${manager} ${sub}` : manager, action: actionFor(sub, match[3]) };
   }
   return null;
+}
+
+function equivalent(manager: Manager, action: string): string {
+  if (action !== 'exec') return `${manager} ${action}`;
+  if (manager === 'npm') return 'npx';
+  if (manager === 'bun') return 'bunx';
+  return `${manager} dlx`;
 }
 
 function isPkgOverride(command: string): boolean {
@@ -70,24 +160,30 @@ function isPkgOverride(command: string): boolean {
     || /(^|[\s;&|])AGENTKIT_ALLOW_PKG=1([\s;&|]|$)/.test(command);
 }
 
-export default async function pkgPolice(_ctx: PluginInput) {
+export default async function pkgPolice(ctx: PluginInput) {
+  const dir = ctx.directory || ctx.worktree || process.cwd();
   return {
     'tool.execute.before': async (
       input: { tool: string; sessionID: string; callID: string },
       output: { args: Record<string, unknown> },
     ): Promise<void> => {
-      const toolName = input.tool?.toLowerCase();
-      if (toolName !== 'bash') return;
-      if (isDisabled()) return;
+      if (input.tool?.toLowerCase() !== 'bash') return;
 
       const command = output.args.command as string | undefined;
       if (!command) return;
       if (isPkgOverride(command)) return;
 
-      const error = detectBlockedPkgManager(command);
-      if (error) {
-        throw new Error(error);
-      }
+      const enforcement = resolveManager(dir);
+      if (!enforcement) return;
+
+      const invocation = detectInvocation(command, enforcement.manager);
+      if (!invocation) return;
+
+      throw new Error(
+        `BLOCKED: '${invocation.label}' — ${enforcement.reason}. `
+          + `Use '${equivalent(enforcement.manager, invocation.action)}'. `
+          + `Override (only when the user approves): prefix with AGENTKIT_ALLOW_PKG=1.`,
+      );
     },
   };
 }

--- a/policies/codex/pkg-police.rules
+++ b/policies/codex/pkg-police.rules
@@ -1,6 +1,11 @@
 # pkg-police.rules — Codex CLI exec policy
 # Blocks: npm, npx, yarn, pnpm commands — enforces bun as package manager
 # Equivalent to: plugins/pkg-police.ts (OpenCode), hooks/claude/pkg-police.sh (Claude Code)
+#
+# Codex exec policies are static and cannot read the agentkit config or look at
+# a lockfile, so this file enforces bun unconditionally. The configurable
+# manager (auto-detection, an explicit manager, off) lives in the OpenCode
+# plugin and the Claude Code hook only.
 
 # ── PACKAGE MANAGER ENFORCEMENT ─────────────────────────────────────────────
 # All JavaScript/TypeScript package management must use bun.

--- a/tests/pkg-police.test.ts
+++ b/tests/pkg-police.test.ts
@@ -1,70 +1,242 @@
-import { beforeAll, describe, expect, test } from 'bun:test';
-import { mkdtempSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import pkgPolice from '../plugins/pkg-police';
 
 const repoRoot = dirname(import.meta.dir);
 const hook = join(repoRoot, 'hooks', 'claude', 'pkg-police.sh');
-const mockCtx = {
-  client: {},
-  project: {},
-  directory: '/tmp',
-  worktree: '/tmp',
-  serverUrl: new URL('http://localhost'),
-  $: {},
-} as any;
 
-function makeInput(command: string) {
-  return {
-    input: { tool: 'bash', sessionID: 'test', callID: 'test' },
-    output: { args: { command } },
-  };
+// /tmp is inode-starved on the build host; /var/tmp is the working scratch.
+const scratch = mkdtempSync('/var/tmp/pkg-police-test-');
+afterAll(() => rmSync(scratch, { recursive: true, force: true }));
+
+type Manager = 'bun' | 'npm' | 'pnpm' | 'yarn';
+
+const LOCKFILE: Record<Manager, string> = {
+  bun: 'bun.lock',
+  npm: 'package-lock.json',
+  pnpm: 'pnpm-lock.yaml',
+  yarn: 'yarn.lock',
+};
+
+const INSTALL: Record<Manager, string> = {
+  bun: 'bun install',
+  npm: 'npm install',
+  pnpm: 'pnpm install',
+  yarn: 'yarn install',
+};
+
+const MANAGERS: Manager[] = ['bun', 'npm', 'pnpm', 'yarn'];
+
+let seq = 0;
+function uniq(prefix: string): string {
+  return join(scratch, `${prefix}-${seq++}`);
 }
 
-function runHook(command: string, env: Record<string, string> = {}): string {
-  const input = JSON.stringify({ tool_input: { command } });
-  return spawnSync('bash', [hook], {
-    input,
+function makeRepo(lockfiles: string[]): string {
+  const dir = uniq('repo');
+  mkdirSync(join(dir, '.git'), { recursive: true });
+  for (const f of lockfiles) writeFileSync(join(dir, f), '');
+  return dir;
+}
+
+function makeConfigHome(body?: string): string {
+  const home = uniq('config');
+  mkdirSync(join(home, 'agentkit'), { recursive: true });
+  if (body !== undefined) writeFileSync(join(home, 'agentkit', 'config.yaml'), body);
+  return home;
+}
+
+const emptyConfigHome = makeConfigHome();
+const noLockRepo = makeRepo([]);
+
+interface RunOpts {
+  cwd?: string;
+  xdg?: string;
+  env?: Record<string, string>;
+}
+
+/** Denial text from the bash hook, or null when the command was allowed. */
+function runHook(command: string, opts: RunOpts = {}): string | null {
+  const result = spawnSync('bash', [hook], {
+    input: JSON.stringify({ tool_input: { command } }),
     encoding: 'utf-8',
-    env: { ...process.env, AGENTKIT_ALLOW_PKG: '', ...env },
-  }).stdout ?? '';
+    cwd: opts.cwd ?? noLockRepo,
+    env: {
+      ...process.env,
+      AGENTKIT_ALLOW_PKG: '',
+      XDG_CONFIG_HOME: opts.xdg ?? emptyConfigHome,
+      ...(opts.env ?? {}),
+    },
+  });
+  const stdout = result.stdout ?? '';
+  if (!stdout.includes('"permissionDecision": "deny"')) return null;
+  return JSON.parse(stdout).reason as string;
 }
 
-beforeAll(() => {
-  // Point the plugin's config lookup at an empty dir so a developer's local
-  // pkg-police.enabled=false cannot flip the blocked-case expectations.
-  process.env.XDG_CONFIG_HOME = mkdtempSync(join(tmpdir(), 'pkg-police-test-'));
+/** Denial text from the OpenCode plugin, or null when the command was allowed. */
+async function runPlugin(command: string, opts: RunOpts = {}): Promise<string | null> {
+  const previousXdg = process.env.XDG_CONFIG_HOME;
+  const previousAllow = process.env.AGENTKIT_ALLOW_PKG;
+  process.env.XDG_CONFIG_HOME = opts.xdg ?? emptyConfigHome;
   delete process.env.AGENTKIT_ALLOW_PKG;
-});
+  for (const [k, v] of Object.entries(opts.env ?? {})) process.env[k] = v;
+  const dir = opts.cwd ?? noLockRepo;
+  try {
+    const hooks = await pkgPolice({ directory: dir, worktree: dir } as never);
+    await hooks['tool.execute.before']!(
+      { tool: 'bash', sessionID: 'test', callID: 'test' },
+      { args: { command } },
+    );
+    return null;
+  } catch (error) {
+    return (error as Error).message;
+  } finally {
+    for (const k of Object.keys(opts.env ?? {})) delete process.env[k];
+    if (previousXdg === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = previousXdg;
+    if (previousAllow !== undefined) process.env.AGENTKIT_ALLOW_PKG = previousAllow;
+  }
+}
 
-describe('Claude pkg-police override', () => {
-  test('denies package managers without the override', () => {
-    expect(runHook('npm ci')).toContain('"permissionDecision": "deny"');
-    expect(runHook('yarn build')).toContain('"permissionDecision": "deny"');
+const IMPLS: Array<[string, (command: string, opts?: RunOpts) => Promise<string | null> | string | null]> = [
+  ['claude hook', runHook],
+  ['opencode plugin', runPlugin],
+];
+
+for (const [name, run] of IMPLS) {
+  describe(`pkg-police auto mode (${name})`, () => {
+    for (const enforced of MANAGERS) {
+      test(`${LOCKFILE[enforced]} enforces ${enforced}`, async () => {
+        const cwd = makeRepo([LOCKFILE[enforced]]);
+        expect(await run(INSTALL[enforced], { cwd })).toBeNull();
+
+        for (const other of MANAGERS.filter((m) => m !== enforced)) {
+          const denial = await run(INSTALL[other], { cwd });
+          expect(denial).toContain(INSTALL[other]);
+          expect(denial).toContain(enforced);
+          expect(denial).toContain(LOCKFILE[enforced]);
+        }
+      });
+    }
+
+    test('bun.lockb is recognised as bun', async () => {
+      const cwd = makeRepo(['bun.lockb']);
+      expect(await run('bun install', { cwd })).toBeNull();
+      expect(await run('npm install', { cwd })).toContain('bun.lockb');
+    });
+
+    test('a lockfile above the working directory still enforces', async () => {
+      const cwd = makeRepo([LOCKFILE.pnpm]);
+      const nested = join(cwd, 'packages', 'app');
+      mkdirSync(nested, { recursive: true });
+      expect(await run('npm install', { cwd: nested })).toContain('pnpm-lock.yaml');
+      expect(await run('pnpm install', { cwd: nested })).toBeNull();
+    });
+
+    test('no lockfile allows every manager', async () => {
+      const cwd = makeRepo([]);
+      for (const m of MANAGERS) expect(await run(INSTALL[m], { cwd })).toBeNull();
+      expect(await run('npx tsc', { cwd })).toBeNull();
+    });
+
+    test('two competing lockfiles allow every manager', async () => {
+      const cwd = makeRepo([LOCKFILE.npm, LOCKFILE.pnpm]);
+      for (const m of MANAGERS) expect(await run(INSTALL[m], { cwd })).toBeNull();
+    });
+
+    test('the exec equivalents map across managers', async () => {
+      const cwd = makeRepo([LOCKFILE.pnpm]);
+      expect(await run('npx tsc --noEmit', { cwd })).toContain('pnpm dlx');
+      expect(await run('bunx tsc --noEmit', { cwd })).toContain('pnpm dlx');
+      expect(await run('pnpm dlx tsc --noEmit', { cwd })).toBeNull();
+    });
+
+    test('bare yarn and pnpm are treated as install', async () => {
+      const cwd = makeRepo([LOCKFILE.npm]);
+      expect(await run('yarn', { cwd })).toContain('npm install');
+      expect(await run('pnpm', { cwd })).toContain('npm install');
+    });
+
+    test('npm shorthands are caught', async () => {
+      const cwd = makeRepo([LOCKFILE.bun]);
+      expect(await run('npm i lodash', { cwd })).toContain('bun add');
+      expect(await run('npm ci', { cwd })).toContain('bun install');
+      expect(await run('npm run build', { cwd })).toContain('bun run');
+    });
   });
 
-  test('inline AGENTKIT_ALLOW_PKG=1 allows the command', () => {
-    expect(runHook('AGENTKIT_ALLOW_PKG=1 npm ci')).not.toContain('deny');
-    expect(runHook('AGENTKIT_ALLOW_PKG=1 yarn build')).not.toContain('deny');
+  describe(`pkg-police configured manager (${name})`, () => {
+    test('manager: npm blocks bun in a bun repo', async () => {
+      const xdg = makeConfigHome('pkg-police:\n  manager: npm\n');
+      const cwd = makeRepo([LOCKFILE.bun]);
+      expect(await run('npm install', { cwd, xdg })).toBeNull();
+      const denial = await run('bun install', { cwd, xdg });
+      expect(denial).toContain('bun install');
+      expect(denial).toContain('npm install');
+      expect(denial).toContain('config');
+      expect(denial).not.toContain('bun.lock');
+    });
+
+    test('manager: off allows everything', async () => {
+      const xdg = makeConfigHome('pkg-police:\n  manager: off\n');
+      const cwd = makeRepo([LOCKFILE.bun]);
+      for (const m of MANAGERS) expect(await run(INSTALL[m], { cwd, xdg })).toBeNull();
+    });
+
+    test('legacy enabled: false allows everything', async () => {
+      const xdg = makeConfigHome('pkg-police:\n  enabled: false\n');
+      const cwd = makeRepo([LOCKFILE.bun]);
+      expect(await run('npm install', { cwd, xdg })).toBeNull();
+    });
+
+    test('manager wins over legacy enabled', async () => {
+      const xdg = makeConfigHome('pkg-police:\n  enabled: false\n  manager: pnpm\n');
+      const cwd = makeRepo([LOCKFILE.bun]);
+      expect(await run('pnpm install', { cwd, xdg })).toBeNull();
+      expect(await run('npm install', { cwd, xdg })).toContain('pnpm install');
+    });
+
+    test('manager: auto falls back to lockfile detection', async () => {
+      const xdg = makeConfigHome('pkg-police:\n  manager: auto\n');
+      const cwd = makeRepo([LOCKFILE.yarn]);
+      expect(await run('yarn add react', { cwd, xdg })).toBeNull();
+      expect(await run('npm install', { cwd, xdg })).toContain('yarn.lock');
+    });
+
+    test('an unknown manager fails safe and allows everything', async () => {
+      const xdg = makeConfigHome('pkg-police:\n  manager: cargo\n');
+      const cwd = makeRepo([LOCKFILE.bun]);
+      for (const m of MANAGERS) expect(await run(INSTALL[m], { cwd, xdg })).toBeNull();
+    });
+
+    test('another section named manager is ignored', async () => {
+      const xdg = makeConfigHome('coding-police:\n  manager: npm\n\npkg-police:\n  manager: pnpm\n');
+      const cwd = makeRepo([]);
+      expect(await run('npm install', { cwd, xdg })).toContain('pnpm install');
+    });
   });
 
-  test('environment AGENTKIT_ALLOW_PKG=1 allows the command', () => {
-    expect(runHook('npm ci', { AGENTKIT_ALLOW_PKG: '1' })).not.toContain('deny');
-  });
+  describe(`pkg-police override (${name})`, () => {
+    test('inline AGENTKIT_ALLOW_PKG=1 allows the command', async () => {
+      const cwd = makeRepo([LOCKFILE.pnpm]);
+      expect(await run('AGENTKIT_ALLOW_PKG=1 npm ci', { cwd })).toBeNull();
+    });
 
-  test('unrelated assignments do not unlock the override', () => {
-    expect(runHook('AGENTKIT_ALLOW_PKG=10 npm ci')).toContain('"permissionDecision": "deny"');
-  });
-});
+    test('environment AGENTKIT_ALLOW_PKG=1 allows the command', async () => {
+      const cwd = makeRepo([LOCKFILE.pnpm]);
+      expect(await run('npm ci', { cwd, env: { AGENTKIT_ALLOW_PKG: '1' } })).toBeNull();
+    });
 
-describe('OpenCode pkg-police override', () => {
-  test('denies without and allows with the inline override', async () => {
-    const hooks = await pkgPolice(mockCtx);
-    const blocked = makeInput('npm ci');
-    expect(hooks['tool.execute.before']!(blocked.input, blocked.output)).rejects.toThrow('bun');
-    const allowed = makeInput('AGENTKIT_ALLOW_PKG=1 npm ci');
-    expect(hooks['tool.execute.before']!(allowed.input, allowed.output)).resolves.toBeUndefined();
+    test('unrelated assignments do not unlock the override', async () => {
+      const cwd = makeRepo([LOCKFILE.pnpm]);
+      expect(await run('AGENTKIT_ALLOW_PKG=10 npm ci', { cwd })).toContain('pnpm install');
+    });
+
+    test('the refusal names the override', async () => {
+      const cwd = makeRepo([LOCKFILE.pnpm]);
+      expect(await run('npm ci', { cwd })).toContain('AGENTKIT_ALLOW_PKG=1');
+    });
   });
-});
+}


### PR DESCRIPTION
Closes #193. Default `auto` infers the enforced manager from the repo's lockfile; explicit `manager:` overrides; `off` disables. Both implementations now share semantics and refusal text (the bash hook previously ignored config entirely).

Executor-built TDD; my independent verification: 44/44 slice, preflight green, and an e2e probe under **real bash 3.2** in a pnpm repo from a nested subdir — parses clean, npm/yarn denied naming pnpm-lock.yaml, pnpm allowed. Notable catch during development: an inline regex form bash 3.2 cannot parse, which in a PreToolUse hook would have denied every command on macOS with the kill switch unreachable.