### PR TITLE
feat(docs): generate the README skills table from the tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,18 +8,28 @@ Reusable AI agent skills, rules, plugins, hooks, and tools for OpenCode, Claude 
 
 ### Skills (SKILL.md -- works everywhere via skills.sh)
 
-| Skill                       | Description                                                                                                     |
-| --------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| **gitops-master**           | GitOps operations for ArgoCD + Kargo: diagnose, verify, promote, setup                                          |
-| **autonomous-workflow**     | Proposal-first development, commit hygiene, decision authority                                                  |
-| **adversarial-review**      | Trace-first falsification of plans and diffs with replayable evidence (explicit opt-in: `--with strict-review`) |
-| **code-quality**            | Warnings-as-errors, no underscore prefixes, test coverage                                                       |
-| **documentation**           | Surface-aware diagrams (Mermaid / ASCII), structured plan format, formatting rules                              |
-| **issue-raiser**            | GitLab issue creation with root cause analysis and git-history-based assignees                                  |
-| **product-intelligence**    | Evidence-backed product briefs with a claim-by-claim ledger; hardened acquisition (opt-in: `--with product`)    |
-| **project-planning**        | Structured project planning: break down ideas into architecture, file structure, roadmap                        |
-| **product-review**          | Build, run, and use declared product surfaces as a separate review lane (opt-in: `--with product`)              |
-| **resource-safe-execution** | On Linux, runs heavy developer commands inside deterministic systemd resource limits                            |
+<!-- generated:skills:start — edit skills/*/SKILL.md, then run scripts/sync-docs-facts.ts -->
+
+| Skill                       | Install                     | Description                                                                                                                                                                                                                                       |
+| --------------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **adversarial-review**      | `--with strict-review` only | Falsify a proposed plan or implementation with independent traces, concrete failing inputs, claims verification, scope re-derivation, and lifecycle analysis.                                                                                     |
+| **architect**               | always                      | Study a system and produce living architecture documentation — explanatory pages with high-quality diagrams.                                                                                                                                      |
+| **autonomous-workflow**     | always                      | Proposal-first development workflow with commit hygiene and decision authority rules.                                                                                                                                                             |
+| **code-quality**            | always                      | Code quality standards: warnings-as-errors, no underscore prefixes for unused vars, mandatory test coverage.                                                                                                                                      |
+| **diagram**                 | always                      | Craft high-quality hand-drawn-style diagrams (Excalidraw JSON rendered to self-contained SVG).                                                                                                                                                    |
+| **documentation**           | always                      | Documentation standards: surface-aware diagrams (Mermaid where markdown renders, ASCII for terminals and diffs), structured plan format, compact tables for comparisons.                                                                          |
+| **github-issue-lifecycle**  | always                      | Issue-first workflow and lifecycle hygiene for GitHub: every piece of work runs against an issue, Projects v2 status stays current on every touch, PRs reference issues without triggering auto-close, and issues close with a verification note. |
+| **gitlab-issue-lifecycle**  | always                      | Issue-first workflow and lifecycle hygiene for GitLab: every piece of work runs against an issue, work-item statuses stay current on every touch, MRs reference issues without auto-closing, and issues close with a verification note.           |
+| **gitops-master**           | always                      | GitOps operations master for ArgoCD + Kargo.                                                                                                                                                                                                      |
+| **issue-raiser**            | always                      | Raises well-structured GitLab issues with root cause analysis, proposed solutions, and correct assignees based on git history.                                                                                                                    |
+| **product-intelligence**    | `--with product`            | Build an evidence-backed product brief from a website, a repository, or supplied documents.                                                                                                                                                       |
+| **product-review**          | `--with product`            | Review a product the way a user meets it — build it, run it, use it — instead of reading a diff.                                                                                                                                                  |
+| **project-planning**        | always                      | Structured project planning: break down a new project idea into plan files covering architecture, file structure, and implementation roadmap.                                                                                                     |
+| **publish-page**            | always                      | Publish content as a live web page with a stable URL (AgentKit Pages, self-hosted artifacts).                                                                                                                                                     |
+| **resource-safe-execution** | always                      | Apply Linux-only deterministic systemd cgroup limits with bounded-run to resource-intensive developer commands.                                                                                                                                   |
+| **test-driven-development** | always                      | Enforces strict Test-Driven Development (TDD) workflow: RED-GREEN-REFACTOR cycle.                                                                                                                                                                 |
+
+<!-- generated:skills:end -->
 
 ### Rules (auto-loaded by file glob match)
 

--- a/docs/site/src/generated/kit-facts.json
+++ b/docs/site/src/generated/kit-facts.json
@@ -223,7 +223,7 @@
       "name": "adversarial-review",
       "group": "strict-review",
       "explicit": true,
-      "description": ">-"
+      "description": "Falsify a proposed plan or implementation with independent traces, concrete failing inputs, claims verification, scope re-derivation, and lifecycle analysis. Use for non-trivial code review, plan refutation, security or reliability changes, bug fixes, merge-gate evidence, and any request to adversarially review or prove a change wrong."
     },
     {
       "name": "architect",
@@ -235,13 +235,13 @@
       "name": "autonomous-workflow",
       "group": "core",
       "explicit": false,
-      "description": ">-"
+      "description": "Proposal-first development workflow with commit hygiene and decision authority rules. Enforces: propose before modifying, atomic commits, no force flags, warnings-as-errors. Use for any project where AI agents are primary developers and need guardrails."
     },
     {
       "name": "code-quality",
       "group": "core",
       "explicit": false,
-      "description": ">-"
+      "description": "Code quality standards: warnings-as-errors, no underscore prefixes for unused vars, mandatory test coverage. Apply to any TypeScript, JavaScript, Rust, or Python project. Triggers: code review, linting, writing new functions, refactoring."
     },
     {
       "name": "diagram",
@@ -253,49 +253,49 @@
       "name": "documentation",
       "group": "core",
       "explicit": false,
-      "description": ">-"
+      "description": "Documentation standards: surface-aware diagrams (Mermaid where markdown renders, ASCII for terminals and diffs), structured plan format, compact tables for comparisons. Use when writing docs, plans, READMEs, or architecture documents in any project."
     },
     {
       "name": "github-issue-lifecycle",
       "group": "core",
       "explicit": false,
-      "description": ">-"
+      "description": "Issue-first workflow and lifecycle hygiene for GitHub: every piece of work runs against an issue, Projects v2 status stays current on every touch, PRs reference issues without triggering auto-close, and issues close with a verification note. GitHub counterpart of gitlab-issue-lifecycle. Triggers: starting tracked work, updating issue/project status, closing issues, referencing issues from PRs."
     },
     {
       "name": "gitlab-issue-lifecycle",
       "group": "core",
       "explicit": false,
-      "description": ">-"
+      "description": "Issue-first workflow and lifecycle hygiene for GitLab: every piece of work runs against an issue, work-item statuses stay current on every touch, MRs reference issues without auto-closing, and issues close with a verification note. Complements issue-raiser (which covers researching and writing a new issue). Triggers: starting tracked work, updating issue status, linking issues to epics, closing issues, referencing issues from MRs."
     },
     {
       "name": "gitops-master",
       "group": "core",
       "explicit": false,
-      "description": ">-"
+      "description": "GitOps operations master for ArgoCD + Kargo. Diagnose stuck stages, verify deployments, manage promotions, configure verification and retry. Triggers: 'stage stuck', 'sync failed', 'promote', 'verify stage', 'kargo', 'argocd', 'gitops', 'pipeline', 'freight'"
     },
     {
       "name": "issue-raiser",
       "group": "core",
       "explicit": false,
-      "description": ">-"
+      "description": "Raises well-structured GitLab issues with root cause analysis, proposed solutions, and correct assignees based on git history. Adapts to any GitLab instance and project conventions automatically. Triggers: raising issues, reporting bugs, creating tickets, filing defects, feature requests, refactoring proposals."
     },
     {
       "name": "product-intelligence",
       "group": "product",
       "explicit": false,
-      "description": ">-"
+      "description": "Build an evidence-backed product brief from a website, a repository, or supplied documents. Every material claim lands in an auditable evidence ledger with a verbatim quote; contradictions are recorded, never smoothed over. Use when asked to research, profile, or write a brief about a product — including this one. Refuses to pad thin evidence into a confident story."
     },
     {
       "name": "product-review",
       "group": "product",
       "explicit": false,
-      "description": ">-"
+      "description": "Review a product the way a user meets it — build it, run it, use it — instead of reading a diff. Consumes .agentkit/product.yaml; refuses and asks when it is missing rather than guessing. Use alongside diff review, never instead of it."
     },
     {
       "name": "project-planning",
       "group": "core",
       "explicit": false,
-      "description": ">-"
+      "description": "Structured project planning: break down a new project idea into plan files covering architecture, file structure, and implementation roadmap. Triggers: 'new project', 'plan a feature', 'break down', 'architecture', 'roadmap', 'design a system'."
     },
     {
       "name": "publish-page",
@@ -307,13 +307,13 @@
       "name": "resource-safe-execution",
       "group": "core",
       "explicit": false,
-      "description": ">-"
+      "description": "Apply Linux-only deterministic systemd cgroup limits with bounded-run to resource-intensive developer commands. Use for dependency installation or upgrades, compilers, typechecks, builds, test suites, linters, Playwright or browser work, code generation, Cargo, Go, and pytest, especially on shared or production-adjacent Linux hosts where an unbounded process could disrupt Kubernetes, ingress, tunnels, or other services."
     },
     {
       "name": "test-driven-development",
       "group": "core",
       "explicit": false,
-      "description": ">-"
+      "description": "Enforces strict Test-Driven Development (TDD) workflow: RED-GREEN-REFACTOR cycle. Tests MUST be written BEFORE implementation. Every change starts with a failing test. Applies to any language (Rust, TypeScript, Python, Go, etc.). Triggers: writing new features, fixing bugs, adding endpoints, refactoring, any code change."
     }
   ],
   "tools": [

--- a/scripts/sync-docs-facts.ts
+++ b/scripts/sync-docs-facts.ts
@@ -145,9 +145,24 @@ function frontmatterDescription(skill: string, root: string): string {
   const source = readFileSync(join(root, 'skills', skill, 'SKILL.md'), 'utf-8');
   const match = /^---\n([\s\S]*?)\n---/.exec(source);
   if (!match) throw new Error(`skills/${skill}/SKILL.md has no frontmatter`);
-  const description = /^description:\s*(.+)$/m.exec(match[1] ?? '');
-  if (!description?.[1]) throw new Error(`skills/${skill}/SKILL.md has no description`);
-  return description[1].trim();
+  const frontmatter = match[1] ?? '';
+  const head = /^description:[ \t]*(.*)$/m.exec(frontmatter);
+  if (!head) throw new Error(`skills/${skill}/SKILL.md has no description`);
+  const value = (head[1] ?? '').trim();
+  // A block scalar (>-, |, …) keeps its text on the following indented lines;
+  // taking the head line verbatim would record the indicator itself.
+  if (!/^[>|][+-]?$/.test(value)) {
+    if (!value) throw new Error(`skills/${skill}/SKILL.md has no description`);
+    return value;
+  }
+  const lines: string[] = [];
+  for (const line of frontmatter.slice(head.index + head[0].length).split('\n').slice(1)) {
+    if (line.trim() === '') continue;
+    if (!/^[ \t]/.test(line)) break;
+    lines.push(line.trim());
+  }
+  if (lines.length === 0) throw new Error(`skills/${skill}/SKILL.md has no description`);
+  return lines.join(' ');
 }
 
 function collectSkills(groups: GroupFact[], membership: Map<string, string>, root: string): SkillFact[] {
@@ -253,6 +268,61 @@ export function serialise(facts: KitFacts): string {
   return `${JSON.stringify(facts, null, 2)}\n`;
 }
 
+const README_MARKERS = {
+  start: '<!-- generated:skills:start — edit skills/*/SKILL.md, then run scripts/sync-docs-facts.ts -->',
+  end: '<!-- generated:skills:end -->',
+} as const;
+
+function firstSentence(text: string): string {
+  const match = /^(.*?\.)\s/.exec(`${text} `);
+  return (match?.[1] ?? text).trim();
+}
+
+function installCell(skill: SkillFact): string {
+  if (skill.group === 'core') return 'always';
+  return skill.explicit ? `\`--with ${skill.group}\` only` : `\`--with ${skill.group}\``;
+}
+
+function markdownTable(header: string[], rows: string[][]): string {
+  const widths = header.map((cell, column) =>
+    Math.max(cell.length, ...rows.map((row) => (row[column] ?? '').length)));
+  const line = (cells: string[]) =>
+    `| ${cells.map((cell, column) => cell.padEnd(widths[column] ?? 0)).join(' | ')} |`;
+  return [
+    line(header),
+    `| ${widths.map((width) => '-'.repeat(width)).join(' | ')} |`,
+    ...rows.map(line),
+  ].join('\n');
+}
+
+export function renderReadmeSkillsSection(facts: KitFacts): string {
+  const rows = facts.skills.map((skill) => [
+    `**${skill.name}**`,
+    installCell(skill),
+    firstSentence(skill.description),
+  ]);
+  return [
+    README_MARKERS.start,
+    '',
+    markdownTable(['Skill', 'Install', 'Description'], rows),
+    '',
+    README_MARKERS.end,
+  ].join('\n');
+}
+
+export function spliceReadme(readme: string, facts: KitFacts): string {
+  const start = readme.indexOf(README_MARKERS.start);
+  const end = readme.indexOf(README_MARKERS.end);
+  if (start === -1 || end === -1 || end < start) {
+    throw new Error('README.md is missing the generated:skills marker pair');
+  }
+  return readme.slice(0, start)
+    + renderReadmeSkillsSection(facts)
+    + readme.slice(end + README_MARKERS.end.length);
+}
+
+const readmePath = join(repoRoot, 'README.md');
+
 export function committedFacts(): string {
   return readFileSync(factsPath, 'utf-8');
 }
