### PR TITLE
fix(pkg-police): three regressions shipped in v0.4.3, plus a Codex policy gap

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,8 +500,19 @@ platforms (OpenCode plugin, Claude Code hook, Codex policy). Checks:
 All thresholds are configurable via `coding-police` in your config. See [Configuration](#configuration).
 
 **pkg-police**: Keeps one JavaScript/TypeScript package manager per project. It intercepts bash
-commands before execution and blocks the managers the project does not use, naming the equivalent
-command in the one it does.
+commands before execution and blocks the other managers, naming the equivalent command in the one
+the project does use. A managed invocation is caught anywhere in the command, so
+`npm ls && npm install` is blocked too.
+
+`pnpm` and `yarn` are package managers whatever the subcommand, so every `pnpm`/`yarn` command is
+blocked. `npm` and `bun` are blocked per subcommand — every one that writes `package.json`,
+`node_modules` or the lockfile (`install`, `ci`, `add`, `remove`/`uninstall`/`rm`, `update`, `link`,
+`prune`, `dedupe`, `run`, `test`, `init`, `publish`, `create`, `exec`/`x`, and their aliases) plus
+`npx`/`bunx`. Read-only queries are deliberately allowed, because they change nothing: `npm ls`,
+`npm view`, `npm outdated`, `npm whoami`, and `bun ./script.ts` (bun is also a runtime). `npm pkg`
+and `npm version` are allowed as well — they edit manifest fields with no cross-manager equivalent
+to suggest. The list is an allow-list of names, not a proof: a subcommand it does not know about
+passes.
 
 By default the enforced manager is inferred from the repository's lockfile, found by walking up
 from the working directory to the git root:
@@ -516,8 +527,9 @@ from the working directory to the git root:
 
 Set `pkg-police.manager` in your agentkit config to `bun`, `npm`, `pnpm`, or `yarn` to enforce one
 everywhere regardless of the lockfile, `auto` for the lockfile default, or `off` to disable the
-unit. An unrecognized value disables it rather than guessing. (The older `enabled: false` still
-reads as `off`; `manager` wins when both are present.)
+unit. Quoting the value is fine (`manager: "bun"`), and a value with trailing junk reads as its
+first word. An unrecognized name disables the unit rather than guessing. (The older `enabled: false`
+still reads as `off`; `manager` wins when both are present.)
 
 Equivalents are mapped across managers, so a blocked `npx tsc` in a pnpm project asks for
 `pnpm dlx tsc`, and a blocked `npm i lodash` in a bun project asks for `bun add`.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -74,9 +74,12 @@ pkg-police:
   #           means there is no basis to judge and nothing is blocked.
   #   bun | npm | pnpm | yarn — enforce that one whatever the lockfile says.
   #   off   — disable the unit entirely.
-  # Commands belonging to any other manager are blocked, with the equivalent
-  # command in the enforced one. AGENTKIT_ALLOW_PKG=1 overrides a single
-  # command regardless of this setting.
+  # An unrecognised name disables the unit; quoting the value is fine.
+  # Every pnpm/yarn command belonging to another manager is blocked, as is every
+  # npm/bun subcommand that writes package.json, node_modules or the lockfile —
+  # read-only queries such as `npm ls` are left alone. The refusal names the
+  # equivalent command in the enforced manager. AGENTKIT_ALLOW_PKG=1 overrides a
+  # single command regardless of this setting.
   manager: auto
 
 version-police:

--- a/hooks/claude/pkg-police.sh
+++ b/hooks/claude/pkg-police.sh
@@ -10,13 +10,24 @@ AGENTKIT_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/agentkit/config.yaml"
 CONFIG_MANAGER=""
 CONFIG_ENABLED=""
 
+# Quoting a scalar is legal YAML, so `manager: "bun"` must read as bun rather
+# than as an unrecognised value that silently disables the unit.
+unquote() {
+  local value="$1"
+  value="${value%\"}"
+  value="${value#\"}"
+  value="${value%\'}"
+  value="${value#\'}"
+  printf '%s' "$value"
+}
+
 load_config() {
   [[ -f "$AGENTKIT_CONFIG" ]] || return 0
   local key value
   while IFS='=' read -r key value; do
     case "$key" in
-      manager) CONFIG_MANAGER="$value" ;;
-      enabled) CONFIG_ENABLED="$value" ;;
+      manager) CONFIG_MANAGER=$(unquote "$value") ;;
+      enabled) CONFIG_ENABLED=$(unquote "$value") ;;
     esac
   done < <(awk '
     /^[^[:space:]#]/ {
@@ -26,7 +37,7 @@ load_config() {
     in_section {
       line = $0
       sub(/^[[:space:]]+/, "", line)
-      if (line !~ /^(manager|enabled):[[:space:]]*[^[:space:]#]+([[:space:]]*#.*)?$/) next
+      if (line !~ /^(manager|enabled):[[:space:]]*[^[:space:]#]/) next
       key = line
       sub(/:.*/, "", key)
       sub(/^[^:]*:[[:space:]]*/, "", line)
@@ -89,11 +100,25 @@ resolve_manager() {
 
 # ── Command classification ──────────────────────────────────────────────────
 BOUND='[^[:alnum:]_-]'
-ARG='([[:space:]]+([^-[:space:]][^[:space:]]*))?'
+# What may follow the command: an operator, a quote, or nothing — but never a
+# character that continues a filename. `cat yarn.lock` names a lockfile and
+# `npm installer` is not npm install, while `npm install; x` and
+# `sh -c "npm ci"` really do invoke the manager.
+TAIL='($|[^[:alnum:]_./-])'
+# A package argument, never a shell operator: `npm install && npm ls` installs
+# the manifest, so its remediation is `install`, not `add &&`.
+ARG='([[:space:]]+([^-;&|<>()[:space:]][^;&|<>()[:space:]]*))?'
+# Every subcommand that rewrites package.json, node_modules or the lockfile,
+# with its aliases. Longest alternative first: JS alternation is ordered, so `i`
+# before `install` would match the prefix and then fail the trailing boundary.
+NPM_SUBS='install-ci-test|install-test|install|uninstall|init|it|i|cit|ci|add|run|remove|rm|r|update|upgrade|up|link|ln|unlink|un|test|publish|prune|dedupe|ddp|exec|create'
+BUN_SUBS='install|init|i|add|run|remove|rm|update|link|unlink|test|publish|create|x'
 
 DETECTED_LABEL=""
 DETECTED_ACTION=""
 
+# The remediation is a command the user should type, so it is always the
+# canonical lowercase form even when the blocked command was not.
 action_for() {
   local sub="$1" arg="$2"
   case "$sub" in
@@ -101,39 +126,48 @@ action_for() {
       [[ -n "$arg" ]] && printf 'add' || printf 'install'
       ;;
     add) printf 'add' ;;
+    uninstall | un | unlink | remove | rm | r) printf 'remove' ;;
+    update | up | upgrade) printf 'update' ;;
+    link | ln) printf 'link' ;;
+    # Reconciling node_modules with the manifest is what a plain install does.
+    prune | dedupe | ddp) printf 'install' ;;
+    install-test | install-ci-test | it | cit) printf 'install' ;;
     exec | dlx | x) printf 'exec' ;;
-    run | test | init | publish | create) printf '%s' "$sub" ;;
+    run) printf 'run' ;;
+    test) printf 'test' ;;
+    init) printf 'init' ;;
+    publish) printf 'publish' ;;
+    create) printf 'create' ;;
     *) printf 'run' ;;
   esac
 }
 
 # npm and bun are runtimes too, so only their package-management subcommands
