### PR TITLE
fix(docs): name the release in the version picker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,11 @@ jobs:
     steps:
       - name: Check out the commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # The docs label the current release. A shallow checkout has no tags, so
+          # a manual publish from main would show a bare "Latest".
+          fetch-tags: true
+          fetch-depth: 0
 
       - name: Install pinned Moon, Bun and Node toolchains
         uses: moonrepo/setup-toolchain@261c62cb5b0f580c7be7c8cd0f023a2e96756095 # v0.6.4
@@ -158,6 +163,8 @@ jobs:
 
       - name: Build the docs site
         working-directory: docs/site
+        env:
+          AGENTKIT_DOCS_VERSION: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
         run: node ./node_modules/astro/bin/astro.mjs build
 
       # Needs the build, so it is a check rather than a test: an extension nobody
@@ -186,6 +193,11 @@ jobs:
     steps:
       - name: Check out the commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # The docs label the current release. A shallow checkout has no tags, so
+          # a manual publish from main would show a bare "Latest".
+          fetch-tags: true
+          fetch-depth: 0
 
       - name: Install pinned Moon, Bun and Node toolchains
         uses: moonrepo/setup-toolchain@261c62cb5b0f580c7be7c8cd0f023a2e96756095 # v0.6.4
@@ -226,6 +238,11 @@ jobs:
     steps:
       - name: Check out the commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # The docs label the current release. A shallow checkout has no tags, so
+          # a manual publish from main would show a bare "Latest".
+          fetch-tags: true
+          fetch-depth: 0
 
       - name: Install pinned Moon, Bun and Node toolchains
         uses: moonrepo/setup-toolchain@261c62cb5b0f580c7be7c8cd0f023a2e96756095 # v0.6.4
@@ -238,6 +255,7 @@ jobs:
       - name: Build and publish the docs site
         env:
           AGENTKIT_SITE_TOKEN: ${{ secrets.AGENTKIT_SITE_TOKEN }}
+          AGENTKIT_DOCS_VERSION: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
         run: |
           if [ -z "$AGENTKIT_SITE_TOKEN" ]; then
             echo 'docs: AGENTKIT_SITE_TOKEN is not configured' >&2

--- a/docs/site/astro.config.mjs
+++ b/docs/site/astro.config.mjs
@@ -1,8 +1,19 @@
+import { execFileSync } from "node:child_process";
 import starlight from "@astrojs/starlight";
 import { defineConfig } from "astro/config";
+import { currentVersionLabel } from "./src/lib/release";
 import mermaid from "astro-mermaid";
 import starlightVersions from "starlight-versions";
 import starlightLinksValidator from "starlight-links-validator";
