### PR TITLE
fix(tests): a not-yet-ready devtools endpoint retries instead of escaping

### DIFF
--- a/tests/publish-page/mermaid-runtime.test.ts
+++ b/tests/publish-page/mermaid-runtime.test.ts
@@ -105,7 +105,12 @@ async function devtoolsEndpoint(profile: string): Promise<string> {
       const [port] = readFileSync(portFile, 'utf-8').split('\n');
       if (/^\d+$/.test(port)) {
         try {
-          const targets = await (await fetch(`http://127.0.0.1:${port}/json/list`)).json() as any[];
+          // The loop deadline only checks between iterations; an accepted-but-
+          // silent socket would otherwise pin a single fetch past all of it.
+          const reply = await fetch(`http://127.0.0.1:${port}/json/list`, {
+            signal: AbortSignal.timeout(1_000),
+          });
+          const targets = await reply.json() as any[];
           const page = targets.find((t) => t.type === 'page');
           if (page?.webSocketDebuggerUrl) return page.webSocketDebuggerUrl;
           lastFailure = `no page target on port ${port} yet`;
@@ -115,6 +120,8 @@ async function devtoolsEndpoint(profile: string): Promise<string> {
       } else {
         lastFailure = `port file present but holds ${JSON.stringify(port)}`;
       }
+    } else if (lastFailure !== 'port file never appeared') {
+      lastFailure = 'port file vanished after appearing — the browser exited';
     }
     await Bun.sleep(50);
   }

--- a/tests/publish-page/mermaid-runtime.test.ts
+++ b/tests/publish-page/mermaid-runtime.test.ts
@@ -95,16 +95,30 @@ async function attach(url: string): Promise<Session> {
 async function devtoolsEndpoint(profile: string): Promise<string> {
   const portFile = join(profile, 'DevToolsActivePort');
   const deadline = Date.now() + 20_000;
+  let lastFailure = 'port file never appeared';
   while (Date.now() < deadline) {
+    // Chrome writes the port file non-atomically and opens the socket after —
+    // an empty read or a refused connection is "not yet", never fatal. The
+    // unguarded fetch here once escaped the loop as a ConnectionRefused on
+    // 127.0.0.1:80 (empty port), wasting the whole retry budget on one race.
     if (existsSync(portFile)) {
       const [port] = readFileSync(portFile, 'utf-8').split('\n');
-      const targets = await (await fetch(`http://127.0.0.1:${port}/json/list`)).json() as any[];
-      const page = targets.find((t) => t.type === 'page');
-      if (page?.webSocketDebuggerUrl) return page.webSocketDebuggerUrl;
+      if (/^\d+$/.test(port)) {
+        try {
+          const targets = await (await fetch(`http://127.0.0.1:${port}/json/list`)).json() as any[];
+          const page = targets.find((t) => t.type === 'page');
+          if (page?.webSocketDebuggerUrl) return page.webSocketDebuggerUrl;
+          lastFailure = `no page target on port ${port} yet`;
+        } catch (error) {
+          lastFailure = `port ${port} not answering yet: ${error}`;
+        }
+      } else {
+        lastFailure = `port file present but holds ${JSON.stringify(port)}`;
+      }
     }
     await Bun.sleep(50);
   }
-  throw new Error(`browser never published a devtools port in ${profile}`);
+  throw new Error(`browser never published a usable devtools endpoint in ${profile} (${lastFailure})`);
 }
 
 async function evaluate(session: Session, expression: string): Promise<unknown> {


### PR DESCRIPTION
Closes #218.

The mermaid browser harness polls for Chrome's `DevToolsActivePort` file, but the fetch inside the poll loop was unguarded. Chrome writes that file non-atomically and opens the socket after — so one mid-write read (empty port → `127.0.0.1:80` → `ConnectionRefused`) threw straight out of the loop with 18s of retry budget unspent. That is the exact portless-URL failure observed on hosted macOS in the v0.5.2 release run.

Now every not-yet shape retries within the budget — non-numeric port, refused socket, no page target — and the timeout message names the last thing it was waiting for instead of a misleading connection error.

Verified: 20/20 consecutive local runs green (the race never reproduced locally — the guarantee is structural: no throw inside the loop can escape it), and the fix preserves the deliberate slow-browser patience the neighbouring test pins.