-# count; pnpm and yarn are package managers whatever the subcommand.
-subcommand_is_managed() {
-  case "$1:$2" in
-    npm:install | npm:i | npm:ci | npm:add | npm:run | npm:test | npm:init | npm:publish | npm:exec | npm:create) return 0 ;;
-    bun:install | bun:i | bun:add | bun:run | bun:test | bun:init | bun:publish | bun:create | bun:x) return 0 ;;
-    *) return 1 ;;
-  esac
-}
-
-detect_invocation() {
-  local cmd="$1" skip="$2" mgr sub arg exe re
+# count; pnpm and yarn are package managers whatever the subcommand. The
+# subcommands live in the pattern rather than in a test after the match, so a
+# managed invocation is found anywhere in the command instead of only at the
+# leftmost `npm <word>` — `npm ls && npm install` must still be caught.
+detect_invocation_inner() {
+  local cmd="$1" skip="$2" mgr sub arg exe re subs
   for mgr in npm bun; do
     [[ "$mgr" == "$skip" ]] && continue
-    exe="npx"
-    [[ "$mgr" == bun ]] && exe="bunx"
+    if [[ "$mgr" == bun ]]; then
+      exe="bunx"
+      subs="$BUN_SUBS"
+    else
+      exe="npx"
+      subs="$NPM_SUBS"
+    fi
     re="(^|$BOUND)${exe}[[:space:]]"
     if [[ "$cmd" =~ $re ]]; then
       DETECTED_LABEL="$exe"
       DETECTED_ACTION="exec"
       return 0
     fi
-    re="(^|$BOUND)${mgr}[[:space:]]+([[:alnum:]:@._-]+)$ARG"
+    re="(^|$BOUND)${mgr}[[:space:]]+($subs)$ARG$TAIL"
     if [[ "$cmd" =~ $re ]]; then
       sub="${BASH_REMATCH[2]}"
       arg="${BASH_REMATCH[4]}"
-      subcommand_is_managed "$mgr" "$sub" || continue
       DETECTED_LABEL="$mgr $sub"
       DETECTED_ACTION=$(action_for "$sub" "$arg")
       return 0
@@ -141,7 +175,7 @@ detect_invocation() {
   done
   for mgr in pnpm yarn; do
     [[ "$mgr" == "$skip" ]] && continue
-    re="(^|$BOUND)${mgr}([[:space:]]+([[:alnum:]:@._-]+))?$ARG($|$BOUND)"
+    re="(^|$BOUND)${mgr}([[:space:]]+([[:alnum:]:@._-]+))?$ARG$TAIL"
     if [[ "$cmd" =~ $re ]]; then
       sub="${BASH_REMATCH[3]}"
       arg="${BASH_REMATCH[5]}"
@@ -151,6 +185,20 @@ detect_invocation() {
     fi
   done
   return 1
+}
+
+# macOS filesystems are case-insensitive, so `NPM install` really does run npm.
+# nocasematch is global state: set it around the matching only, and restore
+# whatever the caller had on every exit path.
+detect_invocation() {
+  local restore status=0
+  # `shopt -p` exits 1 when the option is unset, and a bare non-zero exit from
+  # this hook fails open.
+  restore=$(shopt -p nocasematch) || true
+  shopt -s nocasematch
+  detect_invocation_inner "$1" "$2" || status=$?
+  eval "$restore"
+  return "$status"
 }
 
 equivalent() {

--- a/plugins-cc/agentkit/hooks/pkg-police.sh
+++ b/plugins-cc/agentkit/hooks/pkg-police.sh
@@ -10,13 +10,24 @@ AGENTKIT_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/agentkit/config.yaml"
 CONFIG_MANAGER=""
 CONFIG_ENABLED=""
 
+# Quoting a scalar is legal YAML, so `manager: "bun"` must read as bun rather
+# than as an unrecognised value that silently disables the unit.
+unquote() {
+  local value="$1"
+  value="${value%\"}"
+  value="${value#\"}"
+  value="${value%\'}"
+  value="${value#\'}"
+  printf '%s' "$value"
+}
+
 load_config() {
   [[ -f "$AGENTKIT_CONFIG" ]] || return 0
   local key value
   while IFS='=' read -r key value; do
     case "$key" in
-      manager) CONFIG_MANAGER="$value" ;;
-      enabled) CONFIG_ENABLED="$value" ;;
+      manager) CONFIG_MANAGER=$(unquote "$value") ;;
+      enabled) CONFIG_ENABLED=$(unquote "$value") ;;
     esac
   done < <(awk '
     /^[^[:space:]#]/ {
@@ -26,7 +37,7 @@ load_config() {
     in_section {
       line = $0
       sub(/^[[:space:]]+/, "", line)
-      if (line !~ /^(manager|enabled):[[:space:]]*[^[:space:]#]+([[:space:]]*#.*)?$/) next
+      if (line !~ /^(manager|enabled):[[:space:]]*[^[:space:]#]/) next
       key = line
       sub(/:.*/, "", key)
       sub(/^[^:]*:[[:space:]]*/, "", line)
@@ -89,11 +100,25 @@ resolve_manager() {
 
 # ── Command classification ──────────────────────────────────────────────────
 BOUND='[^[:alnum:]_-]'
-ARG='([[:space:]]+([^-[:space:]][^[:space:]]*))?'
+# What may follow the command: an operator, a quote, or nothing — but never a
+# character that continues a filename. `cat yarn.lock` names a lockfile and
+# `npm installer` is not npm install, while `npm install; x` and
+# `sh -c "npm ci"` really do invoke the manager.
+TAIL='($|[^[:alnum:]_./-])'
+# A package argument, never a shell operator: `npm install && npm ls` installs
+# the manifest, so its remediation is `install`, not `add &&`.
+ARG='([[:space:]]+([^-;&|<>()[:space:]][^;&|<>()[:space:]]*))?'
+# Every subcommand that rewrites package.json, node_modules or the lockfile,
+# with its aliases. Longest alternative first: JS alternation is ordered, so `i`
+# before `install` would match the prefix and then fail the trailing boundary.
+NPM_SUBS='install-ci-test|install-test|install|uninstall|init|it|i|cit|ci|add|run|remove|rm|r|update|upgrade|up|link|ln|unlink|un|test|publish|prune|dedupe|ddp|exec|create'
+BUN_SUBS='install|init|i|add|run|remove|rm|update|link|unlink|test|publish|create|x'
 
 DETECTED_LABEL=""
 DETECTED_ACTION=""
 
+# The remediation is a command the user should type, so it is always the
+# canonical lowercase form even when the blocked command was not.
 action_for() {
   local sub="$1" arg="$2"
   case "$sub" in
@@ -101,39 +126,48 @@ action_for() {
       [[ -n "$arg" ]] && printf 'add' || printf 'install'
       ;;
     add) printf 'add' ;;
+    uninstall | un | unlink | remove | rm | r) printf 'remove' ;;
+    update | up | upgrade) printf 'update' ;;
+    link | ln) printf 'link' ;;
+    # Reconciling node_modules with the manifest is what a plain install does.
+    prune | dedupe | ddp) printf 'install' ;;
+    install-test | install-ci-test | it | cit) printf 'install' ;;
     exec | dlx | x) printf 'exec' ;;
-    run | test | init | publish | create) printf '%s' "$sub" ;;
+    run) printf 'run' ;;
+    test) printf 'test' ;;
+    init) printf 'init' ;;
+    publish) printf 'publish' ;;
+    create) printf 'create' ;;
     *) printf 'run' ;;
   esac
 }
 
 # npm and bun are runtimes too, so only their package-management subcommands