+
+const versionLabel = currentVersionLabel({
+	env: process.env.AGENTKIT_DOCS_VERSION,
+	describe: () =>
+		execFileSync("git", ["describe", "--tags", "--abbrev=0"], {
+			encoding: "utf8",
+			stdio: ["ignore", "pipe", "ignore"],
+		}),
+});
 
 export default defineConfig({
 	site: "https://agentkit.sbs",
@@ -22,7 +33,10 @@ export default defineConfig({
 			plugins: [
 				// Starlight does not check internal links itself, so before this a
 				// renamed page left dangling links that shipped silently.
-				starlightVersions({ versions: [{ slug: "0.4", label: "v0.4" }] }),
+				starlightVersions({
+					current: { label: versionLabel },
+					versions: [{ slug: "0.4", label: "v0.4" }],
+				}),
 				starlightLinksValidator({ errorOnRelativeLinks: false }),
 			],
 			sidebar: [

--- a/docs/site/src/lib/release.ts
+++ b/docs/site/src/lib/release.ts
@@ -1,0 +1,30 @@
+// "Latest" alone does not answer "latest what". The release is resolved at build
+// time rather than committed to a generated file: the tag is created after the
+// commit it points at, so a drift-checked file would disagree with the tree at tag
+// time by construction.
+export interface ReleaseSources {
+	env?: string | undefined;
+	describe?: () => string;
+}
+
+const RELEASE = /^v\d+\.\d+\.\d+$/;
+
+export function currentRelease({ env, describe }: ReleaseSources): string {
+	// CI passes the tag it is building, which needs no git and cannot be ambiguous.
+	if (env && RELEASE.test(env.trim())) return env.trim();
+	if (!describe) return "";
+	try {
+		const described = describe().trim();
+		return RELEASE.test(described) ? described : "";
+	} catch {
+		return "";
+	}
+}
+
+// Version first: the select truncates, and the half a reader sees has to be the
+// part that identifies the release. It also sorts visually with the archived
+// entries, which are labelled `v0.4`.
+export function currentVersionLabel(sources: ReleaseSources): string {
+	const release = currentRelease(sources);
+	return release ? `${release} (latest)` : "Latest";
+}

--- a/scripts/check-test-slices.ts
+++ b/scripts/check-test-slices.ts
@@ -12,7 +12,7 @@ export const TEST_SLICES = {
     'tests/diagram/render.test.ts',
     'tests/diagram/vendor-icons.test.ts',
   ],
-  docs: ['tests/docs/asset-types.test.ts', 'tests/docs/deploy.test.ts', 'tests/docs/facts.test.ts'],
+  docs: ['tests/docs/asset-types.test.ts', 'tests/docs/deploy.test.ts', 'tests/docs/facts.test.ts', 'tests/docs/release-label.test.ts'],
   site: ['tests/site/links.test.ts'],
   hooks: [
     'tests/agentkit-plugin.test.ts',

--- a/tests/docs/release-label.test.ts
+++ b/tests/docs/release-label.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  currentRelease,
+  currentVersionLabel,
+} from '../../docs/site/src/lib/release.ts';
+
+// The picker said "Latest" with no version, so a reader had no way to tell which
+// release the docs described. It has to come from the tag being built, and it must
+// not come from a committed file: the tag is created after the commit it points at,
+// so a drift-checked value would disagree with the tree at tag time.
+describe('the current version label names the release', () => {
+  test('the CI-provided tag wins, needing no git', () => {
+    expect(currentVersionLabel({ env: 'v0.4.5' })).toBe('v0.4.5 (latest)');
+  });
+
+  test('surrounding whitespace from a shell is tolerated', () => {
+    expect(currentRelease({ env: '  v1.2.3\n' })).toBe('v1.2.3');
+  });
+
+  test('git describe is the local fallback', () => {
+    expect(currentVersionLabel({ describe: () => 'v0.4.4\n' })).toBe('v0.4.4 (latest)');
+  });
+
+  test('the env value is preferred over git', () => {
+    expect(currentVersionLabel({ env: 'v9.9.9', describe: () => 'v0.0.1' })).toBe(
+      'v9.9.9 (latest)',
+    );
+  });
+
+  // The version leads the label because the select truncates. With no version to
+  // lead with, a bare "Latest" is honest; inventing a number would not be.
+  test.each([
+    ['no sources at all', {}],
+    ['a describe that throws', { describe: () => { throw new Error('no tags'); } }],
+    ['a non-release ref', { env: 'main' }],
+    ['a release candidate', { env: 'v0.4.5-rc1' }],
+    ['an abbreviated tag', { env: 'v0.4' }],
+    ['empty output', { describe: () => '' }],
+  ])('%s yields a bare Latest rather than a guess', (_label, sources) => {
+    expect(currentVersionLabel(sources)).toBe('Latest');
+  });
+});


### PR DESCRIPTION
The picker read `Latest` with no version, so nothing told a reader which release the docs described. The archived entry said `v0.4` while the release was `v0.4.5`, so they did not line up either.

Now: **`v0.4.5 (latest)`**, then `v0.4`.

- **Version first**, because the select truncates and the visible half must be the part that identifies the release.
- **Resolved at build time**, not committed to a generated file. The tag is created *after* the commit it points at, so a drift-checked value would disagree with the tree at tag time by construction.
- CI passes the tag it is building via `AGENTKIT_DOCS_VERSION`; `git describe` is the local fallback. The docs checkouts now `fetch-tags`, because a shallow checkout has none and a manual publish from `main` would have shown a bare `Latest` again — a gap I only found by working through the dispatch path.
- With neither source available the label stays `Latest` rather than inventing a number.

Extracted to `docs/site/src/lib/release.ts` so it is unit-testable rather than buried in the Astro config: 10 tests covering the CI value, the git fallback, precedence, whitespace, and every degraded case (no tags, a throwing `describe`, a branch ref, an rc tag, an abbreviated tag).