@@ -279,7 +349,10 @@ if (import.meta.main) {
     process.exit(0);
   }
 
-  const fresh = serialise(collectFacts());
+  const facts = collectFacts();
+  const fresh = serialise(facts);
+  const readme = readFileSync(readmePath, 'utf-8');
+  const freshReadme = spliceReadme(readme, facts);
 
   if (process.argv.includes('--check')) {
     let committed = '';
@@ -294,7 +367,11 @@ if (import.meta.main) {
       console.error('  run: bun run scripts/sync-docs-facts.ts');
       process.exit(1);
     }
-    const facts = collectFacts();
+    if (readme !== freshReadme) {
+      console.error('docs facts: the README skills table disagrees with the tree');
+      console.error('  run: bun run scripts/sync-docs-facts.ts');
+      process.exit(1);
+    }
     console.log(
       `docs facts: ${facts.units.length} units, ${facts.skills.length} skills, ` +
         `${facts.groups.length} groups, ${facts.tools.length} tools`,
@@ -302,5 +379,9 @@ if (import.meta.main) {
   } else {
     writeFileSync(factsPath, fresh);
     console.log(`docs facts: wrote ${factsPath}`);
+    if (readme !== freshReadme) {
+      writeFileSync(readmePath, freshReadme);
+      console.log(`docs facts: wrote ${readmePath}`);
+    }
   }
 }

--- a/tests/docs/facts.test.ts
+++ b/tests/docs/facts.test.ts
@@ -8,6 +8,7 @@ import {
   committedFacts,
   pluginHookDrift,
   serialise,
+  spliceReadme,
 } from '../../scripts/sync-docs-facts.ts';
 import {
   factsFor,
@@ -293,6 +294,38 @@ describe('the wiring table comes from the harness settings', () => {
     write('hooks/claude/settings.json', 'not json');
 
     expect(collectWiring(root)).toEqual([]);
+  });
+});
+
+describe('the README skills table comes from the tree', () => {
+  test('a block-scalar description folds to its prose, not the indicator', () => {
+    write('skills/GROUPS', 'group core Everyday skills\n');
+    write(
+      'skills/folded/SKILL.md',
+      '---\nname: folded\ndescription: >-\n  First half of the\n  folded prose.\n---\n',
+    );
+
+    const facts = collectFacts(root);
+    expect(facts.skills[0]?.description).toBe('First half of the folded prose.');
+  });
+
+  test('the committed README matches a regeneration, and an edited row is caught', () => {
+    const repo = join(import.meta.dir, '..', '..');
+    const readme = readFileSync(join(repo, 'README.md'), 'utf-8');
+    const facts = collectFacts(repo);
+
+    expect(spliceReadme(readme, facts)).toBe(readme);
+
+    const tampered = readme.replace('**gitops-master**', '**gitops-master-renamed**');
+    expect(spliceReadme(tampered, facts)).not.toBe(tampered);
+  });
+
+  test('a README without the marker pair fails loudly instead of silently skipping', () => {
+    write('skills/GROUPS', 'group core Everyday skills\n');
+    skill('ordinary', 'Always installed.');
+
+    expect(() => spliceReadme('# no markers here\n', collectFacts(root)))
+      .toThrow('marker pair');
   });
 });
 


### PR DESCRIPTION
Closes #211. Closes #210.

- README "What's Included" skills table is now generated between `<!-- generated:skills:start/end -->` markers by `scripts/sync-docs-facts.ts` — same run, same `--check` already wired into the CI docs job, so a new or renamed skill cannot ship without the README following.
- Table: all 16 skills, an Install column derived from the group (`always` / `--with product` / `--with strict-review` only), first sentence of each SKILL.md description.
- Frontmatter reader folds YAML block scalars (was recording the `>-` indicator as adversarial-review's description, rendered verbatim on the live docs skills table — #210).
- Tests: block-scalar folding, committed-README-matches-regeneration (kills an edited-row mutant), loud failure when the marker pair is missing. dprint-stable output verified.