-# count; pnpm and yarn are package managers whatever the subcommand.
-subcommand_is_managed() {
-  case "$1:$2" in
-    npm:install | npm:i | npm:ci | npm:add | npm:run | npm:test | npm:init | npm:publish | npm:exec | npm:create) return 0 ;;
-    bun:install | bun:i | bun:add | bun:run | bun:test | bun:init | bun:publish | bun:create | bun:x) return 0 ;;
-    *) return 1 ;;
-  esac
-}
-
-detect_invocation() {
-  local cmd="$1" skip="$2" mgr sub arg exe re
+# count; pnpm and yarn are package managers whatever the subcommand. The
+# subcommands live in the pattern rather than in a test after the match, so a
+# managed invocation is found anywhere in the command instead of only at the
+# leftmost `npm <word>` — `npm ls && npm install` must still be caught.
+detect_invocation_inner() {
+  local cmd="$1" skip="$2" mgr sub arg exe re subs
   for mgr in npm bun; do
     [[ "$mgr" == "$skip" ]] && continue
-    exe="npx"
-    [[ "$mgr" == bun ]] && exe="bunx"
+    if [[ "$mgr" == bun ]]; then
+      exe="bunx"
+      subs="$BUN_SUBS"
+    else
+      exe="npx"
+      subs="$NPM_SUBS"
+    fi
     re="(^|$BOUND)${exe}[[:space:]]"
     if [[ "$cmd" =~ $re ]]; then
       DETECTED_LABEL="$exe"
       DETECTED_ACTION="exec"
       return 0
     fi
-    re="(^|$BOUND)${mgr}[[:space:]]+([[:alnum:]:@._-]+)$ARG"
+    re="(^|$BOUND)${mgr}[[:space:]]+($subs)$ARG$TAIL"
     if [[ "$cmd" =~ $re ]]; then
       sub="${BASH_REMATCH[2]}"
       arg="${BASH_REMATCH[4]}"
-      subcommand_is_managed "$mgr" "$sub" || continue
       DETECTED_LABEL="$mgr $sub"
       DETECTED_ACTION=$(action_for "$sub" "$arg")
       return 0
@@ -141,7 +175,7 @@ detect_invocation() {
   done
   for mgr in pnpm yarn; do
     [[ "$mgr" == "$skip" ]] && continue
-    re="(^|$BOUND)${mgr}([[:space:]]+([[:alnum:]:@._-]+))?$ARG($|$BOUND)"
+    re="(^|$BOUND)${mgr}([[:space:]]+([[:alnum:]:@._-]+))?$ARG$TAIL"
     if [[ "$cmd" =~ $re ]]; then
       sub="${BASH_REMATCH[3]}"
       arg="${BASH_REMATCH[5]}"
@@ -151,6 +185,20 @@ detect_invocation() {
     fi
   done
   return 1
+}
+
+# macOS filesystems are case-insensitive, so `NPM install` really does run npm.
+# nocasematch is global state: set it around the matching only, and restore
+# whatever the caller had on every exit path.
+detect_invocation() {
+  local restore status=0
+  # `shopt -p` exits 1 when the option is unset, and a bare non-zero exit from
+  # this hook fails open.
+  restore=$(shopt -p nocasematch) || true
+  shopt -s nocasematch
+  detect_invocation_inner "$1" "$2" || status=$?
+  eval "$restore"
+  return "$status"
 }
 
 equivalent() {

--- a/plugins/pkg-police.ts
+++ b/plugins/pkg-police.ts
@@ -15,13 +15,21 @@ const LOCKFILES: Array<[Manager, string]> = [
   ['yarn', 'yarn.lock'],
 ];
 
-const MANAGED_SUBCOMMANDS: Record<'npm' | 'bun', string[]> = {
-  npm: ['install', 'i', 'ci', 'add', 'run', 'test', 'init', 'publish', 'exec', 'create'],
-  bun: ['install', 'i', 'add', 'run', 'test', 'init', 'publish', 'create', 'x'],
+// Every subcommand that rewrites package.json, node_modules or the lockfile,
+// with its aliases. Longest alternative first — `i` before `install` matches
+// the prefix and then fails the trailing boundary.
+const MANAGED_SUBCOMMANDS: Record<'npm' | 'bun', string> = {
+  npm:
+    'install-ci-test|install-test|install|uninstall|init|it|i|cit|ci|add|run|remove|rm|r|update|upgrade|up|link|ln|unlink|un|test|publish|prune|dedupe|ddp|exec|create',
+  bun: 'install|init|i|add|run|remove|rm|update|link|unlink|test|publish|create|x',
 };
 
 const BOUND = '[^A-Za-z0-9_-]';
-const ARG = '(?:\\s+([^-\\s]\\S*))?';
+// What may follow the command: an operator, a quote, or nothing — but never a
+// character that continues a filename (`cat yarn.lock`, `npm installer`).
+const TAIL = '($|[^A-Za-z0-9_./-])';
+// A package argument, never a shell operator.
+const ARG = '(?:\\s+([^-;&|<>()\\s][^;&|<>()\\s]*))?';
 
 interface Enforcement {
   manager: Manager;
@@ -36,6 +44,12 @@ interface Invocation {
 function configPath(): string {
   const xdg = process.env.XDG_CONFIG_HOME || join(homedir(), '.config');
   return join(xdg, 'agentkit', 'config.yaml');
+}
+
+// Quoting a scalar is legal YAML, so `manager: "bun"` must read as bun rather
+// than as an unrecognised value that silently disables the unit.
+function unquote(value: string): string {
+  return value.replace(/^["']/, '').replace(/["']$/, '');
 }
 
 function readConfigSection(): { manager?: string; enabled?: string } {
@@ -54,7 +68,7 @@ function readConfigSection(): { manager?: string; enabled?: string } {
     }
     if (!inSection) continue;
     const match = /^\s+(manager|enabled):\s*([^\s#]+)/.exec(line);
-    if (match) values[match[1]!] = match[2]!.toLowerCase();
+    if (match) values[match[1]!] = unquote(match[2]!.toLowerCase());
   }
   return values;
 }
@@ -107,23 +121,53 @@ function actionFor(subcommand: string, arg: string | undefined): string {
       return arg ? 'add' : 'install';
     case 'add':
       return 'add';
+    case 'uninstall':
+    case 'un':
+    case 'unlink':
+    case 'remove':
+    case 'rm':
+    case 'r':
+      return 'remove';
+    case 'update':
+    case 'up':
+    case 'upgrade':
+      return 'update';
+    case 'link':
+    case 'ln':
+      return 'link';
+    // Reconciling node_modules with the manifest is what a plain install does.
+    case 'prune':
+    case 'dedupe':
+    case 'ddp':
+    case 'install-test':
+    case 'install-ci-test':
+    case 'it':
+    case 'cit':
+      return 'install';
     case 'exec':
     case 'dlx':
     case 'x':
       return 'exec';
     case 'run':
+      return 'run';
     case 'test':
+      return 'test';
     case 'init':
+      return 'init';
     case 'publish':
+      return 'publish';
     case 'create':
-      return subcommand;
+      return 'create';
     default:
       return 'run';
   }
 }
 
 // npm and bun are runtimes too, so only their package-management subcommands
-// count; pnpm and yarn are package managers whatever the subcommand.
+// count; pnpm and yarn are package managers whatever the subcommand. The
+// subcommands live in the pattern rather than in a test after the match, so a
+// managed invocation is found anywhere in the command instead of only at the
+// leftmost `npm <word>` — `npm ls && npm install` must still be caught.
 function detectInvocation(command: string, skip: Manager): Invocation | null {
   for (const manager of ['npm', 'bun'] as const) {
     if (manager === skip) continue;
@@ -131,19 +175,20 @@ function detectInvocation(command: string, skip: Manager): Invocation | null {
     if (new RegExp(`(^|${BOUND})${exe}\\s`, 'i').test(command)) {
       return { label: exe, action: 'exec' };
     }
-    const match = new RegExp(`(^|${BOUND})${manager}\\s+([\\w:@.-]+)${ARG}`, 'i').exec(command);
+    const subs = MANAGED_SUBCOMMANDS[manager];
+    const pattern = `(^|${BOUND})${manager}\\s+(${subs})${ARG}${TAIL}`;
+    const match = new RegExp(pattern, 'i').exec(command);
     if (!match) continue;
-    const sub = match[2]!.toLowerCase();
-    if (!MANAGED_SUBCOMMANDS[manager].includes(sub)) continue;
-    return { label: `${manager} ${sub}`, action: actionFor(sub, match[3]) };
+    const sub = match[2]!;
+    return { label: `${manager} ${sub}`, action: actionFor(sub.toLowerCase(), match[3]) };
   }
   for (const manager of ['pnpm', 'yarn'] as const) {
     if (manager === skip) continue;
-    const pattern = `(^|${BOUND})${manager}(?:\\s+([\\w:@.-]+))?${ARG}($|${BOUND})`;
+    const pattern = `(^|${BOUND})${manager}(?:\\s+([\\w:@.-]+))?${ARG}${TAIL}`;
     const match = new RegExp(pattern, 'i').exec(command);
     if (!match) continue;
-    const sub = (match[2] ?? '').toLowerCase();
-    return { label: sub ? `${manager} ${sub}` : manager, action: actionFor(sub, match[3]) };
+    const sub = match[2] ?? '';
+    return { label: sub ? `${manager} ${sub}` : manager, action: actionFor(sub.toLowerCase(), match[3]) };
   }
   return null;
 }

--- a/policies/codex/pkg-police.rules
+++ b/policies/codex/pkg-police.rules
@@ -12,15 +12,18 @@
 # npm, npx, yarn, and pnpm are blocked unless the user explicitly overrides.
 
 prefix_rule(
-    pattern = ["npm", ["install", "i", "ci", "run", "test", "init", "publish", "exec", "create"]],
+    pattern = ["npm", ["install-ci-test", "install-test", "install", "uninstall", "init", "it", "i", "cit", "ci", "add", "run", "remove", "rm", "r", "update", "upgrade", "up", "link", "ln", "unlink", "un", "test", "publish", "prune", "dedupe", "ddp", "exec", "create"]],
     decision = "forbidden",
-    justification = "npm is not allowed. Use bun instead: npm install → bun install, npm run → bun run, npm test → bun test.",
+    justification = "npm is not allowed. Use bun instead: npm install → bun install, npm run → bun run, npm test → bun test, npm uninstall → bun remove.",
     match = [
         "npm install",
         "npm i express",
+        "npm add express",
         "npm run build",
         "npm test",
         "npm ci",
+        "npm uninstall express",
+        "npm update",
     ],
     not_match = [
         "bun install",

--- a/tests/pkg-police.test.ts
+++ b/tests/pkg-police.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, describe, expect, test } from 'bun:test';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import pkgPolice from '../plugins/pkg-police';
@@ -104,6 +104,19 @@ async function runPlugin(command: string, opts: RunOpts = {}): Promise<string | 
     if (previousAllow !== undefined) process.env.AGENTKIT_ALLOW_PKG = previousAllow;
   }
 }
+
+describe('pkg-police surfaces agree on the npm subcommands', () => {
+  test('the Codex static policy lists what the hook matches', () => {
+    const script = readFileSync(hook, 'utf-8');
+    const subs = /^NPM_SUBS='([^']+)'/m.exec(script)?.[1]?.split('|');
+    expect(subs?.length).toBeGreaterThan(10);
+
+    const rules = readFileSync(join(repoRoot, 'policies', 'codex', 'pkg-police.rules'), 'utf-8');
+    const listed = /pattern = \["npm", \[([^\]]+)\]\]/.exec(rules)?.[1];
+    const names = listed?.match(/"([^"]+)"/g)?.map((q) => q.slice(1, -1));
+    expect(new Set(names)).toEqual(new Set(subs));
+  });
+});
 
 const IMPLS: Array<[string, (command: string, opts?: RunOpts) => Promise<string | null> | string | null]> = [
   ['claude hook', runHook],

--- a/tests/pkg-police.test.ts
+++ b/tests/pkg-police.test.ts
@@ -70,6 +70,11 @@ function runHook(command: string, opts: RunOpts = {}): string | null {
       ...(opts.env ?? {}),
     },
   });
+  // A non-zero exit that is not 2 is a silently allowed command, so every path
+  // through the hook must exit 0 — including the ones that die under `set -e`.
+  if (result.status !== 0) {
+    throw new Error(`hook exited ${result.status}: ${result.stderr ?? ''}`);
+  }
   const stdout = result.stdout ?? '';
   if (!stdout.includes('"permissionDecision": "deny"')) return null;
   return JSON.parse(stdout).reason as string;
@@ -159,6 +164,24 @@ for (const [name, run] of IMPLS) {
       expect(await run('pnpm', { cwd })).toContain('npm install');
     });
 
+    test('subcommands that rewrite the manifest or lockfile are caught', async () => {
+      const cwd = makeRepo([LOCKFILE.bun]);
+      expect(await run('npm uninstall lodash', { cwd })).toContain('bun remove');
+      expect(await run('npm rm lodash', { cwd })).toContain('bun remove');
+      expect(await run('npm un lodash', { cwd })).toContain('bun remove');
+      expect(await run('npm update', { cwd })).toContain('bun update');
+      expect(await run('npm up', { cwd })).toContain('bun update');
+      expect(await run('npm link ../lib', { cwd })).toContain('bun link');
+      expect(await run('npm dedupe', { cwd })).toContain('bun install');
+      expect(await run('npm prune', { cwd })).toContain('bun install');
+      expect(await run('npm install-test', { cwd })).toContain('bun install');
+      expect(await run('npm it', { cwd })).toContain('bun install');
+
+      const npmRepo = makeRepo([LOCKFILE.npm]);
+      expect(await run('bun remove lodash', { cwd: npmRepo })).toContain('npm remove');
+      expect(await run('bun update', { cwd: npmRepo })).toContain('npm update');
+    });
+
     test('npm shorthands are caught', async () => {
       const cwd = makeRepo([LOCKFILE.bun]);
       expect(await run('npm i lodash', { cwd })).toContain('bun add');
@@ -211,10 +234,104 @@ for (const [name, run] of IMPLS) {
       for (const m of MANAGERS) expect(await run(INSTALL[m], { cwd, xdg })).toBeNull();
     });
 
+    test('a quoted manager value is honored', async () => {
+      const cwd = makeRepo([LOCKFILE.npm]);
+      for (const body of ['pkg-police:\n  manager: "bun"\n', "pkg-police:\n  manager: 'bun'\n"]) {
+        const xdg = makeConfigHome(body);
+        expect(await run('bun install', { cwd, xdg })).toBeNull();
+        const denial = await run('npm install', { cwd, xdg });
+        expect(denial).toContain('bun install');
+        expect(denial).toContain('config');
+      }
+    });
+
+    test('a malformed manager value reads its first token', async () => {
+      const xdg = makeConfigHome('pkg-police:\n  manager: npm oops\n');
+      const cwd = makeRepo([LOCKFILE.bun]);
+      expect(await run('npm install', { cwd, xdg })).toBeNull();
+      expect(await run('bun install', { cwd, xdg })).toContain('npm install');
+    });
+
     test('another section named manager is ignored', async () => {
       const xdg = makeConfigHome('coding-police:\n  manager: npm\n\npkg-police:\n  manager: pnpm\n');
       const cwd = makeRepo([]);
       expect(await run('npm install', { cwd, xdg })).toContain('pnpm install');
+    });
+  });
+
+  describe(`pkg-police compound commands (${name})`, () => {
+    test('a managed invocation later in the command is caught', async () => {
+      const cwd = makeRepo([LOCKFILE.bun]);
+      expect(await run('npm --version && npm install', { cwd })).toContain('bun install');
+      expect(await run('npm ls && npm install', { cwd })).toContain('bun install');
+      expect(await run('echo hello npm world; npm ci', { cwd })).toContain('bun install');
+      expect(await run('true; npm install lodash', { cwd })).toContain('bun add');
+    });
+
+    test('an operator or quote after the command still counts as an invocation', async () => {
+      const cwd = makeRepo([LOCKFILE.bun]);
+      expect(await run('npm install && npm ls', { cwd })).toContain('bun install');
+      expect(await run('npm install; echo done', { cwd })).toContain('bun install');
+      expect(await run('npm install|tee log', { cwd })).toContain('bun install');
+      expect(await run('bash -c "npm ci"', { cwd })).toContain('bun install');
+      expect(await run("sh -c 'npm run build'", { cwd })).toContain('bun run');
+      expect(await run('(npm install)', { cwd })).toContain('bun install');
+    });
+
+    test('a longer word starting with a managed subcommand is not an invocation', async () => {
+      const cwd = makeRepo([LOCKFILE.bun]);
+      expect(await run('npm installer', { cwd })).toBeNull();
+      expect(await run('npm testing', { cwd })).toBeNull();
+    });
+
+    test('npm and bun subcommands outside package management are allowed', async () => {
+      const bunRepo = makeRepo([LOCKFILE.bun]);
+      expect(await run('npm whoami', { cwd: bunRepo })).toBeNull();
+      expect(await run('npm view lodash version', { cwd: bunRepo })).toBeNull();
+      expect(await run('npm ls', { cwd: bunRepo })).toBeNull();
+      expect(await run('echo hello npm world', { cwd: bunRepo })).toBeNull();
+
+      const npmRepo = makeRepo([LOCKFILE.npm]);
+      expect(await run('bun ./script.ts', { cwd: npmRepo })).toBeNull();
+      expect(await run('bun --version', { cwd: npmRepo })).toBeNull();
+    });
+  });
+
+  describe(`pkg-police lockfile names (${name})`, () => {
+    test('naming a lockfile is not an invocation', async () => {
+      const cwd = makeRepo([LOCKFILE.bun]);
+      for (const command of [
+        'rm -f yarn.lock',
+        'git add yarn.lock',
+        'cat yarn.lock',
+        'cat pnpm-lock.yaml',
+        'rm yarn.lock pnpm-lock.yaml',
+        'wc -l ./packages/app/yarn.lock',
+      ]) {
+        expect(await run(command, { cwd })).toBeNull();
+      }
+    });
+  });
+
+  describe(`pkg-police case-insensitivity (${name})`, () => {
+    test('an uppercased manager still counts', async () => {
+      const cwd = makeRepo([LOCKFILE.bun]);
+      expect(await run('NPM install', { cwd })).toContain('bun install');
+      expect(await run('NPX tsc', { cwd })).toContain('bunx');
+      expect(await run('Npm Run build', { cwd })).toContain('bun run');
+      const npmRepo = makeRepo([LOCKFILE.npm]);
+      expect(await run('YARN add react', { cwd: npmRepo })).toContain('npm add');
+    });
+  });
+
+  describe(`pkg-police lockfile walk (${name})`, () => {
+    test('the walk stops at the git root', async () => {
+      const outer = uniq('outer');
+      const inner = join(outer, 'project');
+      mkdirSync(join(inner, '.git'), { recursive: true });
+      writeFileSync(join(outer, LOCKFILE.bun), '');
+      // The bun.lock sits outside the repository, so nothing is enforced.
+      for (const m of MANAGERS) expect(await run(INSTALL[m], { cwd: inner })).toBeNull();
     });
   });
 


### PR DESCRIPTION
v0.4.3 shipped a `pkg-police` weaker than v0.4.1's. Three regressions, confirmed by running the
released hook against the v0.4.1 hook on the same inputs in a `bun.lock` repo:

| Command | v0.4.3 | v0.4.1 | now |
| --- | --- | --- | --- |
| `npm ls && npm install` | **ALLOW** | DENY | DENY |
| `echo hello npm world; npm ci` | **ALLOW** | DENY | DENY |
| `rm -f yarn.lock` | **DENY** | ALLOW | ALLOW |
| `cat yarn.lock` | **DENY** | ALLOW | ALLOW |
| `NPM install` | **ALLOW** | DENY | DENY |
| `npm install` (no lockfile) | ALLOW | DENY | ALLOW — intended, kept |

## Causes

1. **Only the leftmost match was considered.** The regex captured the first `npm <word>` and
   `continue`d off the manager when that word was unmanaged, so every compound command escaped. The
   managed subcommands are now in the pattern, so a managed invocation is found anywhere in the
   string — no loop, nothing to prove about termination.
2. **The lockfile-name arm ended on any non-alphanumeric**, so `yarn.lock` matched `yarn` with an
   empty subcommand and read as a bare install. The tail now rejects filename characters while still
   accepting shell operators — the first attempt used whitespace-or-end and opened a new hole
   (`npm install; echo done` escaped).
3. **The bash hook lost case-insensitivity** while the plugin kept it, so `NPM install` failed open
   on Claude Code — on macOS, where the filesystem is case-insensitive and the bash-3.2 constraint in
   this file exists to serve.

Also fixed: `manager: "bun"` (quoted, legal YAML) silently disabled the whole unit; the two parsers
disagreed on a malformed value; and `policies/codex/pkg-police.rules` listed no mutators, so
`npm add` and `npm uninstall` passed on Codex while the hook refused them. A test now compares the
policy against the hook's list so they cannot drift.

`npm uninstall`/`update`/`link`/`prune` and their aliases are now blocked — they rewrite the
manifest and lockfile, which is the harm the unit exists to prevent. `README.md` no longer claims to
block "the managers the project does not use"; it states that it is an allow-list of names.

## Verification

- 65 pass / 0 fail (was 44). **Tests written first and proven red**: reverted to `7d0efd5` they give
  10 failures across all five defects.
- **Two assertions that could not fail** are now covered — deleting the git-root stop, and widening
  the subcommand match, each previously left the suite at 44/0.
- Mutation-tested: 6 mutants, each kills a test. A top-level `set -e` death now fails 29 tests via a
  new assertion that the hook always exits 0 — a non-zero exit that is not 2 is a silently allowed
  command.
- 74 hand-picked commands run through both implementations: verdict and remediation agree on all.
- The behaviour matrix above independently re-verified against the fixed hook.

## Known limits, stated plainly

- **bash 3.2 was reviewed, not executed** — no 3.2 binary on this host. No associative arrays, no
  `${var,,}`, no `mapfile`, unquoted `=~` right-hand sides, `nocasematch` present since 3.1.
- Pre-existing false denials remain: `git commit -m "npm install fix"` is refused. Given the choice
  the direction is deliberate — a wrong refusal costs one `AGENTKIT_ALLOW_PKG=1`, a wrong allowance
  writes a foreign lockfile and the agent will not notice.