### PR TITLE
docs site: version-independent switching banner on archived builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,13 +152,39 @@ jobs:
       matrix:
         os: ${{ fromJSON(needs.pick-runners.outputs.matrix) }}
     steps:
+      # A tag names a commit the main-push run already tested — same SHA, same
+      # tree, same workflow — so a green run for the exact SHA stands in for a
+      # re-run. Tags only: an untested SHA (direct tag) still runs everything,
+      # and any lookup failure falls through to running the suite.
+      - name: Reuse a green run for this exact commit
+        id: reuse
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tested=false
+          if [ "${GITHUB_REF_TYPE:-}" = "tag" ]; then
+            runs=$(curl -sS --max-time 20 -H "Authorization: Bearer $GH_TOKEN" \
+              "https://api.github.com/repos/$GITHUB_REPOSITORY/actions/runs?head_sha=$GITHUB_SHA&status=success&per_page=20" \
+              || true)
+            if [ -n "$runs" ] && printf '%s' "$runs" | jq -e \
+              --arg wf "$GITHUB_WORKFLOW" --arg id "$GITHUB_RUN_ID" \
+              '[.workflow_runs[]? | select(.name == $wf and (.id | tostring) != $id)] | length > 0' \
+              >/dev/null 2>&1; then
+              tested=true
+              echo "commit $GITHUB_SHA already passed a full $GITHUB_WORKFLOW run — reusing it"
+            fi
+          fi
+          echo "tested=$tested" >> "$GITHUB_OUTPUT"
+
       - name: Check out full history
+        if: steps.reuse.outputs.tested != 'true'
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           filter: blob:none
 
       - name: Install pinned Moon and Bun toolchains
+        if: steps.reuse.outputs.tested != 'true'
         uses: moonrepo/setup-toolchain@261c62cb5b0f580c7be7c8cd0f023a2e96756095 # v0.6.4
         env:
           # proto resolves tool versions against the GitHub API; the self-hosted
@@ -169,22 +195,27 @@ jobs:
           auto-install: true
 
       - name: Install dependencies from the lockfile
+        if: steps.reuse.outputs.tested != 'true'
         run: bun install --frozen-lockfile
 
       - name: Install publish-page skill dependencies
+        if: steps.reuse.outputs.tested != 'true'
         run: bun install --frozen-lockfile --cwd skills/publish-page
 
       - name: Install the pinned d2 renderer
+        if: steps.reuse.outputs.tested != 'true'
         uses: ./.github/actions/install-d2
         with:
           version: 0.7.1
 
       - name: Install the pinned dprint formatter
+        if: steps.reuse.outputs.tested != 'true'
         uses: ./.github/actions/install-dprint
         with:
           version: 0.55.2
 
       - name: Run complete suite
+        if: steps.reuse.outputs.tested != 'true'
         run: moon run agentkit:test-full
 
   docs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ top and ships with the next tag.
 
 ## [Unreleased]
 
