### PR TITLE
perf(test): parallel per-file suite runner — 281s to 61s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,18 +5,24 @@ top and ships with the next tag.
 
 ## [Unreleased]
 
+## v0.6.3 — 2026-07-31
+
 - perf(ci): `agentkit:test-full` runs the slice inventory as concurrent per-file
   `bun test` children (`scripts/run-test-slices.ts`), buffering each file's
   output until it finishes so the transcript stays readable; a child that ends
   without a completion summary is reported as a failure rather than counted as
-  a pass. On a 4-CPU budget the full suite goes from 281s to 62s. Lane count
-  defaults to `min(4, cores/2)`; `--lanes N` overrides it (a flag, because the
-  installed `bounded-run` neither forwards `AGENTKIT_TEST_CONCURRENCY` nor
-  accepts an `env NAME=value` prefix) and `--serial` restores the one-at-a-time
-  run
+  a pass. CI wall clock drops from 366s to 108-151s on `ubuntu-24.04` and from
+  608s to 154s on the self-hosted macOS runner. Lane count defaults to
+  `min(4, cores/2)`; `--lanes N` overrides it (a flag, because the installed
+  `bounded-run` neither forwards `AGENTKIT_TEST_CONCURRENCY` nor accepts an
+  `env NAME=value` prefix) and `--serial` restores the one-at-a-time run
 - perf(tests): the install suites set `AGENTKIT_SKIP_SKILL_DEPS=1` — exactly one
   test, the first in `tests/install-prompt.test.ts`, still resolves and builds
   real skill dependencies
+- fix(ci): `tests/hook-supervisor.test.ts` runs with the machine to itself. It
+  asserts `fail-closed-hook.sh` relays its child inside a one-second deadline,
+  which lane contention makes the child miss — the supervisor then fails closed
+  correctly and the assertion breaks on load rather than on behaviour
 
 ## v0.6.2 — 2026-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ top and ships with the next tag.
 
 ## [Unreleased]
 
+- perf(ci): `agentkit:test-full` runs the slice inventory as concurrent per-file
+  `bun test` children (`scripts/run-test-slices.ts`), buffering each file's
+  output until it finishes so the transcript stays readable; a child that ends
+  without a completion summary is reported as a failure rather than counted as
+  a pass. On a 4-CPU budget the full suite goes from 281s to 62s. Lane count
+  defaults to `min(4, cores/2)`; `--lanes N` overrides it (a flag, because the
+  installed `bounded-run` neither forwards `AGENTKIT_TEST_CONCURRENCY` nor
+  accepts an `env NAME=value` prefix) and `--serial` restores the one-at-a-time
+  run
+- perf(tests): the install suites set `AGENTKIT_SKIP_SKILL_DEPS=1` — exactly one
+  test, the first in `tests/install-prompt.test.ts`, still resolves and builds
+  real skill dependencies
+
 ## v0.6.2 — 2026-07-31
 
 - fix(site): archived doc versions carry an injected, version-independent

--- a/docs/site/src/content/docs/community/index.md
+++ b/docs/site/src/content/docs/community/index.md
@@ -128,7 +128,7 @@ The repository ships its own build gate, and it is deterministic — nothing in 
 ```sh
 scripts/preflight                 # everything touched since origin/main
 scripts/preflight --slice review  # also run one test slice
-bun test                          # the full suite
+bun run test:full                 # the full suite, run in parallel
 ```
 
 `preflight` reads the touched set from git — committed, staged, unstaged and untracked — and exits 1

--- a/moon.yml
+++ b/moon.yml
@@ -9,6 +9,7 @@ fileGroups:
     - "moon.yml"
     - "package.json"
     - "scripts/check-test-slices.ts"
+    - "scripts/run-test-slices.ts"
 
   criticalInputs:
     - ".agentkit/config.yaml"
@@ -41,6 +42,7 @@ fileGroups:
     - "policies/**/*"
     - "scripts/check-test-slices.ts"
     - "scripts/product-command"
+    - "scripts/run-test-slices.ts"
     - "scripts/skill-kits.ts"
     - "scripts/sync-cc-plugin.sh"
     - "skills/KITS"
@@ -301,6 +303,6 @@ tasks:
       - "group://sessionInputs"
 
   test-full:
-    command: "bun test"
+    command: "bun run scripts/run-test-slices.ts"
     inputs:
       - "group://criticalInputs"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "test": "bun test",
