### PR TITLE
feat(deploy): prune docs removed from the build

### DIFF
--- a/docs/site/deploy.sh
+++ b/docs/site/deploy.sh
@@ -97,4 +97,52 @@ for path in "" getting-started/install/; do
 	}
 done
 
+# Uploading never removes: before this, a page deleted from the build kept
+# answering 200 and nothing reported it. Ten migration redirects had to be deleted
+# by hand once for exactly that reason.
+#
+# The failure direction is chosen deliberately. Deleting the wrong object is worse
+# than keeping a stale one, so an implausible diff refuses instead of pruning: a
+# listing that fails, or one that would remove more than half of what is live,
+# stops the deploy rather than guessing.
+#
+# Key lists live in files rather than arrays: under `set -u`, bash 3.2 treats
+# "${empty[@]}" as an unbound variable, and macOS ships 3.2.
+live_keys=$(mktemp)
+built_keys=$(mktemp)
+stale_keys=$(mktemp)
+trap 'rm -f "$auth" "$live_keys" "$built_keys" "$stale_keys"' EXIT
+
+# The fetch is checked on its own: piping it straight into a filter conflates "the
+# listing failed" with "the listing was empty", because grep exits 1 on no match
+# and pipefail then reports the whole pipeline as failed.
+listing=$(mktemp)
+if ! curl -sS --fail-with-body --config "$auth" "$ENDPOINT/api/site-list/docs/" > "$listing" 2>/dev/null; then
+	echo "deploy: could not list what is live — not pruning" >&2
+	exit 1
+fi
+tr ',' '\n' < "$listing" | grep -oE '"docs/[^"]+"' | tr -d '"' | sort -u > "$live_keys" || true
+rm -f "$listing"
+(cd dist && find . -type f | sed 's|^\./|docs/|') | sort -u > "$built_keys"
+comm -23 "$live_keys" "$built_keys" > "$stale_keys"
+
+stale_count=$(grep -c . "$stale_keys" || true)
+live_count=$(grep -c . "$live_keys" || true)
+if [[ "${stale_count:-0}" -gt 0 ]]; then
+	if [[ "$stale_count" -gt $((live_count / 2)) ]]; then
+		echo "deploy: refusing to prune $stale_count of $live_count live objects — that is not a redeploy" >&2
+		sed 's/^/  /' "$stale_keys" >&2
+		exit 1
+	fi
+	while IFS= read -r key; do
+		[[ -n "$key" ]] || continue
+		curl -sS --fail-with-body -X DELETE --config "$auth" "$ENDPOINT/api/site/$key" >/dev/null 2>&1 \
+			|| { echo "deploy: failed to prune $key" >&2; exit 1; }
+		echo "pruned: $key"
+	done < "$stale_keys"
+	echo "deploy: pruned $stale_count object(s) no longer in the build"
+else
+	echo "deploy: nothing to prune"
+fi
+
 echo "deploy: verified live at $SITE_URL/docs/ ($sha)"

--- a/pages/worker/src/worker.js
+++ b/pages/worker/src/worker.js
@@ -214,6 +214,29 @@ async function handleAssetWrite(request, env, path) {
   return Response.json({ ok: true, path, url: `https://agentkit.sbs/${path}` });
 }
 