+## v0.6.2 — 2026-07-31
+
+- fix(site): archived doc versions carry an injected, version-independent
+  switching banner — a tag-era page without the picker no longer strands the
+  reader; the banner reads `/docs/versions.json`, so old archives list even
+  releases that postdate them
+- feat(site): the current docs build emits `/docs/versions.json`, the one
+  source the header picker and the archive banner share
+- ci: the docs publish builds and uploads an archived site per release, so its
+  timeout moves from 20 to 45 minutes — the v0.6.1 tag run died mid-upload,
+  which is why v0.6.1 has no GitHub Release or docs deploy (#240)
+
 ## v0.6.1 — 2026-07-31
 
 - **Enforcement is now opt-in everywhere** (#237). The `resource-police` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ top and ships with the next tag.
 - ci: the docs publish builds and uploads an archived site per release, so its
   timeout moves from 20 to 45 minutes — the v0.6.1 tag run died mid-upload,
   which is why v0.6.1 has no GitHub Release or docs deploy (#240)
+- ci: a tag reuses the green full-suite run of its exact commit instead of
+  re-running both platform suites on a SHA the main push just tested (#243)
+- ci: archives publish incrementally — a slug whose live `archive-stamp.txt`
+  matches (tag, tag sha, banner hash) is neither rebuilt nor re-uploaded, and
+  the prune spares it; dropped slugs still prune (#243)
 
 ## v0.6.1 — 2026-07-31
 

--- a/docs/site/build-archives.sh
+++ b/docs/site/build-archives.sh
@@ -8,6 +8,7 @@ cd "$(dirname "$0")"
 
 DIST="${1:-dist}"
 LIST=src/lib/list-archives.ts
+INJECT=src/lib/inject-banner.ts
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
 die() {
@@ -68,5 +69,11 @@ while IFS=$'\t' read -r slug tag; do
 	escapes=$(grep -rhoE '(href|src)="/docs/[^"]*"' "$DIST_ABS/$slug" 2>/dev/null \
 		| grep -vE "(href|src)=\"/docs/$slug_re/" | sort -u | head -3 || true)
 	[[ -z "$escapes" ]] || die "archive $slug links escape its mount: $escapes"
+
+	# After the escape check, never before: the banner's whole job is to link out
+	# of the archive, and the guard above exists to catch exactly that in the
+	# archive's own content.
+	bun "$INJECT" "$slug" "$DIST_ABS/$slug" || die "archive $slug: banner injection failed"
+
 	echo "[archive] $slug: $(find "$DIST_ABS/$slug" -type f | wc -l | tr -d ' ') files"
 done < "$ENTRIES"

--- a/docs/site/build-archives.sh
+++ b/docs/site/build-archives.sh
@@ -10,6 +10,7 @@ DIST="${1:-dist}"
 LIST=src/lib/list-archives.ts
 INJECT=src/lib/inject-banner.ts
 REPO_ROOT=$(git rev-parse --show-toplevel)
+SITE_URL="${AGENTKIT_SITE_URL:-https://agentkit.sbs}"
 
 die() {
 	echo "build-archives: $*" >&2
@@ -20,6 +21,11 @@ command -v bun >/dev/null || die "bun is required to derive the archive list"
 [[ -d "$DIST" ]] || die "no $DIST — build the current docs first"
 DIST_ABS=$(cd "$DIST" && pwd)
 
+# Rewritten every run: a list left by an earlier run would tell the deploy to
+# spare live objects this build did not reuse.
+REUSED="$DIST_ABS/.reused-archives"
+rm -f "$REUSED"
+
 # Derived from the tags through the same module the picker renders from, and
 # captured before the loop: a process substitution would swallow a derivation
 # failure and read as "no archives", publishing a site whose picker offers
@@ -28,11 +34,29 @@ ENTRIES=$(mktemp)
 trap 'rm -f "$ENTRIES"' EXIT
 bun "$LIST" > "$ENTRIES" || die "could not derive the archive list from $LIST"
 
-while IFS=$'\t' read -r slug tag; do
+while IFS=$'\t' read -r slug tag banner_hash; do
 	[[ "$slug" =~ ^[0-9][0-9.]*$ && "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] \
 		|| die "derived entry is malformed: slug='$slug' tag='$tag'"
+	[[ "$banner_hash" =~ ^[0-9a-f]{16}$ ]] \
+		|| die "derived entry carries no banner hash: slug='$slug'"
 	git -C "$REPO_ROOT" rev-parse -q --verify "refs/tags/$tag" >/dev/null \
 		|| die "tag $tag is not present — fetch tags before building archives"
+
+	stamp="$tag $(git -C "$REPO_ROOT" rev-parse "refs/tags/$tag^{commit}") $banner_hash"
+
+	# An archive is a build of an immutable tag, so only the tag it came from and
+	# the banner injected into it can change what it should contain. When the
+	# published stamp already matches, the live objects are what this run would
+	# produce. Every doubt builds: a failed fetch, an empty read, any mismatch.
+	if [[ "${AGENTKIT_ARCHIVE_REUSE:-}" == 1 ]]; then
+		live_stamp=$(curl -fsS --max-time 20 "$SITE_URL/docs/$slug/archive-stamp.txt" 2>/dev/null || true)
+		if [[ -n "$live_stamp" && "$live_stamp" == "$stamp" ]]; then
+			rm -rf "${DIST_ABS:?}/$slug"
+			printf '%s\n' "$slug" >> "$REUSED"
+			echo "[archive] $slug: reused the published build of $tag"
+			continue
+		fi
+	fi
 
 	echo "[archive] $slug from $tag"
 	tmp=$(mktemp -d)
@@ -74,6 +98,10 @@ while IFS=$'\t' read -r slug tag; do
 	# of the archive, and the guard above exists to catch exactly that in the
 	# archive's own content.
 	bun "$INJECT" "$slug" "$DIST_ABS/$slug" || die "archive $slug: banner injection failed"
+
+	# Written last, so a stamp only ever describes an archive that finished
+	# building and was injected.
+	printf '%s\n' "$stamp" > "$DIST_ABS/$slug/archive-stamp.txt"
 
 	echo "[archive] $slug: $(find "$DIST_ABS/$slug" -type f | wc -l | tr -d ' ') files"
 done < "$ENTRIES"

--- a/docs/site/deploy.sh
+++ b/docs/site/deploy.sh
@@ -29,8 +29,11 @@ fi
 node ./node_modules/astro/bin/astro.mjs build
 
 # Archived versions build from their own tags into dist/<slug>/ — a declared
-# version that fails to build fails the deploy, naming its tag.
-./build-archives.sh dist
+# version that fails to build fails the deploy, naming its tag. Reuse is enabled
+# here and nowhere else: a local build must keep producing the whole site, or the
+# only place the archives are exercised is the one place that skips them.
+AGENTKIT_ARCHIVE_REUSE=1 ./build-archives.sh dist
+REUSED=dist/.reused-archives
 
 # Checked before the stamp is written: a failed build leaves no dist/ at all, and
 # writing the stamp first turns that into a confusing redirection error instead
@@ -70,7 +73,7 @@ uploaded=0
 while IFS= read -r file; do
 	put "$file"
 	uploaded=$((uploaded + 1))
-done < <(find dist -type f ! -name '*.html' ! -path "$STAMP" | sort)
+done < <(find dist -type f ! -name '*.html' ! -path "$STAMP" ! -name .reused-archives | sort)
 
 while IFS= read -r file; do
 	put "$file"
@@ -129,6 +132,21 @@ tr ',' '\n' < "$listing" | grep -oE '"docs/[^"]+"' | tr -d '"' | sort -u > "$liv
 rm -f "$listing"
 (cd dist && find . -type f | sed 's|^\./|docs/|') | sort -u > "$built_keys"
 comm -23 "$live_keys" "$built_keys" > "$stale_keys"
+
+# A reused archive is deliberately absent from dist/, so every one of its live
+# objects looks stale here. Spare exactly the slugs this run reused — dots
+# escaped so `0.5.3` cannot bless `0X5X3` — and do it before the refusal below,
+# which would otherwise measure a deletion nobody proposed. A slug dropped from
+# the selection is in neither list and prunes normally.
+if [[ -s "$REUSED" ]]; then
+	keep_re=$(mktemp)
+	kept=$(mktemp)
+	sed 's/\./\\./g; s|.*|^docs/&/|' "$REUSED" > "$keep_re"
+	grep -vEf "$keep_re" "$stale_keys" > "$kept" || true
+	mv "$kept" "$stale_keys"
+	rm -f "$keep_re"
+	echo "deploy: kept $(grep -c . "$REUSED" || true) reused archive(s) out of the prune"
+fi
 
 stale_count=$(grep -c . "$stale_keys" || true)
 live_count=$(grep -c . "$live_keys" || true)

--- a/docs/site/src/lib/archive-banner.ts
+++ b/docs/site/src/lib/archive-banner.ts
@@ -5,6 +5,8 @@
 // and it reads the version list from the live site rather than from the frozen
 // tag, which cannot know about releases that came after it.
 
+import { createHash } from "node:crypto";
+
 export const BANNER_MARKER = "<!--agentkit-archive-banner-->";
 export const BANNER_ID = "agentkit-archive-banner";
 export const VERSIONS_URL = "/docs/versions.json";
@@ -85,6 +87,13 @@ export function bannerHtml(slug: string): string {
 		+ `<span>You are viewing the v${safe} documentation</span>`
 		+ `<a href="/docs/">Back to the latest documentation &rarr;</a>`
 		+ `</div><style>${style}</style><script>${script}</script>`;
+}
+
+// Identity of the exact bytes a build would inject. An archive is otherwise a
+// build of an immutable tag, so without this a banner change would leave every
+// already-published archive carrying the old one forever.
+export function bannerHash(slug: string): string {
+	return createHash("sha256").update(bannerHtml(slug)).digest("hex").slice(0, 16);
 }
 
 export interface Injection {

--- a/docs/site/src/lib/archive-banner.ts
+++ b/docs/site/src/lib/archive-banner.ts
@@ -1,0 +1,102 @@
+// An archive is a full build of its own tag, so its chrome is whatever that
+// release shipped — the older ones have no version picker at all, and a reader
+// who lands there has no way back. The banner is injected after the build so
+// every archive carries the same switching chrome regardless of its vintage,
+// and it reads the version list from the live site rather than from the frozen
+// tag, which cannot know about releases that came after it.
+
+export const BANNER_MARKER = "<!--agentkit-archive-banner-->";
+export const BANNER_ID = "agentkit-archive-banner";
+export const VERSIONS_URL = "/docs/versions.json";
+
+const escapeHtml = (value: string): string =>
+	value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+
+// Neutral by construction: the banner sits on top of five different eras of this
+// site's design, so it borrows nothing from the page — no CSS variables, no
+// inherited font, no class names that a tag-era stylesheet might also define.
+const style = `
+#${BANNER_ID}{position:sticky;top:0;z-index:2147483647;box-sizing:border-box;
+display:flex;flex-wrap:wrap;align-items:center;justify-content:center;gap:.25rem .75rem;
+padding:.5rem 1rem;margin:0;border:0;border-bottom:1px solid #d4d4d8;background:#f4f4f5;
+color:#18181b;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+font-size:13px;line-height:1.4;text-align:center}
+#${BANNER_ID} a{color:inherit;text-decoration:underline;text-underline-offset:.2em}
+#${BANNER_ID} select{box-sizing:border-box;padding:.15rem .35rem;border:1px solid #a1a1aa;
+background:#fff;color:#18181b;font:inherit;cursor:pointer;max-width:100%}
+@media (prefers-color-scheme:dark){
+#${BANNER_ID}{border-bottom-color:#3f3f46;background:#18181b;color:#e4e4e7}
+#${BANNER_ID} select{border-color:#52525b;background:#27272a;color:#e4e4e7}}
+:root[data-theme="light"] #${BANNER_ID}{border-bottom-color:#d4d4d8;background:#f4f4f5;color:#18181b}
+:root[data-theme="light"] #${BANNER_ID} select{border-color:#a1a1aa;background:#fff;color:#18181b}
+:root[data-theme="dark"] #${BANNER_ID}{border-bottom-color:#3f3f46;background:#18181b;color:#e4e4e7}
+:root[data-theme="dark"] #${BANNER_ID} select{border-color:#52525b;background:#27272a;color:#e4e4e7}
+`.replace(/\n/g, "");
+
+// The offset is measured rather than assumed: these pages carry headers this
+// code has never seen, and a fixed one sits at the viewport top where the
+// banner also wants to be. Anything already pinned to 0 moves down by the
+// banner's height, which is the only way to stay off a header whose selectors
+// and variables are unknown here.
+const script = `(function(){
+var b=document.getElementById(${JSON.stringify(BANNER_ID)});
+if(!b)return;
+var slug=b.getAttribute("data-slug")||"";
+function shift(){
+var h=b.offsetHeight;
+document.documentElement.style.scrollPaddingTop=h+"px";
+var nodes=document.body.querySelectorAll("*");
+for(var i=0;i<nodes.length;i++){
+var el=nodes[i];
+if(el===b||b.contains(el))continue;
+if(el.getAttribute("data-agentkit-shifted")==="1"){el.style.top=h+"px";continue;}
+var cs=window.getComputedStyle(el);
+if((cs.position==="fixed"||cs.position==="sticky")&&parseFloat(cs.top)===0){
+el.setAttribute("data-agentkit-shifted","1");el.style.top=h+"px";}}}
+shift();
+window.addEventListener("resize",shift);
+if(document.fonts&&document.fonts.ready)document.fonts.ready.then(shift);
+fetch(${JSON.stringify(VERSIONS_URL)},{cache:"no-cache"}).then(function(r){
+if(!r.ok)throw new Error(String(r.status));return r.json();}).then(function(data){
+var versions=data&&data.versions;
+if(!Array.isArray(versions)||versions.length<2)return;
+var link=b.querySelector("a");
+if(!link)return;
+var select=document.createElement("select");
+select.setAttribute("aria-label","Select documentation version");
+for(var i=0;i<versions.length;i++){
+var option=document.createElement("option");
+option.value=String(versions[i].path||"");
+option.textContent=String(versions[i].label||"");
+if(option.value==="/docs/"+slug+"/")option.selected=true;
+select.appendChild(option);}
+select.addEventListener("change",function(){window.location.pathname=select.value;});
+link.replaceWith(select);
+shift();
+}).catch(function(){});
+})();`.replace(/\n/g, "");
+
+// The link is server-rendered and the select replaces it only once the list has
+// actually arrived, so a failed fetch, a stale cache or no scripting at all
+// still leaves a way back to the current docs.
+export function bannerHtml(slug: string): string {
+	const safe = escapeHtml(slug);
+	return `${BANNER_MARKER}<div id="${BANNER_ID}" role="region" aria-label="Documentation version" data-slug="${safe}">`
+		+ `<span>You are viewing the v${safe} documentation</span>`
+		+ `<a href="/docs/">Back to the latest documentation &rarr;</a>`
+		+ `</div><style>${style}</style><script>${script}</script>`;
+}
+
+export interface Injection {
+	html: string;
+	injected: boolean;
+	reason?: "already-present" | "no-body";
+}
+
+export function injectBanner(html: string, slug: string): Injection {
+	if (html.includes(BANNER_MARKER)) return { html, injected: false, reason: "already-present" };
+	const body = /<body[^>]*>/i.exec(html);
+	if (!body) return { html, injected: false, reason: "no-body" };
+	const at = body.index + body[0].length;
+	return { html: html.slice(0, at) + bannerHtml(slug) + html.slice(at), injected: true };
+}

--- a/docs/site/src/lib/inject-banner.ts
+++ b/docs/site/src/lib/inject-banner.ts
@@ -1,0 +1,44 @@
+import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { injectBanner } from "./archive-banner";
+
+const [slug, root] = process.argv.slice(2);
+if (!slug || !root) {
+	console.error("usage: inject-banner <slug> <dir>");
+	process.exit(2);
+}
+
+function htmlFiles(dir: string): string[] {
+	const found: string[] = [];
+	for (const entry of readdirSync(dir)) {
+		const path = join(dir, entry);
+		if (statSync(path).isDirectory()) found.push(...htmlFiles(path));
+		else if (entry.endsWith(".html")) found.push(path);
+	}
+	return found;
+}
+
+let injected = 0;
+let present = 0;
+const unwritable: string[] = [];
+
+for (const file of htmlFiles(root)) {
+	const result = injectBanner(readFileSync(file, "utf8"), slug);
+	if (result.injected) {
+		writeFileSync(file, result.html);
+		injected++;
+	} else if (result.reason === "already-present") {
+		present++;
+	} else {
+		unwritable.push(file);
+	}
+}
+
+// A page the injector could not reach is a page that strands its reader, and a
+// count printed alongside the successes would read as a rounding error.
+if (unwritable.length > 0) {
+	console.error(`inject-banner: no <body> to inject into: ${unwritable.slice(0, 3).join(", ")}`);
+	process.exit(1);
+}
+
+console.log(`inject-banner: ${slug} — ${injected} injected, ${present} already carried the banner`);

--- a/docs/site/src/lib/list-archives.ts
+++ b/docs/site/src/lib/list-archives.ts
@@ -1,8 +1,9 @@
+import { bannerHash } from "./archive-banner";
 import { archivedReleases } from "./release";
 
-// The archive builder reads the same list the picker renders, through this one
-// entry point: a shell-side copy of the rule is how a build ends up offering a
-// version it never built.
+// One entry point for the builder and the picker: a shell-side copy of the rule
+// is how a build ends up offering a version it never built. The hash column is
+// what lets the builder tell a published archive from one it must rebuild.
 for (const { slug, tag } of archivedReleases()) {
-	process.stdout.write(`${slug}\t${tag}\n`);
+	process.stdout.write(`${slug}\t${tag}\t${bannerHash(slug)}\n`);
 }

--- a/docs/site/src/pages/versions.json.ts
+++ b/docs/site/src/pages/versions.json.ts
@@ -1,0 +1,13 @@
+import type { APIRoute } from "astro";
+import { archivedReleases, currentRelease, environmentSources, versionOptions } from "../lib/release";
+
+// The switching chrome injected into archived builds reads this. It has to come
+// from the current build rather than from each archive's own tag: a release
+// cannot know which versions followed it.
+export const GET: APIRoute = () => {
+	const release = currentRelease(environmentSources());
+	return new Response(
+		JSON.stringify({ current: release, versions: versionOptions(release, archivedReleases()) }),
+		{ headers: { "content-type": "application/json" } },
+	);
+};

--- a/scripts/check-test-slices.ts
+++ b/scripts/check-test-slices.ts
@@ -14,6 +14,7 @@ export const TEST_SLICES = {
   ],
   docs: [
     'tests/docs/archive-banner.test.ts',
+    'tests/docs/archive-reuse.test.ts',
     'tests/docs/asset-types.test.ts',
     'tests/docs/deploy.test.ts',
     'tests/docs/docs-tone.test.ts',

--- a/scripts/check-test-slices.ts
+++ b/scripts/check-test-slices.ts
@@ -13,6 +13,7 @@ export const TEST_SLICES = {
     'tests/diagram/vendor-icons.test.ts',
   ],
   docs: [
+    'tests/docs/archive-banner.test.ts',
     'tests/docs/asset-types.test.ts',
     'tests/docs/deploy.test.ts',
     'tests/docs/docs-tone.test.ts',

--- a/tests/docs/archive-banner.test.ts
+++ b/tests/docs/archive-banner.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  BANNER_MARKER,
+  bannerHtml,
+  injectBanner,
+} from '../../docs/site/src/lib/archive-banner.ts';
+import { GET } from '../../docs/site/src/pages/versions.json.ts';
+
+const page = (body = '<main>archived page</main>') =>
+  `<!DOCTYPE html><html lang="en"><head><title>Old</title></head><body class="page">${body}</body></html>`;
+
+// An archive is its tag's own build, so its chrome predates the version picker
+// and strands the reader. The banner is added after the build; everything here
+// is about it landing exactly once and carrying a way out even when nothing
+// else on the page works.
+describe('the archive banner is injected into a built page', () => {
+  test('the banner lands immediately inside body, ahead of the archive chrome', () => {
+    const result = injectBanner(page(), '0.5.3');
+    expect(result.injected).toBe(true);
+    expect(result.html).toContain(`<body class="page">${BANNER_MARKER}`);
+    expect(result.html.indexOf(BANNER_MARKER)).toBeLessThan(result.html.indexOf('<main>'));
+  });
+
+  test('the version being read is named in prose, not only in a control', () => {
+    expect(injectBanner(page(), '0.5.3').html).toContain(
+      'You are viewing the v0.5.3 documentation',
+    );
+  });
+
+  // The select is built only once the version list arrives. Without this link a
+  // failed fetch, a cached miss or disabled scripting leaves a dead end.
+  test('a way back to the current docs is server-rendered, not scripted', () => {
+    const { html } = injectBanner(page(), '0.5.3');
+    expect(html).toContain('href="/docs/"');
+    expect(html).toContain('Back to the latest documentation');
+  });
+
+  test('the archive names itself so the script can preselect it', () => {
+    expect(injectBanner(page(), '0.4.5').html).toContain('data-slug="0.4.5"');
+  });
+
+  // Re-running the builder over an existing dist is routine; a second banner
+  // would stack and push the page down twice.
+  test('a second run over an injected page changes nothing', () => {
+    const once = injectBanner(page(), '0.5.3').html;
+    const twice = injectBanner(once, '0.5.3');
+    expect(twice.injected).toBe(false);
+    expect(twice.reason).toBe('already-present');
+    expect(twice.html).toBe(once);
+    expect(twice.html.split(BANNER_MARKER)).toHaveLength(2);
+  });
+
+  test('injecting a page built by a different slug still refuses to stack', () => {
+    const once = injectBanner(page(), '0.5.3').html;
+    expect(injectBanner(once, '0.4.5').injected).toBe(false);
+  });
+
+  test.each([
+    ['no body at all', '<html><head></head></html>'],
+    ['an empty document', ''],
+  ])('%s is reported rather than silently skipped', (_label, html) => {
+    const result = injectBanner(html, '0.5.3');
+    expect(result.injected).toBe(false);
+    expect(result.reason).toBe('no-body');
+    expect(result.html).toBe(html);
+  });
+
+  test('body attributes on the archive survive the injection', () => {
+    const html = '<html><body data-theme="dark" class="x"><p>hi</p></body></html>';
+    expect(injectBanner(html, '0.5.3').html).toContain('<body data-theme="dark" class="x">');
+  });
+
+  // The slug reaches both an attribute and page text; a build that fed it
+  // something quoted would otherwise close the tag early.
+  test('a slug carrying markup cannot break out of the banner', () => {
+    const html = bannerHtml('0.5"><script>alert(1)</script>');
+    expect(html).not.toContain('"><script>alert(1)');
+    expect(html).toContain('&quot;&gt;&lt;script&gt;');
+  });
+
+  test('the banner brings its own styling and behaviour, fetching nothing', () => {
+    const html = bannerHtml('0.5.3');
+    expect(html).toContain('<style>');
+    expect(html).toContain('<script>');
+    expect(html).not.toMatch(/(src|href)="https?:/);
+    expect(html).not.toContain('<link');
+  });
+});
+
+// The banner is only as good as the list it reads; an archive cannot know which
+// releases followed it, so the current build has to publish one.
+describe('the current build publishes the version list', () => {
+  test('the endpoint answers with the same options the picker renders', async () => {
+    const body = await (GET as (context: unknown) => Response)({}).json();
+    expect(Array.isArray(body.versions)).toBe(true);
+    expect(body.versions[0].path).toBe('/docs/');
+    expect(body.versions[0].label).toContain('latest');
+    for (const { label, path } of body.versions) {
+      expect(typeof label).toBe('string');
+      expect(path).toMatch(/^\/docs\/([0-9][0-9.]*\/)?$/);
+    }
+  });
+
+  test('it is JSON, because the banner parses it in a browser', async () => {
+    const response = (GET as (context: unknown) => Response)({});
+    expect(response.headers.get('content-type')).toContain('application/json');
+  });
+});

--- a/tests/docs/archive-reuse.test.ts
+++ b/tests/docs/archive-reuse.test.ts
@@ -1,0 +1,249 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+const REPO = join(import.meta.dir, '..', '..');
+const BUILDER = join(REPO, 'docs', 'site', 'build-archives.sh');
+
+const TAG = 'v1.0.0';
+const SLUG = '1.0.0';
+const HASH = 'abcdef0123456789';
+
+let root: string;
+let site: string;
+let bin: string;
+
+function write(relative: string, body: string): string {
+  const path = join(root, relative);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, body);
+  return path;
+}
+
+function git(...args: string[]): string {
+  const result = spawnSync('git', ['-C', root, ...args], { encoding: 'utf-8' });
+  expect(result.status, result.stderr).toBe(0);
+  return result.stdout.trim();
+}
+
+function stub(name: string, body: string): void {
+  const path = join(bin, name);
+  writeFileSync(path, body);
+  chmodSync(path, 0o755);
+}
+
+// The list module, the injector and the astro build are all reached through
+// these; the reuse decision under test happens before any of them run.
+function stubTools(): void {
+  stub(
+    'bun',
+    [
+      '#!/usr/bin/env bash',
+      'set -eu',
+      `ENTRIES=${JSON.stringify(join(root, '.entries'))}`,
+      `INJECTED=${JSON.stringify(join(root, '.injected'))}`,
+      'case "${1:-}" in',
+      '  install) exit 0 ;;',
+      '  *list-archives*) cat "$ENTRIES"; exit 0 ;;',
+      '  *inject-banner*) printf "%s\\n" "$2" >> "$INJECTED"; exit 0 ;;',
+      'esac',
+      'exit 0',
+    ].join('\n'),
+  );
+  stub(
+    'node',
+    [
+      '#!/usr/bin/env bash',
+      'set -eu',
+      `BUILDS=${JSON.stringify(join(root, '.builds'))}`,
+      'printf "build\\n" >> "$BUILDS"',
+      'mkdir -p dist',
+      'printf "<html><body>archived</body></html>" > dist/index.html',
+      'exit 0',
+    ].join('\n'),
+  );
+}
+
+// Stands in for the published stamp: present means the site answers with it,
+// absent means the fetch fails the way an unreachable or 404 site does.
+function stubPublishedStamp(body: string | null): void {
+  const path = join(root, '.published-stamp');
+  if (body === null) {
+    rmSync(path, { force: true });
+  } else {
+    writeFileSync(path, body);
+  }
+  stub(
+    'curl',
+    [
+      '#!/usr/bin/env bash',
+      'set -eu',
+      `STAMP=${JSON.stringify(path)}`,
+      '[ -f "$STAMP" ] || exit 22',
+      'cat "$STAMP"',
+      'exit 0',
+    ].join('\n'),
+  );
+}
+
+function entries(line: string): void {
+  writeFileSync(join(root, '.entries'), `${line}\n`);
+}
+
+function build(env: Record<string, string> = {}): ReturnType<typeof spawnSync> {
+  return spawnSync('bash', [join(site, 'build-archives.sh'), 'dist'], {
+    encoding: 'utf-8',
+    cwd: site,
+    env: {
+      ...process.env,
+      PATH: `${bin}:${process.env.PATH ?? ''}`,
+      AGENTKIT_SITE_URL: 'https://site.example.test',
+      ...env,
+    },
+  });
+}
+
+const built = () => existsSync(join(root, '.builds'));
+const reusedList = () => {
+  const path = join(site, 'dist', '.reused-archives');
+  return existsSync(path) ? readFileSync(path, 'utf-8').trim().split('\n').filter(Boolean) : [];
+};
+const stampFile = () => {
+  const path = join(site, 'dist', SLUG, 'archive-stamp.txt');
+  return existsSync(path) ? readFileSync(path, 'utf-8') : '';
+};
+
+let tagSha: string;
+let expectedStamp: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'agentkit-archive-reuse-'));
+  site = join(root, 'docs', 'site');
+  bin = join(root, '.bin');
+  mkdirSync(bin, { recursive: true });
+
+  // The tagged tree is what the builder checks out and rebases, so it needs the
+  // two shapes the rebase touches.
+  write('docs/site/astro.config.mjs', 'export default { base: "/docs", };\n');
+  write('docs/site/src/content/docs/index.md', '# archived\n\n[link](/docs/thing/)\n');
+  git('init', '-q');
+  git('config', 'user.email', 'test@example.com');
+  git('config', 'user.name', 'test');
+  git('add', '-A');
+  git('commit', '-qm', 'base');
+  git('tag', TAG);
+  tagSha = git('rev-parse', `refs/tags/${TAG}^{commit}`);
+  expectedStamp = `${TAG} ${tagSha} ${HASH}`;
+
+  cpSync(BUILDER, join(site, 'build-archives.sh'));
+  chmodSync(join(site, 'build-archives.sh'), 0o755);
+  mkdirSync(join(site, 'dist'), { recursive: true });
+  entries(`${SLUG}\t${TAG}\t${HASH}`);
+  stubTools();
+  stubPublishedStamp(null);
+});
+
+afterEach(() => {
+  spawnSync('git', ['-C', root, 'worktree', 'prune'], { encoding: 'utf-8' });
+  rmSync(root, { recursive: true, force: true });
+});
+
+// Rebuilding a version whose tag cannot change is the waste; the stamp is what
+// makes "already published" a fact the builder can check rather than assume.
+describe('an archive is rebuilt only when its stamp would change', () => {
+  test('a matching published stamp skips the build entirely', () => {
+    stubPublishedStamp(`${expectedStamp}\n`);
+    const result = build({ AGENTKIT_ARCHIVE_REUSE: '1' });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(built()).toBe(false);
+    expect(reusedList()).toEqual([SLUG]);
+    expect(existsSync(join(site, 'dist', SLUG))).toBe(false);
+    expect(result.stdout).toContain('reused the published build');
+  });
+
+  test('a different banner hash rebuilds', () => {
+    stubPublishedStamp(`${TAG} ${tagSha} 0000000000000000\n`);
+    const result = build({ AGENTKIT_ARCHIVE_REUSE: '1' });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(built()).toBe(true);
+    expect(reusedList()).toEqual([]);
+    expect(stampFile()).toBe(`${expectedStamp}\n`);
+  });
+
+  test('a different tag commit rebuilds', () => {
+    stubPublishedStamp(`${TAG} 0000000000000000000000000000000000000000 ${HASH}\n`);
+    const result = build({ AGENTKIT_ARCHIVE_REUSE: '1' });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(built()).toBe(true);
+    expect(reusedList()).toEqual([]);
+  });
+
+  // Every uncertain answer has to build: publishing a stale archive because a
+  // fetch blipped is worse than spending the build.
+  test('an unreachable site rebuilds rather than assuming', () => {
+    stubPublishedStamp(null);
+    const result = build({ AGENTKIT_ARCHIVE_REUSE: '1' });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(built()).toBe(true);
+    expect(reusedList()).toEqual([]);
+  });
+
+  test('an empty published stamp rebuilds', () => {
+    stubPublishedStamp('');
+    const result = build({ AGENTKIT_ARCHIVE_REUSE: '1' });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(built()).toBe(true);
+  });
+
+  // Reuse belongs to the deploy. A local build that quietly skipped archives
+  // would leave the only path that exercises them the one that skips them.
+  test('without the deploy opt-in a matching stamp still builds', () => {
+    stubPublishedStamp(`${expectedStamp}\n`);
+    const result = build();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(built()).toBe(true);
+    expect(reusedList()).toEqual([]);
+  });
+
+  test('the stamp names the tag, its commit and the banner', () => {
+    const result = build();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(stampFile()).toBe(`${expectedStamp}\n`);
+  });
+
+  // The list drives what the deploy spares from pruning, so one left behind by
+  // an earlier run would protect objects this run did not reuse.
+  test('a list left by an earlier run does not survive into this one', () => {
+    writeFileSync(join(site, 'dist', '.reused-archives'), '9.9.9\n');
+    const result = build({ AGENTKIT_ARCHIVE_REUSE: '1' });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(reusedList()).toEqual([]);
+  });
+
+  test('an entry with no banner hash is refused rather than stamped blank', () => {
+    entries(`${SLUG}\t${TAG}`);
+    const result = build({ AGENTKIT_ARCHIVE_REUSE: '1' });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('no banner hash');
+  });
+});

--- a/tests/docs/asset-types.test.ts
+++ b/tests/docs/asset-types.test.ts
@@ -62,3 +62,15 @@ describe('every artifact a Starlight build can emit is publishable', () => {
     expect((await put('_astro/app.unmapped')).status).toBe(400);
   });
 });
+
+// Archived versions mount under a dotted directory segment, which is the shape
+// the extension probe has to read as a path rather than as a suffix.
+describe('an archived version publishes under its own slug', () => {
+  test.each([
+    '0.5.3/index.html',
+    '0.5.3/archive-stamp.txt',
+    '0.5.3/_astro/app.aYS1OYVv.css',
+  ])('%s is accepted on the write route', async (rel) => {
+    expect((await put(rel)).status).toBe(200);
+  });
+});

--- a/tests/docs/deploy.test.ts
+++ b/tests/docs/deploy.test.ts
@@ -383,3 +383,96 @@ describe('a page removed from the build stops being served', () => {
     expect(result.stderr).toContain('could not list');
   });
 });
+
+// Archives build from immutable tags, so rebuilding every one on every deploy is
+// pure waste. Reusing them means their objects are live but absent from dist/,
+// which is exactly the shape the prune treats as deleted.
+describe('a reused archive survives the prune that removes deleted pages', () => {
+  function stubArchives(slugs: readonly string[]): void {
+    writeFileSync(
+      join(site, 'build-archives.sh'),
+      [
+        '#!/usr/bin/env bash',
+        'set -eu',
+        `printf '%s\\n' ${slugs.map((slug) => JSON.stringify(slug)).join(' ')} > dist/.reused-archives`,
+        'exit 0',
+      ].join('\n'),
+    );
+    chmodSync(join(site, 'build-archives.sh'), 0o755);
+    // Committed because deploy.sh refuses a dirty tree, and the live sha follows
+    // because the read-back compares against the commit it just published.
+    git('add', '-A');
+    git('commit', '-qm', 'archive stub');
+    writeFileSync(join(root, '.live-sha'), headSha());
+  }
+
+  const live = (extra: readonly string[]) => [
+    ...BUILT.map((file) => `docs/${file}`),
+    ...extra,
+    'docs/build-sha.txt',
+  ];
+
+  test('its live objects are kept even though the build did not produce them', () => {
+    stubArchives(['0.5.3']);
+    remoteKeys(live(['docs/0.5.3/index.html', 'docs/0.5.3/archive-stamp.txt']));
+    const result = deploy();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(deleted()).toEqual([]);
+    expect(result.stdout).toContain('kept 1 reused archive');
+  });
+
+  // The other half of the contract: sparing reused slugs must not spare a version
+  // that left the selection, or dropped archives would be published forever.
+  test('an archive that left the selection still prunes', () => {
+    stubArchives(['0.5.3']);
+    remoteKeys(live(['docs/0.5.3/index.html', 'docs/0.4.5/index.html']));
+    const result = deploy();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(deleted()).toEqual(['docs/0.4.5/index.html']);
+  });
+
+  // The slug reaches a regex, where an unescaped dot matches any character.
+  test('a reused slug spares itself and not a lookalike key', () => {
+    stubArchives(['0.5.3']);
+    remoteKeys(live(['docs/0.5.3/index.html', 'docs/0X5X3/index.html']));
+    const result = deploy();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(deleted()).toEqual(['docs/0X5X3/index.html']);
+  });
+
+  // Sparing has to happen before the >50% refusal. Measured after, a handful of
+  // reused archives reads as a mass deletion and stops every deploy.
+  test('reused objects are not counted by the refusal that guards mass deletion', () => {
+    stubArchives(['0.5.3']);
+    remoteKeys(
+      live(Array.from({ length: 40 }, (_, index) => `docs/0.5.3/page-${index}/index.html`)),
+    );
+    const result = deploy();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('nothing to prune');
+    expect(result.stderr).not.toContain('refusing to prune');
+  });
+
+  test('the reuse list is a build artefact and is never uploaded', () => {
+    stubArchives(['0.5.3']);
+    remoteKeys(live(['docs/0.5.3/index.html']));
+    const result = deploy();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(uploads()).not.toContain('.reused-archives');
+    expect(uploads().filter((key) => key.includes('reused-archives'))).toEqual([]);
+  });
+
+  test('no reuse leaves the prune exactly as it was', () => {
+    remoteKeys(live(['docs/retired/index.html']));
+    const result = deploy();
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(deleted()).toEqual(['docs/retired/index.html']);
+    expect(result.stdout).not.toContain('reused archive');
+  });
+});

--- a/tests/install-prompt.test.ts
+++ b/tests/install-prompt.test.ts
@@ -15,8 +15,9 @@ import { spawnSync } from 'node:child_process';
 
 const repoRoot = dirname(import.meta.dir);
 const installScript = join(repoRoot, 'install.sh');
-// A global install intentionally installs and builds dependency-bearing skills.
-const globalInstallTimeoutMs = 60_000;
+// A global install intentionally installs and builds dependency-bearing
+// skills; a cold-cache runner has crossed 60s doing it.
+const globalInstallTimeoutMs = 120_000;
 
 function countOccurrences(text: string, needle: string): number {
   return text.split(needle).length - 1;


### PR DESCRIPTION
Refs #237 (follow-up to #238/#240; ships as v0.6.2).

Archived doc versions are full builds from their tags, so their chrome is frozen at that tag — the v0.6.0-and-older archives have no version picker, stranding a reader who switches to them (product-owner report).

- `build-archives.sh` injects a self-contained sticky banner into every archived page: "You are viewing the vX.Y.Z documentation" + a version select. Inline CSS/JS only, neutral palette honoring `prefers-color-scheme` and `data-theme`, measures and offsets unknown fixed headers, borrows nothing from tag-era stylesheets.
- The banner reads `/docs/versions.json`, emitted by the **current** build (one source of truth with the header picker via `src/lib/release.ts`), so archives list even releases that postdate them; fetch failure degrades to a "back to latest" link.
- Idempotent injection (marker comment), unit-tested (fixture HTML single-injection, banner content, versions.json emission); current pages verified un-injected.
- Verified with local full build + archive build and screenshots of `/docs/0.4.5/` and `/docs/0.5.3/` in both themes — the banner renders correctly over the oldest tag-era design.
- Changelog: `v0.6.2` section (this + the #240 publish-timeout fix). Per owner decision the unpublished `v0.6.1` tag stays put; v0.6.2 is the tag that publishes.