### PR TITLE
feat(install): version stamp + session-start update notice

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -44,6 +44,8 @@ main() {
 }
 
 # Newest v<major>.<minor>.<patch> tag on the remote, read without cloning.
+# hooks/claude/lib/latest-tag.sh is the sourceable twin — this copy exists
+# because a curl-piped single file has nothing to source; keep them in step.
 # Sorted field by field as numbers: `sort -V` is GNU-only and missing on macOS,
 # and a lexical sort ranks v0.4.9 above v0.4.10.
 latest_tag() {

--- a/hooks/claude/lib/latest-tag.sh
+++ b/hooks/claude/lib/latest-tag.sh
@@ -1,0 +1,21 @@
+# Newest vX.Y.Z tag on a remote, numerically: sort -V is GNU-only and a lexical
+# sort ranks v0.4.9 above v0.4.10. bootstrap.sh carries its own copy because it
+# runs as a curl-piped single file with nothing to source — keep them in step.
+# `timeout` is also GNU-only: Homebrew ships it as gtimeout, stock macOS has
+# neither, and without a bound the caller's own hook timeout is the ceiling.
+latest_remote_tag() {
+	local url="$1" bound="" newest
+	if command -v timeout >/dev/null 2>&1; then
+		bound="timeout 4"
+	elif command -v gtimeout >/dev/null 2>&1; then
+		bound="gtimeout 4"
+	fi
+	newest=$(GIT_TERMINAL_PROMPT=0 GIT_ASKPASS=true $bound git ls-remote --tags --refs "$url" 2>/dev/null \
+		| awk '{ sub(/^refs\/tags\//, "", $2); print $2 }' \
+		| grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+		| sed 's/^v//' \
+		| sort -t. -k1,1n -k2,2n -k3,3n \
+		| tail -1)
+	[ -n "$newest" ] || return 1
+	printf 'v%s\n' "$newest"
+}

--- a/hooks/claude/lib/latest-tag.sh
+++ b/hooks/claude/lib/latest-tag.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # Newest vX.Y.Z tag on a remote, numerically: sort -V is GNU-only and a lexical
 # sort ranks v0.4.9 above v0.4.10. bootstrap.sh carries its own copy because it
 # runs as a curl-piped single file with nothing to source — keep them in step.

--- a/hooks/claude/settings.json
+++ b/hooks/claude/settings.json
@@ -107,6 +107,17 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/update-notice.sh",
+            "timeout": 8
+          }
+        ]
+      }
     ]
   }
 }

--- a/hooks/claude/settings.json
+++ b/hooks/claude/settings.json
@@ -110,6 +110,7 @@
     ],
     "SessionStart": [
       {
+        "matcher": "startup",
         "hooks": [
           {
             "type": "command",

--- a/hooks/claude/update-notice.sh
+++ b/hooks/claude/update-notice.sh
@@ -8,6 +8,11 @@ STAMP="$AGENTKIT_HOME/version"
 CACHE="$AGENTKIT_HOME/.update-check"
 REPO_URL="${AGENTKIT_UPDATE_REMOTE:-https://github.com/developerinlondon/agentkit.git}"
 TTL=86400
+FAILURE_TTL=3600
+
+lib="$(cd "$(dirname "$0")" 2>/dev/null && pwd)/lib/latest-tag.sh"
+[ -r "$lib" ] || exit 0
+. "$lib"
 
 [ -r "$STAMP" ] || exit 0
 installed=$(head -n1 "$STAMP" 2>/dev/null)
@@ -16,24 +21,28 @@ case "$installed" in v[0-9]*) ;; *) exit 0 ;; esac
 now=$(date +%s 2>/dev/null) || exit 0
 latest=""
 if [ -r "$CACHE" ]; then
-	read -r cached_at cached_tag <"$CACHE" 2>/dev/null || true
-	if [ "$cached_at" -gt 0 ] 2>/dev/null && [ $((now - cached_at)) -lt "$TTL" ]; then
-		latest="$cached_tag"
+	read -r cached_at cached_tag _ <"$CACHE" 2>/dev/null || true
+	if [ "${cached_at:-}" -gt 0 ] 2>/dev/null; then
+		age=$((now - cached_at))
+		ttl="$TTL"
+		# A '-' records a recent failed check, so a broken network is retried
+		# on its own clock instead of at every single session start.
+		[ "$cached_tag" = "-" ] && ttl="$FAILURE_TTL"
+		if [ "$age" -ge 0 ] && [ "$age" -lt "$ttl" ]; then
+			case "$cached_tag" in
+			-) exit 0 ;;
+			v[0-9]*.[0-9]*) latest="$cached_tag" ;;
+			esac
+		fi
 	fi
 fi
 
 if [ -z "$latest" ]; then