+// The deploy can only prune what it can enumerate. Scoped to the docs subtree and
+// SITE_TOKEN, same as the write path: a caller that cannot write cannot list.
+async function handleAssetList(request, env, rawPrefix) {
+  if (!env.SITE_TOKEN || bearerToken(request) !== env.SITE_TOKEN) {
+    return new Response("unauthorized\n", { status: 401 });
+  }
+  const bare = rawPrefix.replace(/\/+$/, "");
+  if (!isDocsPath(bare) || !ASSET_RE.test(bare)) {
+    return new Response("invalid prefix\n", { status: 400 });
+  }
+  // Restored explicitly: the router strips the trailing slash, and a prefix of
+  // `docs` would also match a sibling keyspace such as `docsy/`.
+  const prefix = `${bare}/`;
+  const keys = [];
+  let cursor;
+  do {
+    const page = await env.PAGES.list({ prefix: `${SITE_PREFIX}${prefix}`, cursor });
+    for (const object of page.objects) keys.push(object.key.slice(SITE_PREFIX.length));
+    cursor = page.truncated ? page.cursor : undefined;
+  } while (cursor);
+  return Response.json({ ok: true, prefix, keys: keys.sort() });
+}
+
 async function handleAssetDelete(request, env, path) {
   if (!env.SITE_TOKEN || bearerToken(request) !== env.SITE_TOKEN) {
     return new Response("unauthorized\n", { status: 401 });
@@ -240,6 +263,9 @@ export default {
     const host = url.hostname;
     const path = url.pathname.replace(/\/+$/, "").replace(/^\/+/, "");
 
+    if (request.method === "GET" && path.startsWith("api/site-list/")) {
+      return handleAssetList(request, env, path.slice("api/site-list/".length));
+    }
     if (request.method === "PUT" && path.startsWith("api/site/")) {
       return handleAssetWrite(request, env, path.slice("api/site/".length));
     }

--- a/tests/docs/deploy.test.ts
+++ b/tests/docs/deploy.test.ts
@@ -82,12 +82,16 @@ function stubCurl(): void {
       `LOG=${JSON.stringify(join(root, '.uploads'))}`,
       `ARGV=${JSON.stringify(join(root, '.argv'))}`,
       `LIVE=${JSON.stringify(join(root, '.live-sha'))}`,
+      `REMOTE=${JSON.stringify(join(root, '.remote-keys'))}`,
+      `DEL=${JSON.stringify(join(root, '.deleted'))}`,
       'printf "%s\\n" "$*" >> "$ARGV"',
-      'is_put=; is_code=',
+      'is_put=; is_code=; is_delete=',
       'for a in "$@"; do',
-      '  case "$a" in PUT) is_put=1 ;; -w) is_code=1 ;; esac',
+      '  case "$a" in PUT) is_put=1 ;; DELETE) is_delete=1 ;; -w) is_code=1 ;; esac',
       'done',
       'eval "url=\\${$#}"',
+      'if [ -n "$is_delete" ]; then printf "%s\\n" "${url##*/api/site/}" >> "$DEL"; exit 0; fi',
+      'case "$url" in *api/site-list/*) cat "$REMOTE" 2>/dev/null || printf "{\\"keys\\":[]}"; exit 0 ;; esac',
       'if [ -n "$is_put" ]; then printf "%s\\n" "${url##*/api/site/docs/}" >> "$LOG"; exit 0; fi',
       'if [ -n "$is_code" ]; then printf "200"; exit 0; fi',
       'if [ -f "$LIVE" ]; then cat "$LIVE"; fi',
@@ -136,6 +140,16 @@ function deploy(env: Record<string, string> = {}): ReturnType<typeof spawnSync> 
   });
 }
 
+function remoteKeys(keys: string[]): void {
+  writeFileSync(join(root, '.remote-keys'), JSON.stringify({ ok: true, keys }));
+}
+
+function deleted(): string[] {
+  const path = join(root, '.deleted');
+  if (!existsSync(path)) return [];
+  return readFileSync(path, 'utf-8').trim().split('\n').filter(Boolean);
+}
+
 function uploads(): string[] {
   const path = join(root, '.uploads');
   if (!existsSync(path)) return [];
@@ -158,7 +172,7 @@ beforeEach(() => {
   cpSync(DEPLOY, join(site, 'deploy.sh'));
   chmodSync(join(site, 'deploy.sh'), 0o755);
   write('token', 'site-secret');
-  write('.gitignore', 'dist/\n.bin/\n.uploads\n.argv\n.live-sha\ntoken\n');
+  write('.gitignore', 'dist/\n.bin/\n.uploads\n.argv\n.live-sha\n.remote-keys\n.deleted\ntoken\n');
   stubCurl();
   stubBuild(BUILT);
   git('init', '-q');
@@ -285,5 +299,64 @@ describe('a rejected upload stops the deploy', () => {
 
     expect(result.status).toBe(1);
     expect(uploads()).not.toContain('build-sha.txt');
+  });
+});
+
+describe('a page removed from the build stops being served', () => {
+  // Uploading never removed anything, so a deleted page kept answering 200 with
+  // nothing reporting it. Ten migration redirects were deleted by hand for exactly
+  // that reason before this existed.
+  test('an object no longer in the build is pruned and reported', () => {
+    remoteKeys([...BUILT.map((f) => `docs/${f}`), 'docs/retired/index.html', 'docs/build-sha.txt']);
+    const result = deploy();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(deleted()).toEqual(['docs/retired/index.html']);
+    expect(result.stdout).toContain('pruned: docs/retired/index.html');
+  });
+
+  test('nothing to prune is stated rather than implied', () => {
+    remoteKeys([...BUILT.map((f) => `docs/${f}`), 'docs/build-sha.txt']);
+    const result = deploy();
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('nothing to prune');
+    expect(deleted()).toEqual([]);
+  });
+
+  // Deleting the wrong object is worse than keeping a stale one, so an implausible
+  // diff has to stop the deploy rather than act on it.
+  test('a diff that would remove most of the site refuses instead of pruning', () => {
+    remoteKeys([
+      ...BUILT.map((f) => `docs/${f}`),
+      ...Array.from({ length: 40 }, (_, i) => `docs/retired-${i}/index.html`),
+    ]);
+    const result = deploy();
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('refusing to prune');
+    expect(deleted()).toEqual([]);
+  });
+
+  test('a listing that cannot be read stops the deploy rather than pruning blind', () => {
+    stub(
+      'curl',
+      [
+        '#!/usr/bin/env bash',
+        'set -eu',
+        `LIVE=${JSON.stringify(join(root, '.live-sha'))}`,
+        'for a in "$@"; do case "$a" in *api/site-list/*) exit 22 ;; esac; done',
+        'eval "url=\\${$#}"',
+        // the stamp read-back runs before the prune, so it has to succeed or the
+        // deploy never reaches the step under test
+        'case "$url" in *build-sha.txt) cat "$LIVE"; exit 0 ;; esac',
+        'printf "200"',
+        'exit 0',
+      ].join('\n'),
+    );
+    const result = deploy();
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('could not list');
   });
 });

--- a/tests/publish-page/worker.test.ts
+++ b/tests/publish-page/worker.test.ts
@@ -38,6 +38,12 @@ function bucket(seed: Record<string, string> = {}): Bucket {
     async delete(key) {
       writes.delete(key);
     },
+    async list({ prefix }: { prefix: string }) {
+      const objects = [...writes.keys()]
+        .filter((key) => key.startsWith(prefix))
+        .map((key) => ({ key }));
+      return { objects, truncated: false };
+    },
   };
 }
 
@@ -709,5 +715,93 @@ describe('the relaxed docs policy cannot leak onto marketing pages', () => {
     expect(csp).not.toContain("'self'");
     expect(csp).not.toContain('wasm-unsafe-eval');
     expect(res.headers.get('cache-control')).toBeNull();
+  });
+});
+
+describe('the docs listing is what makes pruning possible', () => {
+  const seeded = {
+    '_site/docs/index.html': 'a',
+    '_site/docs/_astro/app.css': 'b',
+    '_site/docs/pagefind/pagefind.js': 'c',
+    '_site/index.html': 'marketing',
+    'pages/deadbeef/index.html': 'a page',
+  };
+
+  test('a site token lists the docs subtree, and nothing outside it', async () => {
+    const store = bucket(seeded);
+    const res = await worker.fetch(
+      new Request('https://agentkit.sbs/api/site-list/docs/', {
+        headers: { authorization: `Bearer ${SITE_TOKEN}` },
+      }),
+      env(store),
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      ok: true,
+      prefix: 'docs/',
+      keys: ['docs/_astro/app.css', 'docs/index.html', 'docs/pagefind/pagefind.js'],
+    });
+  });
+
+  test.each([
+    ['the publish token', PUBLISH_TOKEN],
+    ['no token', null],
+  ])('%s cannot list', async (_label, token) => {
+    const store = bucket(seeded);
+    const headers: Record<string, string> = {};
+    if (token) headers.authorization = `Bearer ${token}`;
+    const res = await worker.fetch(
+      new Request('https://agentkit.sbs/api/site-list/docs/', { headers }),
+      env(store),
+    );
+
+    expect(res.status).toBe(401);
+  });
+
+  test('an unset site token fails closed', async () => {
+    const store = bucket(seeded);
+    const res = await worker.fetch(
+      new Request('https://agentkit.sbs/api/site-list/docs/', {
+        headers: { authorization: 'Bearer ' },
+      }),
+      env(store, { SITE_TOKEN: undefined }),
+    );
+
+    expect(res.status).toBe(401);
+  });
+
+  // The router strips the trailing slash, so the prefix arrives as `docs`. Listing
+  // on that would also match a sibling keyspace.
+  test('a sibling keyspace is not swept in by the prefix', async () => {
+    const store = bucket({
+      '_site/docs/index.html': 'docs',
+      '_site/docsy/index.html': 'not docs',
+    });
+    const res = await worker.fetch(
+      new Request('https://agentkit.sbs/api/site-list/docs/', {
+        headers: { authorization: `Bearer ${SITE_TOKEN}` },
+      }),
+      env(store),
+    );
+
+    expect((await res.json()).keys).toEqual(['docs/index.html']);
+  });
+
+  // Listing outside docs/ would expose the marketing keyspace to a token scoped
+  // to the docs subtree everywhere else.
+  test.each([
+    'https://agentkit.sbs/api/site-list/',
+    'https://agentkit.sbs/api/site-list/pages/',
+    'https://agentkit.sbs/api/site-list/docsy/',
+    'https://agentkit.sbs/api/site-list/../',
+  ])('%s is refused', async (url) => {
+    const store = bucket(seeded);
+    const res = await worker.fetch(
+      new Request(url, { headers: { authorization: `Bearer ${SITE_TOKEN}` } }),
+      env(store),
+    );
+
+    expect(res.status).not.toBe(200);
   });
 });


### PR DESCRIPTION
Refs #202

## Problem
The docs deployment uploaded new files but never removed obsolete ones, leaving deleted pages publicly reachable.

## Change
- Adds a SITE_TOKEN-gated, docs-scoped list endpoint to the Pages worker.
- Diffs the live docs keyset against the built keyset and reports each deleted object.
- Refuses to prune when listing fails or when the removal set exceeds half of live objects.
- Adds regression coverage for pruning, no-op behavior, refusal, token separation, and `docsy/` prefix isolation.

## Verification
- `agentkit-run --profile canary -- bun test tests/docs/deploy.test.ts tests/publish-page/worker.test.ts` — 137 pass.
- `scripts/preflight --base origin/main` — clean.
- Mutation checks caught removal of the list endpoint and weakening of the `docs/` prefix boundary.
- `agentkit-run --profile default -- <Moon 2.4.5 binary> ci` — 4 affected tasks completed: preflight, test-slices, docs (78 pass), and product (440 pass).

The issue remains open pending deployed verification after merge.