### PR TITLE
chore(ci): merge-queue readiness, cancellation-aware gate, de-flaked git fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,10 @@ jobs:
     needs: pick-runners
     if: github.event_name != 'pull_request'
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    # Generous on purpose: the slowest pool machine with cold caches once blew
+    # a 30-minute ceiling on a tag push, and a timed-out full suite cancels the
+    # whole release. A slow release beats a dead one.
+    timeout-minutes: 50
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: Cross-platform CI
 
 on:
   pull_request:
+  # The merge queue validates the projected merge result; the full suite runs
+  # there (the event is not a pull_request), which is what a queue is for.
+  merge_group:
   push:
     branches:
       - main
@@ -395,7 +398,9 @@ jobs:
 
   ci-gate:
     name: CI gate
-    if: always()
+    # Not on cancellation: a superseded run's test jobs die cancelled, and a
+    # gate that still runs then reports a failure for work nobody needs.
+    if: always() && !cancelled()
     needs:
       - affected
       - docs

--- a/tests/coding-police-hook.test.ts
+++ b/tests/coding-police-hook.test.ts
@@ -60,6 +60,27 @@ function commitFile(repoDir: string, relPath: string, content: string): void {
   runGit(['commit', '-q', '-m', `add ${relPath}`], repoDir);
 }
 
+// One commit for a whole tree: rapid-fire per-file commits intermittently lose
+// the previous file's blob on slow-fsync CI runners ("invalid object … Error
+// building trees"), and none of these tests needs per-file history.
+function commitTree(repoDir: string, files: Record<string, string>): void {
+  for (const [relPath, content] of Object.entries(files)) {
+    const abs = join(repoDir, relPath);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, content);
+  }
+  runGit(['add', '-A'], repoDir);
+  runGit(['commit', '-q', '-m', 'fixture tree'], repoDir);
+}
+
+function handlerTree(count: number): Record<string, string> {
+  const files: Record<string, string> = {};
+  for (let i = 0; i < count; i++) {
+    files[`src/handlers/h${i}.ts`] = `export const h${i} = ${i};\n`;
+  }
+  return files;
+}
+
 function runHookOnFile(configYaml: string, root: string, filePath: string) {
   const configDir = join(root, 'config', 'agentkit');
   mkdirSync(configDir, { recursive: true });
@@ -272,9 +293,7 @@ describe('Claude coding-police monolith directory', () => {
   test('blocks a new source file in a directory already at the cap', () => {
     const root = mkdtempSync(join(tmpdir(), 'agentkit-dircap-'));
     makeGitRepo(root);
-    for (let i = 0; i < 15; i++) {
-      commitFile(root, `src/handlers/h${i}.ts`, `export const h${i} = ${i};\n`);
-    }
+    commitTree(root, handlerTree(15));
     const target = join(root, 'src/handlers/h15.ts');
     writeFileSync(target, 'export const h15 = 15;\n');
 
@@ -290,9 +309,7 @@ describe('Claude coding-police monolith directory', () => {
   test('allows overwriting an already-tracked file in an over-cap directory', () => {
     const root = mkdtempSync(join(tmpdir(), 'agentkit-dircap-'));
     makeGitRepo(root);
-    for (let i = 0; i < 16; i++) {
-      commitFile(root, `src/handlers/h${i}.ts`, `export const h${i} = ${i};\n`);
-    }
+    commitTree(root, handlerTree(16));
     const target = join(root, 'src/handlers/h0.ts');
     writeFileSync(target, 'export const h0 = 100;\n');
 
@@ -306,9 +323,7 @@ describe('Claude coding-police monolith directory', () => {
   test('max-dir-files: 0 disables the check', () => {
     const root = mkdtempSync(join(tmpdir(), 'agentkit-dircap-'));
     makeGitRepo(root);
-    for (let i = 0; i < 20; i++) {
-      commitFile(root, `src/handlers/h${i}.ts`, `export const h${i} = ${i};\n`);
-    }
+    commitTree(root, handlerTree(20));
     const target = join(root, 'src/handlers/h20.ts');
     writeFileSync(target, 'export const h20 = 20;\n');
 
@@ -322,9 +337,7 @@ describe('Claude coding-police monolith directory', () => {
   test('exclude-patterns suppresses the check for homogeneous collections', () => {
     const root = mkdtempSync(join(tmpdir(), 'agentkit-dircap-'));
     makeGitRepo(root);
-    for (let i = 0; i < 15; i++) {
-      commitFile(root, `src/routes/r${i}.ts`, `export const r${i} = ${i};\n`);
-    }
+    commitTree(root, Object.fromEntries(Array.from({ length: 15 }, (_, i) => [`src/routes/r${i}.ts`, `export const r${i} = ${i};\n`])));
     const target = join(root, 'src/routes/r15.ts');
     writeFileSync(target, 'export const r15 = 15;\n');
 
@@ -342,9 +355,7 @@ describe('Claude coding-police monolith directory', () => {
   test('ignores non-code files even in an over-cap directory', () => {
     const root = mkdtempSync(join(tmpdir(), 'agentkit-dircap-'));
     makeGitRepo(root);
-    for (let i = 0; i < 15; i++) {
-      commitFile(root, `src/handlers/h${i}.ts`, `export const h${i} = ${i};\n`);
-    }
+    commitTree(root, handlerTree(15));
     const target = join(root, 'src/handlers/notes.md');
     writeFileSync(target, '# notes\n');
 


### PR DESCRIPTION
Closes #224. The three delivery-speed items measured during today's release train:

| Fix | Cost it removes |
|---|---|
| `merge_group` trigger | prerequisite for the merge queue — once this merges, the queue replaces strict up-to-date-branch protection, deleting the extra full CI cycle every queued PR currently pays after each merge (~15 min/PR) |
| gate skips cancelled runs (`always() && !cancelled()`) | a superseded run's `always()` gate reported failure for cancelled work — read as a red PR and cost a manual rerun today |
| fixture trees commit once, not 15 rapid-fire per-file commits | the "invalid object … Error building trees" race cost three full reruns today; 10/10 soak clean after, and the fixtures never needed per-file history |

Merge-queue rollout after this merges (repo settings, not code): enable the queue on `main` via ruleset, drop the strict up-to-date requirement it obsoletes. Sequenced after PRs #219/#228 land so nothing mid-flight changes mechanics.

Also queued behind this (filed separately): the install-suite spawns dozens of full global installs; a shared fixture would roughly halve full-suite wall time.