-	# Newest vX.Y.Z on the remote, numerically: sort -V is GNU-only, and a
-	# lexical sort ranks v0.4.9 above v0.4.10.
-	latest=$(timeout 4 git ls-remote --tags --refs "$REPO_URL" 2>/dev/null \
-		| awk '{ sub(/^refs\/tags\//, "", $2); print $2 }' \
-		| grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
-		| sed 's/^v//' \
-		| sort -t. -k1,1n -k2,2n -k3,3n \
-		| tail -1)
-	[ -n "$latest" ] || exit 0
-	latest="v$latest"
-	printf '%s %s\n' "$now" "$latest" >"$CACHE" 2>/dev/null || true
+	if ! latest=$(latest_remote_tag "$REPO_URL"); then
+		printf '%s -\n' "$now" 2>/dev/null >"$CACHE" || true
+		exit 0
+	fi
+	printf '%s %s\n' "$now" "$latest" 2>/dev/null >"$CACHE" || true
 fi
 
 case "$latest" in v[0-9]*) ;; *) exit 0 ;; esac

--- a/hooks/claude/update-notice.sh
+++ b/hooks/claude/update-notice.sh
@@ -12,6 +12,7 @@ FAILURE_TTL=3600
 
 lib="$(cd "$(dirname "$0")" 2>/dev/null && pwd)/lib/latest-tag.sh"
 [ -r "$lib" ] || exit 0
+# shellcheck source=lib/latest-tag.sh
 . "$lib"
 
 [ -r "$STAMP" ] || exit 0

--- a/hooks/claude/update-notice.sh
+++ b/hooks/claude/update-notice.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# SessionStart: one line when a newer AgentKit release exists. Never blocks and
+# never installs anything — every failure path here is silence, because a
+# version check must not cost a session anything.
+
+AGENTKIT_HOME="${AGENTKIT_HOME:-$HOME/.agentkit}"
+STAMP="$AGENTKIT_HOME/version"
+CACHE="$AGENTKIT_HOME/.update-check"
+REPO_URL="${AGENTKIT_UPDATE_REMOTE:-https://github.com/developerinlondon/agentkit.git}"
+TTL=86400
+
+[ -r "$STAMP" ] || exit 0
+installed=$(head -n1 "$STAMP" 2>/dev/null)
+case "$installed" in v[0-9]*) ;; *) exit 0 ;; esac
+
+now=$(date +%s 2>/dev/null) || exit 0
+latest=""
+if [ -r "$CACHE" ]; then
+	read -r cached_at cached_tag <"$CACHE" 2>/dev/null || true
+	if [ "$cached_at" -gt 0 ] 2>/dev/null && [ $((now - cached_at)) -lt "$TTL" ]; then
+		latest="$cached_tag"
+	fi
+fi
+
+if [ -z "$latest" ]; then
+	# Newest vX.Y.Z on the remote, numerically: sort -V is GNU-only, and a
+	# lexical sort ranks v0.4.9 above v0.4.10.
+	latest=$(timeout 4 git ls-remote --tags --refs "$REPO_URL" 2>/dev/null \
+		| awk '{ sub(/^refs\/tags\//, "", $2); print $2 }' \
+		| grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+		| sed 's/^v//' \
+		| sort -t. -k1,1n -k2,2n -k3,3n \
+		| tail -1)
+	[ -n "$latest" ] || exit 0
+	latest="v$latest"
+	printf '%s %s\n' "$now" "$latest" >"$CACHE" 2>/dev/null || true
+fi
+
+case "$latest" in v[0-9]*) ;; *) exit 0 ;; esac
+[ "$latest" = "$installed" ] && exit 0
+
+newer=$(printf '%s\n%s\n' "${installed#v}" "${latest#v}" \
+	| sort -t. -k1,1n -k2,2n -k3,3n | tail -1)
+[ "v$newer" = "$latest" ] || exit 0
+
+echo "[agentkit] $installed installed — $latest is available: re-run install.sh --global from an updated clone (or the curl bootstrap)."
+exit 0

--- a/install.sh
+++ b/install.sh
@@ -181,6 +181,22 @@ KITS_STATE_FILE="$AGENTKIT_HOME/kits"
 RETIRED_KITS_STATE_FILE="$AGENTKIT_HOME/groups"
 RETIRED_KIT_REPLACEMENT=adversarial-review
 
