### PR TITLE
ci: raise docs-publish timeout for per-release archive builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,7 +306,9 @@ jobs:
       - full
       - worker-publish
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    # The publish builds every archived version from its tag and uploads all of
+    # them; at the archive cap that is well past the old 20-minute bound.
+    timeout-minutes: 45
     steps:
       - name: Check out the commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
The v0.6.1 tag run's docs publish was killed at its 20-minute job timeout mid-upload (orphan curl), which failed the CI gate and skipped the GitHub Release. The job now builds and uploads an archived site per release tag (#238), so the bound moves to 45 minutes. Refs #237.