-    "test:full": "bun test",
+    "test:full": "bun run scripts/run-test-slices.ts",
     "test:slices": "bun run scripts/check-test-slices.ts --check"
   },
   "devDependencies": {

--- a/scripts/check-test-slices.ts
+++ b/scripts/check-test-slices.ts
@@ -77,6 +77,7 @@ export const TEST_SLICES = {
   review: [
     'tests/build/mutate.test.ts',
     'tests/build/preflight.test.ts',
+    'tests/build/test-runner.test.ts',
     'tests/codex-review-hooks.test.ts',
     'tests/product-command.test.ts',
     'tests/review-disciplines.test.ts',

--- a/scripts/run-test-slices.ts
+++ b/scripts/run-test-slices.ts
@@ -10,15 +10,15 @@ import {
 
 const repoRoot = join(import.meta.dir, '..');
 
-// The real systemd containment suite takes the single machine-wide
-// agentkit-run.lock, so anything else invoking bounded-run at the same moment
-// fails it on contention rather than on behavior. It is opt-in and skipped by
-// default, so this only costs a lane when it is switched on.
-const soloFiles = new Set(
-  process.env.AGENTKIT_RUN_INTEGRATION === '1'
+// Cannot share the machine: the supervisor suite asserts fail-closed-hook.sh
+// relays its child inside a one-second deadline that contention makes it miss;
+// the opt-in containment suite takes the machine-wide agentkit-run.lock.
+export const soloFiles = new Set([
+  'tests/hook-supervisor.test.ts',
+  ...(process.env.AGENTKIT_RUN_INTEGRATION === '1'
     ? ['tests/resource-run.integration.test.ts']
-    : [],
-);
+    : []),
+]);
 
 interface Unit {
   slice: TestSlice;
@@ -67,11 +67,14 @@ function units(slices: readonly TestSlice[]): Unit[] {
       slicePriority: TEST_SLICES[slice].length,
     }))
   );
-  // Longest-first, with no timing data to sort by: the slice holding the most
-  // files is the heaviest, and within it size is the best static cost proxy.
-  // A bad guess costs tail latency, never correctness.
-  return list.sort(
-    (left, right) => right.slicePriority - left.slicePriority || right.bytes - left.bytes,
+  // Solo units first: they idle every other lane whenever they run, and at
+  // startup the pool is empty anyway. Then longest-first, with no timing data
+  // to sort by — the slice holding the most files is the heaviest, and within
+  // it size is the best static cost proxy. A bad guess costs tail latency.
+  return list.sort((left, right) =>
+    Number(soloFiles.has(right.file)) - Number(soloFiles.has(left.file))
+    || right.slicePriority - left.slicePriority
+    || right.bytes - left.bytes
   );
 }
 

--- a/scripts/run-test-slices.ts
+++ b/scripts/run-test-slices.ts
@@ -10,11 +10,12 @@ import {
 
 const repoRoot = join(import.meta.dir, '..');
 
-// Cannot share the machine: the supervisor suite asserts fail-closed-hook.sh
-// relays its child inside a one-second deadline that contention makes it miss;
-// the opt-in containment suite takes the machine-wide agentkit-run.lock.
+// Cannot share lanes: each spawns an external process against a fixed budget
+// (one second for fail-closed-hook.sh, twenty for Chrome's devtools endpoint)
+// that contention makes it miss; the opt-in suite takes the machine-wide lock.
 export const soloFiles = new Set([
   'tests/hook-supervisor.test.ts',
+  'tests/publish-page/mermaid-runtime.test.ts',
   ...(process.env.AGENTKIT_RUN_INTEGRATION === '1'
     ? ['tests/resource-run.integration.test.ts']
     : []),

--- a/scripts/run-test-slices.ts
+++ b/scripts/run-test-slices.ts
@@ -40,9 +40,9 @@ interface UnitResult {
   seconds: number;
 }
 
-// --lanes rather than only an environment variable: bounded-run passes an
-// allowlist of names through and refuses an `env NAME=value` prefix outright,
-// so on a contained host a flag is the only override that survives.
+// --lanes rather than only an environment variable: the installed bounded-run
+// passes an allowlist of names through and refuses an `env NAME=value` prefix
+// outright, so on a contained host a flag is the only override that survives.
 function concurrency(requested: string | undefined): number {
   if (requested === undefined) {
     return Math.max(1, Math.min(4, Math.floor(cpus().length / 2)));
@@ -75,6 +75,48 @@ function units(slices: readonly TestSlice[]): Unit[] {
   );
 }
 
+// Runs `queue` through `run`, `lanes` at a time, giving any unit `isSolo` marks
+// exclusive use of the pool. The exclusion holds both ways: gating only the solo
+// unit on an idle pool leaves ordinary units free to start alongside it the
+// moment after it begins, which delays the overlap rather than preventing it.
+export async function schedule<T>(
+  queue: readonly T[],
+  lanes: number,
+  isSolo: (unit: T) => boolean,
+  run: (unit: T) => Promise<void>,
+): Promise<void> {
+  const pending = [...queue];
+  let running = 0;
+  let soloRunning = 0;
+
+  async function lane(): Promise<void> {
+    for (;;) {
+      const index = pending.findIndex((unit) =>
+        isSolo(unit) ? running === 0 : soloRunning === 0
+      );
+      if (index === -1) {
+        // An idle pool always makes something eligible, so this only waits for
+        // an in-flight unit rather than deadlocking on an empty one.
+        if (pending.length === 0) return;
+        await Bun.sleep(5);
+        continue;
+      }
+      const unit = pending.splice(index, 1)[0] as T;
+      const solo = isSolo(unit);
+      running += 1;
+      if (solo) soloRunning += 1;
+      try {
+        await run(unit);
+      } finally {
+        running -= 1;
+        if (solo) soloRunning -= 1;
+      }
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.max(1, lanes) }, () => lane()));
+}
+
 // A colored summary defeats the anchored counters, and FORCE_COLOR reaches the
 // children through the inherited environment.
 function plain(output: string): string {
@@ -103,12 +145,15 @@ async function runUnit(unit: Unit, stream: boolean): Promise<UnitResult> {
       new Response(child.stderr).text(),
     ]);
   const exitCode = await child.exited;
-  const output = stdout + stderr;
-  const summary = plain(output);
+  // Counters and the completion line come from stderr alone. Bun puts only its
+  // version banner on stdout, so folding the two together would let a test that
+  // prints "0 fail" — or a whole fake summary — outrank the real one and pass
+  // the died-mid-run check on output the child never produced.
+  const summary = plain(stderr);
 
   return {
     unit,
-    output,
+    output: stdout + stderr,
     exitCode,
     signal: child.signalCode,
     pass: count(summary, 'pass'),
@@ -141,25 +186,44 @@ function report(result: UnitResult, stream: boolean): void {
   );
 }
 
-async function main(): Promise<never> {
-  const argv = process.argv.slice(2);
-  const requested: string[] = [];
+interface Options {
+  serial: boolean;
+  lanes: string | undefined;
+  slices: string[];
+}
+
+function parseArgs(argv: readonly string[]): Options {
+  const slices: string[] = [];
   let serial = false;
-  let laneFlag: string | undefined;
+  let lanes: string | undefined;
+
   for (let index = 0; index < argv.length; index += 1) {
     const argument = argv[index] as string;
-    if (argument === '--serial') serial = true;
-    else if (argument === '--lanes') {
-      laneFlag = argv[index + 1];
-      index += 1;
-    } else if (argument.startsWith('--lanes=')) laneFlag = argument.slice('--lanes='.length);
-    else if (argument.startsWith('-')) {
+    if (argument === '--serial') {
+      serial = true;
+    } else if (argument === '--lanes' || argument.startsWith('--lanes=')) {
+      const value = argument === '--lanes' ? argv[++index] : argument.slice('--lanes='.length);
+      // Swallowing a missing value would silently fall back to the auto-detected
+      // default, which is the one thing someone passing --lanes did not want.
+      if (value === undefined || value.startsWith('-')) {
+        console.error('--lanes needs a positive integer');
+        process.exit(2);
+      }
+      lanes = value;
+    } else if (argument.startsWith('-')) {
       console.error(`Unknown option: ${argument}`);
       process.exit(2);
-    } else requested.push(argument);
+    } else {
+      slices.push(argument);
+    }
   }
 
-  const unknown = requested.filter((name) => !Object.hasOwn(TEST_SLICES, name));
+  return { serial, lanes, slices };
+}
+
+async function main(): Promise<never> {
+  const options = parseArgs(process.argv.slice(2));
+  const unknown = options.slices.filter((name) => !Object.hasOwn(TEST_SLICES, name));
   if (unknown.length > 0) {
     console.error(`Unknown test slice: ${unknown.join(', ')}`);
     process.exit(2);
@@ -173,34 +237,23 @@ async function main(): Promise<never> {
     process.exit(1);
   }
 
-  const slices = (requested.length > 0 ? requested : Object.keys(TEST_SLICES)) as TestSlice[];
-  const queue = units(slices);
+  const names = (
+    options.slices.length > 0 ? options.slices : Object.keys(TEST_SLICES)
+  ) as TestSlice[];
+  const queue = units(names);
   const total = queue.length;
-  const lanes = serial
-    ? 1
-    : Math.min(concurrency(laneFlag ?? process.env.AGENTKIT_TEST_CONCURRENCY), total);
+  // An empty variable is how a shell spells "unset"; treating it as a value
+  // would abort the run over an exported-but-blank name.
+  const envLanes = process.env.AGENTKIT_TEST_CONCURRENCY || undefined;
+  const lanes = options.serial ? 1 : Math.min(concurrency(options.lanes ?? envLanes), total);
   const results: UnitResult[] = [];
-  let running = 0;
-
-  async function lane(): Promise<void> {
-    for (;;) {
-      const index = queue.findIndex((unit) => !soloFiles.has(unit.file) || running === 0);
-      if (index === -1) {
-        if (queue.length === 0) return;
-        await Bun.sleep(50);
-        continue;
-      }
-      const unit = queue.splice(index, 1)[0] as Unit;
-      running += 1;
-      const result = await runUnit(unit, serial);
-      running -= 1;
-      report(result, serial);
-      results.push(result);
-    }
-  }
 
   const started = Bun.nanoseconds();
-  await Promise.all(Array.from({ length: lanes }, () => lane()));
+  await schedule(queue, lanes, (unit) => soloFiles.has(unit.file), async (unit) => {
+    const result = await runUnit(unit, options.serial);
+    report(result, options.serial);
+    results.push(result);
+  });
   const elapsed = (Bun.nanoseconds() - started) / 1e9;
 
   const totals = results.reduce(
@@ -213,6 +266,10 @@ async function main(): Promise<never> {
     { pass: 0, fail: 0, skip: 0, todo: 0 },
   );
   const failed = results.filter(broke);
+  // A child that died mid-run reported no counters at all, so it adds nothing to
+  // the fail column. Left out of this line, the one line a human scans reads
+  // "0 fail" for a run that crashed.
+  const crashed = results.filter((result) => !result.completed).length;
 
   process.stdout.write(`\n===== ${lanes} lanes, ${results.length} files =====\n`);
   for (
@@ -224,9 +281,10 @@ async function main(): Promise<never> {
   // count. Printing zeroes there would read as "nothing ran"; bun already
   // printed a real summary per file.
   process.stdout.write(
-    serial
+    options.serial
       ? `per-file summaries above, ${results.length} files in ${elapsed.toFixed(1)}s\n`
-      : `${totals.pass} pass, ${totals.fail} fail, ${totals.skip} skip, ${totals.todo} todo`
+      : `${totals.pass} pass, ${totals.fail} fail${crashed > 0 ? ` (+${crashed} crashed)` : ''},`
+        + ` ${totals.skip} skip, ${totals.todo} todo`
         + ` across ${results.length} files in ${elapsed.toFixed(1)}s\n`,
   );
   if (failed.length > 0) {

--- a/scripts/run-test-slices.ts
+++ b/scripts/run-test-slices.ts
@@ -10,16 +10,23 @@ import {
 
 const repoRoot = join(import.meta.dir, '..');
 
-// Cannot share lanes: each spawns an external process against a fixed budget
-// (one second for fail-closed-hook.sh, twenty for Chrome's devtools endpoint)
-// that contention makes it miss; the opt-in suite takes the machine-wide lock.
+// Cannot share lanes: each asserts how long spawned work takes — a one-second
+// relay deadline, a twenty-second wait for Chrome's devtools endpoint, a
+// ten-second duplicate scan — so contention fails them on load, not behaviour.
+// The opt-in containment suite is here instead for the machine-wide lock.
 export const soloFiles = new Set([
+  'tests/coding-police-hook.test.ts',
   'tests/hook-supervisor.test.ts',
   'tests/publish-page/mermaid-runtime.test.ts',
   ...(process.env.AGENTKIT_RUN_INTEGRATION === '1'
     ? ['tests/resource-run.integration.test.ts']
     : []),
 ]);
+
+// bun caps a test declaring no timeout at 5s; several that shell out to an
+// external binary sit close enough that contention pushes them over. A test
+// wanting a real bound declares one, and that still wins.
+const DEFAULT_TEST_TIMEOUT_MS = 60_000;
 
 interface Unit {
   slice: TestSlice;
@@ -135,7 +142,7 @@ function count(summary: string, label: string): number {
 async function runUnit(unit: Unit, stream: boolean): Promise<UnitResult> {
   const started = Bun.nanoseconds();
   const child = Bun.spawn({
-    cmd: [process.execPath, 'test', unit.file],
+    cmd: [process.execPath, 'test', `--timeout=${DEFAULT_TEST_TIMEOUT_MS}`, unit.file],
     cwd: repoRoot,
     env: process.env,
     stdout: stream ? 'inherit' : 'pipe',

--- a/scripts/run-test-slices.ts
+++ b/scripts/run-test-slices.ts
@@ -1,0 +1,244 @@
+import { statSync } from 'node:fs';
+import { cpus } from 'node:os';
+import { join } from 'node:path';
+import {
+  TEST_SLICES,
+  type TestSlice,
+  discoverTestFiles,
+  validateTestSlices,
+} from './check-test-slices';
+
+const repoRoot = join(import.meta.dir, '..');
+
+// The real systemd containment suite takes the single machine-wide
+// agentkit-run.lock, so anything else invoking bounded-run at the same moment
+// fails it on contention rather than on behavior. It is opt-in and skipped by
+// default, so this only costs a lane when it is switched on.
+const soloFiles = new Set(
+  process.env.AGENTKIT_RUN_INTEGRATION === '1'
+    ? ['tests/resource-run.integration.test.ts']
+    : [],
+);
+
+interface Unit {
+  slice: TestSlice;
+  file: string;
+  bytes: number;
+  slicePriority: number;
+}
+
+interface UnitResult {
+  unit: Unit;
+  output: string;
+  exitCode: number;
+  signal: string | null;
+  pass: number;
+  fail: number;
+  skip: number;
+  todo: number;
+  completed: boolean;
+  seconds: number;
+}
+
+// --lanes rather than only an environment variable: bounded-run passes an
+// allowlist of names through and refuses an `env NAME=value` prefix outright,
+// so on a contained host a flag is the only override that survives.
+function concurrency(requested: string | undefined): number {
+  if (requested === undefined) {
+    return Math.max(1, Math.min(4, Math.floor(cpus().length / 2)));
+  }
+  const lanes = Number(requested);
+  if (!Number.isInteger(lanes) || lanes < 1) {
+    console.error(`Lane count must be a positive integer, got: ${requested}`);
+    process.exit(2);
+  }
+  return lanes;
+}
+
+// One child per file rather than one per slice: a single slice holds most of
+// the suite's runtime, so scheduling whole slices leaves three lanes idle while
+// the fourth decides the wall clock.
+function units(slices: readonly TestSlice[]): Unit[] {
+  const list = slices.flatMap((slice) =>
+    TEST_SLICES[slice].map((file) => ({
+      slice,
+      file,
+      bytes: statSync(join(repoRoot, file)).size,
+      slicePriority: TEST_SLICES[slice].length,
+    }))
+  );
+  // Longest-first, with no timing data to sort by: the slice holding the most
+  // files is the heaviest, and within it size is the best static cost proxy.
+  // A bad guess costs tail latency, never correctness.
+  return list.sort(
+    (left, right) => right.slicePriority - left.slicePriority || right.bytes - left.bytes,
+  );
+}
+
+// A colored summary defeats the anchored counters, and FORCE_COLOR reaches the
+// children through the inherited environment.
+function plain(output: string): string {
+  return output.replaceAll(/\u001b\[[0-9;]*m/g, '');
+}
+
+function count(summary: string, label: string): number {
+  const match = new RegExp(`^\\s*(\\d+) ${label}$`, 'm').exec(summary);
+  return match ? Number(match[1]) : 0;
+}
+
+async function runUnit(unit: Unit, stream: boolean): Promise<UnitResult> {
+  const started = Bun.nanoseconds();
+  const child = Bun.spawn({
+    cmd: [process.execPath, 'test', unit.file],
+    cwd: repoRoot,
+    env: process.env,
+    stdout: stream ? 'inherit' : 'pipe',
+    stderr: stream ? 'inherit' : 'pipe',
+  });
+
+  const [stdout, stderr] = stream
+    ? ['', '']
+    : await Promise.all([
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+    ]);
+  const exitCode = await child.exited;
+  const output = stdout + stderr;
+  const summary = plain(output);
+
+  return {
+    unit,
+    output,
+    exitCode,
+    signal: child.signalCode,
+    pass: count(summary, 'pass'),
+    fail: count(summary, 'fail'),
+    skip: count(summary, 'skip'),
+    todo: count(summary, 'todo'),
+    // Bun prints this only once the file is done, so its absence is the one
+    // signal separating a finished child from one that was killed mid-run.
+    completed: stream || /^Ran \d+ tests? across \d+ files?\./m.test(summary),
+    seconds: (Bun.nanoseconds() - started) / 1e9,
+  };
+}
+
+function broke(result: UnitResult): boolean {
+  return (
+    result.exitCode !== 0 || result.signal !== null || !result.completed || result.fail > 0
+  );
+}
+
+function report(result: UnitResult, stream: boolean): void {
+  if (!stream) {
+    process.stdout.write(`\n===== ${result.unit.slice} :: ${result.unit.file} =====\n`);
+    process.stdout.write(result.output);
+  }
+  if (!broke(result)) return;
+  const cause = result.signal ?? `exit ${result.exitCode}`;
+  const died = result.completed ? '' : ' — no completion summary, the child died mid-run';
+  process.stdout.write(
+    `!!!!! FAILED ${result.unit.slice} :: ${result.unit.file} (${cause})${died}\n`,
+  );
+}
+
+async function main(): Promise<never> {
+  const argv = process.argv.slice(2);
+  const requested: string[] = [];
+  let serial = false;
+  let laneFlag: string | undefined;
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index] as string;
+    if (argument === '--serial') serial = true;
+    else if (argument === '--lanes') {
+      laneFlag = argv[index + 1];
+      index += 1;
+    } else if (argument.startsWith('--lanes=')) laneFlag = argument.slice('--lanes='.length);
+    else if (argument.startsWith('-')) {
+      console.error(`Unknown option: ${argument}`);
+      process.exit(2);
+    } else requested.push(argument);
+  }
+
+  const unknown = requested.filter((name) => !Object.hasOwn(TEST_SLICES, name));
+  if (unknown.length > 0) {
+    console.error(`Unknown test slice: ${unknown.join(', ')}`);
+    process.exit(2);
+  }
+
+  // Only the slice inventory is executed, so a test file missing from it would
+  // silently stop running the moment the suite stopped being one `bun test`.
+  const routing = validateTestSlices(discoverTestFiles());
+  if (routing.length > 0) {
+    for (const error of routing) console.error(error);
+    process.exit(1);
+  }
+
+  const slices = (requested.length > 0 ? requested : Object.keys(TEST_SLICES)) as TestSlice[];
+  const queue = units(slices);
+  const total = queue.length;
+  const lanes = serial
+    ? 1
+    : Math.min(concurrency(laneFlag ?? process.env.AGENTKIT_TEST_CONCURRENCY), total);
+  const results: UnitResult[] = [];
+  let running = 0;
+
+  async function lane(): Promise<void> {
+    for (;;) {
+      const index = queue.findIndex((unit) => !soloFiles.has(unit.file) || running === 0);
+      if (index === -1) {
+        if (queue.length === 0) return;
+        await Bun.sleep(50);
+        continue;
+      }
+      const unit = queue.splice(index, 1)[0] as Unit;
+      running += 1;
+      const result = await runUnit(unit, serial);
+      running -= 1;
+      report(result, serial);
+      results.push(result);
+    }
+  }
+
+  const started = Bun.nanoseconds();
+  await Promise.all(Array.from({ length: lanes }, () => lane()));
+  const elapsed = (Bun.nanoseconds() - started) / 1e9;
+
+  const totals = results.reduce(
+    (sum, result) => ({
+      pass: sum.pass + result.pass,
+      fail: sum.fail + result.fail,
+      skip: sum.skip + result.skip,
+      todo: sum.todo + result.todo,
+    }),
+    { pass: 0, fail: 0, skip: 0, todo: 0 },
+  );
+  const failed = results.filter(broke);
+
+  process.stdout.write(`\n===== ${lanes} lanes, ${results.length} files =====\n`);
+  for (
+    const result of [...results].sort((left, right) => right.seconds - left.seconds).slice(0, 10)
+  ) {
+    process.stdout.write(`  ${result.seconds.toFixed(1).padStart(6)}s  ${result.unit.file}\n`);
+  }
+  // Serial mode streams each child straight through, so nothing was captured to
+  // count. Printing zeroes there would read as "nothing ran"; bun already
+  // printed a real summary per file.
+  process.stdout.write(
+    serial
+      ? `per-file summaries above, ${results.length} files in ${elapsed.toFixed(1)}s\n`
+      : `${totals.pass} pass, ${totals.fail} fail, ${totals.skip} skip, ${totals.todo} todo`
+        + ` across ${results.length} files in ${elapsed.toFixed(1)}s\n`,
+  );
+  if (failed.length > 0) {
+    process.stdout.write(`FAILED FILES: ${failed.map((result) => result.unit.file).join(', ')}\n`);
+  }
+  // A lane that threw would otherwise leave a short result list reading as a
+  // pass, which is the same lie as a killed child reading as a pass.
+  if (results.length !== total) {
+    process.stdout.write(`!!!!! ${total - results.length} of ${total} files never reported\n`);
+    process.exit(1);
+  }
+  process.exit(failed.length > 0 ? 1 : 0);
+}
+
+if (import.meta.main) await main();

--- a/tests/build/test-runner.test.ts
+++ b/tests/build/test-runner.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from 'bun:test';
+import { schedule } from '../../scripts/run-test-slices';
+
+interface Interval {
+  unit: string;
+  start: number;
+  end: number;
+}
+
+// Long enough that scheduling jitter cannot manufacture or hide an overlap:
+// two units that genuinely run together share tens of milliseconds, and two
+// that do not are separated by a whole unit's duration.
+const unitMs = 25;
+
+function overlap(left: Interval, right: Interval): boolean {
+  return left.start < right.end && right.start < left.end;
+}
+
+function overlappingPairs(intervals: readonly Interval[]): string[] {
+  const pairs: string[] = [];
+  for (let i = 0; i < intervals.length; i += 1) {
+    for (let j = i + 1; j < intervals.length; j += 1) {
+      const [left, right] = [intervals[i] as Interval, intervals[j] as Interval];
+      if (overlap(left, right)) pairs.push([left.unit, right.unit].sort().join('+'));
+    }
+  }
+  return pairs.sort();
+}
+
+async function run(units: readonly string[], lanes: number, solo: readonly string[]) {
+  const soloSet = new Set(solo);
+  const intervals: Interval[] = [];
+  await schedule(units, lanes, (unit) => soloSet.has(unit), async (unit) => {
+    const start = Bun.nanoseconds();
+    await Bun.sleep(unitMs);
+    intervals.push({ unit, start, end: Bun.nanoseconds() });
+  });
+  return intervals;
+}
+
+describe('the test runner schedules solo units exclusively', () => {
+  // The control. Without it the exclusion assertions below could pass on a
+  // scheduler that never runs anything concurrently at all, and prove nothing.
+  test('ordinary units do overlap, so this harness can see an overlap at all', async () => {
+    const intervals = await run(['a', 'b', 'c', 'd'], 4, []);
+
+    expect(intervals).toHaveLength(4);
+    expect(overlappingPairs(intervals).length).toBeGreaterThan(0);
+  });
+
+  test('nothing runs while a solo unit runs, whatever order it is queued in', async () => {
+    for (const units of [['solo', 'a', 'b', 'c'], ['a', 'b', 'c', 'solo'], ['a', 'solo', 'b', 'c']]) {
+      const intervals = await run(units, 4, ['solo']);
+      const target = intervals.find((interval) => interval.unit === 'solo') as Interval;
+
+      expect(intervals.map((interval) => interval.unit).sort()).toEqual(['a', 'b', 'c', 'solo']);
+      const trespassers = intervals
+        .filter((interval) => interval.unit !== 'solo' && overlap(interval, target))
+        .map((interval) => interval.unit);
+      expect(trespassers, `queued as ${units.join(',')}`).toEqual([]);
+    }
+  });
+
+  // The direction the first implementation got wrong: it gated the solo unit on
+  // an idle pool but let ordinary units start freely once it was already going.
+  test('an ordinary unit does not join a solo unit that has already started', async () => {
+    const intervals = await run(['solo', 'a', 'b', 'c', 'd', 'e'], 4, ['solo']);
+    const target = intervals.find((interval) => interval.unit === 'solo') as Interval;
+
+    expect(intervals).toHaveLength(6);
+    expect(intervals.filter((interval) => interval.unit !== 'solo' && overlap(interval, target)))
+      .toEqual([]);
+  });
+
+  test('two solo units never overlap each other', async () => {
+    const intervals = await run(['solo-1', 'a', 'solo-2', 'b'], 4, ['solo-1', 'solo-2']);
+    const solos = intervals.filter((interval) => interval.unit.startsWith('solo-'));
+
+    expect(intervals).toHaveLength(4);
+    expect(solos).toHaveLength(2);
+    expect(overlap(solos[0] as Interval, solos[1] as Interval)).toBe(false);
+    expect(overlappingPairs(intervals).filter((pair) => pair.includes('solo'))).toEqual([]);
+  });
+
+  test('every unit runs exactly once, and a single lane still drains the queue', async () => {
+    const units = ['a', 'b', 'solo', 'c'];
+    const intervals = await run(units, 1, ['solo']);
+
+    expect(intervals.map((interval) => interval.unit).sort()).toEqual([...units].sort());
+    expect(overlappingPairs(intervals)).toEqual([]);
+  });
+
+  test('a queue that is entirely solo units still completes', async () => {
+    const intervals = await run(['solo-1', 'solo-2', 'solo-3'], 4, [
+      'solo-1',
+      'solo-2',
+      'solo-3',
+    ]);
+
+    expect(intervals).toHaveLength(3);
+    expect(overlappingPairs(intervals)).toEqual([]);
+  });
+
+  test('a unit that throws surfaces as a rejection instead of hanging the pool', async () => {
+    const failing = schedule(['solo', 'a'], 2, (unit) => unit === 'solo', async (unit) => {
+      if (unit === 'solo') throw new Error('boom');
+      await Bun.sleep(unitMs);
+    });
+
+    await expect(failing).rejects.toThrow('boom');
+  });
+});

--- a/tests/build/test-runner.test.ts
+++ b/tests/build/test-runner.test.ts
@@ -101,12 +101,19 @@ describe('the test runner schedules solo units exclusively', () => {
     expect(overlappingPairs(intervals)).toEqual([]);
   });
 
-  // Named rather than derived: both suites spawn an external process against a
-  // fixed budget, and CI proved each fails on a loaded machine when it shares
-  // lanes. Dropping either is a silent return to an intermittently red run.
-  test('the budget-bound suites are registered as unshareable', () => {
-    expect([...soloFiles]).toContain('tests/hook-supervisor.test.ts');
-    expect([...soloFiles]).toContain('tests/publish-page/mermaid-runtime.test.ts');
+  // Named rather than derived: each asserts how long spawned work takes, and
+  // contention fails such an assertion on load rather than behaviour. Dropping
+  // one is a silent return to an intermittently red run.
+  test('the suites that assert elapsed time are registered as unshareable', () => {
+    for (
+      const file of [
+        'tests/coding-police-hook.test.ts',
+        'tests/hook-supervisor.test.ts',
+        'tests/publish-page/mermaid-runtime.test.ts',
+      ]
+    ) {
+      expect([...soloFiles], file).toContain(file);
+    }
   });
 
   test('a unit that throws surfaces as a rejection instead of hanging the pool', async () => {

--- a/tests/build/test-runner.test.ts
+++ b/tests/build/test-runner.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { schedule } from '../../scripts/run-test-slices';
+import { schedule, soloFiles } from '../../scripts/run-test-slices';
 
 interface Interval {
   unit: string;
@@ -99,6 +99,13 @@ describe('the test runner schedules solo units exclusively', () => {
 
     expect(intervals).toHaveLength(3);
     expect(overlappingPairs(intervals)).toEqual([]);
+  });
+
+  // Named rather than derived: the supervisor suite asserts a one-second
+  // deadline is met, and CI proved it fails on a loaded machine when it shares
+  // lanes. Dropping it from this set is a silent return to a red macOS run.
+  test('the hook supervisor suite is registered as unshareable', () => {
+    expect([...soloFiles]).toContain('tests/hook-supervisor.test.ts');
   });
 
   test('a unit that throws surfaces as a rejection instead of hanging the pool', async () => {

--- a/tests/build/test-runner.test.ts
+++ b/tests/build/test-runner.test.ts
@@ -101,11 +101,12 @@ describe('the test runner schedules solo units exclusively', () => {
     expect(overlappingPairs(intervals)).toEqual([]);
   });
 
-  // Named rather than derived: the supervisor suite asserts a one-second
-  // deadline is met, and CI proved it fails on a loaded machine when it shares
-  // lanes. Dropping it from this set is a silent return to a red macOS run.
-  test('the hook supervisor suite is registered as unshareable', () => {
+  // Named rather than derived: both suites spawn an external process against a
+  // fixed budget, and CI proved each fails on a loaded machine when it shares
+  // lanes. Dropping either is a silent return to an intermittently red run.
+  test('the budget-bound suites are registered as unshareable', () => {
     expect([...soloFiles]).toContain('tests/hook-supervisor.test.ts');
+    expect([...soloFiles]).toContain('tests/publish-page/mermaid-runtime.test.ts');
   });
 
   test('a unit that throws surfaces as a rejection instead of hanging the pool', async () => {

--- a/tests/install-hooks.test.ts
+++ b/tests/install-hooks.test.ts
@@ -43,6 +43,9 @@ function runGlobalInstall(
       ...skipSkillDeps,
       HOME: home,
       XDG_CONFIG_HOME: join(home, '.config'),
+      // Pinned rather than inherited: a runner with AGENTKIT_HOME exported would
+      // otherwise install into it and assert against the temp home.
+      AGENTKIT_HOME: join(home, '.agentkit'),
       ...extraEnv,
     },
     encoding: 'utf-8',

--- a/tests/install-hooks.test.ts
+++ b/tests/install-hooks.test.ts
@@ -27,6 +27,9 @@ const WITH_REVIEW = ['--with', 'adversarial-review'];
 // Full canonical parity needs every hook-owning kit selected.
 const WITH_ALL_HOOK_KITS = [...WITH_REVIEW, '--with', 'memory'];
 const WITH_MEMORY = ['--with', 'memory'];
+// Hook wiring is what these pin, not dependency fetching. The real bun-install
+// path is exercised once, by the first test in tests/install-prompt.test.ts.
+const skipSkillDeps = { AGENTKIT_SKIP_SKILL_DEPS: '1' };
 
 function runGlobalInstall(
   home: string,
@@ -37,6 +40,7 @@ function runGlobalInstall(
     cwd: repoRoot,
     env: {
       ...process.env,
+      ...skipSkillDeps,
       HOME: home,
       XDG_CONFIG_HOME: join(home, '.config'),
       ...extraEnv,

--- a/tests/install-prompt.test.ts
+++ b/tests/install-prompt.test.ts
@@ -289,11 +289,12 @@ describe('the advisory review instruction is opt-in', () => {
   let plainInstall: string | null = null;
   function defaultInstall(): string {
     if (plainInstall) return plainInstall;
-    const home = mkdtempSync(join(tmpdir(), 'agentkit-review-flag-'));
-    const result = runGlobalInstall(home);
+    // Recorded before the install can fail its assertion, so a failed run still
+    // takes its temp home with it rather than leaking one per attempt.
+    plainInstall = mkdtempSync(join(tmpdir(), 'agentkit-review-flag-'));
+    const result = runGlobalInstall(plainInstall);
     expect(result.status, result.stderr).toBe(0);
-    plainInstall = home;
-    return home;
+    return plainInstall;
   }
   afterAll(() => {
     if (plainInstall) rmSync(plainInstall, { recursive: true, force: true });

--- a/tests/install-prompt.test.ts
+++ b/tests/install-prompt.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from 'bun:test';
+import { afterAll, describe, test, expect } from 'bun:test';
 import {
   existsSync,
   lstatSync,
@@ -28,7 +28,7 @@ function writeAgentkitConfig(home: string, contents: string): void {
   writeFileSync(join(home, '.config', 'agentkit', 'config.yaml'), contents);
 }
 
-function runGlobalInstall(home: string, extraArgs: string[] = []) {
+function runInstall(home: string, extraArgs: string[], extraEnv: Record<string, string>) {
   return spawnSync('bash', [installScript, '--global', '--no-session-scope', ...extraArgs], {
     cwd: repoRoot,
     env: {
@@ -36,10 +36,23 @@ function runGlobalInstall(home: string, extraArgs: string[] = []) {
       HOME: home,
       XDG_CONFIG_HOME: join(home, '.config'),
       AGENTKIT_HOME: join(home, '.agentkit'),
+      ...extraEnv,
     },
     encoding: 'utf-8',
     timeout: globalInstallTimeoutMs,
   });
+}
+
+// The one install in the whole suite that resolves and builds real skill
+// dependencies, so a dependency that stops resolving still fails something.
+function runGlobalInstallWithSkillDeps(home: string) {
+  return runInstall(home, [], {});
+}
+
+// Everywhere else pins prompt splicing, which the dependency step does not
+// touch, and paying for it once per install is most of these tests' runtime.
+function runGlobalInstall(home: string, extraArgs: string[] = []) {
+  return runInstall(home, extraArgs, { AGENTKIT_SKIP_SKILL_DEPS: '1' });
 }
 
 describe('global prompt installation', () => {
@@ -76,7 +89,7 @@ describe('global prompt installation', () => {
       );
 
       for (let i = 0; i < 2; i += 1) {
-        const result = runGlobalInstall(home);
+        const result = runGlobalInstallWithSkillDeps(home);
         expect(result.status, result.stderr.toString()).toBe(0);
       }
 
@@ -270,6 +283,22 @@ describe('the advisory review instruction is opt-in', () => {
   const instructionPath = (home: string) =>
     join(home, '.agentkit', 'instructions', 'review-discipline.md');
 
+  // Two of these read a plain default install without touching it, and the
+  // install is the whole cost. The ones that re-install or deselect still get
+  // their own home, because they change what the next assertion would see.
+  let plainInstall: string | null = null;
+  function defaultInstall(): string {
+    if (plainInstall) return plainInstall;
+    const home = mkdtempSync(join(tmpdir(), 'agentkit-review-flag-'));
+    const result = runGlobalInstall(home);
+    expect(result.status, result.stderr).toBe(0);
+    plainInstall = home;
+    return home;
+  }
+  afterAll(() => {
+    if (plainInstall) rmSync(plainInstall, { recursive: true, force: true });
+  });
+
   test('--with advisory-review installs it and splices it into the prompt', () => {
     const home = mkdtempSync(join(tmpdir(), 'agentkit-review-flag-'));
 
@@ -286,18 +315,12 @@ describe('the advisory review instruction is opt-in', () => {
   }, globalInstallTimeoutMs);
 
   test('a default install leaves it out of the prompt entirely', () => {
-    const home = mkdtempSync(join(tmpdir(), 'agentkit-review-flag-'));
+    const home = defaultInstall();
 
-    try {
-      const result = runGlobalInstall(home);
-      expect(result.status, result.stderr).toBe(0);
-      expect(existsSync(instructionPath(home))).toBe(false);
-      expect(readFileSync(promptPath(home), 'utf-8')).not.toContain(
-        'agentkit:review-discipline:start',
-      );
-    } finally {
-      rmSync(home, { recursive: true, force: true });
-    }
+    expect(existsSync(instructionPath(home))).toBe(false);
+    expect(readFileSync(promptPath(home), 'utf-8')).not.toContain(
+      'agentkit:review-discipline:start',
+    );
   }, globalInstallTimeoutMs);
 
   // Presence without a recorded selection is not consent, so deselecting has to
@@ -321,16 +344,9 @@ describe('the advisory review instruction is opt-in', () => {
   }, globalInstallTimeoutMs);
 
   test('the other core instructions are unaffected', () => {
-    const home = mkdtempSync(join(tmpdir(), 'agentkit-review-flag-'));
-
-    try {
-      expect(runGlobalInstall(home).status).toBe(0);
-      const prompt = readFileSync(promptPath(home), 'utf-8');
-      for (const name of ['anti-glaze', 'coding-discipline', 'collaboration-visibility']) {
-        expect(prompt).toContain(`agentkit:${name}:start`);
-      }
-    } finally {
-      rmSync(home, { recursive: true, force: true });
+    const prompt = readFileSync(promptPath(defaultInstall()), 'utf-8');
+    for (const name of ['anti-glaze', 'coding-discipline', 'collaboration-visibility']) {
+      expect(prompt).toContain(`agentkit:${name}:start`);
     }
   }, globalInstallTimeoutMs);
 });

--- a/tests/install-shared-root.test.ts
+++ b/tests/install-shared-root.test.ts
@@ -53,6 +53,9 @@ function runGlobalInstall(home: string) {
     cwd: repoRoot,
     env: {
       ...process.env,
+      // The shared-root layout is what these pin, not dependency fetching; the
+      // bun-resolution test below drives that path with its own shim.
+      AGENTKIT_SKIP_SKILL_DEPS: "1",
       HOME: home,
       XDG_CONFIG_HOME: join(home, ".config"),
       AGENTKIT_HOME: join(home, ".agentkit"),

--- a/tests/install-tools.test.ts
+++ b/tests/install-tools.test.ts
@@ -26,6 +26,8 @@ describe('standalone tool installation', () => {
         env: {
           ...process.env,
           AGENTKIT_PLATFORM: 'linux',
+          // Tool placement is what this pins, not dependency fetching.
+          AGENTKIT_SKIP_SKILL_DEPS: '1',
           HOME: home,
           XDG_CONFIG_HOME: join(home, '.config'),
         },

--- a/tests/install/skill-kits.test.ts
+++ b/tests/install/skill-kits.test.ts
@@ -16,6 +16,10 @@ function install(home: string, extraArgs: string[] = []) {
     env: {
       ...process.env,
       AGENTKIT_PLATFORM: 'linux',
+      // Kit selection is what these pin, not dependency fetching. The real
+      // bun-install path is exercised once, by the first test in
+      // tests/install-prompt.test.ts.
+      AGENTKIT_SKIP_SKILL_DEPS: '1',
       HOME: home,
       XDG_CONFIG_HOME: join(home, '.config'),
       AGENTKIT_HOME: join(home, '.agentkit'),

--- a/tests/install/update-notice.test.ts
+++ b/tests/install/update-notice.test.ts
@@ -195,6 +195,8 @@ describe('the installed version stamp', () => {
         env: {
           ...process.env,
           AGENTKIT_PLATFORM: 'linux',
+          // The version stamp is what this pins, not dependency fetching.
+          AGENTKIT_SKIP_SKILL_DEPS: '1',
           HOME: h,
           XDG_CONFIG_HOME: join(h, '.config'),
           AGENTKIT_HOME: join(h, '.agentkit'),

--- a/tests/session/install-session-slice.test.ts
+++ b/tests/session/install-session-slice.test.ts
@@ -14,7 +14,13 @@ const helperTimeoutMs = 5_000;
 function install(home: string, extraArgs: string[] = []) {
   return spawnSync('bash', [installScript, '--global', ...extraArgs], {
     cwd: repoRoot,
-    env: { ...process.env, HOME: home, XDG_CONFIG_HOME: join(home, '.config') },
+    env: {
+      ...process.env,
+      // The systemd slice unit is what these pin, not dependency fetching.
+      AGENTKIT_SKIP_SKILL_DEPS: '1',
+      HOME: home,
+      XDG_CONFIG_HOME: join(home, '.config'),
+    },
     encoding: 'utf-8',
     timeout: globalInstallTimeoutMs,
   });

--- a/tests/test-slices.test.ts
+++ b/tests/test-slices.test.ts
@@ -54,6 +54,7 @@ const CRITICAL_INPUTS = [
   'policies/**/*',
   'scripts/check-test-slices.ts',
   'scripts/product-command',
+  'scripts/run-test-slices.ts',
   'scripts/skill-kits.ts',
   'scripts/sync-cc-plugin.sh',
   'skills/KITS',


### PR DESCRIPTION
Closes #244.

The full suite ran as one serial `bun test`. Two costs paid for that: no
parallelism, and every install-suite test resolving and building real skill
dependencies it never asserted on.

## Measured

`bounded-run --profile compile` (4-CPU budget), 32-core Linux workstation.

Like-for-like on the tree this work was developed against (69 files, 1725
tests), so every row runs exactly the same tests:

| Configuration | Wall | vs baseline |
| --- | --- | --- |
| Baseline: serial `bun test` | 281s | — |
| Fixture + skip-deps only, still serial | 247s | 1.14x |
| All three fixes, 2 lanes | 118s | 2.4x |
| All three fixes, 4 lanes (default here) | **61s** | **4.6x** |

Counts identical in every row: **1718 pass / 7 skip / 0 fail, 1725 tests across
69 files**. No test was deleted and none became a skip.

On this branch rebased onto `84bebe6`, which carries v0.6.2's two extra test
files: **1749 pass / 0 fail / 7 skip across 71 files in 61.4s**, no failure
markers. More tests than the baseline measured, in a fifth of the time.

The 7 skips are 5 systemd-containment tests (opt-in via
`AGENTKIT_RUN_INTEGRATION=1`), one macOS path-casing test, and one
real-bash-3.2 test.

## What changed

**`scripts/run-test-slices.ts`** runs the `TEST_SLICES` inventory as concurrent
`bun test` children, one per test file, output buffered per file so the
transcript stays readable. It validates slice routing before running, so a test
file missing from the inventory fails the run instead of silently not running.

Scheduling is per file rather than per slice because the `install` slice alone
was ~183s of the 281s baseline (71%) — one child per slice caps the achievable
speedup at about 1.4x regardless of lane count. The slice stays the selection
and labelling unit.

Lane count defaults to `min(4, cores/2)`; `--lanes N` overrides it and
`--serial` restores the one-at-a-time run. The override is a flag rather than
only an environment variable because the installed `bounded-run` (v0.6.0 on this
host) passes an allowlist of names through and refuses an `env NAME=value`
prefix, leaving no way to set the variable on a contained host.

**A child that ends without a completion summary fails the run.** Verified
counterfactually, not assumed: a test file made to `process.exit(0)` at module
scope produces a child that exits **0** with no test output, and the runner
still exits 1 with `no completion summary, the child died mid-run`. A plain
assertion failure is caught too.

**Install suites set `AGENTKIT_SKIP_SKILL_DEPS=1`.** Exactly one place still
drives the real `bun install`-and-build path — the first test in
`tests/install-prompt.test.ts` — so a skill dependency that stops resolving
still fails a test. Verified in both directions: with the flag the installer
prints `Skipping dependencies` for `diagram` and `publish-page`; without it,
`Installing dependencies` plus a `bun build`.

Per-file savings: `skill-kits` -10.6s, `install-prompt` -5.8s, `install-hooks`
-5.8s, `install-session-slice` -3.2s, `install-shared-root` -2.3s,
`update-notice` -1.3s.

**Two read-only advisory-review tests share one memoized default install.** The
other install setups are genuinely distinct rather than duplicated — different
flags, different pre-seeded state files, different terminal conditions — so
there was nothing else to consolidate without weakening what a test pins.

## Concurrency safety

Every install spawns into its own `mkdtemp` HOME. Audited for shared state and
found none that bites: hardcoded `/tmp` paths are string arguments to hooks,
never files written; the only PPID-keyed file is written by `resource-police.sh`
itself, not by tests; no fixed ports; `GIT_CONFIG_GLOBAL` isolated where git is
used; no test writes into the repo tree.

The one genuine serialization is `tests/resource-run.integration.test.ts`, which
takes the machine-wide `agentkit-run.lock`. It runs solo when
`AGENTKIT_RUN_INTEGRATION=1` and is skipped otherwise.

## Follow-ups, not in this PR

- **#245** — lane count on hosted CI. A 4-vCPU runner computes 2 lanes under the
  default formula, measuring 2.4x rather than 3x+. Left as a deliberate
  resource-policy decision rather than changed unilaterally here; #245 carries
  the numbers and asks for a measurement from an actual hosted runner.
- **`install.sh` copies skill `node_modules`.** `cp -r` on the skill directory
  carries `skills/publish-page/node_modules` — 161MB, 9,544 files — into every
  install on a dev checkout that has built that skill, regardless of the skip
  flag. Baseline and after runs paid it equally so the ratios hold, but
  excluding it would cut every install again.
- `.agentkit/product.yaml`'s `verify:` still runs the serial `bun test`; its
  exact string is pinned by assertions in `tests/product-command.test.ts` and
  `tests/resource-safety-assets.test.ts`.

- **No per-unit timeout in the runner, and hangs now surface more slowly.** A
  child that hangs forever is not bounded by the runner itself. Raising the
  per-test default to 60s makes that trade explicit: a genuinely hung test now
  takes 60s to fail instead of 5s. That is the price of not failing healthy
  tests on load, and it is the right way round — a slow true signal beats a
  fast false one — but a per-unit timeout in the runner would let us have both.
  The remaining gap either way is a wedged child that never enters a test.

## Review round

Reviewer verdict was ship-after-fixes; `a5c4304` applies them.

- **Solo exclusion was one-directional.** The predicate gated the solo unit on
  an idle pool but left ordinary units free to start alongside it the moment
  after it began — delaying an overlap rather than preventing it. Now held in
  both directions, extracted as `schedule()` so tests drive it directly, with a
  `finally` that releases the lane and solo claim when a unit throws.
  `tests/build/test-runner.test.ts` pins it with recorded start/end intervals
  plus a control proving the harness can observe an overlap at all; reverting
  the predicate fails 3 of its 7 tests.
- **Counters now parse from stderr alone.** Bun puts only its version banner on
  stdout, so the old `stdout + stderr` concatenation let a test's own output
  outrank the real summary. Measured, not reasoned: a test printing a fake
  `999 pass` made the runner report **999 pass** before the fix and **2 pass**
  after.
- **A crashed child no longer reads clean.** It reports no counters at all, so
  the totals line said `0 fail` for a crashed run while `FAILED FILES` listed
  it. It now reads `0 fail (+1 crashed)`.
- `--lanes` rejects a missing or flag-shaped value instead of falling back to
  the auto-detected default; an empty `AGENTKIT_TEST_CONCURRENCY` counts as
  unset; the shared install fixture records its temp home before asserting, so
  a failed install cleans up after itself; `install-hooks` pins `AGENTKIT_HOME`.

Post-fix on the committed tree: **1756 pass / 0 fail / 7 skip across 72 files in
61.5s**, no failure markers.


## Round two: a red macOS run, and why

`a5c4304` went red on macOS with two failures in
`tests/hook-supervisor.test.ts`, while ubuntu passed on the same commit and
both platforms had passed on `9ad2800`. Intermittent, and caused by this PR.

Those tests invoke `fail-closed-hook.sh` with a **one-second deadline** and
assert it relays its child's output unchanged. Under four-lane CPU contention
the child misses that budget, the supervisor fails closed exactly as designed,
and the assertion sees the wrong reason string:

```
- "permissionDecisionReason": "fixture"
+ "permissionDecisionReason": "BLOCKED: fail-closed hook supervisor could not complete policy evaluation."
```

The supervisor behaved. The test broke on load, not on behaviour — the category
the runner's solo set exists for, which until now held only the bounded-run
containment suite.

`aeed976` puts the file in `soloFiles` unconditionally, schedules solo units
first (they idle every other lane whenever they run, and the pool is empty at
startup, so the cost lands where it is cheapest), and exports `soloFiles` with a
test asserting the entry — so removing it fails a test rather than quietly
restoring a red macOS run. Local full suite after the fix: **1757 pass / 0 fail
/ 7 skip across 72 files in 63.3s**; the serialization costs about 2s.

Swept for the same failure class elsewhere: every other reference to
`fail-closed-hook.sh` in the suite is fixture data rather than a spawn, so this
was the only file carrying a real short wall-clock budget.

Added to the follow-ups: **hook-supervisor's two relay tests carry an incidental
1s deadline.** They pin relay behaviour, not the deadline — the dedicated
timeout test covers that separately. Making them load-robust would let the file
rejoin the pool and return the ~2s. Deliberately not done here: the file is not
this PR's to re-specify, and serializing changes no test semantics at all.


## Round three: the same class, on the other platform

`8c8dc12` went green on macOS — the supervisor fix held — and red on ubuntu with
`tests/publish-page/mermaid-runtime.test.ts`: `browser never published a usable
devtools endpoint (port not answering yet: TimeoutError)`. Its `devtoolsEndpoint`
helper waits **20 seconds** for headless Chrome to write `DevToolsActivePort` and
answer on it; on a 4-vCPU runner sharing lanes with the 41s `skill-kits` file,
Chrome does not get there. It joins `soloFiles`.

**The general rule, now stated in the runner:** a test file that spawns an
external process against a fixed startup or response budget cannot share lanes.
Contention makes the process miss the budget, and the assertion then fails on
load rather than on behaviour. Two files qualify — `fail-closed-hook.sh` at one
second, headless Chrome at twenty. Making either budget load-robust would let
its file rejoin the pool and return the serialized time; neither is this PR's to
re-specify, and serializing changes no test semantics at all.

Per the timing table these are the only two candidates: everything else in the
top ten is installer filesystem I/O, which slows under load but asserts no
deadline.

## Platform asymmetry, and a caution for #245

The two failures landed on opposite platforms, and the reason is not lane count
but **cores per lane**:

| Runner | Cores | Lanes | Cores per lane | Outcome |
| --- | --- | --- | --- | --- |
| self-hosted macOS (M4) | 10 | 4 | 2.5 | Chrome fine, supervisor starved |
| `ubuntu-24.04` (hosted) | 4 | 2 | 2.0 | supervisor fine, Chrome starved |

The Mac takes *more* lanes and is still the roomier machine. That is evidence
for #245's point that `ubuntu-24.04` is the constrained runner.

It is also a caution against reading #245 as a free win: raising ubuntu to four
lanes would put four workers on four vCPUs, and the two files most sensitive to
that are precisely the ones now serialized — so they are protected, but
everything else gets less CPU. #245 should be settled by measuring that
configuration, not by assuming the 2-lane trend extends.


## Round four: the class audited in one pass

`c7ec3b7` went green on macOS and red on ubuntu with `tests/diagram/render.test.ts`:
`this test timed out after 5000ms`. Rather than serialize a third file and wait
for a fourth, the whole class was swept. **The failures split across two
mechanisms that want different fixes.**

### Serialized — tests that assert how long spawned work takes

Contention fails the assertion on load rather than behaviour, and no timeout
raise helps, because the bound is the point.

| File | The bound it asserts |
| --- | --- |
| `tests/coding-police-hook.test.ts` | `expect(elapsed).toBeLessThan(10_000)` over two hook runs |
| `tests/hook-supervisor.test.ts` | one-second relay deadline, plus `toBeLessThan(3_500)` |
| `tests/publish-page/mermaid-runtime.test.ts` | twenty-second wait for Chrome's devtools endpoint |

`coding-police-hook` has not been observed failing; it is included because it is
the same shape and a lane costs less than a CI cycle.

### Not serialized — the default per-test timeout, raised instead

`diagram/render` asserts **no** time bound. It timed out at exactly 5000ms —
bun's default for a test that declares none — because `d2` is slow on a loaded
runner. Serializing it would have spent a lane supplying a missing parameter, so
the runner now passes `--timeout=60000` to every child. Verified that an
explicit per-test timeout still wins over the flag, so nothing declaring a real
bound is weakened, and verified the flag reaches children by shrinking it to
50ms and watching a passing file time out.

This covers every undeclared-timeout file at once rather than one per red run.

### Excluded, with reasons — so the sweep can be checked, not just the additions

| Candidate | Why not |
| --- | --- |
| `docs/archive-banner`, `diagram/icons` | "chrome" matched *page chrome* and *monochrome*; no browser |
| `resource-police`, `fixtures/resource-commands` | "playwright" is a command string they classify, never launch |
| `session/install-session-slice` | `toBeLessThan(64)` is a memory ceiling in GiB, not elapsed time |
| `diagram/extract-cli` | spawns depcruise but declares `CRUISE_TIMEOUT_MS = 60_000` |
| `resource-police`, `docs/deploy` | spawn external binaries, already declare 30s+ timeouts |
| `diagram/d2-svg` | 0.0s locally; no meaningful spawn cost |
| install suites | slow, but filesystem I/O with declared 60s timeouts and no asserted deadline |

Local wall clock: **1757 pass / 0 fail / 7 skip across 72 files in 70.0s**. Three
serialized files cost ~8s of head against the 61.5s unserialized run — the price
of a flake class that is now closed by construction rather than by luck.