+# Answers "what is this machine running?" in one cat, and feeds the
+# session-start update notice. Best effort: no git metadata, no stamp — and the
+# notice stays silent rather than comparing against a guess.
+write_version_stamp() {
+	local version
+	version=$(git -C "$REPO_DIR" describe --tags --exact-match HEAD 2>/dev/null) \
+		|| version=$(git -C "$REPO_DIR" describe --tags 2>/dev/null) \
+		|| version=$(git -C "$REPO_DIR" rev-parse --short HEAD 2>/dev/null) \
+		|| { echo "[version] No git metadata in $REPO_DIR — not stamping." >&2; return 0; }
+	{
+		printf '%s\n' "$version"
+		printf 'installed_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+	} >"$AGENTKIT_HOME/version"
+	echo "[version] Stamped: $version ($AGENTKIT_HOME/version)"
+}
+
 kits_state_header() {
 	echo "# Skill kits chosen at install time; a bare install.sh --global keeps them."
 	echo "# Delete a line to stop installing that kit (installed skills are left alone)."
@@ -1079,8 +1095,22 @@ merge_claude_settings() {
 			echo "[claude] Adding hooks to existing: $settings_file"
 		fi
 
-		# Deep merge: keep existing keys, overlay our hooks
-		echo "$existing" | jq --argjson new_hooks "$hooks_json" '. * $new_hooks' >"${settings_file}.tmp"
+		# Deep merge, except SessionStart: `*` replaces arrays wholesale, and
+		# other tooling legitimately wires its own SessionStart entries — those
+		# must survive, so agentkit's entry appends after its old copy is
+		# stripped. The police events stay replace-semantics on purpose: there
+		# agentkit's wiring is the single source of truth.
+		echo "$existing" | jq --argjson new_hooks "$hooks_json" '
+      ($new_hooks.hooks.SessionStart // []) as $ours
+      | ((.hooks // {}).SessionStart // []) as $theirs
+      | . * ($new_hooks | del(.hooks.SessionStart))
+      | .hooks.SessionStart = (
+          ($theirs | map(select(
+            ((.hooks // []) | any(.command // "" | contains("update-notice.sh"))) | not
+          ))) + $ours
+        )
+      | if (.hooks.SessionStart | length) == 0 then del(.hooks.SessionStart) else . end
+    ' >"${settings_file}.tmp"
 		mv "${settings_file}.tmp" "$settings_file"
 	else
 		# Create new settings file with just hooks
@@ -1548,6 +1578,7 @@ if [[ "$GLOBAL" == true ]]; then
 	install_config
 	write_persisted_kits
 	echo "[kits] Selected: $SELECTED_KITS ($KITS_STATE_FILE)"
+	write_version_stamp
 	echo ""
 
 	# ── Shared content root (single copy) ──

--- a/install.sh
+++ b/install.sh
@@ -1105,9 +1105,12 @@ merge_claude_settings() {
       | ((.hooks // {}).SessionStart // []) as $theirs
       | . * ($new_hooks | del(.hooks.SessionStart))
       | .hooks.SessionStart = (
-          ($theirs | map(select(
-            ((.hooks // []) | any(.command // "" | contains("update-notice.sh"))) | not
-          ))) + $ours
+          ($theirs
+            | map(.hooks = ((.hooks // []) | map(select(
+                ((.command // "") | contains("update-notice.sh")) | not
+              ))))
+            | map(select((.hooks | length) > 0))
+          ) + $ours
         )
       | if (.hooks.SessionStart | length) == 0 then del(.hooks.SessionStart) else . end
     ' >"${settings_file}.tmp"

--- a/plugins-cc/agentkit-adversarial-review/hooks/lib/latest-tag.sh
+++ b/plugins-cc/agentkit-adversarial-review/hooks/lib/latest-tag.sh
@@ -1,0 +1,21 @@
+# Newest vX.Y.Z tag on a remote, numerically: sort -V is GNU-only and a lexical
+# sort ranks v0.4.9 above v0.4.10. bootstrap.sh carries its own copy because it
+# runs as a curl-piped single file with nothing to source — keep them in step.
+# `timeout` is also GNU-only: Homebrew ships it as gtimeout, stock macOS has
+# neither, and without a bound the caller's own hook timeout is the ceiling.
+latest_remote_tag() {
+	local url="$1" bound="" newest
+	if command -v timeout >/dev/null 2>&1; then
+		bound="timeout 4"
+	elif command -v gtimeout >/dev/null 2>&1; then
+		bound="gtimeout 4"
+	fi
+	newest=$(GIT_TERMINAL_PROMPT=0 GIT_ASKPASS=true $bound git ls-remote --tags --refs "$url" 2>/dev/null \
+		| awk '{ sub(/^refs\/tags\//, "", $2); print $2 }' \
+		| grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+		| sed 's/^v//' \
+		| sort -t. -k1,1n -k2,2n -k3,3n \
+		| tail -1)
+	[ -n "$newest" ] || return 1
+	printf 'v%s\n' "$newest"
+}

--- a/plugins-cc/agentkit-adversarial-review/hooks/lib/latest-tag.sh
+++ b/plugins-cc/agentkit-adversarial-review/hooks/lib/latest-tag.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # Newest vX.Y.Z tag on a remote, numerically: sort -V is GNU-only and a lexical
 # sort ranks v0.4.9 above v0.4.10. bootstrap.sh carries its own copy because it
 # runs as a curl-piped single file with nothing to source — keep them in step.

--- a/plugins-cc/agentkit/hooks/hooks.json
+++ b/plugins-cc/agentkit/hooks/hooks.json
@@ -90,6 +90,17 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/update-notice.sh",
+            "timeout": 8
+          }
+        ]
+      }
     ]
   }
 }

--- a/plugins-cc/agentkit/hooks/hooks.json
+++ b/plugins-cc/agentkit/hooks/hooks.json
@@ -93,6 +93,7 @@
     ],
     "SessionStart": [
       {
+        "matcher": "startup",
         "hooks": [
           {
             "type": "command",

--- a/plugins-cc/agentkit/hooks/lib/latest-tag.sh
+++ b/plugins-cc/agentkit/hooks/lib/latest-tag.sh
@@ -1,0 +1,21 @@
+# Newest vX.Y.Z tag on a remote, numerically: sort -V is GNU-only and a lexical
+# sort ranks v0.4.9 above v0.4.10. bootstrap.sh carries its own copy because it
+# runs as a curl-piped single file with nothing to source — keep them in step.
+# `timeout` is also GNU-only: Homebrew ships it as gtimeout, stock macOS has
+# neither, and without a bound the caller's own hook timeout is the ceiling.
+latest_remote_tag() {
+	local url="$1" bound="" newest
+	if command -v timeout >/dev/null 2>&1; then
+		bound="timeout 4"
+	elif command -v gtimeout >/dev/null 2>&1; then
+		bound="gtimeout 4"
+	fi
+	newest=$(GIT_TERMINAL_PROMPT=0 GIT_ASKPASS=true $bound git ls-remote --tags --refs "$url" 2>/dev/null \
+		| awk '{ sub(/^refs\/tags\//, "", $2); print $2 }' \
+		| grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+		| sed 's/^v//' \
+		| sort -t. -k1,1n -k2,2n -k3,3n \
+		| tail -1)
+	[ -n "$newest" ] || return 1
+	printf 'v%s\n' "$newest"
+}

--- a/plugins-cc/agentkit/hooks/lib/latest-tag.sh
+++ b/plugins-cc/agentkit/hooks/lib/latest-tag.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # Newest vX.Y.Z tag on a remote, numerically: sort -V is GNU-only and a lexical
 # sort ranks v0.4.9 above v0.4.10. bootstrap.sh carries its own copy because it
 # runs as a curl-piped single file with nothing to source — keep them in step.

--- a/plugins-cc/agentkit/hooks/update-notice.sh
+++ b/plugins-cc/agentkit/hooks/update-notice.sh
@@ -8,6 +8,11 @@ STAMP="$AGENTKIT_HOME/version"
 CACHE="$AGENTKIT_HOME/.update-check"
 REPO_URL="${AGENTKIT_UPDATE_REMOTE:-https://github.com/developerinlondon/agentkit.git}"
 TTL=86400
+FAILURE_TTL=3600
+
+lib="$(cd "$(dirname "$0")" 2>/dev/null && pwd)/lib/latest-tag.sh"
+[ -r "$lib" ] || exit 0
+. "$lib"
 
 [ -r "$STAMP" ] || exit 0
 installed=$(head -n1 "$STAMP" 2>/dev/null)
@@ -16,24 +21,28 @@ case "$installed" in v[0-9]*) ;; *) exit 0 ;; esac
 now=$(date +%s 2>/dev/null) || exit 0
 latest=""
 if [ -r "$CACHE" ]; then
-	read -r cached_at cached_tag <"$CACHE" 2>/dev/null || true
-	if [ "$cached_at" -gt 0 ] 2>/dev/null && [ $((now - cached_at)) -lt "$TTL" ]; then
-		latest="$cached_tag"
+	read -r cached_at cached_tag _ <"$CACHE" 2>/dev/null || true
+	if [ "${cached_at:-}" -gt 0 ] 2>/dev/null; then
+		age=$((now - cached_at))
+		ttl="$TTL"
+		# A '-' records a recent failed check, so a broken network is retried
+		# on its own clock instead of at every single session start.
+		[ "$cached_tag" = "-" ] && ttl="$FAILURE_TTL"
+		if [ "$age" -ge 0 ] && [ "$age" -lt "$ttl" ]; then
+			case "$cached_tag" in
+			-) exit 0 ;;
+			v[0-9]*.[0-9]*) latest="$cached_tag" ;;
+			esac
+		fi
 	fi
 fi
 
 if [ -z "$latest" ]; then
-	# Newest vX.Y.Z on the remote, numerically: sort -V is GNU-only, and a
-	# lexical sort ranks v0.4.9 above v0.4.10.
-	latest=$(timeout 4 git ls-remote --tags --refs "$REPO_URL" 2>/dev/null \
-		| awk '{ sub(/^refs\/tags\//, "", $2); print $2 }' \
-		| grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
-		| sed 's/^v//' \
-		| sort -t. -k1,1n -k2,2n -k3,3n \
-		| tail -1)
-	[ -n "$latest" ] || exit 0
-	latest="v$latest"
-	printf '%s %s\n' "$now" "$latest" >"$CACHE" 2>/dev/null || true
+	if ! latest=$(latest_remote_tag "$REPO_URL"); then
+		printf '%s -\n' "$now" 2>/dev/null >"$CACHE" || true
+		exit 0
+	fi
+	printf '%s %s\n' "$now" "$latest" 2>/dev/null >"$CACHE" || true
 fi
 
 case "$latest" in v[0-9]*) ;; *) exit 0 ;; esac

--- a/plugins-cc/agentkit/hooks/update-notice.sh
+++ b/plugins-cc/agentkit/hooks/update-notice.sh
@@ -12,6 +12,7 @@ FAILURE_TTL=3600
 
 lib="$(cd "$(dirname "$0")" 2>/dev/null && pwd)/lib/latest-tag.sh"
 [ -r "$lib" ] || exit 0
+# shellcheck source=lib/latest-tag.sh
 . "$lib"
 
 [ -r "$STAMP" ] || exit 0

--- a/plugins-cc/agentkit/hooks/update-notice.sh
+++ b/plugins-cc/agentkit/hooks/update-notice.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# SessionStart: one line when a newer AgentKit release exists. Never blocks and
+# never installs anything — every failure path here is silence, because a
+# version check must not cost a session anything.
+
+AGENTKIT_HOME="${AGENTKIT_HOME:-$HOME/.agentkit}"
+STAMP="$AGENTKIT_HOME/version"
+CACHE="$AGENTKIT_HOME/.update-check"
+REPO_URL="${AGENTKIT_UPDATE_REMOTE:-https://github.com/developerinlondon/agentkit.git}"
+TTL=86400
+
+[ -r "$STAMP" ] || exit 0
+installed=$(head -n1 "$STAMP" 2>/dev/null)
+case "$installed" in v[0-9]*) ;; *) exit 0 ;; esac
+
+now=$(date +%s 2>/dev/null) || exit 0
+latest=""
+if [ -r "$CACHE" ]; then
+	read -r cached_at cached_tag <"$CACHE" 2>/dev/null || true
+	if [ "$cached_at" -gt 0 ] 2>/dev/null && [ $((now - cached_at)) -lt "$TTL" ]; then
+		latest="$cached_tag"
+	fi
+fi
+
+if [ -z "$latest" ]; then
+	# Newest vX.Y.Z on the remote, numerically: sort -V is GNU-only, and a
+	# lexical sort ranks v0.4.9 above v0.4.10.
+	latest=$(timeout 4 git ls-remote --tags --refs "$REPO_URL" 2>/dev/null \
+		| awk '{ sub(/^refs\/tags\//, "", $2); print $2 }' \
+		| grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+		| sed 's/^v//' \
+		| sort -t. -k1,1n -k2,2n -k3,3n \
+		| tail -1)
+	[ -n "$latest" ] || exit 0
+	latest="v$latest"
+	printf '%s %s\n' "$now" "$latest" >"$CACHE" 2>/dev/null || true
+fi
+
+case "$latest" in v[0-9]*) ;; *) exit 0 ;; esac
+[ "$latest" = "$installed" ] && exit 0
+
+newer=$(printf '%s\n%s\n' "${installed#v}" "${latest#v}" \
+	| sort -t. -k1,1n -k2,2n -k3,3n | tail -1)
+[ "v$newer" = "$latest" ] || exit 0
+
+echo "[agentkit] $installed installed — $latest is available: re-run install.sh --global from an updated clone (or the curl bootstrap)."
+exit 0

--- a/scripts/check-test-slices.ts
+++ b/scripts/check-test-slices.ts
@@ -40,6 +40,7 @@ export const TEST_SLICES = {
     'tests/install/manifest-readers.test.ts',
     'tests/install/plugin-scripts.test.ts',
     'tests/install/skill-kits.test.ts',
+    'tests/install/update-notice.test.ts',
     'tests/install/wizard.test.ts',
   ],
   integrations: ['tests/infra-tools-mcp.test.ts', 'tests/test-slices.test.ts'],

--- a/tests/install/update-notice.test.ts
+++ b/tests/install/update-notice.test.ts
@@ -128,6 +128,7 @@ describe('the session-start update notice', () => {
   // machine pays a fresh network attempt forever.
   test('a failed check writes a negative cache that later runs honour', () => {
     const h = home('v0.1.0');
+    const remote = remoteWithTags(['v9.9.9']);
     try {
       const first = runNotice(h, '/nonexistent/remote');
       expect(first.status).toBe(0);
@@ -135,11 +136,14 @@ describe('the session-start update notice', () => {
       const cache = readFileSync(join(h, '.agentkit', '.update-check'), 'utf-8');
       expect(cache.trim()).toMatch(/^\d+ -$/);
 
-      const second = runNotice(h, '/nonexistent/remote');
+      // Against a WORKING remote holding an update: only the honoured negative
+      // cache can explain silence here.
+      const second = runNotice(h, remote);
       expect(second.status).toBe(0);
       expect(second.stdout).toBe('');
     } finally {
       rmSync(h, { force: true, recursive: true });
+      rmSync(remote, { force: true, recursive: true });
     }
   });
 

--- a/tests/install/update-notice.test.ts
+++ b/tests/install/update-notice.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, test } from 'bun:test';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const repoRoot = dirname(dirname(import.meta.dir));
+const notice = join(repoRoot, 'hooks', 'claude', 'update-notice.sh');
+
+function sh(command: string, env: Record<string, string> = {}) {
+  return spawnSync('bash', ['-c', command], {
+    encoding: 'utf-8',
+    env: { ...process.env, ...env },
+    timeout: 30_000,
+  });
+}
+
+// A local remote the check can ls-remote without the network.
+function remoteWithTags(tags: string[]): string {
+  const dir = mkdtempSync(join(tmpdir(), 'agentkit-remote-'));
+  sh(
+    `cd "${dir}" && git init -q && git -c user.email=t@t -c user.name=t commit -q --allow-empty -m x`
+      + tags.map((t) => ` && git tag ${t}`).join(''),
+  );
+  return dir;
+}
+
+function home(installed?: string): string {
+  const dir = mkdtempSync(join(tmpdir(), 'agentkit-notice-'));
+  mkdirSync(join(dir, '.agentkit'), { recursive: true });
+  if (installed) writeFileSync(join(dir, '.agentkit', 'version'), `${installed}\ninstalled_at=x\n`);
+  return dir;
+}
+
+function runNotice(homeDir: string, remote: string) {
+  return sh(`"${notice}"`, {
+    HOME: homeDir,
+    AGENTKIT_HOME: join(homeDir, '.agentkit'),
+    AGENTKIT_UPDATE_REMOTE: remote,
+  });
+}
+
+describe('the session-start update notice', () => {
+  test('names both versions when the remote is ahead', () => {
+    const h = home('v0.5.0');
+    const remote = remoteWithTags(['v0.5.0', 'v0.5.2', 'v0.4.9']);
+    try {
+      const r = runNotice(h, remote);
+      expect(r.status, r.stderr).toBe(0);
+      expect(r.stdout).toContain('v0.5.0 installed');
+      expect(r.stdout).toContain('v0.5.2 is available');
+    } finally {
+      rmSync(h, { force: true, recursive: true });
+      rmSync(remote, { force: true, recursive: true });
+    }
+  });
+
+  function expectSilence(h: string, remote: string) {
+    try {
+      const r = runNotice(h, remote);
+      expect(r.status, r.stderr).toBe(0);
+      expect(r.stdout).toBe('');
+    } finally {
+      rmSync(h, { force: true, recursive: true });
+      if (remote.includes('agentkit-remote-')) rmSync(remote, { force: true, recursive: true });
+    }
+  }
+
+  test('says nothing when the installed version is current', () => {
+    expectSilence(home('v0.5.2'), remoteWithTags(['v0.5.2']));
+  });
+
+  // v0.4.9 vs v0.4.10 is the lexical-sort trap; the numeric field sort must
+  // also refuse to call an OLDER remote "available" (a rollback is not news).
+  test('orders versions numerically, and an older remote stays silent', () => {
+    expectSilence(home('v0.4.10'), remoteWithTags(['v0.4.9']));
+  });
+
+  test('a missing stamp, a sha stamp, and an unreachable remote are all silence', () => {
+    const noStamp = home();
+    const shaStamp = home('abc1234');
+    const unreachable = home('v0.1.0');
+    try {
+      for (const [h, remote] of [
+        [noStamp, remoteWithTags(['v9.9.9'])],
+        [shaStamp, remoteWithTags(['v9.9.9'])],
+        [unreachable, '/nonexistent/remote'],
+      ] as const) {
+        const r = runNotice(h, remote);
+        expect(r.status, r.stderr).toBe(0);
+        expect(r.stdout).toBe('');
+      }
+    } finally {
+      for (const d of [noStamp, shaStamp, unreachable]) rmSync(d, { force: true, recursive: true });
+    }
+  });
+
+  test('a fresh cache answers without touching the remote', () => {
+    const h = home('v0.1.0');
+    const now = Math.floor(Date.now() / 1000);
+    writeFileSync(join(h, '.agentkit', '.update-check'), `${now} v0.2.0\n`);
+    try {
+      // The remote does not exist: only the cache can supply the answer.
+      const r = runNotice(h, '/nonexistent/remote');
+      expect(r.status).toBe(0);
+      expect(r.stdout).toContain('v0.2.0 is available');
+    } finally {
+      rmSync(h, { force: true, recursive: true });
+    }
+  });
+
+  test('a stale cache is refreshed from the remote', () => {
+    const h = home('v0.1.0');
+    writeFileSync(join(h, '.agentkit', '.update-check'), `1000 v0.0.1\n`);
+    const remote = remoteWithTags(['v0.3.0']);
+    try {
+      const r = runNotice(h, remote);
+      expect(r.status).toBe(0);
+      expect(r.stdout).toContain('v0.3.0 is available');
+      expect(readFileSync(join(h, '.agentkit', '.update-check'), 'utf-8')).toContain('v0.3.0');
+    } finally {
+      rmSync(h, { force: true, recursive: true });
+      rmSync(remote, { force: true, recursive: true });
+    }
+  });
+});
+
+describe('the installed version stamp', () => {
+  function installGlobally(h: string) {
+    return spawnSync(
+      'bash',
+      [join(repoRoot, 'install.sh'), '--global', '--no-session-scope', '--no-prompt'],
+      {
+        cwd: repoRoot,
+        encoding: 'utf-8',
+        timeout: 120_000,
+        env: {
+          ...process.env,
+          AGENTKIT_PLATFORM: 'linux',
+          HOME: h,
+          XDG_CONFIG_HOME: join(h, '.config'),
+          AGENTKIT_HOME: join(h, '.agentkit'),
+          CODEX_HOME: join(h, '.codex'),
+        },
+      },
+    );
+  }
+
+  test('a global install stamps the resolved version', () => {
+    const h = mkdtempSync(join(tmpdir(), 'agentkit-stamp-'));
+    try {
+      const r = installGlobally(h);
+      expect(r.status, r.stderr).toBe(0);
+      const stamp = readFileSync(join(h, '.agentkit', 'version'), 'utf-8');
+      expect(stamp.split('\n')[0]).toMatch(/^(v\d+\.\d+\.\d+|[0-9a-f]{7,})/);
+      expect(stamp).toContain('installed_at=');
+      // The hook landed and the wiring appended SessionStart without clobbering
+      // a foreign entry present before the install.
+      expect(existsSync(join(h, '.agentkit', 'hooks', 'update-notice.sh'))).toBe(true);
+    } finally {
+      rmSync(h, { force: true, recursive: true });
+    }
+  }, 120_000);
+
+  test('SessionStart wiring appends beside a foreign hook, once, across reruns', () => {
+    const h = mkdtempSync(join(tmpdir(), 'agentkit-stamp-'));
+    try {
+      const settings = join(h, '.claude', 'settings.json');
+      mkdirSync(dirname(settings), { recursive: true });
+      writeFileSync(
+        settings,
+        JSON.stringify({
+          hooks: { SessionStart: [{ hooks: [{ type: 'command', command: 'other-tool.sh' }] }] },
+        }),
+      );
+      for (let i = 0; i < 2; i += 1) {
+        const r = installGlobally(h);
+        expect(r.status, r.stderr).toBe(0);
+      }
+      const wired = JSON.parse(readFileSync(settings, 'utf-8'));
+      const flat = wired.hooks.SessionStart.flatMap((g: any) => g.hooks ?? []);
+      expect(flat.filter((e: any) => e.command === 'other-tool.sh')).toHaveLength(1);
+      expect(flat.filter((e: any) => String(e.command).includes('update-notice.sh'))).toHaveLength(1);
+    } finally {
+      rmSync(h, { force: true, recursive: true });
+    }
+  }, 240_000);
+});

--- a/tests/install/update-notice.test.ts
+++ b/tests/install/update-notice.test.ts
@@ -95,6 +95,54 @@ describe('the session-start update notice', () => {
     }
   });
 
+  // timeout(1) is GNU coreutils; stock macOS has neither it nor gtimeout. The
+  // first cut of this hook died silently there — command-not-found inside the
+  // substitution reads as "no update". The bound must be optional.
+  test('a PATH without timeout or gtimeout still notices an update', () => {
+    const h = home('v0.1.0');
+    const remote = remoteWithTags(['v0.2.0']);
+    const bin = mkdtempSync(join(tmpdir(), 'agentkit-thinpath-'));
+    try {
+      for (const tool of ['bash', 'git', 'awk', 'grep', 'sed', 'sort', 'tail', 'head', 'date', 'dirname', 'printf']) {
+        const located = sh(`command -v ${tool}`).stdout.trim();
+        if (located) sh(`ln -s "${located}" "${join(bin, tool)}"`);
+      }
+      const r = spawnSync('bash', [notice], {
+        encoding: 'utf-8',
+        timeout: 30_000,
+        env: {
+          PATH: bin,
+          HOME: h,
+          AGENTKIT_HOME: join(h, '.agentkit'),
+          AGENTKIT_UPDATE_REMOTE: remote,
+        },
+      });
+      expect(r.status, r.stderr).toBe(0);
+      expect(r.stdout).toContain('v0.2.0 is available');
+    } finally {
+      for (const d of [h, remote, bin]) rmSync(d, { force: true, recursive: true });
+    }
+  });
+
+  // A failed check must be remembered, or every session start on an offline
+  // machine pays a fresh network attempt forever.
+  test('a failed check writes a negative cache that later runs honour', () => {
+    const h = home('v0.1.0');
+    try {
+      const first = runNotice(h, '/nonexistent/remote');
+      expect(first.status).toBe(0);
+      expect(first.stdout).toBe('');
+      const cache = readFileSync(join(h, '.agentkit', '.update-check'), 'utf-8');
+      expect(cache.trim()).toMatch(/^\d+ -$/);
+
+      const second = runNotice(h, '/nonexistent/remote');
+      expect(second.status).toBe(0);
+      expect(second.stdout).toBe('');
+    } finally {
+      rmSync(h, { force: true, recursive: true });
+    }
+  });
+
   test('a fresh cache answers without touching the remote', () => {
     const h = home('v0.1.0');
     const now = Math.floor(Date.now() / 1000);


### PR DESCRIPTION
Closes #216. The notify-only design as decided: nothing auto-applies.

## What

- **`~/.agentkit/version`**: global installs stamp the resolved tag (or describe/sha for non-tag clones) plus install time. "What is this machine running?" becomes one `cat` — previously it required diffing installed files against a checkout.
- **Session-start notice**: a Claude `SessionStart` hook prints exactly one line when the newest remote tag is ahead of the stamp:
  `[agentkit] v0.5.2 installed — v0.5.3 is available: re-run install.sh --global from an updated clone (or the curl bootstrap).`
  The remote answer caches for 24h (`~/.agentkit/.update-check`), the `ls-remote` carries a 4s timeout, and every failure path — no stamp, sha stamp, unreachable remote, malformed cache — is **silence**. A version check must never cost a session anything.
- **SessionStart merges by append, not replace**: jq's `*` replaces arrays wholesale, so wiring SessionStart through the existing deep merge would have deleted other tooling's session hooks (OMC's, on the primary dev machine). agentkit's entry now appends after stripping only its own older copy; foreign entries survive re-runs — pinned by a test that seeds one and installs twice.
- Plugin mirror + hooks.json carry the new event; the test-slice map covers the new test file.

## Verification

- 8/8 targeted tests: ahead → named notice; current/older/sha-stamp/no-stamp/unreachable → silence; numeric ordering (v0.4.9 < v0.4.10); fresh cache answers without the network; stale cache refreshes.
- Full suite: 1665 tests, one unrelated review-police timeout under parallel load, clean in isolation.