### PR TITLE
docs: say that installs resolve a release tag, not main

### DIFF
--- a/docs/site/src/content/docs/getting-started/install.mdx
+++ b/docs/site/src/content/docs/getting-started/install.mdx
@@ -26,11 +26,28 @@ curl -fsSL https://raw.githubusercontent.com/developerinlondon/agentkit/main/boo
 # with options:  … | bash -s -- --with product
 ```
 
+**This installs the newest release tag, not `main`.** The bootstrap script itself is read from
+`main` — it is a single file, so a truncated download is a syntax error rather than a partial
+install — but the kit it installs is the latest `vX.Y.Z`. It prints which release it resolved:
+
+```
+[bootstrap] Latest release: v0.4.5
+```
+
+`AGENTKIT_REF` overrides that:
+
+```sh
+AGENTKIT_REF=main   curl -fsSL …/bootstrap.sh | bash   # unreleased, bleeding edge
+AGENTKIT_REF=v0.4.3 curl -fsSL …/bootstrap.sh | bash   # pin an older release
+```
+
+An origin with no `vX.Y.Z` tag stops the install rather than quietly falling back to `main`.
+
 Piped stdin is not a terminal, so the optional-group question never fires on this path — it
 installs `core` only unless you pass `--with <group>`.
 
 If `~/.agentkit-src` already exists with local changes, bootstrap refuses rather than resetting
-over them.
+over them. When it is clean, a re-run moves it to the newly resolved ref.
 
   </TabItem>
   <TabItem label="Clone first">

--- a/docs/site/src/content/docs/reference/cli-and-tools.md
+++ b/docs/site/src/content/docs/reference/cli-and-tools.md
@@ -315,6 +315,7 @@ whitespace-stripped, so `a, b` behaves like `a,b`.
 | `AGENTKIT_SKIP_PROMPT` | unset — any **non-empty** value suppresses the group question (a non-empty `CI` does the same) | `install.sh`   |
 | `AGENTKIT_SRC`         | `~/.agentkit-src`                                                                              | `bootstrap.sh` |
 | `AGENTKIT_REPO_URL`    | `https://github.com/developerinlondon/agentkit.git`                                            | `bootstrap.sh` |
+| `AGENTKIT_REF`         | unset — the newest `vX.Y.Z` tag. Takes a tag or a branch; `main` is the unreleased edge        | `bootstrap.sh` |
 
 ### Skill-specific
 


### PR DESCRIPTION
Follows #203, which made `bootstrap.sh` resolve the newest `vX.Y.Z` tag.

`main` is internally inconsistent without this: the installer resolves a release, and the install
page still describes cloning `main`. That is a false claim about the feature just shipped, on the
first page a new user reads — so this has to land before a release tag publishes the docs.

- `install.mdx`: states the newest release is installed, shows the `[bootstrap] Latest release: …`
  line, documents `AGENTKIT_REF` for both bleeding edge and pinning, and notes that a tagless origin
  stops the install rather than falling back.
- `reference/cli-and-tools.md`: `AGENTKIT_REF` added to the environment table.
- Notes that a clean existing clone now moves to the newly resolved ref — new behaviour a re-runner
  will notice.

**The archived `0.4` snapshot is deliberately unchanged.** v0.4 really did install `main`, so the
frozen page is correct about the release it documents. A frozen version that silently acquired
today's behaviour would be the exact defect the freeze mechanism exists to prevent.

Verified: 57 pages, all internal links valid, 61 docs tests pass, `check-dist-assets` clean over 246
files, dprint clean.