### PR TITLE
feat(wip): half-done surface, and a plan-level done gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,22 @@ top and ships with the next tag.
 ## [Unreleased]
 
 - feat(wip): `wip` reports what was started and not finished in a repository —
-  unmerged branches with age and commit count, worktrees with a loud warning on
-  dirty ones, open merge requests or pull requests and what holds each, open
-  issues you authored (separating those whose text says they were carved out of
-  other work), and plans with unclosed gaps. GitHub and GitLab both resolve from
-  the `origin` host, including self-hosted; a repository with neither CLI still
-  reports the git-only sections and names in a `NOTE` what went unchecked.
-  Merged-ness is decided by merging into the default branch in memory and
-  comparing trees: an ancestry count calls a squash-merged branch outstanding
-  forever, and neither a two-dot nor a three-dot diff answers the question
+  branches with age and commit count, worktrees with a loud warning on dirty
+  ones, open merge requests or pull requests and what holds each, open issues
+  you authored (separating those whose text says they were carved out of other
+  work), and plans with unclosed gaps. GitHub and GitLab both resolve from the
+  `origin` host, including self-hosted.
+  Whether a branch is finished is the **forge's** answer, never git topology. A
+  squash merge destroys the topological evidence by design, and measured against
+  nine branches of known outcome every git-only rule called all seven merged ones
+  outstanding: ancestry counts, two-dot and three-dot diffs, and an in-memory
+  `merge-tree` tree comparison alike — the last passing a two-commit fixture and
+  failing on a real repository, because a fixture whose default branch has not
+  moved cannot distinguish the case it exists to prove. States are separated into
+  merged (cleanup), closed-without-merging (a decision), open, and never-opened
+  (the interesting one). With no forge reachable there is no local rule to fall
+  back to, so the branch state is reported as UNKNOWN and marked DEGRADED rather
+  than guessed at in the alarming direction
 - feat(plan-gate): a plan may not be treated as done while its own gaps section
   lists work that is neither ticked, struck through, nor carrying an issue
   reference. `tools/plan-gate` is the single parser; `plan-police` is a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ top and ships with the next tag.
 
 ## [Unreleased]
 
+- feat(wip): `wip` reports what was started and not finished in a repository —
+  unmerged branches with age and commit count, worktrees with a loud warning on
+  dirty ones, open merge requests or pull requests and what holds each, open
+  issues you authored (separating those whose text says they were carved out of
+  other work), and plans with unclosed gaps. GitHub and GitLab both resolve from
+  the `origin` host, including self-hosted; a repository with neither CLI still
+  reports the git-only sections and names in a `NOTE` what went unchecked.
+  Merged-ness is decided by merging into the default branch in memory and
+  comparing trees: an ancestry count calls a squash-merged branch outstanding
+  forever, and neither a two-dot nor a three-dot diff answers the question
+- feat(plan-gate): a plan may not be treated as done while its own gaps section
+  lists work that is neither ticked, struck through, nor carrying an issue
+  reference. `tools/plan-gate` is the single parser; `plan-police` is a
+  PreToolUse hook on `Edit|Write` that judges the content an edit is about to
+  land and refuses the edit, with `AGENTKIT_SKIP_HOOKS=plan-police` as the
+  recorded exception. Plan layout is discovered from common conventions and
+  overridable per repository under `wip:` in `.agentkit/config.yaml`
+
 ## v0.6.3 — 2026-07-31
 
 - perf(ci): `agentkit:test-full` runs the slice inventory as concurrent per-file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,18 @@ top and ships with the next tag.
   merged (cleanup), closed-without-merging (a decision), open, and never-opened
   (the interesting one). With no forge reachable there is no local rule to fall
   back to, so the branch state is reported as UNKNOWN and marked DEGRADED rather
-  than guessed at in the alarming direction
+  than guessed at in the alarming direction.
+  The headline counts unfinished branches only — branches, worktrees, issues and
+  plan gaps are four different things with four different remedies, and one
+  number covering all of them cannot be acted on; the rest are broken out on a
+  `COUNTS` line. A branch with nothing committed, no worktree checked out on it,
+  and no change ever opened is hidden as never-started, which on one real
+  repository removed 20 of 41 branches (all worktree-harness bookkeeping) and
+  took the headline from 150 to 4. The rule is structural rather than by name:
+  having commits disqualifies a branch from being hidden, so it cannot bury a
+  harness branch that did real work, and a dirty worktree keeps a zero-commit
+  branch visible because that is where uncommitted work lives. What is hidden is
+  counted and named in a NOTE
 - feat(plan-gate): a plan may not be treated as done while its own gaps section
   lists work that is neither ticked, struck through, nor carrying an issue
   reference. `tools/plan-gate` is the single parser; `plan-police` is a

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Reusable AI agent skills, rules, plugins, hooks, and tools for OpenCode, Claude 
 | **ruminate**                | `--with memory`                  | Mine past Claude Code conversations for corrections, preferences, and knowledge that never reached the brain vault.                                                                                                                               |
 | **test-driven-development** | always                           | Enforces strict Test-Driven Development (TDD) workflow: RED-GREEN-REFACTOR cycle.                                                                                                                                                                 |
 | **uninstall**               | always                           | Remove AgentKit, or one of its skill kits, without hand-deleting files.                                                                                                                                                                           |
+| **wip**                     | always                           | Report what was started and not finished in a repository — unmerged branches, dirty worktrees, open merge requests and what holds them, open issues you filed, and plans whose own gaps section still lists untracked work.                       |
 
 <!-- generated:skills:end -->
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -163,3 +163,27 @@ comment-police:
   #   exclude-patterns:
   #     - vendor/
   #     - generated/
+
+# Read by the `wip` status surface, the `plan-gate` checker, and the
+# plan-police hook. A repository's own .agentkit/config.yaml overrides this.
+wip:
+  # Where plans live. Replaces the defaults outright:
+  # plans/, docs/plans/, doc/plans/, .omc/plans/, PLAN.md, PLANS.md
+  plan-paths: []
+  # Example:
+  #   plan-paths:
+  #     - design/decisions
+  #     - ROADMAP.md
+
+  # Headings whose list items are gaps. Matched case-insensitively against the
+  # whole heading text.
+  # gap-headings: 'known gaps|loose ends|snags'
+
+  # What it looks like for a plan to claim it is finished. plan-police refuses
+  # an edit that adds one of these while a gap is neither ticked nor tracked.
+  # done-markers: '^[[:space:]]*status[[:space:]]*:[[:space:]]*(done|shipped)'
+
+  # What counts as a gap being tracked by an issue. A Jira-style PROJ-123 is
+  # deliberately absent by default: nothing distinguishes it from a hex digest
+  # or a UTF-8 label, and a wrong "tracked" loses the gap silently.
+  # issue-refs: '#[0-9]+|![0-9]+|[A-Z][A-Z0-9]+-[0-9]+'

--- a/docs/site/src/content/docs/concepts/police-hooks.md
+++ b/docs/site/src/content/docs/concepts/police-hooks.md
@@ -33,8 +33,15 @@ With the `adversarial-review` kit selected, `review-police` is appended at 60s a
 registration catches non-`Bash` merge tools by name. Without that kit, the installer strips both
 registrations out of `settings.json` on the way in — so the default chain is six hooks, not seven.
 
-`Edit` and `Write` are followed by three quality hooks: `format-police`, `coding-police`,
-`comment-police`.
+`Edit` and `Write` are intercepted twice. Before the write, `plan-police` (15s) judges the content
+the edit is about to land; after it, three quality hooks run on the result: `format-police`,
+`coding-police`, `comment-police`.
+
+That split is deliberate rather than incidental. A `PostToolUse` hook can only object to a file that
+already exists, which is the right shape for "this file is now too long" and the wrong shape for
+"this edit is about to claim a plan is finished when it is not" — by then the claim is written. So
+`plan-police` reconstructs the post-edit content itself and refuses beforehand, using the
+`PreToolUse` deny contract below rather than the exit-2 convention.
 
 `resource-police` sits in that chain but is configuration-gated: with the default config
 (`resource-police` and `delegation-police` both disabled) it exits without checking anything.

--- a/docs/site/src/content/docs/cookbook/find-what-is-half-done.md
+++ b/docs/site/src/content/docs/cookbook/find-what-is-half-done.md
@@ -1,0 +1,81 @@
+---
+title: Find what is half done
+description: Ask the repository what you started and did not finish, instead of taking an agent's summary of its own work on trust.
+sidebar:
+  order: 7
+---
+
+`wip` is read-only. It blocks nothing, changes nothing, and answers one question across as many
+repositories as you give it: **what did I start and not finish?**
+
+```sh
+wip                       # this repository
+wip ~/code/a ~/code/b     # several, one block each
+wip --limit 0             # no bounding
+wip --no-forge            # git and plans only, no network
+```
+
+```
+neutron — 9 half-done
+ BRANCH    feat/incidents-ui           0d    1 commits  !633 open
+ BRANCH    fix/core-name-everywhere    7d    0 commits  no MR/PR ever opened
+ ABANDONED feat/model-catalog-auto     5d   !492 closed without merging
+ WORKTREE  wt/corename2                DIRTY 11 modified, 2 untracked — do NOT remove at ~/wt/corename2
+ MR/PR     !628 (fix/voice)            held: no approving review
+ FILED     #311 #312 — authored, open, unfixed
+ DEFERRED  #313 — carved out of other work
+ PLAN      plans/057.md                2 gap(s) unclosed
+ MERGED    fix/old — merged on the forge; cleanup, not unfinished work
+```
+
+## Read the rows in this order
+
+**`DIRTY` worktrees first.** Uncommitted and untracked files die with the checkout and no branch ref
+carries them. Commit, stash, or leave it alone — never remove a dirty one.
+
+**`no MR/PR ever opened` next.** That is work that exists only on your machine. Everything else is
+at least visible to someone.
+
+**`ABANDONED` is not a problem to fix.** A change closed without merging was a decision. It appears
+so that a deliberate stop is not mistaken for a forgotten one.
+
+**`MERGED` is cleanup, not work.** The content landed; only the local ref is left.
+
+```sh
+git checkout main && git pull && git fetch -p
+git branch -vv | awk '/: gone]/ {print $1}' | xargs -r git branch -D
+```
+
+## Trust the NOTE rows
+
+An absent section means "nothing found". A `NOTE` means "not looked at" — they are never conflated,
+and a bounded list always says how many entries it dropped.
+
+The one to take seriously:
+
+```
+NOTE  branch state is DEGRADED: only the forge can tell a squash-merged branch
+      from an unfinished one, so no branch above is known to be outstanding
+```
+
+Whether a branch is finished is the forge's answer, not git's — a squash merge destroys the
+topological evidence, so every git-only rule reports merged branches as outstanding forever. With no
+forge reachable, `wip` reports that it does not know rather than guessing in the alarming direction.
+`--no-forge` produces the same honest degradation deliberately.
+
+## Before you call a plan done
+
+The `PLAN` rows come from `plan-gate`, which reads a plan's own gaps section:
+
+```sh
+plan-gate                  # every plan under this repository
+plan-gate --require-done   # only plans that already claim to be finished
+```
+
+A gap stops blocking when you tick it (`- [x] …`), strike it through, or name the issue that now
+carries it (`#123`, `!123`, `GH-123`, or the issue URL). `plan-police` runs the same checker on any
+edit that marks a plan done and refuses the edit while a bare gap stands — filing the issue and
+pasting its number is the fix.
+
+Plan layout is discovered from six common roots and is configurable per repository; see
+[Configuration](/docs/reference/configuration/) for `wip.plan-paths` and `wip.issue-refs`.

--- a/docs/site/src/content/docs/cookbook/find-what-is-half-done.md
+++ b/docs/site/src/content/docs/cookbook/find-what-is-half-done.md
@@ -16,17 +16,38 @@ wip --no-forge            # git and plans only, no network
 ```
 
 ```
-neutron — 9 half-done
- BRANCH    feat/incidents-ui           0d    1 commits  !633 open
- BRANCH    fix/core-name-everywhere    7d    0 commits  no MR/PR ever opened
- ABANDONED feat/model-catalog-auto     5d   !492 closed without merging
+neutron — 4 unfinished branch(es)
+ BRANCH    feat/incidents-ui           0d   1 commits  !633 open
+ BRANCH    fix/core-name-everywhere    7d   0 commits  no MR/PR ever opened
+ ABANDONED feat/model-catalog-auto     5d  !492 closed without merging
  WORKTREE  wt/corename2                DIRTY 11 modified, 2 untracked — do NOT remove at ~/wt/corename2
- MR/PR     !628 (fix/voice)            held: no approving review
+ MR/PR     !633 (feat/incidents-ui)    held: no approving review
  FILED     #311 #312 — authored, open, unfixed
  DEFERRED  #313 — carved out of other work
  PLAN      plans/057.md                2 gap(s) unclosed
+ COUNTS    1 abandoned · 20 worktree(s) · 2 open change(s) · 100 filed issue(s) · 1 plan(s) with gaps
+ NOTE      20 branch(es) hidden: nothing committed, no worktree, no change ever opened
  MERGED    fix/old — merged on the forge; cleanup, not unfinished work
 ```
+
+## What the headline counts, and what is hidden
+
+The headline is **unfinished branches only**. Branches, worktrees, issues and plan gaps are four
+different kinds of thing with four different remedies, so summing them into one number gives a
+figure nobody can act on. The rest are broken out on the `COUNTS` line.
+
+A branch is hidden when **nothing was committed, no worktree is checked out on it, and no change
+was ever opened**. Nothing was started, so there is nothing to finish. On one real repository that
+removed 20 of 41 branches — all created by a worktree harness — and took the headline from a
+meaningless 150 to an actionable 4.
+
+The test is structural, never by name. A `worktree-agent-*` pattern would look tidier and is worse:
+it would hide such a branch that _does_ carry commits, which is real unfinished work. Having commits
+disqualifies a branch from being hidden, so this rule cannot make that mistake. Nor can it hide the
+case that matters most — a branch with no commits but a **dirty worktree**, where uncommitted work
+actually lives; the worktree keeps it visible.
+
+Whatever is hidden is counted and stated in a `NOTE`. Silent omission reads as "nothing else to see".
 
 ## Read the rows in this order
 

--- a/docs/site/src/content/docs/cookbook/index.md
+++ b/docs/site/src/content/docs/cookbook/index.md
@@ -36,3 +36,4 @@ skill; `product-intelligence` needs `--with product`.
 | [Contain a heavy build](/docs/cookbook/contain-a-build/)               | Linux, provisioned work slice |
 | [Declare what your repo ships](/docs/cookbook/declare-your-product/)   | `--with product`              |
 | [Override a guard, once, on purpose](/docs/cookbook/override-a-guard/) | core                          |
+| [Find what is half done](/docs/cookbook/find-what-is-half-done/)       | core                          |

--- a/docs/site/src/content/docs/reference/cli-and-tools.md
+++ b/docs/site/src/content/docs/reference/cli-and-tools.md
@@ -1,17 +1,19 @@
 ---
 title: CLI and tools
-description: The five executables in tools/, their flags and exit codes, and every AGENTKIT_ environment variable with the file that reads it.
+description: The seven executables in tools/, their flags and exit codes, and every AGENTKIT_ environment variable with the file that reads it.
 sidebar:
   order: 3
 ---
 
-Five executables ship in `tools/`. Two of them are Linux-only and the installer omits them
+Seven executables ship in `tools/`. Two of them are Linux-only and the installer omits them
 elsewhere; two of them only arrive with the explicit `adversarial-review` kit.
 
 | Tool                 | Platform   | Ships with                  |
 | -------------------- | ---------- | --------------------------- |
 | `bounded-run`        | Linux only | every install               |
 | `agent-session`      | Linux only | every install               |
+| `wip`                | portable   | every install               |
+| `plan-gate`          | portable   | every install               |
 | `fix-ascii-boxes.py` | portable   | every install               |
 | `review-gate`        | portable   | `--with adversarial-review` |
 | `review-profile`     | portable   | `--with adversarial-review` |
@@ -26,7 +28,8 @@ Project installs expose them at `<project>/.claude/tools/`. `agentkit-run` remai
 `bounded-run` from the tool's previous name.
 
 The Claude plugins carry their own copies, from an explicit allowlist in
-`scripts/sync-cc-plugin.sh`: the core `agentkit` plugin gets `bounded-run` only, and
+`scripts/sync-cc-plugin.sh`: the core `agentkit` plugin gets `bounded-run`, `wip` and
+`plan-gate`, and
 `review-gate`/`review-profile` go to `agentkit-adversarial-review` instead. `resource-police` accepts
 `$CLAUDE_PLUGIN_ROOT/tools/bounded-run` as a trusted runner and names that path when it denies an
 unbounded command — the runner is trusted by installed path, never by filename.
@@ -152,6 +155,126 @@ It is the one tool here with no `--help`. Its first argument is the command to r
 `agent-session --help` tries to resolve `--help` on `PATH` and exits `69` with
 `cannot find '--help' on PATH outside the shim directory`.
 :::
+
+## `wip`
+
+Read-only. Reports what was started and not finished, for one repository or several. It blocks
+nothing, changes nothing, and exits `0` unless an argument is unusable.
+
+```
+wip [--limit N] [--no-forge] [REPO...]
+```
+
+| Row         | Means                                                                        |
+| ----------- | ---------------------------------------------------------------------------- |
+| `BRANCH`    | an open change, or none ever opened, or state unknown                        |
+| `ABANDONED` | a change closed without merging — a decision, not an oversight               |
+| `WORKTREE`  | a checkout that still exists; `DIRTY` ones hold work no branch ref will save |
+| `MR/PR`     | open and authored by you, with what stands between it and merging            |
+| `FILED`     | issues you opened that are still open                                        |
+| `DEFERRED`  | filed issues whose text says they were carved out of other work              |
+| `PLAN`      | a plan whose gaps section lists work neither closed nor tracked              |
+| `MERGED`    | merged on the forge — cleanup, not unfinished work                           |
+| `NOTE`      | something that was **not** checked, and why                                  |
+
+### Branch state comes from the forge
+
+Whether a branch is finished is answered by the forge, never by git topology. A squash merge
+destroys the topological evidence by design: the squashed commit is not an ancestor of the branch,
+and the merge base stays before the squash forever.
+
+Measured against nine branches of known outcome, every git-only rule reported all seven merged ones
+as still outstanding:
+
+| Rule                                    | On a squash-merged branch                                       |
+| --------------------------------------- | --------------------------------------------------------------- |
+| `rev-list --count base..head`           | ahead forever — the squash is not an ancestor                   |
+| `git diff base..head`                   | shows the default branch's own later commits as deletions       |
+| `git diff base...head`                  | shows the branch's changes since the merge base — never empty   |
+| `merge-tree --write-tree`, tree compare | correct on a small fixture, wrong once the default branch moves |
+
+The last of those is the trap worth naming: it passes a two-commit fixture and fails on a real
+repository, because a fixture whose default branch has not moved cannot distinguish the case it
+exists to prove.
+
+`wip` asks the forge for every change whose source branch matches, normalises the state to
+merged / open / closed, and queries by name for any branch older than the bulk listing window.
+One merged change outranks a closed one on the same branch.
+
+### When the forge cannot answer
+
+There is no local rule to fall back to, so `wip` reports that it does not know:
+
+```
+BRANCH    feat/thing    12d   3 commits  state UNKNOWN — forge could not be asked
+NOTE      branch state is DEGRADED: only the forge can tell a squash-merged branch
+          from an unfinished one, so no branch above is known to be outstanding
+```
+
+An absent section means "nothing found"; a `NOTE` means "not looked at". A bounded list always says
+how many entries it dropped. `--limit 0` removes the bound; `--no-forge` skips the network entirely
+and degrades the same way.
+
+### Forges
+
+GitHub and GitLab both work, resolved per repository from its `origin` host — including self-hosted,
+via `gh auth status --hostname` and the GitLab version endpoint. Note that the two disagree on
+spelling: GitHub reports `OPEN`, GitLab reports `opened`; `merged` and `closed` coincide.
+
+### Exit codes
+
+| Code | Meaning                                           |
+| ---- | ------------------------------------------------- |
+| `0`  | reported, whatever it found                       |
+| `2`  | an argument is not a git repository, or bad usage |
+
+## `plan-gate`
+
+Judges whether a plan may be treated as done, by parsing its own gaps section. This is the single
+parser for that section: `wip` calls it to report, and `plan-police` calls it to refuse an edit that
+declares a plan done while a gap stands. A second scanner would eventually disagree with this one.
+
+```
+plan-gate [options] [PLAN...]
+
+  --repo DIR         repository root to discover plans in (default: cwd)
+  --stdin NAME       read one plan's content from stdin; NAME is the path to report
+  --matches PATH     exit 0 if PATH would be judged as a plan, 1 if not
+  --require-done     only report blocking gaps for plans that mark themselves done
+  --all              also list gaps that are closed or tracked
+  --tsv              machine output: STATUS<TAB>PLAN<TAB>LINE<TAB>TEXT
+  --quiet            no output; exit status only
+  --list-plans       print the plan files that would be judged, then exit
+```
+
+A gap is one list item under a gaps heading. It stops blocking when the author does one of two
+things they would do anyway:
+
+- **ticks it** — `- [x] …`, or strikes it through (`- ~~no longer applies~~`)
+- **names the issue that carries it** — `#123`, `!123`, `GH-123`, or an issue/MR/PR URL, on the
+  gap's own line or a sub-bullet under it
+
+The referenced issue's _state_ is deliberately not checked. That keeps the gate offline and
+deterministic; `wip` reports open authored issues separately.
+
+`--matches` is the single source of what counts as a plan. `plan-police` asks rather than matching
+for itself, so the hook and the gate cannot drift apart — and a path is compared physically, since
+a symlink above the repository (macOS reaches every temporary directory through `/var` →
+`/private/var`) would otherwise make a plan stop looking like one, silently.
+
+### Exit codes
+
+Both the hook and CI branch on these, so they are part of the contract.
+
+| Code | Meaning                                                         |
+| ---- | --------------------------------------------------------------- |
+| `0`  | nothing blocking — no open gap, or the plan does not claim done |
+| `1`  | at least one gap is neither closed nor tracked                  |
+| `2`  | usage error                                                     |
+| `3`  | fault — a named plan is missing or unreadable                   |
+
+Discovery and matching are configurable per repository; see
+[Configuration](/docs/reference/configuration/).
 
 ## `review-gate`
 

--- a/docs/site/src/content/docs/reference/cli-and-tools.md
+++ b/docs/site/src/content/docs/reference/cli-and-tools.md
@@ -175,7 +175,27 @@ wip [--limit N] [--no-forge] [REPO...]
 | `DEFERRED`  | filed issues whose text says they were carved out of other work              |
 | `PLAN`      | a plan whose gaps section lists work neither closed nor tracked              |
 | `MERGED`    | merged on the forge — cleanup, not unfinished work                           |
-| `NOTE`      | something that was **not** checked, and why                                  |
+| `COUNTS`    | the other kinds of outstanding thing, broken out rather than summed          |
+| `NOTE`      | something that was **not** checked or was hidden, and why                    |
+
+### What the headline counts, and what is hidden
+
+The headline is **unfinished branches only**. Branches, worktrees, issues and plan gaps are four
+different kinds of thing with four different remedies, so summing them into one number gives a
+figure nobody can act on. The rest are broken out on the `COUNTS` line.
+
+A branch is hidden when **nothing was committed, no worktree is checked out on it, and no change
+was ever opened**. Nothing was started, so there is nothing to finish. On one real repository that
+removed 20 of 41 branches — all created by a worktree harness — and took the headline from a
+meaningless 150 to an actionable 4.
+
+The test is structural, never by name. A `worktree-agent-*` pattern would look tidier and is worse:
+it would hide such a branch that _does_ carry commits, which is real unfinished work. Having commits
+disqualifies a branch from being hidden, so this rule cannot make that mistake. Nor can it hide the
+case that matters most — a branch with no commits but a **dirty worktree**, where uncommitted work
+actually lives; the worktree keeps it visible.
+
+Whatever is hidden is counted and stated in a `NOTE`. Silent omission reads as "nothing else to see".
 
 ### Branch state comes from the forge
 

--- a/docs/site/src/content/docs/reference/configuration.md
+++ b/docs/site/src/content/docs/reference/configuration.md
@@ -33,22 +33,23 @@ note that the tables below mark each case at the point it applies.
 | ------------------------------------------------------------------ | ------------------------------------------ |
 | `comment-police.forbidden-patterns` **replaces** the built-in list | a seeded config matches 6 patterns, not 13 |
 | `comment-police.max-header-lines` + `forbidden-patterns`           | the OpenCode plugin only                   |
-| repo-level `.agentkit/config.yaml`                                 | the `review:` section only                 |
+| repo-level `.agentkit/config.yaml`                                 | the `review:` and `wip:` sections only     |
 
 ## Which implementation reads which section
 
 A police unit is a policy with up to three implementations, and they do not read config equally.
 
-| Section             | Claude/Grok hook              | OpenCode plugin         | Codex policy                      |
-| ------------------- | ----------------------------- | ----------------------- | --------------------------------- |
-| `review`            | — (`review-profile` reads it) | —                       | —                                 |
-| `git-police`        | `allowed-repos`               | `allowed-repos`         | not read                          |
-| `coding-police`     | all keys                      | all keys                | not read                          |
-| `comment-police`    | 3 of 5 keys (below)           | all keys                | not read                          |
-| `pkg-police`        | `manager`                     | `manager`               | installed only for explicit `bun` |
-| `resource-police`   | `enabled`, `bounded`          | `enabled`, `bounded`    | installed only when `enabled`     |
-| `delegation-police` | `enabled`                     | `enabled`               | installed only when `enabled`     |
-| `version-police`    | no such hook                  | `enabled`, `exceptions` | no such policy                    |
+| Section             | Claude/Grok hook                | OpenCode plugin         | Codex policy                      |
+| ------------------- | ------------------------------- | ----------------------- | --------------------------------- |
+| `review`            | — (`review-profile` reads it)   | —                       | —                                 |
+| `git-police`        | `allowed-repos`                 | `allowed-repos`         | not read                          |
+| `coding-police`     | all keys                        | all keys                | not read                          |
+| `comment-police`    | 3 of 5 keys (below)             | all keys                | not read                          |
+| `pkg-police`        | `manager`                       | `manager`               | installed only for explicit `bun` |
+| `resource-police`   | `enabled`, `bounded`            | `enabled`, `bounded`    | installed only when `enabled`     |
+| `delegation-police` | `enabled`                       | `enabled`               | installed only when `enabled`     |
+| `version-police`    | no such hook                    | `enabled`, `exceptions` | no such policy                    |
+| `wip`               | `plan-police` (via `plan-gate`) | —                       | no such policy                    |
 
 `format-police`, `kubectl-police`, `mr-police` and `pages-police` read no config at all; their
 exceptions are per-command environment variables. The Codex `.rules` files contain no config
@@ -270,3 +271,60 @@ which has no comments to carry an inline waiver.
 so this section has no effect on the other three clients. It also honours
 `AGENTKIT_SKIP_HOOKS=version-police`, but not the `all` keyword (see
 [CLI and tools](/docs/reference/cli-and-tools/)).
+
+## `wip`
+
+Read by `tools/wip`, `tools/plan-gate`, and the `plan-police` hook through the gate. Unlike every
+other section here, a repository's own `.agentkit/config.yaml` overrides the user-level file — plan
+layout is a property of the repository, not of the person reading it.
+
+```yaml
+wip:
+  plan-paths: []
+  # gap-headings: 'known gaps|loose ends|snags'
+  # done-markers: '^[[:space:]]*status[[:space:]]*:[[:space:]]*(done|shipped)'
+  # issue-refs: '#[0-9]+|![0-9]+|[A-Z][A-Z0-9]+-[0-9]+'
+```
+
+### `plan-paths`
+
+Where plans live, relative to the repository root. Each entry may be a directory (searched
+recursively for `*.md`) or a single file.
+
+**It replaces the defaults outright — it does not extend them.** Setting one entry means the six
+built-in roots stop being searched:
+
+```
+plans/   docs/plans/   doc/plans/   .omc/plans/   PLAN.md   PLANS.md
+```
+
+So a repository that keeps plans in `plans/` _and_ `design/` must list both, not just the new one.
+Leaving the key empty or absent keeps all six.
+
+### `gap-headings` and `done-markers`
+
+`gap-headings` matches case-insensitively against a whole heading; its list items are the gaps.
+`done-markers` is what it looks like for a plan to claim it is finished — `plan-police` refuses an
+edit that adds one of these while a gap is neither ticked nor tracked.
+
+### `issue-refs`
+
+What counts as a gap being tracked by an issue. The default accepts `#123`, `!123`, `GH-123`, and
+issue/MR/PR URLs.
+
+A Jira-style `PROJ-123` is **deliberately absent by default**, and the reasoning matters more than
+the key. Nothing distinguishes a Jira key from an ordinary token in prose — `UTF-8` and `SHA-256`
+have the same shape — so enabling it makes a gap description like _"the retry path still assumes
+UTF-8"_ read as tracked when nothing tracks it.
+
+Note the direction of that failure. A false _untracked_ is loud and costs an author one edit; a
+false _tracked_ silently closes a real gap and lets the plan be called done with work still in it,
+which is the exact defect this tooling exists to catch. Turn it on where `PROJ-123` genuinely
+appears in your plans, and leave it off where it does not:
+
+```yaml
+wip:
+  issue-refs: "#[0-9]+|![0-9]+|[A-Z][A-Z0-9]+-[0-9]+"
+```
+
+Setting it replaces the default pattern, so keep the forms you still use.

--- a/docs/site/src/content/docs/reference/hooks.mdx
+++ b/docs/site/src/content/docs/reference/hooks.mdx
@@ -68,6 +68,7 @@ a unit cannot go missing from this table, but a cell can be incomplete.
 | `kubectl-police` | `kubectl create` or `kubectl apply` against Kargo custom resources, where the GitOps controller owns the state |
 | `mr-police` | opening another GitLab merge request while one you authored is already open on the repository |
 | `pages-police` | a direct write to the Pages API, which would bypass the publish-time figure lint and the canonical git history, and an unapproved `--allow-bare-svg` |
+| `plan-police` | an edit that marks a plan done while its own gaps section still lists work that is neither ticked, struck through, nor carrying an issue reference. It judges the content the edit is about to land, so an edit that closes the last gap in the same breath passes |
 | `pkg-police` | package-management subcommands belonging to a manager the project does not use — inferred from the lockfile, so `bun install` is refused in an `npm` project just as `npm install` is in a bun one. Read-only queries such as `npm ls` pass |
 | `resource-police` | a heavy command not run through the **installed** `bounded-run` — trust is by installed path, not by filename, so a copy in the current directory is still refused — plus delegated workloads, which `bounded-run` cannot contain at all, and commands whose shell nesting it cannot parse (Linux only) |
 | `review-police` | a forge merge unless review evidence passed for the forge-selected source head and the current target |

--- a/docs/site/src/generated/kit-facts.json
+++ b/docs/site/src/generated/kit-facts.json
@@ -90,6 +90,15 @@
       ]
     },
     {
+      "name": "plan",
+      "mechanisms": [
+        "hook"
+      ],
+      "claudePlugins": [
+        "agentkit"
+      ]
+    },
+    {
       "name": "resource",
       "mechanisms": [
         "hook",
@@ -172,6 +181,13 @@
       "event": "PreToolUse",
       "matcher": "Bash",
       "timeout": 10,
+      "failClosedBudget": null
+    },
+    {
+      "unit": "plan",
+      "event": "PreToolUse",
+      "matcher": "Edit|Write",
+      "timeout": 15,
       "failClosedBudget": null
     },
     {
@@ -343,13 +359,21 @@
       "kit": "core",
       "explicit": false,
       "description": "Remove AgentKit, or one of its skill kits, without hand-deleting files. Covers `install.sh --uninstall` for a global or project install, what it reverts inside configs the user owns, what it deliberately leaves alone, and how kit removal differs between opt-in and consent-gated kits. Use when asked to uninstall AgentKit, remove a kit, undo the installer, or clean a machine of it."
+    },
+    {
+      "name": "wip",
+      "kit": "core",
+      "explicit": false,
+      "description": "Report what was started and not finished in a repository — unmerged branches, dirty worktrees, open merge requests and what holds them, open issues you filed, and plans whose own gaps section still lists untracked work. Read-only; it changes nothing. Use when asked \"what is half done\", \"what did I leave unfinished\", \"what is still open\", \"status of my work\", \"anything abandoned\", before picking up work after a break, and before calling a plan finished."
     }
   ],
   "tools": [
     "agent-session",
     "bounded-run",
     "fix-ascii-boxes.py",
+    "plan-gate",
     "review-gate",
-    "review-profile"
+    "review-profile",
+    "wip"
   ]
 }

--- a/hooks/claude/plan-police.sh
+++ b/hooks/claude/plan-police.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# plan-police.sh — Claude Code PreToolUse hook (matcher: Edit|Write)
+# Blocks: marking a plan done while its own gaps section still lists a gap that
+# is neither closed nor carried by an issue. The judgement is plan-gate's; this
+# hook only reconstructs the post-edit content and hands it over. PreToolUse
+# because the point is to refuse the edit — a PostToolUse hook must exit 2 to be
+# heard at all, and by then the claim is already written.
+set -euo pipefail
+
+if [[ -n "${AGENTKIT_SKIP_HOOKS:-}" ]]; then
+	_skip=",$(printf '%s' "$AGENTKIT_SKIP_HOOKS" | tr -d '[:space:]'),"
+	case "$_skip" in
+	*",plan-police,"* | *",all,"*) exit 0 ;;
+	esac
+fi
+
+# shellcheck source=lib/hook-input.sh
+source "${BASH_SOURCE[0]%/*}/lib/hook-input.sh"
+agentkit_slurp_input
+
+if ! agentkit_is_file_write_tool; then
+	exit 0
+fi
+
+FILE_PATH=$(agentkit_file_path)
+[[ -n "$FILE_PATH" ]] || exit 0
+case "$FILE_PATH" in
+*.md | *.markdown) ;;
+*) exit 0 ;;
+esac
+
+HOOK_DIR="${BASH_SOURCE[0]%/*}"
+PLAN_GATE=""
+for candidate in "$HOOK_DIR/../tools/plan-gate" "$HOOK_DIR/../../tools/plan-gate"; do
+	if [[ -x "$candidate" ]]; then
+		PLAN_GATE="$candidate"
+		break
+	fi
+done
+
+FILE_DIR="${FILE_PATH%/*}"
+[[ "$FILE_DIR" == "$FILE_PATH" ]] && FILE_DIR="$PWD"
+REPO=$(git -C "$FILE_DIR" rev-parse --show-toplevel 2>/dev/null || printf '%s' "$FILE_DIR")
+
+if [[ -z "$PLAN_GATE" ]]; then
+	# A missing checker must not read as a clean plan. Say so once, on the files
+	# it would have judged, rather than passing silently on every edit.
+	case "$FILE_PATH" in
+	*/plans/* | */plan/*)
+		agentkit_advise_json "plan-police: the packaged plan-gate checker is missing, so this plan's gaps were NOT checked. Reinstall agentkit, or run plan-gate manually before calling the plan done."
+		;;
+	esac
+	exit 0
+fi
+
+if ! "$PLAN_GATE" --repo "$REPO" --matches "$FILE_PATH" >/dev/null 2>&1; then
+	exit 0
+fi
+
+# split/1 takes its separator literally, so an old_string full of regex
+# metacharacters stays data. It is also the only codepoint-safe option: jq's
+# string `index` reports a BYTE offset while `.[a:b]` slices codepoints, so one
+# em dash earlier in the file shifts every replacement two characters.
+compose_content() {
+	local existing=""
+	if [[ -f "$FILE_PATH" ]]; then
+		existing=$(cat "$FILE_PATH")
+	fi
+	printf '%s' "$existing" | jq -Rs --argjson payload "$(agentkit_jq_raw -c '.tool_input // .toolInput // {}')" '
+		. as $original
+		| ($payload.content // $payload.new_str // null) as $whole
+		| if $whole != null and ($payload.old_string // $payload.oldString // null) == null then $whole
+		  else
+		    (if ($payload.edits | type) == "array" then $payload.edits else [$payload] end)
+		    | reduce .[] as $edit ($original;
+		        . as $text
+		        | ($edit.old_string // $edit.oldString // "") as $old
+		        | ($edit.new_string // $edit.newString // "") as $new
+		        | if $old == "" then $text
+		          elif ($edit.replace_all // $edit.replaceAll // false) then ($text | split($old) | join($new))
+		          else ($text | split($old)) as $parts
+		            | if ($parts | length) <= 1 then $text
+		              else $parts[0] + $new + ($parts[1:] | join($old))
+		              end
+		          end)
+		  end
+	' -r
+}
+
+CONTENT=$(compose_content 2>/dev/null || true)
+[[ -n "$CONTENT" ]] || exit 0
+
+if GAPS=$(printf '%s' "$CONTENT" | "$PLAN_GATE" --require-done --stdin "$FILE_PATH" 2>/dev/null); then
+	exit 0
+fi
+
+agentkit_deny_json "BLOCKED: this edit marks ${FILE_PATH##*/} done while its own gaps section still lists work that is neither closed nor tracked by an issue.
+
+${GAPS}
+
+Close each gap one of two ways: tick it (\`- [x] …\`) or strike it through once it no longer applies, or file an issue and name it on the line (\`#123\`, \`!123\`, \`PROJ-123\`, or the issue URL). A gap that survives the plan with no issue behind it is how work disappears.
+
+To record a deliberate exception, set AGENTKIT_SKIP_HOOKS=plan-police for the session."
+exit 0

--- a/hooks/claude/plan-police.sh
+++ b/hooks/claude/plan-police.sh
@@ -98,7 +98,9 @@ agentkit_deny_json "BLOCKED: this edit marks ${FILE_PATH##*/} done while its own
 
 ${GAPS}
 
-Close each gap one of two ways: tick it (\`- [x] …\`) or strike it through once it no longer applies, or file an issue and name it on the line (\`#123\`, \`!123\`, \`PROJ-123\`, or the issue URL). A gap that survives the plan with no issue behind it is how work disappears.
+Close each gap one of two ways: tick it (\`- [x] …\`) or strike it through once it no longer applies, or file an issue and name it on the line (\`#123\`, \`!123\`, \`GH-123\`, or the issue URL). A gap that survives the plan with no issue behind it is how work disappears.
+
+A Jira-style PROJ-123 is NOT recognised by default — nothing tells it apart from a hex digest or a UTF-8 label, and a wrong \"tracked\" loses the gap silently. Set wip.issue-refs in .agentkit/config.yaml to accept it.
 
 To record a deliberate exception, set AGENTKIT_SKIP_HOOKS=plan-police for the session."
 exit 0

--- a/hooks/claude/settings.json
+++ b/hooks/claude/settings.json
@@ -49,6 +49,17 @@
         ]
       },
       {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/plan-police.sh",
+            "timeout": 15,
+            "statusMessage": "plan-police: checking the plan's gaps..."
+          }
+        ]
+      },
+      {
         "matcher": ".*[Mm]erge.*",
         "hooks": [
           {

--- a/moon.yml
+++ b/moon.yml
@@ -227,6 +227,14 @@ fileGroups:
     - "tests/session/**/*"
     - "tools/agent-session"
 
+  wipInputs:
+    - "hooks/claude/lib/hook-input.sh"
+    - "hooks/claude/plan-police.sh"
+    - "skills/wip/**/*"
+    - "tests/wip/**/*"
+    - "tools/plan-gate"
+    - "tools/wip"
+
 tasks:
   preflight:
     command: "scripts/preflight"
@@ -301,6 +309,12 @@ tasks:
     inputs:
       - "group://ciConfig"
       - "group://sessionInputs"
+
+  test-wip:
+    command: "bun run scripts/check-test-slices.ts wip"
+    inputs:
+      - "group://ciConfig"
+      - "group://wipInputs"
 
   test-full:
     command: "bun run scripts/run-test-slices.ts"

--- a/plugins-cc/agentkit/hooks/hooks.json
+++ b/plugins-cc/agentkit/hooks/hooks.json
@@ -41,6 +41,17 @@
             "statusMessage": "mr-police: checking for unmerged MRs..."
           }
         ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/plan-police.sh",
+            "timeout": 15,
+            "statusMessage": "plan-police: checking the plan's gaps..."
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/plugins-cc/agentkit/hooks/plan-police.sh
+++ b/plugins-cc/agentkit/hooks/plan-police.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# plan-police.sh — Claude Code PreToolUse hook (matcher: Edit|Write)
+# Blocks: marking a plan done while its own gaps section still lists a gap that
+# is neither closed nor carried by an issue. The judgement is plan-gate's; this
+# hook only reconstructs the post-edit content and hands it over. PreToolUse
+# because the point is to refuse the edit — a PostToolUse hook must exit 2 to be
+# heard at all, and by then the claim is already written.
+set -euo pipefail
+
+if [[ -n "${AGENTKIT_SKIP_HOOKS:-}" ]]; then
+	_skip=",$(printf '%s' "$AGENTKIT_SKIP_HOOKS" | tr -d '[:space:]'),"
+	case "$_skip" in
+	*",plan-police,"* | *",all,"*) exit 0 ;;
+	esac
+fi
+
+# shellcheck source=lib/hook-input.sh
+source "${BASH_SOURCE[0]%/*}/lib/hook-input.sh"
+agentkit_slurp_input
+
+if ! agentkit_is_file_write_tool; then
+	exit 0
+fi
+
+FILE_PATH=$(agentkit_file_path)
+[[ -n "$FILE_PATH" ]] || exit 0
+case "$FILE_PATH" in
+*.md | *.markdown) ;;
+*) exit 0 ;;
+esac
+
+HOOK_DIR="${BASH_SOURCE[0]%/*}"
+PLAN_GATE=""
+for candidate in "$HOOK_DIR/../tools/plan-gate" "$HOOK_DIR/../../tools/plan-gate"; do
+	if [[ -x "$candidate" ]]; then
+		PLAN_GATE="$candidate"
+		break
+	fi
+done
+
+FILE_DIR="${FILE_PATH%/*}"
+[[ "$FILE_DIR" == "$FILE_PATH" ]] && FILE_DIR="$PWD"
+REPO=$(git -C "$FILE_DIR" rev-parse --show-toplevel 2>/dev/null || printf '%s' "$FILE_DIR")
+
+if [[ -z "$PLAN_GATE" ]]; then
+	# A missing checker must not read as a clean plan. Say so once, on the files
+	# it would have judged, rather than passing silently on every edit.
+	case "$FILE_PATH" in
+	*/plans/* | */plan/*)
+		agentkit_advise_json "plan-police: the packaged plan-gate checker is missing, so this plan's gaps were NOT checked. Reinstall agentkit, or run plan-gate manually before calling the plan done."
+		;;
+	esac
+	exit 0
+fi
+
+if ! "$PLAN_GATE" --repo "$REPO" --matches "$FILE_PATH" >/dev/null 2>&1; then
+	exit 0
+fi
+
+# split/1 takes its separator literally, so an old_string full of regex
+# metacharacters stays data. It is also the only codepoint-safe option: jq's
+# string `index` reports a BYTE offset while `.[a:b]` slices codepoints, so one
+# em dash earlier in the file shifts every replacement two characters.
+compose_content() {
+	local existing=""
+	if [[ -f "$FILE_PATH" ]]; then
+		existing=$(cat "$FILE_PATH")
+	fi
+	printf '%s' "$existing" | jq -Rs --argjson payload "$(agentkit_jq_raw -c '.tool_input // .toolInput // {}')" '
+		. as $original
+		| ($payload.content // $payload.new_str // null) as $whole
+		| if $whole != null and ($payload.old_string // $payload.oldString // null) == null then $whole
+		  else
+		    (if ($payload.edits | type) == "array" then $payload.edits else [$payload] end)
+		    | reduce .[] as $edit ($original;
+		        . as $text
+		        | ($edit.old_string // $edit.oldString // "") as $old
+		        | ($edit.new_string // $edit.newString // "") as $new
+		        | if $old == "" then $text
+		          elif ($edit.replace_all // $edit.replaceAll // false) then ($text | split($old) | join($new))
+		          else ($text | split($old)) as $parts
+		            | if ($parts | length) <= 1 then $text
+		              else $parts[0] + $new + ($parts[1:] | join($old))
+		              end
+		          end)
+		  end
+	' -r
+}
+
+CONTENT=$(compose_content 2>/dev/null || true)
+[[ -n "$CONTENT" ]] || exit 0
+
+if GAPS=$(printf '%s' "$CONTENT" | "$PLAN_GATE" --require-done --stdin "$FILE_PATH" 2>/dev/null); then
+	exit 0
+fi
+
+agentkit_deny_json "BLOCKED: this edit marks ${FILE_PATH##*/} done while its own gaps section still lists work that is neither closed nor tracked by an issue.
+
+${GAPS}
+
+Close each gap one of two ways: tick it (\`- [x] …\`) or strike it through once it no longer applies, or file an issue and name it on the line (\`#123\`, \`!123\`, \`PROJ-123\`, or the issue URL). A gap that survives the plan with no issue behind it is how work disappears.
+
+To record a deliberate exception, set AGENTKIT_SKIP_HOOKS=plan-police for the session."
+exit 0

--- a/plugins-cc/agentkit/hooks/plan-police.sh
+++ b/plugins-cc/agentkit/hooks/plan-police.sh
@@ -98,7 +98,9 @@ agentkit_deny_json "BLOCKED: this edit marks ${FILE_PATH##*/} done while its own
 
 ${GAPS}
 
-Close each gap one of two ways: tick it (\`- [x] …\`) or strike it through once it no longer applies, or file an issue and name it on the line (\`#123\`, \`!123\`, \`PROJ-123\`, or the issue URL). A gap that survives the plan with no issue behind it is how work disappears.
+Close each gap one of two ways: tick it (\`- [x] …\`) or strike it through once it no longer applies, or file an issue and name it on the line (\`#123\`, \`!123\`, \`GH-123\`, or the issue URL). A gap that survives the plan with no issue behind it is how work disappears.
+
+A Jira-style PROJ-123 is NOT recognised by default — nothing tells it apart from a hex digest or a UTF-8 label, and a wrong \"tracked\" loses the gap silently. Set wip.issue-refs in .agentkit/config.yaml to accept it.
 
 To record a deliberate exception, set AGENTKIT_SKIP_HOOKS=plan-police for the session."
 exit 0

--- a/plugins-cc/agentkit/skills/wip/SKILL.md
+++ b/plugins-cc/agentkit/skills/wip/SKILL.md
@@ -25,26 +25,29 @@ wip --no-forge            # git and plans only, no network
 
 ```
 neutron — 9 half-done
- BRANCH    fix/voice-truncate-275    5d    3 commits  no MR/PR
- WORKTREE  wt/corename2              DIRTY 11 modified, 2 untracked — do NOT remove at ~/wt/corename2
- MR/PR     !628 (fix/voice)          held: no approving review
+ BRANCH    feat/incidents-ui           0d    1 commits  !633 open
+ BRANCH    fix/core-name-everywhere    7d    0 commits  no MR/PR ever opened
+ ABANDONED feat/model-catalog-auto     5d   !492 closed without merging
+ WORKTREE  wt/corename2                DIRTY 11 modified, 2 untracked — do NOT remove at ~/wt/corename2
+ MR/PR     !628 (fix/voice)            held: no approving review
  FILED     #311 #312 — authored, open, unfixed
  DEFERRED  #313 — carved out of other work
- PLAN      plans/057.md              2 gap(s) unclosed
- MERGED    fix/old — content already on main; safe to delete
+ PLAN      plans/057.md                2 gap(s) unclosed
+ MERGED    fix/old — merged on the forge; cleanup, not unfinished work
  NOTE      unrecognised forge host 'git.example.com' — merge requests and issues not checked
 ```
 
-| Row        | Means                                                                        |
-| ---------- | ---------------------------------------------------------------------------- |
-| `BRANCH`   | content is not on the default branch yet                                     |
-| `WORKTREE` | a checkout that still exists; `DIRTY` ones hold work no branch ref will save |
-| `MR/PR`    | open and authored by you, with what stands between it and merging            |
-| `FILED`    | issues you opened that are still open                                        |
-| `DEFERRED` | filed issues whose text says they were carved out of other work              |
-| `PLAN`     | a plan whose gaps section lists work that is neither closed nor tracked      |
-| `MERGED`   | branches whose content already landed — cleanup, not work                    |
-| `NOTE`     | something that was **not** checked, and why                                  |
+| Row         | Means                                                                        |
+| ----------- | ---------------------------------------------------------------------------- |
+| `BRANCH`    | an open change, or none ever opened, or state unknown                        |
+| `ABANDONED` | a change closed without merging — a decision, not an oversight               |
+| `WORKTREE`  | a checkout that still exists; `DIRTY` ones hold work no branch ref will save |
+| `MR/PR`     | open and authored by you, with what stands between it and merging            |
+| `FILED`     | issues you opened that are still open                                        |
+| `DEFERRED`  | filed issues whose text says they were carved out of other work              |
+| `PLAN`      | a plan whose gaps section lists work neither closed nor tracked              |
+| `MERGED`    | merged on the forge — cleanup, not unfinished work                           |
+| `NOTE`      | something that was **not** checked, and why                                  |
 
 A `NOTE` row is the important one. An absent section means "nothing found";
 a `NOTE` means "not looked at". They are never conflated, and a bounded list
@@ -55,21 +58,33 @@ always says how many entries it dropped.
 Uncommitted and untracked files die with the checkout, and the branch ref does
 not carry them. Commit them, stash them, or leave the worktree alone.
 
-## Why merged-ness is not counted by commits
+## Whether a branch is finished is the forge's answer, not git's
 
-`git rev-list --count origin/main..branch` calls a branch ahead **forever** in a
-squash-merge repository — the squashed commit is not an ancestor of anything.
-Trusting it invents abandoned work that does not exist. Two other rules fail as
-well, both verified against a squash-merge fixture rather than assumed:
+A squash merge destroys the topological evidence by design: the squashed commit is not an ancestor
+of the branch, and the merge base stays before the squash forever.
 
-| Rule                          | Fails because                                                                                                          |
-| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `rev-list --count base..head` | a squashed branch is ahead forever                                                                                     |
-| `git diff base..head`         | the default branch's own later commits appear as deletions on yours                                                    |
-| `git diff base...head`        | answers a different question — the branch's changes since the merge base, non-empty for every branch that did anything |
+Measured against nine branches of known outcome, **every git-only rule reported all seven merged
+ones as still outstanding**:
 
-`wip` merges the branch into the default branch in memory and asks whether the
-result differs from the default branch. Nothing else survives a squash merge.
+| Rule                                    | On a squash-merged branch                                       |
+| --------------------------------------- | --------------------------------------------------------------- |
+| `rev-list --count base..head`           | ahead forever — the squash is not an ancestor                   |
+| `git diff base..head`                   | shows the default branch's own later commits as deletions       |
+| `git diff base...head`                  | shows the branch's changes since the merge base — never empty   |
+| `merge-tree --write-tree`, tree compare | correct on a small fixture, wrong once the default branch moves |
+
+The last row is the trap: it passes a two-commit fixture and fails on a real repository, because a
+fixture whose default branch has not moved cannot distinguish the case it exists to prove.
+
+So `wip` asks the forge, and distinguishes four answers that mean different things:
+
+- **merged** — cleanup, not unfinished work
+- **closed without merging** — deliberately abandoned, which reads differently from forgotten
+- **open** — in flight
+- **no change ever opened** — the genuinely interesting one
+
+**When the forge cannot answer, it says so and stops.** There is no local rule to fall back to, and
+guessing loudly in the alarming direction is how a tool like this gets ignored.
 
 ## Plans: when a plan may be called done
 

--- a/plugins-cc/agentkit/skills/wip/SKILL.md
+++ b/plugins-cc/agentkit/skills/wip/SKILL.md
@@ -24,17 +24,18 @@ wip --no-forge            # git and plans only, no network
 ## Reading the output
 
 ```
-neutron — 9 half-done
- BRANCH    feat/incidents-ui           0d    1 commits  !633 open
- BRANCH    fix/core-name-everywhere    7d    0 commits  no MR/PR ever opened
- ABANDONED feat/model-catalog-auto     5d   !492 closed without merging
+neutron — 4 unfinished branch(es)
+ BRANCH    feat/incidents-ui           0d   1 commits  !633 open
+ BRANCH    fix/core-name-everywhere    7d   0 commits  no MR/PR ever opened
+ ABANDONED feat/model-catalog-auto     5d  !492 closed without merging
  WORKTREE  wt/corename2                DIRTY 11 modified, 2 untracked — do NOT remove at ~/wt/corename2
- MR/PR     !628 (fix/voice)            held: no approving review
+ MR/PR     !633 (feat/incidents-ui)    held: no approving review
  FILED     #311 #312 — authored, open, unfixed
  DEFERRED  #313 — carved out of other work
  PLAN      plans/057.md                2 gap(s) unclosed
+ COUNTS    1 abandoned · 20 worktree(s) · 2 open change(s) · 100 filed issue(s) · 1 plan(s) with gaps
+ NOTE      20 branch(es) hidden: nothing committed, no worktree, no change ever opened
  MERGED    fix/old — merged on the forge; cleanup, not unfinished work
- NOTE      unrecognised forge host 'git.example.com' — merge requests and issues not checked
 ```
 
 | Row         | Means                                                                        |
@@ -47,11 +48,31 @@ neutron — 9 half-done
 | `DEFERRED`  | filed issues whose text says they were carved out of other work              |
 | `PLAN`      | a plan whose gaps section lists work neither closed nor tracked              |
 | `MERGED`    | merged on the forge — cleanup, not unfinished work                           |
-| `NOTE`      | something that was **not** checked, and why                                  |
+| `COUNTS`    | the other kinds of outstanding thing, broken out rather than summed          |
+| `NOTE`      | something that was **not** checked or was hidden, and why                    |
 
 A `NOTE` row is the important one. An absent section means "nothing found";
 a `NOTE` means "not looked at". They are never conflated, and a bounded list
 always says how many entries it dropped.
+
+## What the headline counts, and what is hidden
+
+The headline is **unfinished branches only**. Branches, worktrees, issues and plan gaps are four
+different kinds of thing with four different remedies, so summing them into one number gives a
+figure nobody can act on. The rest are broken out on the `COUNTS` line.
+
+A branch is hidden when **nothing was committed, no worktree is checked out on it, and no change
+was ever opened**. Nothing was started, so there is nothing to finish. On one real repository that
+removed 20 of 41 branches — all created by a worktree harness — and took the headline from a
+meaningless 150 to an actionable 4.
+
+The test is structural, never by name. A `worktree-agent-*` pattern would look tidier and is worse:
+it would hide such a branch that _does_ carry commits, which is real unfinished work. Having commits
+disqualifies a branch from being hidden, so this rule cannot make that mistake. Nor can it hide the
+case that matters most — a branch with no commits but a **dirty worktree**, where uncommitted work
+actually lives; the worktree keeps it visible.
+
+Whatever is hidden is counted and stated in a `NOTE`. Silent omission reads as "nothing else to see".
 
 ## Never remove a DIRTY worktree
 

--- a/plugins-cc/agentkit/skills/wip/SKILL.md
+++ b/plugins-cc/agentkit/skills/wip/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: wip
+description: >-
+  Report what was started and not finished in a repository — unmerged branches,
+  dirty worktrees, open merge requests and what holds them, open issues you
+  filed, and plans whose own gaps section still lists untracked work. Read-only;
+  it changes nothing. Use when asked "what is half done", "what did I leave
+  unfinished", "what is still open", "status of my work", "anything abandoned",
+  before picking up work after a break, and before calling a plan finished.
+---
+
+# wip
+
+Answers one question — _what did I start and not finish?_ — from the repository
+rather than from an agent's recollection of what it did.
+
+```
+wip                       # this repository
+wip ~/code/a ~/code/b     # several, one block each
+wip --limit 0             # no bounding
+wip --no-forge            # git and plans only, no network
+```
+
+## Reading the output
+
+```
+neutron — 9 half-done
+ BRANCH    fix/voice-truncate-275    5d    3 commits  no MR/PR
+ WORKTREE  wt/corename2              DIRTY 11 modified, 2 untracked — do NOT remove at ~/wt/corename2
+ MR/PR     !628 (fix/voice)          held: no approving review
+ FILED     #311 #312 — authored, open, unfixed
+ DEFERRED  #313 — carved out of other work
+ PLAN      plans/057.md              2 gap(s) unclosed
+ MERGED    fix/old — content already on main; safe to delete
+ NOTE      unrecognised forge host 'git.example.com' — merge requests and issues not checked
+```
+
+| Row        | Means                                                                        |
+| ---------- | ---------------------------------------------------------------------------- |
+| `BRANCH`   | content is not on the default branch yet                                     |
+| `WORKTREE` | a checkout that still exists; `DIRTY` ones hold work no branch ref will save |
+| `MR/PR`    | open and authored by you, with what stands between it and merging            |
+| `FILED`    | issues you opened that are still open                                        |
+| `DEFERRED` | filed issues whose text says they were carved out of other work              |
+| `PLAN`     | a plan whose gaps section lists work that is neither closed nor tracked      |
+| `MERGED`   | branches whose content already landed — cleanup, not work                    |
+| `NOTE`     | something that was **not** checked, and why                                  |
+
+A `NOTE` row is the important one. An absent section means "nothing found";
+a `NOTE` means "not looked at". They are never conflated, and a bounded list
+always says how many entries it dropped.
+
+## Never remove a DIRTY worktree
+
+Uncommitted and untracked files die with the checkout, and the branch ref does
+not carry them. Commit them, stash them, or leave the worktree alone.
+
+## Why merged-ness is not counted by commits
+
+`git rev-list --count origin/main..branch` calls a branch ahead **forever** in a
+squash-merge repository — the squashed commit is not an ancestor of anything.
+Trusting it invents abandoned work that does not exist. Two other rules fail as
+well, both verified against a squash-merge fixture rather than assumed:
+
+| Rule                          | Fails because                                                                                                          |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `rev-list --count base..head` | a squashed branch is ahead forever                                                                                     |
+| `git diff base..head`         | the default branch's own later commits appear as deletions on yours                                                    |
+| `git diff base...head`        | answers a different question — the branch's changes since the merge base, non-empty for every branch that did anything |
+
+`wip` merges the branch into the default branch in memory and asks whether the
+result differs from the default branch. Nothing else survives a squash merge.
+
+## Plans: when a plan may be called done
+
+A plan's gaps section is the most honest record of what is outstanding. A gap
+stops blocking when the author does one of two things they would do anyway:
+
+- **tick it** — `- [x] …`, or strike it through (`- ~~no longer applies~~`)
+- **name the issue that carries it** — `#123`, `!123`, or an issue/MR/PR URL,
+  on the gap's own line or a sub-bullet under it
+
+A bare bullet with neither is what the gate refuses: work stated in the plan,
+with nothing anywhere that will bring it back.
+
+```
+plan-gate                       # every plan under this repository
+plan-gate --all --tsv           # machine-readable, closed and tracked included
+plan-gate --require-done        # only judge plans that claim to be done
+```
+
+`plan-police` runs the same checker on every edit that marks a plan done, and
+refuses the edit while such a gap stands. Filing the issue and pasting its number
+is the fix; `AGENTKIT_SKIP_HOOKS=plan-police` records a deliberate exception.
+
+## Configuration
+
+Plan layout varies, so nothing about it is hardcoded. Defaults are `plans/`,
+`docs/plans/`, `doc/plans/`, `.omc/plans/`, `PLAN.md` and `PLANS.md`, and a
+`wip:` section in `~/.config/agentkit/config.yaml` — or the repository's own
+`.agentkit/config.yaml`, which wins — replaces them.
+
+```yaml
+wip:
+  plan-paths:
+    - design/decisions
+  gap-headings: "known gaps|loose ends|snags"
+  done-markers: "^[[:space:]]*status[[:space:]]*:[[:space:]]*(done|shipped)"
+  issue-refs: "#[0-9]+|![0-9]+|[A-Z][A-Z0-9]+-[0-9]+"
+```
+
+`issue-refs` is where a Jira shop adds `PROJ-123`. It is not on by default:
+nothing distinguishes a Jira key from a hex digest or a UTF-8 label, and a false
+"tracked" loses the gap silently — the one direction this tool must not fail in.
+
+## Forges
+
+GitHub and GitLab both work, resolved per repository from its `origin` host —
+including self-hosted instances, via `gh auth status` and the GitLab version
+endpoint. A repository with neither CLI still reports branches, worktrees and
+plans, and says in a `NOTE` what it could not check.

--- a/plugins-cc/agentkit/tools/plan-gate
+++ b/plugins-cc/agentkit/tools/plan-gate
@@ -132,16 +132,32 @@ discover_plans() {
 	return 0
 }
 
+# The physical path of a file that need not exist yet: its directory is resolved
+# through symlinks, its name kept. Both sides of the comparison below must be
+# physical or the match fails wherever a symlink sits above the repository —
+# macOS reaches every temporary directory through /var -> /private/var, and git
+# reports the resolved form while the harness passes the unresolved one. The
+# failure is silent and open: the path stops looking like a plan, and the gate
+# waves the edit through.
+physical_path() {
+	local path="$1" dir base
+	base="${path##*/}"
+	dir="${path%/*}"
+	[[ "$dir" == "$path" ]] && dir="."
+	if dir="$(cd "$dir" 2>/dev/null && pwd -P)"; then
+		printf '%s/%s' "$dir" "$base"
+		return 0
+	fi
+	printf '%s' "$path"
+	return 0
+}
+
 # Whether a path would be judged as a plan. plan-police asks rather than
 # matching for itself, so the hook and the gate cannot disagree.
 path_is_plan() {
-	local path="$1" repo="$2" entry candidate dir
+	local path="$1" repo="$2" entry candidate
 	[[ "$path" == *.md ]] || return 1
-	if [[ "$path" != /* ]]; then
-		dir="${path%/*}"
-		[[ "$dir" == "$path" ]] && dir="."
-		path="$(cd "$dir" 2>/dev/null && pwd)/${path##*/}" || return 1
-	fi
+	path="$(physical_path "$path")"
 	while IFS= read -r entry; do
 		[[ -n "$entry" ]] || continue
 		candidate="$repo/$entry"
@@ -355,7 +371,7 @@ if [[ -n "$MATCH_PATH" && "$REPO_GIVEN" == 0 ]]; then
 	[[ "$MATCH_DIR" == "$MATCH_PATH" ]] && MATCH_DIR="."
 	REPO="$(git -C "$MATCH_DIR" rev-parse --show-toplevel 2>/dev/null || printf '%s' "$PWD")"
 fi
-if ! REPO="$(cd "$REPO" 2>/dev/null && pwd)"; then
+if ! REPO="$(cd "$REPO" 2>/dev/null && pwd -P)"; then
 	printf 'plan-gate: unreadable repo\n' >&2
 	exit 3
 fi

--- a/plugins-cc/agentkit/tools/plan-gate
+++ b/plugins-cc/agentkit/tools/plan-gate
@@ -1,0 +1,420 @@
+#!/usr/bin/env bash
+# plan-gate — judge whether a plan may be treated as done.
+#
+# A plan's own gaps section is the most honest record of what is outstanding,
+# and nothing reads it. This is the single parser for that section: `wip` calls
+# it to report, plan-police calls it to refuse an edit that declares a plan done
+# while a gap stands. A second scanner would eventually disagree with this one.
+#
+# A gap stops blocking when the author ticks it or names the issue that now
+# carries it — nothing bespoke to remember.
+#
+# Exit: 0 nothing blocking, 1 blocking gaps, 2 usage, 3 fault (unreadable input).
+set -euo pipefail
+
+VERSION=1
+
+usage() {
+	cat <<'EOF'
+Usage: plan-gate [options] [PLAN...]
+
+  PLAN               plan file or directory. Default: plans discovered under --repo.
+
+  --repo DIR         repository root to discover plans in (default: cwd)
+  --stdin NAME       read one plan's content from stdin; NAME is the path to report
+  --matches PATH     exit 0 if PATH would be judged as a plan, 1 if not
+  --require-done     only report blocking gaps for plans that mark themselves done
+  --all              also list gaps that are closed or tracked
+  --tsv              machine output: STATUS<TAB>PLAN<TAB>LINE<TAB>TEXT
+  --quiet            no output; exit status only
+  --list-plans       print the plan files that would be judged, then exit
+  --version          print the tool version
+  -h, --help         this text
+
+Exit: 0 nothing blocking, 1 blocking gaps, 2 usage, 3 fault.
+EOF
+}
+
+# Defaults, each overridable from the `wip:` section of the agentkit config.
+GAP_HEADINGS='(known|open|remaining|outstanding|unresolved|deferred) *(gaps?|work|items?)?|gaps?|not done|follow.?ups?|todo'
+DONE_MARKERS='^[[:space:]]*(#+[[:space:]]*)?(\*\*|__)?status(\*\*|__)?[[:space:]]*[:=][[:space:]]*[^[:alnum:]]*(done|complete|completed|shipped|delivered|finished|closed)\b'
+PLAN_PATHS=""
+
+# A forge issue reference: GitHub/GitLab number, GitLab MR, or an issue/MR/PR
+# URL. A Jira-style KEY-123 is deliberately absent — nothing tells it apart from
+# UTF-8 or SHA-256, and a false "tracked" is the direction that loses a gap.
+# Jira shops add the pattern back through the `issue-refs` config key.
+ISSUE_REFS='(^|[^[:alnum:]_/])(#[0-9]+|![0-9]+|[Gg][Hh]-[0-9]+)([^[:alnum:]]|$)|https?://[^[:space:]]*(/issues/|/-/issues/|/merge_requests/|/pull/|/browse/)'
+
+# Emits the `wip:` section as key=value lines, so no caller re-parses YAML.
+read_wip_section() {
+	local file="$1"
+	[[ -f "$file" ]] || return 0
+	awk '
+		/^[^[:space:]#]/ { in_section = ($0 ~ /^wip:/); in_paths = 0; next }
+		!in_section { next }
+		{
+			line = $0
+			sub(/^[[:space:]]+/, "", line)
+			if (line ~ /^#/ || line == "") next
+			if (in_paths) {
+				if (line ~ /^-[[:space:]]*./) {
+					value = line
+					sub(/^-[[:space:]]*/, "", value)
+					gsub(/["'\'']/, "", value)
+					sub(/[[:space:]]+#.*$/, "", value)
+					print "plan-path=" value
+					next
+				}
+				in_paths = 0
+			}
+			if (line ~ /^plan-paths:[[:space:]]*$/) { in_paths = 1; next }
+			if (line !~ /^(gap-headings|done-markers|issue-refs):[[:space:]]*./) next
+			key = line
+			sub(/:.*/, "", key)
+			sub(/^[^:]*:[[:space:]]*/, "", line)
+			gsub(/^["'\'']|["'\'']$/, "", line)
+			if (line == "") next
+			print key "=" line
+		}
+	' "$file"
+	return 0
+}
+
+# Global config first, then the repository's, so a repository setting wins.
+load_config() {
+	local repo="$1" file key value
+	local global="${AGENTKIT_CONFIG:-${XDG_CONFIG_HOME:-$HOME/.config}/agentkit/config.yaml}"
+	for file in "$global" "$repo/.agentkit/config.yaml"; do
+		while IFS='=' read -r key value; do
+			case "$key" in
+			gap-headings) GAP_HEADINGS="$value" ;;
+			done-markers) DONE_MARKERS="$value" ;;
+			issue-refs) ISSUE_REFS="$value" ;;
+			plan-path) PLAN_PATHS="$PLAN_PATHS$value"$'\n' ;;
+			esac
+		done < <(read_wip_section "$file")
+	done
+	return 0
+}
+
+# Conventions vary, so the default is a list of candidate roots rather than one
+# layout, and `wip.plan-paths` replaces the list outright.
+default_plan_paths() {
+	printf '%s\n' plans docs/plans doc/plans .omc/plans PLAN.md PLANS.md
+}
+
+configured_plan_paths() {
+	if [[ -n "$PLAN_PATHS" ]]; then
+		printf '%s' "$PLAN_PATHS"
+	else
+		default_plan_paths
+	fi
+	return 0
+}
+
+find_plan_files() {
+	find "$1" -type f -name '*.md' \
+		-not -path '*/node_modules/*' -not -path '*/.git/*' 2>/dev/null | sort
+}
+
+discover_plans() {
+	local repo="$1" entry candidate
+	while IFS= read -r entry; do
+		[[ -n "$entry" ]] || continue
+		candidate="$repo/$entry"
+		if [[ -d "$candidate" ]]; then
+			find_plan_files "$candidate"
+		elif [[ -f "$candidate" ]]; then
+			printf '%s\n' "$candidate"
+		fi
+	done < <(configured_plan_paths)
+	return 0
+}
+
+# Whether a path would be judged as a plan. plan-police asks rather than
+# matching for itself, so the hook and the gate cannot disagree.
+path_is_plan() {
+	local path="$1" repo="$2" entry candidate dir
+	[[ "$path" == *.md ]] || return 1
+	if [[ "$path" != /* ]]; then
+		dir="${path%/*}"
+		[[ "$dir" == "$path" ]] && dir="."
+		path="$(cd "$dir" 2>/dev/null && pwd)/${path##*/}" || return 1
+	fi
+	while IFS= read -r entry; do
+		[[ -n "$entry" ]] || continue
+		candidate="$repo/$entry"
+		if [[ "$path" == "$candidate" || "$path" == "$candidate"/* ]]; then
+			return 0
+		fi
+	done < <(configured_plan_paths)
+	return 1
+}
+
+# Emits STATUS<TAB>LINE<TAB>TEXT for every gap entry in the content on stdin.
+parse_gaps() {
+	awk -v gapre="$GAP_HEADINGS" -v refre="$ISSUE_REFS" '
+		BEGIN { fence = 0; insec = 0; seclvl = 0; baseind = -1; n = 0 }
+		{
+			raw = $0
+			sub(/\r$/, "", raw)
+			trimmed = raw
+			sub(/^[[:space:]]+/, "", trimmed)
+
+			# A heading inside a fenced block is sample text, not structure.
+			if (trimmed ~ /^(```|~~~)/) { fence = 1 - fence; next }
+			if (fence) next
+
+			if (trimmed ~ /^#+[[:space:]]/) {
+				lvl = 0
+				while (substr(trimmed, lvl + 1, 1) == "#") lvl++
+				htext = substr(trimmed, lvl + 1)
+				sub(/^[[:space:]]+/, "", htext)
+				sub(/[[:space:]]*#+[[:space:]]*$/, "", htext)
+				if (insec && lvl <= seclvl) insec = 0
+				if (!insec && tolower(htext) ~ ("^(" gapre ")$")) {
+					insec = 1; seclvl = lvl; baseind = -1
+				}
+				next
+			}
+			if (!insec) next
+
+			i = 1; ind = 0
+			while (1) {
+				c = substr(raw, i, 1)
+				if (c == " ") { ind++; i++ }
+				else if (c == "\t") { ind += 4; i++ }
+				else break
+			}
+			rest = substr(raw, i)
+
+			if (rest ~ /^([-*+]|[0-9]+[.)])[[:space:]]/) {
+				if (baseind < 0) baseind = ind
+				if (ind <= baseind) {
+					n++
+					body = rest
+					sub(/^([-*+]|[0-9]+[.)])[[:space:]]+/, "", body)
+					ln[n] = FNR; first[n] = body; full[n] = body
+				} else if (n > 0) {
+					full[n] = full[n] " " rest
+				}
+				next
+			}
+			if (rest == "") next
+			# Indented prose belongs to the entry above it; unindented prose is
+			# section commentary and belongs to none.
+			if (ind > 0 && n > 0) full[n] = full[n] " " rest
+			next
+		}
+		END {
+			for (k = 1; k <= n; k++) {
+				text = first[k]
+				closed = 0
+				if (text ~ /^\[[xX]\][[:space:]]/) closed = 1
+				sub(/^\[[ xX]\][[:space:]]+/, "", text)
+				if (text ~ /^~~.*~~[[:space:]]*$/) closed = 1
+				status = "OPEN"
+				if (closed) status = "CLOSED"
+				else if (full[k] ~ refre) status = "TRACKED"
+				printf "%s\t%d\t%s\n", status, ln[k], text
+			}
+		}
+	'
+}
+
+marks_done() {
+	grep -qiE "$DONE_MARKERS" <<<"$1"
+}
+
+TRUNCATE_AT=110
+
+report_plan() {
+	local plan="$1" content="$2"
+	local gaps blocking status line text shown
+	gaps="$(printf '%s\n' "$content" | parse_gaps)"
+	blocking=0
+	if [[ -n "$gaps" ]]; then
+		blocking=$(grep -c '^OPEN	' <<<"$gaps" || true)
+	fi
+
+	if [[ "$REQUIRE_DONE" == 1 ]] && ! marks_done "$content"; then
+		return 0
+	fi
+	if [[ "$blocking" -gt 0 ]]; then
+		FOUND_BLOCKING=$((FOUND_BLOCKING + blocking))
+	fi
+	if [[ "$QUIET" == 1 || -z "$gaps" ]]; then
+		return 0
+	fi
+
+	shown=0
+	while IFS=$'\t' read -r status line text; do
+		[[ -n "$status" ]] || continue
+		if [[ "$SHOW_ALL" != 1 && "$status" != "OPEN" ]]; then
+			continue
+		fi
+		if [[ "$TSV" == 1 ]]; then
+			printf '%s\t%s\t%s\t%s\n' "$status" "$plan" "$line" "$text"
+			shown=$((shown + 1))
+			continue
+		fi
+		if [[ "$shown" == 0 ]]; then
+			printf '%s — %d gap(s) unclosed\n' "$plan" "$blocking"
+		fi
+		if [[ "${#text}" -gt "$TRUNCATE_AT" ]]; then
+			text="${text:0:$TRUNCATE_AT}… [truncated for display; full text in the plan]"
+		fi
+		printf '  %-8s L%-5s %s\n' "$status" "$line" "$text"
+		shown=$((shown + 1))
+	done <<<"$gaps"
+	return 0
+}
+
+REPO="$PWD"
+REPO_GIVEN=0
+STDIN_NAME=""
+MATCH_PATH=""
+REQUIRE_DONE=0
+SHOW_ALL=0
+TSV=0
+QUIET=0
+LIST_ONLY=0
+TARGETS=""
+
+need_value() {
+	if [[ "$1" -lt 2 ]]; then
+		usage >&2
+		exit 2
+	fi
+	return 0
+}
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--repo)
+		need_value $#
+		REPO="$2"
+		REPO_GIVEN=1
+		shift 2
+		;;
+	--stdin)
+		need_value $#
+		STDIN_NAME="$2"
+		shift 2
+		;;
+	--matches)
+		need_value $#
+		MATCH_PATH="$2"
+		shift 2
+		;;
+	--require-done)
+		REQUIRE_DONE=1
+		shift
+		;;
+	--all)
+		SHOW_ALL=1
+		shift
+		;;
+	--tsv)
+		TSV=1
+		shift
+		;;
+	--quiet)
+		QUIET=1
+		shift
+		;;
+	--list-plans)
+		LIST_ONLY=1
+		shift
+		;;
+	--version)
+		printf 'plan-gate %s\n' "$VERSION"
+		exit 0
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	-*)
+		printf 'plan-gate: unknown option %s\n' "$1" >&2
+		usage >&2
+		exit 2
+		;;
+	*)
+		TARGETS="$TARGETS$1"$'\n'
+		shift
+		;;
+	esac
+done
+
+# A bare --matches is asked from wherever the harness happens to be, so the
+# repository comes from the path under judgement rather than from the cwd.
+if [[ -n "$MATCH_PATH" && "$REPO_GIVEN" == 0 ]]; then
+	MATCH_DIR="${MATCH_PATH%/*}"
+	[[ "$MATCH_DIR" == "$MATCH_PATH" ]] && MATCH_DIR="."
+	REPO="$(git -C "$MATCH_DIR" rev-parse --show-toplevel 2>/dev/null || printf '%s' "$PWD")"
+fi
+if ! REPO="$(cd "$REPO" 2>/dev/null && pwd)"; then
+	printf 'plan-gate: unreadable repo\n' >&2
+	exit 3
+fi
+
+load_config "$REPO"
+
+if [[ -n "$MATCH_PATH" ]]; then
+	if path_is_plan "$MATCH_PATH" "$REPO"; then
+		exit 0
+	fi
+	exit 1
+fi
+
+FOUND_BLOCKING=0
+
+collect_targets() {
+	local target
+	while IFS= read -r target; do
+		[[ -n "$target" ]] || continue
+		if [[ -d "$target" ]]; then
+			find_plan_files "$target"
+		elif [[ -f "$target" ]]; then
+			printf '%s\n' "$target"
+		else
+			printf 'plan-gate: no such plan: %s\n' "$target" >&2
+			return 3
+		fi
+	done <<<"$TARGETS"
+	return 0
+}
+
+if [[ -n "$STDIN_NAME" ]]; then
+	CONTENT="$(cat)"
+	report_plan "$STDIN_NAME" "$CONTENT"
+else
+	if [[ -n "$TARGETS" ]]; then
+		PLAN_LIST="$(collect_targets)" || exit 3
+	else
+		PLAN_LIST="$(discover_plans "$REPO")"
+	fi
+
+	if [[ "$LIST_ONLY" == 1 ]]; then
+		if [[ -n "$PLAN_LIST" ]]; then
+			printf '%s\n' "$PLAN_LIST"
+		fi
+		exit 0
+	fi
+
+	while IFS= read -r plan; do
+		[[ -n "$plan" ]] || continue
+		if [[ ! -r "$plan" ]]; then
+			printf 'plan-gate: unreadable: %s\n' "$plan" >&2
+			exit 3
+		fi
+		report_plan "$plan" "$(cat "$plan")"
+	done <<<"$PLAN_LIST"
+fi
+
+if [[ "$FOUND_BLOCKING" -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/plugins-cc/agentkit/tools/wip
+++ b/plugins-cc/agentkit/tools/wip
@@ -302,6 +302,34 @@ emit_class() {
 	return 0
 }
 
+# Branches that have a worktree attached. A branch with nothing committed still
+# holds work if a checkout is sitting on it — that is where uncommitted work
+# lives — so this is what separates "nothing started" from "started, uncommitted".
+worktree_branches() {
+	git_in worktree list --porcelain 2>/dev/null |
+		awk '$1 == "branch" { sub(/^refs\/heads\//, "", $2); print $2 }'
+	return 0
+}
+
+# Nothing committed, nowhere checked out, and no change ever opened: nothing was
+# started. A harness that creates a branch per worktree leaves dozens of these,
+# and they crowd out the rows that matter — being loudly wrong about the size of
+# your backlog trains a reader to skim past it.
+#
+# The test is structural rather than by name deliberately. A name pattern would
+# hide a harness branch that DOES carry commits, which is real unfinished work;
+# this cannot, because having commits disqualifies a branch from being hidden.
+# Only ever asked about a branch the forge has no change for; the call sites are
+# the single place that decides, so there is no state guard duplicated here.
+branch_is_unstarted() {
+	local branch="$1"
+	[[ "$(git_in rev-list --count "$BASE..$branch" 2>/dev/null || printf '1')" == "0" ]] || return 1
+	case "$WORKTREE_BRANCHES" in
+	*"|$branch|"*) return 1 ;;
+	esac
+	return 0
+}
+
 # STATE<TAB>BRANCH<TAB>REF<TAB>TRACK, judged once. A caller that classified
 # inside a command substitution would lose the result to the subshell.
 # STATE is merged / opened / closed / none / unknown, where `none` means the
@@ -313,7 +341,11 @@ classify_branches() {
 		[[ -n "$branch" ]] || continue
 		[[ "$branch" == "$DEFAULT" ]] && continue
 		if [[ -z "$FORGE" ]]; then
-			emit_class 'unknown' "$branch" '' "$track"
+			if branch_is_unstarted "$branch"; then
+				emit_class 'unstarted' "$branch" '' "$track"
+			else
+				emit_class 'unknown' "$branch" '' "$track"
+			fi
 			continue
 		fi
 		answer=$(best_state_for "$branch" "$FORGE_STATES")
@@ -321,12 +353,26 @@ classify_branches() {
 			answer=$(best_state_for "$branch" "$(forge_branch_state_one "$branch")")
 		fi
 		if [[ -z "$answer" ]]; then
-			emit_class 'none' "$branch" '' "$track"
+			if branch_is_unstarted "$branch"; then
+				emit_class 'unstarted' "$branch" '' "$track"
+			else
+				emit_class 'none' "$branch" '' "$track"
+			fi
 			continue
 		fi
 		IFS=$'\t' read -r state ref <<<"$answer"
 		emit_class "$state" "$branch" "$ref" "$track"
 	done < <(git_in for-each-ref --format='%(refname:short)%09%(upstream:track)' refs/heads 2>/dev/null)
+	return 0
+}
+
+unstarted_count() {
+	local state
+	local n=0
+	while IFS=$'\t' read -r state _ _ _; do
+		[[ "$state" == "unstarted" ]] && n=$((n + 1))
+	done <<<"$BRANCH_CLASS"
+	printf '%d' "$n"
 	return 0
 }
 
@@ -490,7 +536,7 @@ count_lines() {
 }
 
 report_repo() {
-	local branches abandoned worktrees changes issues plans total
+	local branches abandoned worktrees changes issues plans hidden
 
 	DEFAULT="$(default_branch)"
 	BASE="$(base_ref "$DEFAULT")"
@@ -508,6 +554,7 @@ report_repo() {
 	if [[ -n "$FORGE" ]]; then
 		FORGE_STATES="$(forge_branch_states)"
 	fi
+	WORKTREE_BRANCHES="|$(worktree_branches | tr '\n' '|')"
 	BRANCH_CLASS="$(classify_branches)"
 	CLEANUP="$(merged_branch_names)"
 
@@ -518,10 +565,7 @@ report_repo() {
 	issues="$(section_issues)" || fail_section section_issues
 	plans="$(section_plans)" || fail_section section_plans
 
-	total=$(($(count_lines "$branches") + $(count_lines "$abandoned") + $(count_lines "$worktrees") +
-		$(count_lines "$CHANGES") + $(count_lines "$ISSUES") + $(count_lines "$plans")))
-
-	printf '%s — %d half-done\n' "${REPO##*/}" "$total"
+	printf '%s — %d unfinished branch(es)\n' "${REPO##*/}" "$(count_lines "$branches")"
 	emit_bounded 'branch(es)' "$branches"
 	emit_bounded 'abandoned branch(es)' "$abandoned"
 	emit_bounded 'worktree(s)' "$worktrees"
@@ -529,6 +573,13 @@ report_repo() {
 	emit_bounded 'issue line(s)' "$issues"
 	emit_bounded 'plan(s)' "$plans"
 
+	printf ' %-9s %s abandoned · %s worktree(s) · %s open change(s) · %s filed issue(s) · %s plan(s) with gaps\n' \
+		'COUNTS' "$(count_lines "$abandoned")" "$(count_lines "$worktrees")" \
+		"$(count_lines "$CHANGES")" "$(count_lines "$ISSUES")" "$(count_lines "$plans")"
+	hidden="$(unstarted_count)"
+	if [[ "$hidden" -gt 0 ]]; then
+		printf ' %-9s %s\n' 'NOTE' "$hidden branch(es) hidden: nothing committed, no worktree, no change ever opened"
+	fi
 	if [[ -n "$CLEANUP" ]]; then
 		printf ' %-9s %s\n' 'MERGED' "$(bound_list "$CLEANUP") — merged on the forge; cleanup, not unfinished work"
 	fi

--- a/plugins-cc/agentkit/tools/wip
+++ b/plugins-cc/agentkit/tools/wip
@@ -1,0 +1,510 @@
+#!/usr/bin/env bash
+# wip — what was started and not finished, for one repository or several.
+#
+# Read-only: it blocks nothing and changes nothing. It exists so a human never
+# has to take an agent's summary of its own work on trust.
+#
+# The one thing here worth knowing: merged-ness is decided by CONTENT, never by
+# ancestry. See branch_is_merged for why every cheaper rule gets it wrong.
+set -euo pipefail
+
+VERSION=1
+LIMIT=20
+FORGE_ENABLED=1
+
+usage() {
+	cat <<'EOF'
+Usage: wip [options] [REPO...]
+
+  REPO           repository path. Default: the current directory's repository.
+
+  --limit N      rows per section before the rest is summarised (default 20; 0 = all)
+  --no-forge     skip merge-request/pull-request and issue lookups
+  --version      print the tool version
+  -h, --help     this text
+
+Exit: 0 always, unless a repository argument is unusable (2).
+EOF
+}
+
+# ── git ─────────────────────────────────────────────────────────────────────
+git_in() { git -C "$REPO" "$@"; }
+
+# origin/HEAD names the default branch when the clone recorded it; the probes
+# after it are for clones that never did.
+default_branch() {
+	local ref candidate
+	ref=$(git_in symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null || true)
+	if [[ -n "$ref" ]]; then
+		printf '%s' "${ref##*/}"
+		return 0
+	fi
+	for candidate in main master trunk develop; do
+		if git_in show-ref --verify --quiet "refs/remotes/origin/$candidate"; then
+			printf '%s' "$candidate"
+			return 0
+		fi
+	done
+	for candidate in main master trunk develop; do
+		if git_in show-ref --verify --quiet "refs/heads/$candidate"; then
+			printf '%s' "$candidate"
+			return 0
+		fi
+	done
+	git_in rev-parse --abbrev-ref HEAD 2>/dev/null || printf '%s' 'main'
+}
+
+base_ref() {
+	if git_in show-ref --verify --quiet "refs/remotes/origin/$1"; then
+		printf 'origin/%s' "$1"
+	else
+		printf '%s' "$1"
+	fi
+}
+
+# Merging the branch into the default branch and getting the default branch's
+# own tree back means its content is already there — however it arrived, and
+# whatever the default branch has done since.
+#
+# Every cheaper rule was tried against a squash-merge fixture and fails:
+# `rev-list --count base..branch` counts a squashed branch as ahead forever,
+# because the squashed commit is not an ancestor of anything. A two-dot diff
+# reports the default branch's own later commits as deletions on the branch. A
+# three-dot diff answers a different question entirely — the branch's changes
+# since the merge base — which is non-empty for every branch that did anything.
+branch_is_merged() {
+	local merged_tree base_tree merge_base files
+	local -a paths=()
+
+	if ! base_tree=$(git_in rev-parse "$BASE^{tree}" 2>/dev/null); then
+		return 1
+	fi
+	if merged_tree=$(git_in merge-tree --write-tree "$BASE" "$1" 2>/dev/null); then
+		if [[ "$merged_tree" == "$base_tree" ]]; then
+			return 0
+		fi
+		return 1
+	fi
+
+	# Older git has no --write-tree. Comparing only the files the branch touched
+	# keeps the default branch's unrelated progress out of the answer.
+	if ! merge_base=$(git_in merge-base "$BASE" "$1" 2>/dev/null); then
+		return 1
+	fi
+	files=$(git_in diff --name-only "$merge_base" "$1" 2>/dev/null || true)
+	if [[ -z "$files" ]]; then
+		return 0
+	fi
+	while IFS= read -r line; do
+		[[ -n "$line" ]] && paths+=("$line")
+	done <<<"$files"
+	if git_in diff --quiet "$BASE" "$1" -- "${paths[@]}" 2>/dev/null; then
+		return 0
+	fi
+	return 1
+}
+
+age_days() {
+	local when now
+	when=$(git_in log -1 --format=%ct "$1" 2>/dev/null || printf '0')
+	now=$(date +%s)
+	printf '%d' $(((now - when) / 86400))
+}
+
+# ── forge ───────────────────────────────────────────────────────────────────
+# Resolved per repository, never assumed. A repository whose forge cannot be
+# reached reports that fact rather than an empty section, because an empty
+# section reads as "nothing outstanding".
+FORGE=""
+FORGE_NOTE=""
+
+detect_forge() {
+	FORGE=""
+	FORGE_NOTE=""
+	if [[ "$FORGE_ENABLED" != 1 ]]; then
+		FORGE_NOTE="skipped (--no-forge)"
+		return 0
+	fi
+	local url host
+	url=$(git_in remote get-url origin 2>/dev/null || true)
+	if [[ -z "$url" ]]; then
+		FORGE_NOTE="no origin remote — merge requests and issues not checked"
+		return 0
+	fi
+	host=$(printf '%s' "$url" | sed -E 's#^(git\+)?(ssh://)?(git@|https?://)?([^:/]+).*#\4#')
+
+	if [[ "$host" == "github.com" ]] || (command -v gh >/dev/null 2>&1 && gh auth status --hostname "$host" >/dev/null 2>&1); then
+		if command -v gh >/dev/null 2>&1; then
+			FORGE="github"
+			GH_HOSTNAME="$host"
+			return 0
+		fi
+		FORGE_NOTE="github repo but gh is not installed — merge requests and issues not checked"
+		return 0
+	fi
+	if command -v glab >/dev/null 2>&1; then
+		if (cd "$REPO" && GITLAB_HOST="$host" glab api /version >/dev/null 2>&1); then
+			FORGE="gitlab"
+			GITLAB_HOSTNAME="$host"
+			return 0
+		fi
+	fi
+	if [[ "$host" == *gitlab* ]]; then
+		FORGE_NOTE="gitlab repo but glab is unavailable or unauthenticated — merge requests and issues not checked"
+		return 0
+	fi
+	FORGE_NOTE="unrecognised forge host '$host' — merge requests and issues not checked"
+	return 0
+}
+
+# One row per open change authored by the current user:
+# NUMBER<TAB>HEAD_BRANCH<TAB>HOLDS
+open_changes() {
+	case "$FORGE" in
+	github)
+		(cd "$REPO" && GH_HOST="$GH_HOSTNAME" gh pr list --author '@me' --state open --limit 100 \
+			--json number,headRefName,isDraft,mergeable,reviewDecision,statusCheckRollup 2>/dev/null) |
+			jq -r '.[] | [
+				("#" + (.number | tostring)),
+				.headRefName,
+				([ (if .isDraft then "draft" else empty end),
+				   (if .mergeable == "CONFLICTING" then "conflicts" else empty end),
+				   (if ([.statusCheckRollup[]? | select(.conclusion == "FAILURE" or .conclusion == "TIMED_OUT" or .state == "FAILURE")] | length) > 0
+				      then "checks failing" else empty end),
+				   (if .reviewDecision == "CHANGES_REQUESTED" then "changes requested"
+				    elif .reviewDecision == "APPROVED" then empty
+				    else "no approving review" end)
+				 ] | join(", "))
+			] | @tsv' || true
+		;;
+	gitlab)
+		(cd "$REPO" && GITLAB_HOST="$GITLAB_HOSTNAME" glab mr list --author '@me' --output json --per-page 100 2>/dev/null) |
+			jq -r '(if type == "array" then . else (.merge_requests // []) end)[] | [
+				("!" + (.iid | tostring)),
+				.source_branch,
+				([ (if (.draft // .work_in_progress // false) then "draft" else empty end),
+				   (if .has_conflicts then "conflicts" else empty end),
+				   (if (.upvotes // 0) == 0 then "no approving review" else empty end)
+				 ] | join(", "))
+			] | @tsv' || true
+		;;
+	esac
+	return 0
+}
+
+# NUMBER<TAB>FLAG — FLAG marks an issue whose body says it was carved out of
+# other work. Filing one of those is a deferral, and deferrals should be visible.
+SPLIT_HINT='split out of|split from|carved out|carved from|extracted from|broken out of|deferred from|follow-?up (to|from)|descoped from|out of scope for'
+
+open_authored_issues() {
+	case "$FORGE" in
+	github)
+		(cd "$REPO" && GH_HOST="$GH_HOSTNAME" gh issue list --author '@me' --state open --limit 100 \
+			--json number,body,title 2>/dev/null) |
+			jq -r --arg re "$SPLIT_HINT" '.[] |
+				[ ("#" + (.number | tostring)),
+				  (if ((.body // "") + " " + (.title // "") | test($re; "i")) then "split" else "" end)
+				] | @tsv' || true
+		;;
+	gitlab)
+		(cd "$REPO" && GITLAB_HOST="$GITLAB_HOSTNAME" glab issue list --author '@me' --output json --per-page 100 2>/dev/null) |
+			jq -r --arg re "$SPLIT_HINT" '(if type == "array" then . else (.issues // []) end)[] |
+				[ ("#" + (.iid | tostring)),
+				  (if ((.description // "") + " " + (.title // "") | test($re; "i")) then "split" else "" end)
+				] | @tsv' || true
+		;;
+	esac
+	return 0
+}
+
+# ── output ──────────────────────────────────────────────────────────────────
+# Bounded sections say what they dropped. A silent cap reads as "nothing else
+# to see", which is the failure this whole tool exists to prevent.
+emit_bounded() {
+	local label="$1" body="$2" total shown
+	[[ -n "$body" ]] || return 0
+	total=$(grep -c . <<<"$body" || true)
+	if [[ "$LIMIT" -gt 0 && "$total" -gt "$LIMIT" ]]; then
+		shown="$LIMIT"
+	else
+		shown="$total"
+	fi
+	printf '%s' "$(head -n "$shown" <<<"$body")"
+	printf '\n'
+	if [[ "$shown" -lt "$total" ]]; then
+		printf ' %-9s %s\n' "…" "$((total - shown)) more $label not shown (--limit 0 for all)"
+	fi
+	return 0
+}
+
+# An inline list of identifiers, capped the same way and just as loudly.
+bound_list() {
+	local items="${1# }" total kept
+	total=$(wc -w <<<"$items" | tr -d ' ')
+	if [[ "$LIMIT" -le 0 || "$total" -le "$LIMIT" ]]; then
+		printf '%s' "$items"
+		return 0
+	fi
+	kept=$(cut -d' ' -f"1-$LIMIT" <<<"$items")
+	printf '%s +%d more (--limit 0 for all)' "$kept" "$((total - LIMIT))"
+	return 0
+}
+
+# ── sections ────────────────────────────────────────────────────────────────
+CHANGES=""
+CLEANUP=""
+
+change_for_branch() {
+	local head number
+	while IFS=$'\t' read -r number head _; do
+		if [[ -n "$head" && "$head" == "$1" ]]; then
+			printf '%s' "$number"
+			return 0
+		fi
+	done <<<"$CHANGES"
+	return 0
+}
+
+# STATUS<TAB>BRANCH<TAB>UPSTREAM_TRACK, judged once. A caller that classified
+# inside a command substitution would lose the merged list to the subshell.
+classify_branches() {
+	local branch track
+	while IFS=$'\t' read -r branch track; do
+		[[ -n "$branch" ]] || continue
+		[[ "$branch" == "$DEFAULT" ]] && continue
+		if branch_is_merged "$branch"; then
+			printf 'MERGED\t%s\t%s\n' "$branch" "$track"
+		else
+			printf 'OPEN\t%s\t%s\n' "$branch" "$track"
+		fi
+	done < <(git_in for-each-ref --format='%(refname:short)%09%(upstream:track)' refs/heads 2>/dev/null)
+	return 0
+}
+
+merged_branch_names() {
+	local status branch
+	while IFS=$'\t' read -r status branch _; do
+		[[ "$status" == "MERGED" ]] && printf ' %s' "$branch"
+	done <<<"$BRANCH_CLASS"
+	return 0
+}
+
+section_branches() {
+	local status branch track ahead days change note body=""
+	while IFS=$'\t' read -r status branch track; do
+		[[ "$status" == "OPEN" ]] || continue
+		ahead=$(git_in rev-list --count "$BASE..$branch" 2>/dev/null || printf '0')
+		days=$(age_days "$branch")
+		change=$(change_for_branch "$branch")
+		if [[ -n "$change" ]]; then
+			note="$change"
+		elif [[ -n "$FORGE" ]]; then
+			note="no MR/PR"
+		else
+			note="MR/PR unknown"
+		fi
+		if [[ "$track" == *gone* ]]; then
+			note="$note; upstream gone but content NOT merged"
+		fi
+		body="$body$(printf ' %-9s %-34s %3sd  %3s commits  %s' 'BRANCH' "$branch" "$days" "$ahead" "$note")"$'\n'
+	done <<<"$BRANCH_CLASS"
+	printf '%s' "$body"
+	return 0
+}
+
+# A dirty worktree is called out because removing one destroys the uncommitted
+# and untracked files in it; the branch ref does not carry them.
+section_worktrees() {
+	local path branch modified untracked state body=""
+	while IFS= read -r line; do
+		case "$line" in
+		"worktree "*)
+			path="${line#worktree }"
+			branch=""
+			;;
+		"branch "*) branch="${line#branch refs/heads/}" ;;
+		"detached") branch="(detached)" ;;
+		"")
+			[[ -n "${path:-}" ]] || continue
+			[[ "$path" == "$REPO" ]] && {
+				path=""
+				continue
+			}
+			modified=$(git -C "$path" status --porcelain 2>/dev/null | grep -cv '^??' || true)
+			untracked=$(git -C "$path" status --porcelain 2>/dev/null | grep -c '^??' || true)
+			if [[ "$modified" -gt 0 || "$untracked" -gt 0 ]]; then
+				state=$(printf 'DIRTY %s modified, %s untracked — do NOT remove' "$modified" "$untracked")
+			else
+				state="clean"
+			fi
+			body="$body$(printf ' %-9s %-34s %s at %s' 'WORKTREE' "${branch:-(no branch)}" "$state" "${path/#$HOME/\~}")"$'\n'
+				path=""
+			;;
+		esac
+	done < <(
+		git_in worktree list --porcelain 2>/dev/null
+		printf '\n'
+	)
+	printf '%s' "$body"
+	return 0
+}
+
+section_changes() {
+	local number head holds body=""
+	while IFS=$'\t' read -r number head holds; do
+		[[ -n "$number" ]] || continue
+		body="$body$(printf ' %-9s %-34s held: %s' 'MR/PR' "$number ($head)" "${holds:-nothing — ready}")"$'\n'
+	done <<<"$CHANGES"
+	printf '%s' "$body"
+	return 0
+}
+
+section_issues() {
+	local number flag plain="" split="" body=""
+	while IFS=$'\t' read -r number flag; do
+		[[ -n "$number" ]] || continue
+		if [[ "$flag" == "split" ]]; then
+			split="$split $number"
+		else
+			plain="$plain $number"
+		fi
+	done <<<"$ISSUES"
+	if [[ -n "$plain" ]]; then
+		body="$body$(printf ' %-9s %s' 'FILED' "$(bound_list "$plain") — authored, open, unfixed")"$'\n'
+	fi
+	if [[ -n "$split" ]]; then
+		body="$body$(printf ' %-9s %s' 'DEFERRED' "$(bound_list "$split") — carved out of other work")"$'\n'
+	fi
+	printf '%s' "$body"
+	return 0
+}
+
+section_plans() {
+	local plan open name body="" seen=""
+	[[ -n "$PLAN_GATE" ]] || return 0
+	while IFS=$'\t' read -r _ plan _ _; do
+		[[ -n "$plan" ]] || continue
+		case " $seen " in *" $plan "*) continue ;; esac
+		seen="$seen $plan"
+		open=$(grep -cF "	$plan	" <<<"$PLAN_ROWS" || true)
+		name="${plan#"$REPO"/}"
+		body="$body$(printf ' %-9s %-34s %s gap(s) unclosed' 'PLAN' "$name" "$open")"$'\n'
+	done <<<"$PLAN_ROWS"
+	printf '%s' "$body"
+	return 0
+}
+
+count_lines() {
+	if [[ -z "$1" ]]; then
+		printf '0'
+		return 0
+	fi
+	grep -c . <<<"$1" || true
+}
+
+report_repo() {
+	local branches worktrees changes issues plans total
+
+	DEFAULT="$(default_branch)"
+	BASE="$(base_ref "$DEFAULT")"
+	detect_forge
+	CHANGES="$(open_changes)"
+	ISSUES=""
+	if [[ -n "$FORGE" ]]; then
+		ISSUES="$(open_authored_issues)"
+	fi
+	PLAN_ROWS=""
+	if [[ -n "$PLAN_GATE" ]]; then
+		PLAN_ROWS="$("$PLAN_GATE" --repo "$REPO" --tsv 2>/dev/null | grep '^OPEN	' || true)"
+	fi
+	BRANCH_CLASS="$(classify_branches)"
+	CLEANUP="$(merged_branch_names)"
+
+	branches="$(section_branches)"
+	worktrees="$(section_worktrees)"
+	changes="$(section_changes)"
+	issues="$(section_issues)"
+	plans="$(section_plans)"
+
+	total=$(($(count_lines "$branches") + $(count_lines "$worktrees") +
+		$(count_lines "$CHANGES") + $(count_lines "$ISSUES") + $(count_lines "$plans")))
+
+	printf '%s — %d half-done\n' "${REPO##*/}" "$total"
+	emit_bounded 'branch(es)' "$branches"
+	emit_bounded 'worktree(s)' "$worktrees"
+	emit_bounded 'change(s)' "$changes"
+	emit_bounded 'issue line(s)' "$issues"
+	emit_bounded 'plan(s)' "$plans"
+
+	if [[ -n "$CLEANUP" ]]; then
+		printf ' %-9s %s\n' 'MERGED' "$(bound_list "$CLEANUP") — content already on $DEFAULT; safe to delete"
+	fi
+	if [[ -n "$FORGE_NOTE" ]]; then
+		printf ' %-9s %s\n' 'NOTE' "$FORGE_NOTE"
+	fi
+	if [[ -z "$PLAN_GATE" ]]; then
+		printf ' %-9s %s\n' 'NOTE' 'plan-gate not found beside this tool — plans not checked'
+	fi
+	return 0
+}
+
+# ── arguments ───────────────────────────────────────────────────────────────
+TARGETS=""
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--limit)
+		if [[ $# -lt 2 || ! "$2" =~ ^[0-9]+$ ]]; then
+			usage >&2
+			exit 2
+		fi
+		LIMIT="$2"
+		shift 2
+		;;
+	--no-forge)
+		FORGE_ENABLED=0
+		shift
+		;;
+	--version)
+		printf 'wip %s\n' "$VERSION"
+		exit 0
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	-*)
+		printf 'wip: unknown option %s\n' "$1" >&2
+		usage >&2
+		exit 2
+		;;
+	*)
+		TARGETS="$TARGETS$1"$'\n'
+		shift
+		;;
+	esac
+done
+
+[[ -n "$TARGETS" ]] || TARGETS="$PWD"$'\n'
+
+TOOL_DIR="${BASH_SOURCE[0]%/*}"
+PLAN_GATE=""
+for candidate in "$TOOL_DIR/plan-gate" "$TOOL_DIR/../tools/plan-gate"; do
+	if [[ -x "$candidate" ]]; then
+		PLAN_GATE="$candidate"
+		break
+	fi
+done
+
+FIRST=1
+while IFS= read -r target; do
+	[[ -n "$target" ]] || continue
+	if ! REPO="$(git -C "$target" rev-parse --show-toplevel 2>/dev/null)"; then
+		printf 'wip: not a git repository: %s\n' "$target" >&2
+		exit 2
+	fi
+	[[ "$FIRST" == 1 ]] || printf '\n'
+	FIRST=0
+	report_repo
+done <<<"$TARGETS"
+exit 0

--- a/plugins-cc/agentkit/tools/wip
+++ b/plugins-cc/agentkit/tools/wip
@@ -350,7 +350,7 @@ branch_is_cleanup() {
 
 # Merged branches are cleanup, not unfinished work, and leave this section.
 section_branches() {
-	local state branch track ref ahead days note body=""
+	local state branch track ref ahead days body="" note=""
 	while IFS=$'\t' read -r state branch ref track; do
 		[[ "$ref" == "-" ]] && ref=""
 		[[ "$track" == "-" ]] && track=""
@@ -470,6 +470,17 @@ section_plans() {
 	return 0
 }
 
+# A section builds its rows in a command substitution, so a failure inside one
+# yields an empty string — indistinguishable from "nothing to report" in a tool
+# whose whole purpose is that work does not disappear quietly. Each capture is
+# guarded so a failure is loud and non-zero instead. The calls stay direct:
+# dispatching through a variable would blind shellcheck's dead-code check, which
+# has already caught real dead code in this file.
+fail_section() {
+	printf 'wip: the %s section failed — this report is INCOMPLETE\n' "$1" >&2
+	exit 3
+}
+
 count_lines() {
 	if [[ -z "$1" ]]; then
 		printf '0'
@@ -500,12 +511,12 @@ report_repo() {
 	BRANCH_CLASS="$(classify_branches)"
 	CLEANUP="$(merged_branch_names)"
 
-	branches="$(section_branches)"
-	abandoned="$(section_abandoned)"
-	worktrees="$(section_worktrees)"
-	changes="$(section_changes)"
-	issues="$(section_issues)"
-	plans="$(section_plans)"
+	branches="$(section_branches)" || fail_section section_branches
+	abandoned="$(section_abandoned)" || fail_section section_abandoned
+	worktrees="$(section_worktrees)" || fail_section section_worktrees
+	changes="$(section_changes)" || fail_section section_changes
+	issues="$(section_issues)" || fail_section section_issues
+	plans="$(section_plans)" || fail_section section_plans
 
 	total=$(($(count_lines "$branches") + $(count_lines "$abandoned") + $(count_lines "$worktrees") +
 		$(count_lines "$CHANGES") + $(count_lines "$ISSUES") + $(count_lines "$plans")))

--- a/plugins-cc/agentkit/tools/wip
+++ b/plugins-cc/agentkit/tools/wip
@@ -4,8 +4,9 @@
 # Read-only: it blocks nothing and changes nothing. It exists so a human never
 # has to take an agent's summary of its own work on trust.
 #
-# The one thing here worth knowing: merged-ness is decided by CONTENT, never by
-# ancestry. See branch_is_merged for why every cheaper rule gets it wrong.
+# The one thing here worth knowing: whether a branch is finished is answered by
+# the FORGE, never by git topology. See forge_branch_states for the measurement
+# behind that, and for why there is no local rule to fall back to.
 set -euo pipefail
 
 VERSION=1
@@ -62,46 +63,84 @@ base_ref() {
 	fi
 }
 
-# Merging the branch into the default branch and getting the default branch's
-# own tree back means its content is already there — however it arrived, and
-# whatever the default branch has done since.
+# A squash merge destroys the topological evidence by design: the squashed
+# commit is not an ancestor of the branch, and the merge base stays before the
+# squash forever. Only the forge records that a change from this branch merged.
 #
-# Every cheaper rule was tried against a squash-merge fixture and fails:
-# `rev-list --count base..branch` counts a squashed branch as ahead forever,
-# because the squashed commit is not an ancestor of anything. A two-dot diff
-# reports the default branch's own later commits as deletions on the branch. A
-# three-dot diff answers a different question entirely — the branch's changes
-# since the merge base — which is non-empty for every branch that did anything.
-branch_is_merged() {
-	local merged_tree base_tree merge_base files
-	local -a paths=()
+# Measured against nine branches of known outcome, every git-only rule reported
+# all seven merged ones as outstanding: ancestry counts, a two-dot diff, a
+# three-dot diff, and an in-memory merge-tree comparison alike. The last of
+# those passed a two-commit fixture and still failed here, because a fixture
+# whose default branch has not moved cannot distinguish the case it exists to
+# prove. There is no local rule to fall back to, so when the forge cannot
+# answer, this reports that it does not know rather than guessing loudly.
 
-	if ! base_tree=$(git_in rev-parse "$BASE^{tree}" 2>/dev/null); then
-		return 1
+# BRANCH<TAB>STATE<TAB>REF for every change the forge knows of. States are
+# normalised to merged / opened / closed.
+forge_branch_states() {
+	case "$FORGE" in
+	github)
+		(cd "$REPO" && GH_HOST="$GH_HOSTNAME" gh pr list --state all --limit 200 \
+			--json headRefName,number,state 2>/dev/null) |
+			jq -r '.[] | [.headRefName, (.state | ascii_downcase), ("#" + (.number | tostring))] | @tsv' || true
+		;;
+	gitlab)
+		(cd "$REPO" && GITLAB_HOST="$GITLAB_HOSTNAME" \
+			glab api "projects/:fullpath/merge_requests?state=all&per_page=100&order_by=updated_at" 2>/dev/null) |
+			jq -r 'if type == "array" then .[] else empty end
+				| [.source_branch, .state, ("!" + (.iid | tostring))] | @tsv' || true
+		;;
+	esac
+	return 0
+}
+
+# The bulk listing is capped, so a branch older than the window needs asking for
+# by name rather than being silently called untracked.
+forge_branch_state_one() {
+	case "$FORGE" in
+	github)
+		(cd "$REPO" && GH_HOST="$GH_HOSTNAME" gh pr list --head "$1" --state all --limit 10 \
+			--json headRefName,number,state 2>/dev/null) |
+			jq -r '.[] | [.headRefName, (.state | ascii_downcase), ("#" + (.number | tostring))] | @tsv' || true
+		;;
+	gitlab)
+		(cd "$REPO" && GITLAB_HOST="$GITLAB_HOSTNAME" \
+			glab api "projects/:fullpath/merge_requests?source_branch=$1&state=all" 2>/dev/null) |
+			jq -r 'if type == "array" then .[] else empty end
+				| [.source_branch, .state, ("!" + (.iid | tostring))] | @tsv' || true
+		;;
+	esac
+	return 0
+}
+
+# A branch may carry several changes over its life. Merged wins: one merged
+# change means the work landed, whatever was closed alongside it.
+best_state_for() {
+	local branch="$1" rows name state ref
+	local open_ref="" closed_ref=""
+	rows=$(printf '%s\n' "$2" | grep -F "$branch	" || true)
+	if [[ -z "$rows" ]]; then
+		printf ''
+		return 0
 	fi
-	if merged_tree=$(git_in merge-tree --write-tree "$BASE" "$1" 2>/dev/null); then
-		if [[ "$merged_tree" == "$base_tree" ]]; then
+	while IFS=$'\t' read -r name state ref; do
+		[[ "$name" == "$branch" ]] || continue
+		case "$state" in
+		merged)
+			printf 'merged\t%s' "$ref"
 			return 0
-		fi
-		return 1
+			;;
+		# GitHub says OPEN, GitLab says opened; merged and closed coincide.
+		open | opened | locked) [[ -n "$open_ref" ]] || open_ref="$ref" ;;
+		closed) [[ -n "$closed_ref" ]] || closed_ref="$ref" ;;
+		esac
+	done <<<"$rows"
+	if [[ -n "$open_ref" ]]; then
+		printf 'opened\t%s' "$open_ref"
+	elif [[ -n "$closed_ref" ]]; then
+		printf 'closed\t%s' "$closed_ref"
 	fi
-
-	# Older git has no --write-tree. Comparing only the files the branch touched
-	# keeps the default branch's unrelated progress out of the answer.
-	if ! merge_base=$(git_in merge-base "$BASE" "$1" 2>/dev/null); then
-		return 1
-	fi
-	files=$(git_in diff --name-only "$merge_base" "$1" 2>/dev/null || true)
-	if [[ -z "$files" ]]; then
-		return 0
-	fi
-	while IFS= read -r line; do
-		[[ -n "$line" ]] && paths+=("$line")
-	done <<<"$files"
-	if git_in diff --quiet "$BASE" "$1" -- "${paths[@]}" 2>/dev/null; then
-		return 0
-	fi
-	return 1
+	return 0
 }
 
 age_days() {
@@ -254,57 +293,80 @@ bound_list() {
 CHANGES=""
 CLEANUP=""
 
-change_for_branch() {
-	local head number
-	while IFS=$'\t' read -r number head _; do
-		if [[ -n "$head" && "$head" == "$1" ]]; then
-			printf '%s' "$number"
-			return 0
-		fi
-	done <<<"$CHANGES"
+# Tab counts as IFS whitespace, so `read` collapses a run of them: an empty
+# field silently shifts every later field one place left, and the reference
+# lands in the variable meant for the upstream marker. A placeholder keeps the
+# columns aligned; consumers turn it back into an empty string.
+emit_class() {
+	printf '%s\t%s\t%s\t%s\n' "$1" "$2" "${3:--}" "${4:--}"
 	return 0
 }
 
-# STATUS<TAB>BRANCH<TAB>UPSTREAM_TRACK, judged once. A caller that classified
-# inside a command substitution would lose the merged list to the subshell.
+# STATE<TAB>BRANCH<TAB>REF<TAB>TRACK, judged once. A caller that classified
+# inside a command substitution would lose the result to the subshell.
+# STATE is merged / opened / closed / none / unknown, where `none` means the
+# forge answered and has never seen a change from this branch — the genuinely
+# interesting case — and `unknown` means nobody could answer.
 classify_branches() {
-	local branch track
+	local branch track answer state ref
 	while IFS=$'\t' read -r branch track; do
 		[[ -n "$branch" ]] || continue
 		[[ "$branch" == "$DEFAULT" ]] && continue
-		if branch_is_merged "$branch"; then
-			printf 'MERGED\t%s\t%s\n' "$branch" "$track"
-		else
-			printf 'OPEN\t%s\t%s\n' "$branch" "$track"
+		if [[ -z "$FORGE" ]]; then
+			emit_class 'unknown' "$branch" '' "$track"
+			continue
 		fi
+		answer=$(best_state_for "$branch" "$FORGE_STATES")
+		if [[ -z "$answer" ]]; then
+			answer=$(best_state_for "$branch" "$(forge_branch_state_one "$branch")")
+		fi
+		if [[ -z "$answer" ]]; then
+			emit_class 'none' "$branch" '' "$track"
+			continue
+		fi
+		IFS=$'\t' read -r state ref <<<"$answer"
+		emit_class "$state" "$branch" "$ref" "$track"
 	done < <(git_in for-each-ref --format='%(refname:short)%09%(upstream:track)' refs/heads 2>/dev/null)
 	return 0
 }
 
 merged_branch_names() {
-	local status branch
-	while IFS=$'\t' read -r status branch _; do
-		[[ "$status" == "MERGED" ]] && printf ' %s' "$branch"
+	local state branch
+	while IFS=$'\t' read -r state branch _ _; do
+		[[ "$state" == "merged" ]] && printf ' %s' "$branch"
 	done <<<"$BRANCH_CLASS"
 	return 0
 }
 
+branch_is_cleanup() {
+	local state branch
+	while IFS=$'\t' read -r state branch _ _; do
+		if [[ "$branch" == "$1" && "$state" == "merged" ]]; then
+			return 0
+		fi
+	done <<<"$BRANCH_CLASS"
+	return 1
+}
+
+# Merged branches are cleanup, not unfinished work, and leave this section.
 section_branches() {
-	local status branch track ahead days change note body=""
-	while IFS=$'\t' read -r status branch track; do
-		[[ "$status" == "OPEN" ]] || continue
+	local state branch track ref ahead days note body=""
+	while IFS=$'\t' read -r state branch ref track; do
+		[[ "$ref" == "-" ]] && ref=""
+		[[ "$track" == "-" ]] && track=""
+		case "$state" in
+		opened | none | unknown) ;;
+		*) continue ;;
+		esac
 		ahead=$(git_in rev-list --count "$BASE..$branch" 2>/dev/null || printf '0')
 		days=$(age_days "$branch")
-		change=$(change_for_branch "$branch")
-		if [[ -n "$change" ]]; then
-			note="$change"
-		elif [[ -n "$FORGE" ]]; then
-			note="no MR/PR"
-		else
-			note="MR/PR unknown"
-		fi
+		case "$state" in
+		opened) note="$ref open" ;;
+		none) note="no MR/PR ever opened" ;;
+		unknown) note="state UNKNOWN — forge could not be asked" ;;
+		esac
 		if [[ "$track" == *gone* ]]; then
-			note="$note; upstream gone but content NOT merged"
+			note="$note; upstream branch deleted"
 		fi
 		body="$body$(printf ' %-9s %-34s %3sd  %3s commits  %s' 'BRANCH' "$branch" "$days" "$ahead" "$note")"$'\n'
 	done <<<"$BRANCH_CLASS"
@@ -312,8 +374,20 @@ section_branches() {
 	return 0
 }
 
-# A dirty worktree is called out because removing one destroys the uncommitted
-# and untracked files in it; the branch ref does not carry them.
+# A change closed without merging is a decision, not an oversight. It reads
+# differently from work nobody ever opened, so it gets its own row.
+section_abandoned() {
+	local state branch track ref days body=""
+	while IFS=$'\t' read -r state branch ref track; do
+		[[ "$state" == "closed" ]] || continue
+		[[ "$ref" == "-" ]] && ref=""
+		days=$(age_days "$branch")
+		body="$body$(printf ' %-9s %-34s %3sd  %s closed without merging' 'ABANDONED' "$branch" "$days" "$ref")"$'\n'
+	done <<<"$BRANCH_CLASS"
+	printf '%s' "$body"
+	return 0
+}
+
 section_worktrees() {
 	local path branch modified untracked state body=""
 	while IFS= read -r line; do
@@ -334,6 +408,8 @@ section_worktrees() {
 			untracked=$(git -C "$path" status --porcelain 2>/dev/null | grep -c '^??' || true)
 			if [[ "$modified" -gt 0 || "$untracked" -gt 0 ]]; then
 				state=$(printf 'DIRTY %s modified, %s untracked — do NOT remove' "$modified" "$untracked")
+			elif [[ -n "$branch" ]] && branch_is_cleanup "$branch"; then
+				state="clean; branch already merged — cleanup"
 			else
 				state="clean"
 			fi
@@ -403,7 +479,7 @@ count_lines() {
 }
 
 report_repo() {
-	local branches worktrees changes issues plans total
+	local branches abandoned worktrees changes issues plans total
 
 	DEFAULT="$(default_branch)"
 	BASE="$(base_ref "$DEFAULT")"
@@ -417,30 +493,37 @@ report_repo() {
 	if [[ -n "$PLAN_GATE" ]]; then
 		PLAN_ROWS="$("$PLAN_GATE" --repo "$REPO" --tsv 2>/dev/null | grep '^OPEN	' || true)"
 	fi
+	FORGE_STATES=""
+	if [[ -n "$FORGE" ]]; then
+		FORGE_STATES="$(forge_branch_states)"
+	fi
 	BRANCH_CLASS="$(classify_branches)"
 	CLEANUP="$(merged_branch_names)"
 
 	branches="$(section_branches)"
+	abandoned="$(section_abandoned)"
 	worktrees="$(section_worktrees)"
 	changes="$(section_changes)"
 	issues="$(section_issues)"
 	plans="$(section_plans)"
 
-	total=$(($(count_lines "$branches") + $(count_lines "$worktrees") +
+	total=$(($(count_lines "$branches") + $(count_lines "$abandoned") + $(count_lines "$worktrees") +
 		$(count_lines "$CHANGES") + $(count_lines "$ISSUES") + $(count_lines "$plans")))
 
 	printf '%s — %d half-done\n' "${REPO##*/}" "$total"
 	emit_bounded 'branch(es)' "$branches"
+	emit_bounded 'abandoned branch(es)' "$abandoned"
 	emit_bounded 'worktree(s)' "$worktrees"
 	emit_bounded 'change(s)' "$changes"
 	emit_bounded 'issue line(s)' "$issues"
 	emit_bounded 'plan(s)' "$plans"
 
 	if [[ -n "$CLEANUP" ]]; then
-		printf ' %-9s %s\n' 'MERGED' "$(bound_list "$CLEANUP") — content already on $DEFAULT; safe to delete"
+		printf ' %-9s %s\n' 'MERGED' "$(bound_list "$CLEANUP") — merged on the forge; cleanup, not unfinished work"
 	fi
 	if [[ -n "$FORGE_NOTE" ]]; then
 		printf ' %-9s %s\n' 'NOTE' "$FORGE_NOTE"
+		printf ' %-9s %s\n' 'NOTE' 'branch state is DEGRADED: only the forge can tell a squash-merged branch from an unfinished one, so no branch above is known to be outstanding'
 	fi
 	if [[ -z "$PLAN_GATE" ]]; then
 		printf ' %-9s %s\n' 'NOTE' 'plan-gate not found beside this tool — plans not checked'

--- a/scripts/check-test-slices.ts
+++ b/scripts/check-test-slices.ts
@@ -86,6 +86,11 @@ export const TEST_SLICES = {
     'tests/review-profile.test.ts',
   ],
   session: ['tests/session/agent-session.test.ts', 'tests/session/install-session-slice.test.ts'],
+  wip: [
+    'tests/wip/plan-gate.test.ts',
+    'tests/wip/plan-police.test.ts',
+    'tests/wip/wip.test.ts',
+  ],
 } as const;
 
 export type TestSlice = keyof typeof TEST_SLICES;

--- a/scripts/sync-cc-plugin.sh
+++ b/scripts/sync-cc-plugin.sh
@@ -173,8 +173,7 @@ echo "[sync] kit plugins -> .claude-plugin/marketplace.json"
 
 # Portable tools used by bundled hooks. Keep this allowlist explicit: other
 # top-level tools are not necessarily plugin-facing commands.
-# shellcheck disable=SC2043 # One entry today; the allowlist is the point, not the loop.
-for tool in bounded-run; do
+for tool in bounded-run plan-gate wip; do
 	cp "$REPO_DIR/tools/$tool" "$PLUGIN_DIR/tools/$tool"
 	chmod +x "$PLUGIN_DIR/tools/$tool"
 done

--- a/skills/wip/SKILL.md
+++ b/skills/wip/SKILL.md
@@ -25,26 +25,29 @@ wip --no-forge            # git and plans only, no network
 
 ```
 neutron — 9 half-done
- BRANCH    fix/voice-truncate-275    5d    3 commits  no MR/PR
- WORKTREE  wt/corename2              DIRTY 11 modified, 2 untracked — do NOT remove at ~/wt/corename2
- MR/PR     !628 (fix/voice)          held: no approving review
+ BRANCH    feat/incidents-ui           0d    1 commits  !633 open
+ BRANCH    fix/core-name-everywhere    7d    0 commits  no MR/PR ever opened
+ ABANDONED feat/model-catalog-auto     5d   !492 closed without merging
+ WORKTREE  wt/corename2                DIRTY 11 modified, 2 untracked — do NOT remove at ~/wt/corename2
+ MR/PR     !628 (fix/voice)            held: no approving review
  FILED     #311 #312 — authored, open, unfixed
  DEFERRED  #313 — carved out of other work
- PLAN      plans/057.md              2 gap(s) unclosed
- MERGED    fix/old — content already on main; safe to delete
+ PLAN      plans/057.md                2 gap(s) unclosed
+ MERGED    fix/old — merged on the forge; cleanup, not unfinished work
  NOTE      unrecognised forge host 'git.example.com' — merge requests and issues not checked
 ```
 
-| Row        | Means                                                                        |
-| ---------- | ---------------------------------------------------------------------------- |
-| `BRANCH`   | content is not on the default branch yet                                     |
-| `WORKTREE` | a checkout that still exists; `DIRTY` ones hold work no branch ref will save |
-| `MR/PR`    | open and authored by you, with what stands between it and merging            |
-| `FILED`    | issues you opened that are still open                                        |
-| `DEFERRED` | filed issues whose text says they were carved out of other work              |
-| `PLAN`     | a plan whose gaps section lists work that is neither closed nor tracked      |
-| `MERGED`   | branches whose content already landed — cleanup, not work                    |
-| `NOTE`     | something that was **not** checked, and why                                  |
+| Row         | Means                                                                        |
+| ----------- | ---------------------------------------------------------------------------- |
+| `BRANCH`    | an open change, or none ever opened, or state unknown                        |
+| `ABANDONED` | a change closed without merging — a decision, not an oversight               |
+| `WORKTREE`  | a checkout that still exists; `DIRTY` ones hold work no branch ref will save |
+| `MR/PR`     | open and authored by you, with what stands between it and merging            |
+| `FILED`     | issues you opened that are still open                                        |
+| `DEFERRED`  | filed issues whose text says they were carved out of other work              |
+| `PLAN`      | a plan whose gaps section lists work neither closed nor tracked              |
+| `MERGED`    | merged on the forge — cleanup, not unfinished work                           |
+| `NOTE`      | something that was **not** checked, and why                                  |
 
 A `NOTE` row is the important one. An absent section means "nothing found";
 a `NOTE` means "not looked at". They are never conflated, and a bounded list
@@ -55,21 +58,33 @@ always says how many entries it dropped.
 Uncommitted and untracked files die with the checkout, and the branch ref does
 not carry them. Commit them, stash them, or leave the worktree alone.
 
-## Why merged-ness is not counted by commits
+## Whether a branch is finished is the forge's answer, not git's
 
-`git rev-list --count origin/main..branch` calls a branch ahead **forever** in a
-squash-merge repository — the squashed commit is not an ancestor of anything.
-Trusting it invents abandoned work that does not exist. Two other rules fail as
-well, both verified against a squash-merge fixture rather than assumed:
+A squash merge destroys the topological evidence by design: the squashed commit is not an ancestor
+of the branch, and the merge base stays before the squash forever.
 
-| Rule                          | Fails because                                                                                                          |
-| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `rev-list --count base..head` | a squashed branch is ahead forever                                                                                     |
-| `git diff base..head`         | the default branch's own later commits appear as deletions on yours                                                    |
-| `git diff base...head`        | answers a different question — the branch's changes since the merge base, non-empty for every branch that did anything |
+Measured against nine branches of known outcome, **every git-only rule reported all seven merged
+ones as still outstanding**:
 
-`wip` merges the branch into the default branch in memory and asks whether the
-result differs from the default branch. Nothing else survives a squash merge.
+| Rule                                    | On a squash-merged branch                                       |
+| --------------------------------------- | --------------------------------------------------------------- |
+| `rev-list --count base..head`           | ahead forever — the squash is not an ancestor                   |
+| `git diff base..head`                   | shows the default branch's own later commits as deletions       |
+| `git diff base...head`                  | shows the branch's changes since the merge base — never empty   |
+| `merge-tree --write-tree`, tree compare | correct on a small fixture, wrong once the default branch moves |
+
+The last row is the trap: it passes a two-commit fixture and fails on a real repository, because a
+fixture whose default branch has not moved cannot distinguish the case it exists to prove.
+
+So `wip` asks the forge, and distinguishes four answers that mean different things:
+
+- **merged** — cleanup, not unfinished work
+- **closed without merging** — deliberately abandoned, which reads differently from forgotten
+- **open** — in flight
+- **no change ever opened** — the genuinely interesting one
+
+**When the forge cannot answer, it says so and stops.** There is no local rule to fall back to, and
+guessing loudly in the alarming direction is how a tool like this gets ignored.
 
 ## Plans: when a plan may be called done
 

--- a/skills/wip/SKILL.md
+++ b/skills/wip/SKILL.md
@@ -24,17 +24,18 @@ wip --no-forge            # git and plans only, no network
 ## Reading the output
 
 ```
-neutron — 9 half-done
- BRANCH    feat/incidents-ui           0d    1 commits  !633 open
- BRANCH    fix/core-name-everywhere    7d    0 commits  no MR/PR ever opened
- ABANDONED feat/model-catalog-auto     5d   !492 closed without merging
+neutron — 4 unfinished branch(es)
+ BRANCH    feat/incidents-ui           0d   1 commits  !633 open
+ BRANCH    fix/core-name-everywhere    7d   0 commits  no MR/PR ever opened
+ ABANDONED feat/model-catalog-auto     5d  !492 closed without merging
  WORKTREE  wt/corename2                DIRTY 11 modified, 2 untracked — do NOT remove at ~/wt/corename2
- MR/PR     !628 (fix/voice)            held: no approving review
+ MR/PR     !633 (feat/incidents-ui)    held: no approving review
  FILED     #311 #312 — authored, open, unfixed
  DEFERRED  #313 — carved out of other work
  PLAN      plans/057.md                2 gap(s) unclosed
+ COUNTS    1 abandoned · 20 worktree(s) · 2 open change(s) · 100 filed issue(s) · 1 plan(s) with gaps
+ NOTE      20 branch(es) hidden: nothing committed, no worktree, no change ever opened
  MERGED    fix/old — merged on the forge; cleanup, not unfinished work
- NOTE      unrecognised forge host 'git.example.com' — merge requests and issues not checked
 ```
 
 | Row         | Means                                                                        |
@@ -47,11 +48,31 @@ neutron — 9 half-done
 | `DEFERRED`  | filed issues whose text says they were carved out of other work              |
 | `PLAN`      | a plan whose gaps section lists work neither closed nor tracked              |
 | `MERGED`    | merged on the forge — cleanup, not unfinished work                           |
-| `NOTE`      | something that was **not** checked, and why                                  |
+| `COUNTS`    | the other kinds of outstanding thing, broken out rather than summed          |
+| `NOTE`      | something that was **not** checked or was hidden, and why                    |
 
 A `NOTE` row is the important one. An absent section means "nothing found";
 a `NOTE` means "not looked at". They are never conflated, and a bounded list
 always says how many entries it dropped.
+
+## What the headline counts, and what is hidden
+
+The headline is **unfinished branches only**. Branches, worktrees, issues and plan gaps are four
+different kinds of thing with four different remedies, so summing them into one number gives a
+figure nobody can act on. The rest are broken out on the `COUNTS` line.
+
+A branch is hidden when **nothing was committed, no worktree is checked out on it, and no change
+was ever opened**. Nothing was started, so there is nothing to finish. On one real repository that
+removed 20 of 41 branches — all created by a worktree harness — and took the headline from a
+meaningless 150 to an actionable 4.
+
+The test is structural, never by name. A `worktree-agent-*` pattern would look tidier and is worse:
+it would hide such a branch that _does_ carry commits, which is real unfinished work. Having commits
+disqualifies a branch from being hidden, so this rule cannot make that mistake. Nor can it hide the
+case that matters most — a branch with no commits but a **dirty worktree**, where uncommitted work
+actually lives; the worktree keeps it visible.
+
+Whatever is hidden is counted and stated in a `NOTE`. Silent omission reads as "nothing else to see".
 
 ## Never remove a DIRTY worktree
 

--- a/skills/wip/SKILL.md
+++ b/skills/wip/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: wip
+description: >-
+  Report what was started and not finished in a repository — unmerged branches,
+  dirty worktrees, open merge requests and what holds them, open issues you
+  filed, and plans whose own gaps section still lists untracked work. Read-only;
+  it changes nothing. Use when asked "what is half done", "what did I leave
+  unfinished", "what is still open", "status of my work", "anything abandoned",
+  before picking up work after a break, and before calling a plan finished.
+---
+
+# wip
+
+Answers one question — _what did I start and not finish?_ — from the repository
+rather than from an agent's recollection of what it did.
+
+```
+wip                       # this repository
+wip ~/code/a ~/code/b     # several, one block each
+wip --limit 0             # no bounding
+wip --no-forge            # git and plans only, no network
+```
+
+## Reading the output
+
+```
+neutron — 9 half-done
+ BRANCH    fix/voice-truncate-275    5d    3 commits  no MR/PR
+ WORKTREE  wt/corename2              DIRTY 11 modified, 2 untracked — do NOT remove at ~/wt/corename2
+ MR/PR     !628 (fix/voice)          held: no approving review
+ FILED     #311 #312 — authored, open, unfixed
+ DEFERRED  #313 — carved out of other work
+ PLAN      plans/057.md              2 gap(s) unclosed
+ MERGED    fix/old — content already on main; safe to delete
+ NOTE      unrecognised forge host 'git.example.com' — merge requests and issues not checked
+```
+
+| Row        | Means                                                                        |
+| ---------- | ---------------------------------------------------------------------------- |
+| `BRANCH`   | content is not on the default branch yet                                     |
+| `WORKTREE` | a checkout that still exists; `DIRTY` ones hold work no branch ref will save |
+| `MR/PR`    | open and authored by you, with what stands between it and merging            |
+| `FILED`    | issues you opened that are still open                                        |
+| `DEFERRED` | filed issues whose text says they were carved out of other work              |
+| `PLAN`     | a plan whose gaps section lists work that is neither closed nor tracked      |
+| `MERGED`   | branches whose content already landed — cleanup, not work                    |
+| `NOTE`     | something that was **not** checked, and why                                  |
+
+A `NOTE` row is the important one. An absent section means "nothing found";
+a `NOTE` means "not looked at". They are never conflated, and a bounded list
+always says how many entries it dropped.
+
+## Never remove a DIRTY worktree
+
+Uncommitted and untracked files die with the checkout, and the branch ref does
+not carry them. Commit them, stash them, or leave the worktree alone.
+
+## Why merged-ness is not counted by commits
+
+`git rev-list --count origin/main..branch` calls a branch ahead **forever** in a
+squash-merge repository — the squashed commit is not an ancestor of anything.
+Trusting it invents abandoned work that does not exist. Two other rules fail as
+well, both verified against a squash-merge fixture rather than assumed:
+
+| Rule                          | Fails because                                                                                                          |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `rev-list --count base..head` | a squashed branch is ahead forever                                                                                     |
+| `git diff base..head`         | the default branch's own later commits appear as deletions on yours                                                    |
+| `git diff base...head`        | answers a different question — the branch's changes since the merge base, non-empty for every branch that did anything |
+
+`wip` merges the branch into the default branch in memory and asks whether the
+result differs from the default branch. Nothing else survives a squash merge.
+
+## Plans: when a plan may be called done
+
+A plan's gaps section is the most honest record of what is outstanding. A gap
+stops blocking when the author does one of two things they would do anyway:
+
+- **tick it** — `- [x] …`, or strike it through (`- ~~no longer applies~~`)
+- **name the issue that carries it** — `#123`, `!123`, or an issue/MR/PR URL,
+  on the gap's own line or a sub-bullet under it
+
+A bare bullet with neither is what the gate refuses: work stated in the plan,
+with nothing anywhere that will bring it back.
+
+```
+plan-gate                       # every plan under this repository
+plan-gate --all --tsv           # machine-readable, closed and tracked included
+plan-gate --require-done        # only judge plans that claim to be done
+```
+
+`plan-police` runs the same checker on every edit that marks a plan done, and
+refuses the edit while such a gap stands. Filing the issue and pasting its number
+is the fix; `AGENTKIT_SKIP_HOOKS=plan-police` records a deliberate exception.
+
+## Configuration
+
+Plan layout varies, so nothing about it is hardcoded. Defaults are `plans/`,
+`docs/plans/`, `doc/plans/`, `.omc/plans/`, `PLAN.md` and `PLANS.md`, and a
+`wip:` section in `~/.config/agentkit/config.yaml` — or the repository's own
+`.agentkit/config.yaml`, which wins — replaces them.
+
+```yaml
+wip:
+  plan-paths:
+    - design/decisions
+  gap-headings: "known gaps|loose ends|snags"
+  done-markers: "^[[:space:]]*status[[:space:]]*:[[:space:]]*(done|shipped)"
+  issue-refs: "#[0-9]+|![0-9]+|[A-Z][A-Z0-9]+-[0-9]+"
+```
+
+`issue-refs` is where a Jira shop adds `PROJ-123`. It is not on by default:
+nothing distinguishes a Jira key from a hex digest or a UTF-8 label, and a false
+"tracked" loses the gap silently — the one direction this tool must not fail in.
+
+## Forges
+
+GitHub and GitLab both work, resolved per repository from its `origin` host —
+including self-hosted instances, via `gh auth status` and the GitLab version
+endpoint. A repository with neither CLI still reports branches, worktrees and
+plans, and says in a `NOTE` what it could not check.

--- a/tests/agentkit-plugin.test.ts
+++ b/tests/agentkit-plugin.test.ts
@@ -101,8 +101,10 @@ const PRE_TOOL_USE_HOOKS = [
   'mr-police.sh',
   'resource-police.sh',
 ];
+// Not a Bash gate: it judges the content an Edit or Write is about to land.
+const PRE_TOOL_USE_WRITE_HOOKS = ['plan-police.sh'];
 const POST_TOOL_USE_HOOKS = ['format-police.sh', 'coding-police.sh', 'comment-police.sh'];
-const ALL_POLICE_HOOKS = [...PRE_TOOL_USE_HOOKS, ...POST_TOOL_USE_HOOKS];
+const ALL_POLICE_HOOKS = [...PRE_TOOL_USE_HOOKS, ...PRE_TOOL_USE_WRITE_HOOKS, ...POST_TOOL_USE_HOOKS];
 // The merge gate is consent-gated: it ships in agentkit-adversarial-review, never in core.
 const REVIEW_HOOKS = ['fail-closed-hook.sh', 'review-police.sh'];
 const MEMORY_HOOKS = ['brain-index.sh', 'brain-inject.sh'];
@@ -163,18 +165,21 @@ describe('agentkit plugin hooks', () => {
   test('hooks.json wires exactly the police hooks under ${CLAUDE_PLUGIN_ROOT}', () => {
     const hooks = readJson('hooks', 'hooks.json').hooks;
 
-    // One Bash block: the merge-shaped matcher exists only to reach
-    // review-police, so it leaves with it.
-    expect(hooks.PreToolUse).toHaveLength(1);
+    // Two blocks: the Bash gates, and the write gates that judge file content.
+    // The merge-shaped matcher exists only to reach review-police, so it leaves
+    // with it.
+    expect(hooks.PreToolUse).toHaveLength(2);
     expect(hooks.PreToolUse[0].matcher).toBe('Bash');
     expect(commandBasenames(hooks.PreToolUse[0].hooks).sort()).toEqual([...PRE_TOOL_USE_HOOKS].sort());
+    expect(hooks.PreToolUse[1].matcher).toBe('Edit|Write');
+    expect(commandBasenames(hooks.PreToolUse[1].hooks).sort()).toEqual([...PRE_TOOL_USE_WRITE_HOOKS].sort());
 
     expect(hooks.PostToolUse).toHaveLength(1);
     expect(hooks.PostToolUse[0].matcher).toBe('Edit|Write');
     expect(commandBasenames(hooks.PostToolUse[0].hooks).sort()).toEqual([...POST_TOOL_USE_HOOKS].sort());
 
     // Every command must resolve inside the plugin, never a ~/.claude path.
-    const allEntries = [...hooks.PreToolUse[0].hooks, ...hooks.PostToolUse[0].hooks];
+    const allEntries = [...hooks.PreToolUse.flatMap((group: any) => group.hooks), ...hooks.PostToolUse[0].hooks];
     for (const entry of allEntries) {
       expect(entry.command).toStartWith('${CLAUDE_PLUGIN_ROOT}/hooks/');
       expect(entry.command).not.toContain('.claude/hooks');
@@ -198,7 +203,8 @@ describe('agentkit plugin hooks', () => {
   test('every referenced police script exists and is executable', () => {
     // hooks.json must reference these and they must be present + runnable.
     const referenced = new Set(
-      readJson('hooks', 'hooks.json').hooks.PreToolUse[0].hooks
+      readJson('hooks', 'hooks.json').hooks.PreToolUse
+        .flatMap((group: { hooks: { command: string }[] }) => group.hooks)
         .concat(readJson('hooks', 'hooks.json').hooks.PostToolUse[0].hooks)
         .map((entry: { command: string }) => basename(entry.command)),
     );

--- a/tests/install-hooks.test.ts
+++ b/tests/install-hooks.test.ts
@@ -146,9 +146,11 @@ describe('Claude Code and Codex hook wiring', () => {
       // The canonical file carries the whole wiring; a default install ships it
       // minus the kit-owned hooks: the review gate leaves the Bash kit and takes
       // the merge-shaped matcher kit with it, the brain hooks leave PostToolUse
-      // and take the SessionStart kit with them.
-      expect(canonical.hooks.PreToolUse).toHaveLength(2);
-      expect(settings.hooks.PreToolUse.map((kit: any) => kit.matcher)).toEqual(['Bash']);
+      // and take the SessionStart kit with them. The write-gate kit is core and
+      // stays.
+      expect(canonical.hooks.PreToolUse).toHaveLength(3);
+      expect(settings.hooks.PreToolUse.map((kit: any) => kit.matcher)).toEqual(['Bash', 'Edit|Write']);
+      expect(commandNames(settings.hooks.PreToolUse[1].hooks)).toEqual(['plan-police.sh']);
       expect(commandNames(settings.hooks.PreToolUse[0].hooks)).toEqual(
         commandNames(canonical.hooks.PreToolUse[0].hooks).filter(
           (name) => name !== 'review-police.sh',

--- a/tests/wip/fixture.ts
+++ b/tests/wip/fixture.ts
@@ -1,4 +1,4 @@
-import { chmodSync, mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, mkdtempSync, realpathSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -12,9 +12,14 @@ export interface Sandbox {
   binDir: string;
 }
 
-/** A temporary HOME, so no tool under test reads the developer's real config. */
+/**
+ * A temporary HOME, so no tool under test reads the developer's real config.
+ * The root is resolved through symlinks: macOS reaches every temporary
+ * directory via /var -> /private/var, and git reports the resolved form, so an
+ * unresolved fixture path compares unequal to everything the tools produce.
+ */
 export function makeSandbox(prefix: string): Sandbox {
-  const root = mkdtempSync(join(tmpdir(), prefix));
+  const root = realpathSync(mkdtempSync(join(tmpdir(), prefix)));
   const home = join(root, 'home');
   const binDir = join(root, 'bin');
   mkdirSync(home, { recursive: true });

--- a/tests/wip/fixture.ts
+++ b/tests/wip/fixture.ts
@@ -1,0 +1,119 @@
+import { chmodSync, mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+export const repoRoot = dirname(dirname(import.meta.dir));
+export const toolTimeoutMs = 20_000;
+
+export interface Sandbox {
+  root: string;
+  home: string;
+  binDir: string;
+}
+
+/** A temporary HOME, so no tool under test reads the developer's real config. */
+export function makeSandbox(prefix: string): Sandbox {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  const home = join(root, 'home');
+  const binDir = join(root, 'bin');
+  mkdirSync(home, { recursive: true });
+  mkdirSync(binDir, { recursive: true });
+  return { root, home, binDir };
+}
+
+export function sandboxEnv(box: Sandbox, overrides: Record<string, string> = {}) {
+  return {
+    ...process.env,
+    HOME: box.home,
+    XDG_CONFIG_HOME: join(box.home, '.config'),
+    PATH: `${box.binDir}:${process.env.PATH ?? '/usr/bin:/bin'}`,
+    GIT_CONFIG_GLOBAL: join(box.home, '.gitconfig'),
+    GIT_CONFIG_SYSTEM: '/dev/null',
+    ...overrides,
+  };
+}
+
+/**
+ * A PATH holding only the named binaries. "gh is missing" is only an honest
+ * probe when the runtime genuinely cannot find it — a shim that fails tests a
+ * failing tool, which is a different assertion.
+ */
+export function restrictedPath(box: Sandbox, names: string[]): string {
+  const dir = join(box.root, 'restricted-bin');
+  mkdirSync(dir, { recursive: true });
+  for (const name of names) {
+    const found = spawnSync('sh', ['-c', `command -v ${name}`], { encoding: 'utf8' });
+    if (found.status !== 0) throw new Error(`fixture needs ${name} on PATH`);
+    symlinkSync(found.stdout.trim(), join(dir, name));
+  }
+  return dir;
+}
+
+export function writeExecutable(path: string, content: string): void {
+  writeFileSync(path, content);
+  chmodSync(path, 0o755);
+}
+
+export function run(argv: string[], box: Sandbox, cwd: string, overrides: Record<string, string> = {}) {
+  return spawnSync(argv[0], argv.slice(1), {
+    encoding: 'utf8',
+    cwd,
+    env: sandboxEnv(box, overrides),
+    timeout: toolTimeoutMs,
+  });
+}
+
+export function git(repo: string, box: Sandbox, ...args: string[]) {
+  const result = spawnSync('git', ['-C', repo, ...args], {
+    encoding: 'utf8',
+    env: sandboxEnv(box, {
+      GIT_AUTHOR_NAME: 'Fixture',
+      GIT_AUTHOR_EMAIL: 'fixture@example.invalid',
+      GIT_COMMITTER_NAME: 'Fixture',
+      GIT_COMMITTER_EMAIL: 'fixture@example.invalid',
+    }),
+    timeout: toolTimeoutMs,
+  });
+  if (result.status !== 0) {
+    throw new Error(`git ${args.join(' ')} failed: ${result.stderr || result.stdout}`);
+  }
+  return result;
+}
+
+export function commitFile(repo: string, box: Sandbox, name: string, body: string, message: string): void {
+  const path = join(repo, name);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, body);
+  git(repo, box, 'add', name);
+  git(repo, box, 'commit', '-q', '-m', message);
+}
+
+/**
+ * A clone whose default branch took a squashed copy of the branch's content.
+ * This is the shape that makes an ancestry check lie: the squashed commit is
+ * not an ancestor of the branch, so `rev-list origin/main..branch` still counts.
+ */
+export function makeSquashMergeRepo(box: Sandbox): string {
+  const repo = join(box.root, 'repo');
+  mkdirSync(repo, { recursive: true });
+  git(repo, box, 'init', '-q', '-b', 'main');
+  commitFile(repo, box, 'README.md', '# fixture\n', 'init');
+
+  git(repo, box, 'checkout', '-q', '-b', 'feat/squashed');
+  commitFile(repo, box, 'a.txt', 'one\n', 'a1');
+  commitFile(repo, box, 'a.txt', 'one\ntwo\n', 'a2');
+
+  git(repo, box, 'checkout', '-q', '-b', 'feat/unmerged', 'main');
+  commitFile(repo, box, 'b.txt', 'b\n', 'b1');
+
+  git(repo, box, 'checkout', '-q', 'main');
+  git(repo, box, 'merge', '--squash', 'feat/squashed');
+  git(repo, box, 'commit', '-q', '-m', 'squashed feat/squashed');
+
+  // A remote whose refs a real clone would have. `origin/main` is what every
+  // comparison in wip is made against.
+  git(repo, box, 'update-ref', 'refs/remotes/origin/main', 'main');
+  git(repo, box, 'remote', 'add', 'origin', 'https://forge.invalid/acme/fixture.git');
+  return repo;
+}

--- a/tests/wip/plan-gate.test.ts
+++ b/tests/wip/plan-gate.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { makeSandbox, repoRoot, sandboxEnv, type Sandbox, toolTimeoutMs } from './fixture';
@@ -235,6 +235,21 @@ describe('path matching', () => {
       });
       expect(matched.status, `${path} was discovered but not matched`).toBe(0);
     }
+  });
+
+  test('a symlinked --repo still matches its own plans', () => {
+    const repo = join(box.root, 'r4');
+    mkdirSync(join(repo, 'plans'), { recursive: true });
+    writeFileSync(join(repo, 'plans', 'p.md'), '# p\n');
+    const link = join(box.root, 'r4-link');
+    symlinkSync(repo, link);
+
+    const viaLink = spawnSync(planGate, ['--repo', link, '--matches', join(link, 'plans', 'p.md')], {
+      encoding: 'utf8',
+      env: sandboxEnv(box),
+      timeout: toolTimeoutMs,
+    });
+    expect(viaLink.status, 'a symlinked --repo stopped recognising its own plan').toBe(0);
   });
 
   test('--matches accepts a plan path that does not exist yet', () => {

--- a/tests/wip/plan-gate.test.ts
+++ b/tests/wip/plan-gate.test.ts
@@ -167,6 +167,20 @@ describe('configuration', () => {
     expect(result.stdout).toContain('repo-level heading won');
   });
 
+  test('a Jira-style key does not track a gap by default', () => {
+    const map = statuses('## Known gaps\n\n- the retry path, tracked in PROJ-123\n');
+    expect(map['the retry path, tracked in PROJ-123']).toBe('OPEN');
+  });
+
+  test('issue-refs makes a Jira-style key track a gap', () => {
+    const result = withConfig(
+      'wip:\n  issue-refs: "#[0-9]+|[A-Z][A-Z0-9]+-[0-9]+"\n',
+      '## Known gaps\n\n- the retry path, tracked in PROJ-123\n',
+    );
+    expect(result.stdout).toContain('TRACKED');
+    expect(result.stdout).toContain('PROJ-123');
+  });
+
   test('plan-paths replaces the discovered layout', () => {
     const repo = join(box.root, 'r2');
     mkdirSync(join(repo, '.agentkit'), { recursive: true });
@@ -191,6 +205,38 @@ describe('configuration', () => {
 });
 
 describe('path matching', () => {
+  // Discovery and --matches are two readers of one plan-path list. The day they
+  // disagree, plan-police silently stops covering a plan that `wip` still
+  // reports, so the invariant is asserted rather than assumed.
+  test('every plan discovery finds is also a plan --matches accepts', () => {
+    const repo = join(box.root, 'agree');
+    mkdirSync(join(repo, 'plans', 'nested', 'deeper'), { recursive: true });
+    mkdirSync(join(repo, 'docs', 'plans'), { recursive: true });
+    mkdirSync(join(repo, '.omc', 'plans'), { recursive: true });
+    writeFileSync(join(repo, 'PLAN.md'), '# root\n');
+    writeFileSync(join(repo, 'plans', 'a.md'), '# a\n');
+    writeFileSync(join(repo, 'plans', 'nested', 'b.md'), '# b\n');
+    writeFileSync(join(repo, 'plans', 'nested', 'deeper', 'c.md'), '# c\n');
+    writeFileSync(join(repo, 'docs', 'plans', 'd.md'), '# d\n');
+    writeFileSync(join(repo, '.omc', 'plans', 'e.md'), '# e\n');
+
+    const listed = spawnSync(planGate, ['--repo', repo, '--list-plans'], {
+      encoding: 'utf8',
+      env: sandboxEnv(box),
+      timeout: toolTimeoutMs,
+    }).stdout.split('\n').filter(Boolean);
+
+    expect(listed.length).toBe(6);
+    for (const path of listed) {
+      const matched = spawnSync(planGate, ['--repo', repo, '--matches', path], {
+        encoding: 'utf8',
+        env: sandboxEnv(box),
+        timeout: toolTimeoutMs,
+      });
+      expect(matched.status, `${path} was discovered but not matched`).toBe(0);
+    }
+  });
+
   test('--matches accepts a plan path that does not exist yet', () => {
     const repo = join(box.root, 'r3');
     mkdirSync(join(repo, 'plans'), { recursive: true });

--- a/tests/wip/plan-gate.test.ts
+++ b/tests/wip/plan-gate.test.ts
@@ -1,0 +1,227 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { makeSandbox, repoRoot, sandboxEnv, type Sandbox, toolTimeoutMs } from './fixture';
+
+const planGate = join(repoRoot, 'tools', 'plan-gate');
+
+let box: Sandbox;
+
+beforeEach(() => {
+  box = makeSandbox('plan-gate-');
+});
+
+afterEach(() => {
+  rmSync(box.root, { recursive: true, force: true });
+});
+
+function judge(content: string, args: string[] = [], name = '/tmp/plan.md') {
+  return spawnSync(planGate, [...args, '--stdin', name], {
+    encoding: 'utf8',
+    input: content,
+    env: sandboxEnv(box),
+    timeout: toolTimeoutMs,
+  });
+}
+
+function statuses(content: string): Record<string, string> {
+  const result = judge(content, ['--all', '--tsv']);
+  expect(result.stderr).toBe('');
+  const map: Record<string, string> = {};
+  for (const line of result.stdout.split('\n')) {
+    if (!line.trim()) continue;
+    const [status, , , text] = line.split('\t');
+    map[text] = status;
+  }
+  return map;
+}
+
+const planWithGaps = [
+  '# Plan 057 — device exec',
+  '',
+  '**Status**: Done',
+  '',
+  '## Known gaps',
+  '',
+  '- exec_mode/exec_allow have no UI — Highest-value remaining item',
+  '- [x] incident rows are written but never rendered',
+  '- ~~reflex audit double counts~~',
+  '- approval gate has no timeout, tracked in #311',
+  '- rate limiting is per-node only',
+  '',
+  '## Next steps',
+  '',
+  '- ship it',
+  '',
+].join('\n');
+
+describe('gap classification', () => {
+  test('an untracked, unticked gap blocks', () => {
+    const result = judge(planWithGaps);
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('exec_mode/exec_allow have no UI');
+    expect(result.stdout).toContain('rate limiting is per-node only');
+  });
+
+  test('a ticked, struck-through, or issue-bearing gap does not block', () => {
+    const map = statuses(planWithGaps);
+    expect(map['incident rows are written but never rendered']).toBe('CLOSED');
+    expect(map['~~reflex audit double counts~~']).toBe('CLOSED');
+    expect(map['approval gate has no timeout, tracked in #311']).toBe('TRACKED');
+    expect(map['exec_mode/exec_allow have no UI — Highest-value remaining item']).toBe('OPEN');
+  });
+
+  test('an issue named on a sub-bullet still tracks the gap above it', () => {
+    const map = statuses('## Known gaps\n\n- the retry path is unbuilt\n  - filed as #42\n');
+    expect(map['the retry path is unbuilt']).toBe('TRACKED');
+  });
+
+  test('a GitLab merge-request reference tracks a gap', () => {
+    const map = statuses('## Known gaps\n\n- the retry path is unbuilt, see !42\n');
+    expect(map['the retry path is unbuilt, see !42']).toBe('TRACKED');
+  });
+
+  test('an issue URL tracks a gap', () => {
+    const map = statuses('## Known gaps\n\n- unbuilt https://forge.invalid/a/b/-/issues/7\n');
+    expect(map['unbuilt https://forge.invalid/a/b/-/issues/7']).toBe('TRACKED');
+  });
+
+  test('items outside the gaps section are not gaps', () => {
+    const result = judge(planWithGaps, ['--all', '--tsv']);
+    expect(result.stdout).not.toContain('ship it');
+  });
+
+  test('a gaps heading inside a fenced block is sample text', () => {
+    const content = ['# P', '', '```md', '## Known gaps', '', '- a documented example gap', '```', ''].join('\n');
+    const result = judge(content);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe('');
+  });
+
+  test('a deeper subheading does not end the section', () => {
+    const content = ['## Known gaps', '', '- first', '', '### Detail', '', '- second', ''].join('\n');
+    const map = statuses(content);
+    expect(map.first).toBe('OPEN');
+    expect(map.second).toBe('OPEN');
+  });
+});
+
+describe('done gating', () => {
+  test('--require-done stays silent while the plan does not claim done', () => {
+    const inProgress = planWithGaps.replace('**Status**: Done', '**Status**: In progress');
+    const result = judge(inProgress, ['--require-done']);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe('');
+  });
+
+  test('--require-done blocks once the plan claims done', () => {
+    const result = judge(planWithGaps, ['--require-done']);
+    expect(result.status).toBe(1);
+  });
+
+  test('several spellings of done are recognised', () => {
+    for (const marker of ['Status: shipped', '**Status**: Complete', '## Status: DELIVERED']) {
+      const content = `# P\n\n${marker}\n\n## Known gaps\n\n- untracked thing\n`;
+      expect(judge(content, ['--require-done']).status).toBe(1);
+    }
+  });
+
+  test('a done plan whose gaps are all closed or tracked passes', () => {
+    const content = '# P\n\nStatus: Done\n\n## Known gaps\n\n- [x] a\n- b #12\n- ~~c~~\n';
+    expect(judge(content, ['--require-done']).status).toBe(0);
+  });
+});
+
+describe('configuration', () => {
+  function withConfig(yaml: string, planBody: string) {
+    const configDir = join(box.home, '.config', 'agentkit');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'config.yaml'), yaml);
+    return judge(planBody, ['--all', '--tsv']);
+  }
+
+  test('gap-headings can name a project-specific section', () => {
+    const body = '## Loose ends\n\n- something unfinished\n';
+    expect(judge(body, ['--tsv']).stdout).toBe('');
+    const result = withConfig('wip:\n  gap-headings: "loose ends"\n', body);
+    expect(result.stdout).toContain('something unfinished');
+  });
+
+  test('a repository config overrides the global one', () => {
+    const configDir = join(box.home, '.config', 'agentkit');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'config.yaml'), 'wip:\n  gap-headings: "loose ends"\n');
+
+    const repo = join(box.root, 'r');
+    mkdirSync(join(repo, '.agentkit'), { recursive: true });
+    mkdirSync(join(repo, 'plans'), { recursive: true });
+    writeFileSync(join(repo, '.agentkit', 'config.yaml'), 'wip:\n  gap-headings: "snags"\n');
+    writeFileSync(join(repo, 'plans', 'p.md'), '## Snags\n\n- repo-level heading won\n');
+
+    const result = spawnSync(planGate, ['--repo', repo, '--tsv'], {
+      encoding: 'utf8',
+      env: sandboxEnv(box),
+      timeout: toolTimeoutMs,
+    });
+    expect(result.stdout).toContain('repo-level heading won');
+  });
+
+  test('plan-paths replaces the discovered layout', () => {
+    const repo = join(box.root, 'r2');
+    mkdirSync(join(repo, '.agentkit'), { recursive: true });
+    mkdirSync(join(repo, 'design'), { recursive: true });
+    writeFileSync(join(repo, '.agentkit', 'config.yaml'), 'wip:\n  plan-paths:\n    - design\n');
+    writeFileSync(join(repo, 'design', 'd.md'), '## Known gaps\n\n- found via plan-paths\n');
+
+    const listed = spawnSync(planGate, ['--repo', repo, '--list-plans'], {
+      encoding: 'utf8',
+      env: sandboxEnv(box),
+      timeout: toolTimeoutMs,
+    });
+    expect(listed.stdout).toContain('design/d.md');
+
+    const result = spawnSync(planGate, ['--repo', repo, '--tsv'], {
+      encoding: 'utf8',
+      env: sandboxEnv(box),
+      timeout: toolTimeoutMs,
+    });
+    expect(result.stdout).toContain('found via plan-paths');
+  });
+});
+
+describe('path matching', () => {
+  test('--matches accepts a plan path that does not exist yet', () => {
+    const repo = join(box.root, 'r3');
+    mkdirSync(join(repo, 'plans'), { recursive: true });
+    const yes = spawnSync(planGate, ['--repo', repo, '--matches', join(repo, 'plans', 'unwritten.md')], {
+      encoding: 'utf8',
+      env: sandboxEnv(box),
+      timeout: toolTimeoutMs,
+    });
+    expect(yes.status).toBe(0);
+    const no = spawnSync(planGate, ['--repo', repo, '--matches', join(repo, 'README.md')], {
+      encoding: 'utf8',
+      env: sandboxEnv(box),
+      timeout: toolTimeoutMs,
+    });
+    expect(no.status).toBe(1);
+  });
+});
+
+describe('reporting', () => {
+  test('an unreadable target is a fault, not a clean plan', () => {
+    const result = spawnSync(planGate, [join(box.root, 'missing.md')], {
+      encoding: 'utf8',
+      env: sandboxEnv(box),
+      timeout: toolTimeoutMs,
+    });
+    expect(result.status).toBe(3);
+  });
+
+  test('a long gap line says it was truncated', () => {
+    const long = 'x'.repeat(400);
+    const result = judge(`## Known gaps\n\n- ${long}\n`);
+    expect(result.stdout).toContain('truncated for display');
+  });
+});

--- a/tests/wip/plan-police.test.ts
+++ b/tests/wip/plan-police.test.ts
@@ -95,6 +95,19 @@ describe('the gate', () => {
     expect(reason).not.toContain('approval timeout');
   });
 
+  test('every reference form the refusal offers actually unblocks the edit', () => {
+    const { reason } = ask(deployedHook(), edit());
+    const offered = [...reason.matchAll(/`([^`]+)`/g)]
+      .map((match) => match[1])
+      .filter((form) => /\d/.test(form) && !form.startsWith('- ['));
+
+    expect(offered.length).toBeGreaterThan(0);
+    for (const form of offered) {
+      writeFileSync(plan, `# P — x\n\n**Status**: In progress\n\n## Known gaps\n\n- a gap, see ${form}\n`);
+      expect(ask(deployedHook(), edit()).verdict, `${form} was offered as a fix`).toBe('allow');
+    }
+  });
+
   test('an edit that does not claim done is left alone', () => {
     const { verdict } = ask(deployedHook(), edit({ old_string: 'device exec', new_string: 'device execution' }));
     expect(verdict).toBe('allow');

--- a/tests/wip/plan-police.test.ts
+++ b/tests/wip/plan-police.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { copyFileSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { git, makeSandbox, repoRoot, sandboxEnv, type Sandbox, toolTimeoutMs, writeExecutable } from './fixture';
+
+const sourceHook = join(repoRoot, 'hooks', 'claude', 'plan-police.sh');
+const sourceLib = join(repoRoot, 'hooks', 'claude', 'lib', 'hook-input.sh');
+const sourceGate = join(repoRoot, 'tools', 'plan-gate');
+
+let box: Sandbox;
+let repo: string;
+let plan: string;
+
+/**
+ * install.sh copies hooks into a flat directory beside tools/, which is one
+ * level shallower than the source tree. Exercising the source layout alone
+ * would never load the hook the way a user runs it.
+ */
+function deployedHook(withGate = true): string {
+  const root = join(box.root, 'deployed');
+  mkdirSync(join(root, 'hooks', 'lib'), { recursive: true });
+  mkdirSync(join(root, 'tools'), { recursive: true });
+  const hook = join(root, 'hooks', 'plan-police.sh');
+  writeExecutable(hook, readFileSync(sourceHook, 'utf8'));
+  copyFileSync(sourceLib, join(root, 'hooks', 'lib', 'hook-input.sh'));
+  if (withGate) writeExecutable(join(root, 'tools', 'plan-gate'), readFileSync(sourceGate, 'utf8'));
+  return hook;
+}
+
+function ask(hook: string, payload: unknown, overrides: Record<string, string> = {}) {
+  const result = spawnSync(hook, [], {
+    encoding: 'utf8',
+    input: JSON.stringify(payload),
+    cwd: repo,
+    env: sandboxEnv(box, overrides),
+    timeout: toolTimeoutMs,
+  });
+  expect(result.status).toBe(0);
+  const decision = result.stdout.trim()
+    ? (JSON.parse(result.stdout) as { hookSpecificOutput?: { permissionDecision?: string }; reason?: string })
+    : null;
+  return {
+    verdict: decision?.hookSpecificOutput?.permissionDecision ?? (decision ? 'advise' : 'allow'),
+    reason: decision?.reason ?? result.stdout,
+  };
+}
+
+// An em dash in the title is deliberate: jq's string `index` counts bytes while
+// slicing counts codepoints, so a naive reconstruction silently corrupts the
+// file from the first multibyte character onward.
+const PLAN_BODY = [
+  '# Plan 057 — device exec',
+  '',
+  '**Status**: In progress',
+  '',
+  '## Known gaps',
+  '',
+  '- exec_mode/exec_allow have no UI — highest-value remaining item',
+  '- approval timeout, tracked in #311',
+  '',
+].join('\n');
+
+beforeEach(() => {
+  box = makeSandbox('plan-police-');
+  repo = join(box.root, 'repo');
+  mkdirSync(join(repo, 'plans'), { recursive: true });
+  git(repo, box, 'init', '-q', '-b', 'main');
+  plan = join(repo, 'plans', '057.md');
+  writeFileSync(plan, PLAN_BODY);
+});
+
+afterEach(() => {
+  rmSync(box.root, { recursive: true, force: true });
+});
+
+const markDone = {
+  tool_name: 'Edit',
+  tool_input: { file_path: '', old_string: '**Status**: In progress', new_string: '**Status**: Done' },
+};
+
+function edit(overrides: Record<string, unknown> = {}) {
+  return { ...markDone, tool_input: { ...markDone.tool_input, file_path: plan, ...overrides } };
+}
+
+describe('the gate', () => {
+  test('an edit that marks a plan done while a gap is untracked is refused', () => {
+    const { verdict, reason } = ask(deployedHook(), edit());
+    expect(verdict).toBe('deny');
+    expect(reason).toContain('exec_mode/exec_allow have no UI');
+  });
+
+  test('the refusal names the gap but not the ones already tracked', () => {
+    const { reason } = ask(deployedHook(), edit());
+    expect(reason).not.toContain('approval timeout');
+  });
+
+  test('an edit that does not claim done is left alone', () => {
+    const { verdict } = ask(deployedHook(), edit({ old_string: 'device exec', new_string: 'device execution' }));
+    expect(verdict).toBe('allow');
+  });
+
+  test('a plan whose gaps are all closed or tracked may be marked done', () => {
+    writeFileSync(plan, '# P — x\n\n**Status**: In progress\n\n## Known gaps\n\n- [x] a\n- b #12\n- ~~c~~\n');
+    expect(ask(deployedHook(), edit()).verdict).toBe('allow');
+  });
+
+  test('an edit that closes the gap in the same breath is allowed', () => {
+    const payload = {
+      tool_name: 'MultiEdit',
+      tool_input: {
+        file_path: plan,
+        edits: [
+          { old_string: 'have no UI — highest-value remaining item', new_string: 'have no UI, filed as #999' },
+          { old_string: '**Status**: In progress', new_string: '**Status**: Done' },
+        ],
+      },
+    };
+    expect(ask(deployedHook(), payload).verdict).toBe('allow');
+  });
+
+  test('writing a whole new plan that claims done with an open gap is refused', () => {
+    const payload = {
+      tool_name: 'Write',
+      tool_input: {
+        file_path: join(repo, 'plans', 'new.md'),
+        content: '# New — thing\n\nStatus: Shipped\n\n## Known gaps\n\n- nothing tracks the retry path\n',
+      },
+    };
+    expect(ask(deployedHook(), payload).verdict).toBe('deny');
+  });
+
+  test('the reconstruction survives multibyte characters earlier in the file', () => {
+    const { reason } = ask(deployedHook(), edit());
+    expect(reason).toContain('exec_mode/exec_allow have no UI — highest-value remaining item');
+    expect(reason).not.toContain('****');
+  });
+
+  test('an old_string full of regex metacharacters is treated as data', () => {
+    writeFileSync(plan, '# P\n\nstate [x] (a|b) *: pending\n\n## Known gaps\n\n- untracked thing\n');
+    const payload = {
+      tool_name: 'Edit',
+      tool_input: { file_path: plan, old_string: 'state [x] (a|b) *: pending', new_string: 'Status: Done' },
+    };
+    expect(ask(deployedHook(), payload).verdict).toBe('deny');
+  });
+});
+
+describe('what the gate leaves alone', () => {
+  test('a markdown file outside the plan paths', () => {
+    const readme = join(repo, 'README.md');
+    writeFileSync(readme, PLAN_BODY);
+    expect(ask(deployedHook(), edit({ file_path: readme })).verdict).toBe('allow');
+  });
+
+  test('a non-markdown file', () => {
+    const other = join(repo, 'plans', 'notes.txt');
+    writeFileSync(other, PLAN_BODY);
+    expect(ask(deployedHook(), edit({ file_path: other })).verdict).toBe('allow');
+  });
+
+  test('a tool that is not a file write', () => {
+    const payload = { tool_name: 'Bash', tool_input: { command: 'echo hi' } };
+    expect(ask(deployedHook(), payload).verdict).toBe('allow');
+  });
+
+  test('the documented kill switch', () => {
+    expect(ask(deployedHook(), edit(), { AGENTKIT_SKIP_HOOKS: 'plan-police' }).verdict).toBe('allow');
+    expect(ask(deployedHook(), edit(), { AGENTKIT_SKIP_HOOKS: 'all' }).verdict).toBe('allow');
+  });
+
+  test('an unrelated hook name in the kill switch does not disarm it', () => {
+    expect(ask(deployedHook(), edit(), { AGENTKIT_SKIP_HOOKS: 'coding-police' }).verdict).toBe('deny');
+  });
+});
+
+describe('when the checker is missing', () => {
+  test('a plan edit says the gaps went unchecked rather than passing in silence', () => {
+    const { verdict, reason } = ask(deployedHook(false), edit());
+    expect(verdict).toBe('advise');
+    expect(reason).toContain('NOT checked');
+  });
+});
+
+describe('the source layout also resolves the checker', () => {
+  test('running the hook from hooks/claude finds tools/plan-gate two levels up', () => {
+    expect(ask(sourceHook, edit()).verdict).toBe('deny');
+  });
+});

--- a/tests/wip/plan-police.test.ts
+++ b/tests/wip/plan-police.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { copyFileSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { copyFileSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { git, makeSandbox, repoRoot, sandboxEnv, type Sandbox, toolTimeoutMs, writeExecutable } from './fixture';
@@ -156,6 +156,29 @@ describe('the gate', () => {
       tool_input: { file_path: plan, old_string: 'state [x] (a|b) *: pending', new_string: 'Status: Done' },
     };
     expect(ask(deployedHook(), payload).verdict).toBe('deny');
+  });
+});
+
+describe('paths reached through a symlink', () => {
+  // macOS reaches every temporary directory via /var -> /private/var, so git
+  // reports one form and the harness passes the other. A path that stops
+  // looking like a plan fails OPEN and in silence, which is the one direction
+  // this gate must never fail in. Reproduced here on every platform.
+  test('a plan under a symlinked repository path is still gated', () => {
+    const link = join(box.root, 'link-to-repo');
+    symlinkSync(repo, link);
+    const through = join(link, 'plans', '057.md');
+
+    const matched = spawnSync(join(repoRoot, 'tools', 'plan-gate'), ['--matches', through], {
+      encoding: 'utf8',
+      cwd: repo,
+      env: sandboxEnv(box),
+      timeout: toolTimeoutMs,
+    });
+    expect(matched.status, 'the symlinked path was not recognised as a plan').toBe(0);
+
+    const { verdict } = ask(deployedHook(), edit({ file_path: through }));
+    expect(verdict).toBe('deny');
   });
 });
 

--- a/tests/wip/wip.test.ts
+++ b/tests/wip/wip.test.ts
@@ -1,0 +1,272 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { join } from 'node:path';
+import {
+  commitFile,
+  git,
+  makeSandbox,
+  makeSquashMergeRepo,
+  repoRoot,
+  restrictedPath,
+  run,
+  type Sandbox,
+  writeExecutable,
+} from './fixture';
+
+const wip = join(repoRoot, 'tools', 'wip');
+
+const BARE_TOOLS = ['bash', 'git', 'jq', 'sed', 'grep', 'date', 'wc', 'cut', 'head', 'tr', 'cat', 'find', 'sort'];
+
+let box: Sandbox;
+let repo: string;
+
+beforeEach(() => {
+  box = makeSandbox('wip-');
+  repo = makeSquashMergeRepo(box);
+});
+
+afterEach(() => {
+  rmSync(box.root, { recursive: true, force: true });
+});
+
+function report(args: string[] = ['--no-forge'], overrides: Record<string, string> = {}) {
+  const result = run([wip, ...args, repo], box, box.root, overrides);
+  expect(result.status).toBe(0);
+  return result.stdout;
+}
+
+function lineFor(output: string, label: string, needle: string): string | undefined {
+  return output.split('\n').find((line) => line.includes(` ${label} `) && line.includes(needle));
+}
+
+describe('merged-ness is decided by content, not ancestry', () => {
+  test('a squash-merged branch is reported as merged, not as work in progress', () => {
+    const out = report();
+    expect(lineFor(out, 'BRANCH', 'feat/squashed')).toBeUndefined();
+    expect(out).toContain('MERGED');
+    expect(lineFor(out, 'MERGED', 'feat/squashed')).toBeDefined();
+  });
+
+  test('a branch whose content is not on the default branch is still reported', () => {
+    const out = report();
+    expect(lineFor(out, 'BRANCH', 'feat/unmerged')).toBeDefined();
+  });
+
+  test('the default branch advancing does not turn a merged branch back into work', () => {
+    commitFile(repo, box, 'later.txt', 'later\n', 'main moves on');
+    git(repo, box, 'update-ref', 'refs/remotes/origin/main', 'main');
+    const out = report();
+    expect(lineFor(out, 'BRANCH', 'feat/squashed')).toBeUndefined();
+    expect(lineFor(out, 'MERGED', 'feat/squashed')).toBeDefined();
+    expect(lineFor(out, 'BRANCH', 'feat/unmerged')).toBeDefined();
+  });
+
+  test('git without merge-tree --write-tree still answers both cases correctly', () => {
+    const realGit = spawnSync('sh', ['-c', 'command -v git'], { encoding: 'utf8' }).stdout.trim();
+    writeExecutable(
+      join(box.binDir, 'git'),
+      ['#!/usr/bin/env bash', 'for a in "$@"; do', '  if [[ "$a" == "merge-tree" ]]; then exit 129; fi', 'done', `exec ${realGit} "$@"`]
+        .join('\n'),
+    );
+    const out = report();
+    expect(lineFor(out, 'MERGED', 'feat/squashed')).toBeDefined();
+    expect(lineFor(out, 'BRANCH', 'feat/unmerged')).toBeDefined();
+    expect(lineFor(out, 'BRANCH', 'feat/squashed')).toBeUndefined();
+  });
+
+  test('an unmerged branch reports its age and commit count', () => {
+    const line = lineFor(report(), 'BRANCH', 'feat/unmerged') ?? '';
+    expect(line).toMatch(/\d+d/);
+    expect(line).toMatch(/1 commits/);
+  });
+
+  test('a branch whose upstream is gone but whose content is not merged says so', () => {
+    git(repo, box, 'update-ref', 'refs/remotes/origin/feat/unmerged', 'feat/unmerged');
+    git(repo, box, 'branch', '--set-upstream-to=origin/feat/unmerged', 'feat/unmerged');
+    git(repo, box, 'update-ref', '-d', 'refs/remotes/origin/feat/unmerged');
+    const line = lineFor(report(), 'BRANCH', 'feat/unmerged') ?? '';
+    expect(line).toContain('upstream gone but content NOT merged');
+  });
+});
+
+describe('worktrees', () => {
+  test('a dirty worktree is flagged and warned against removing', () => {
+    const wt = join(box.root, 'wt-dirty');
+    git(repo, box, 'worktree', 'add', '-q', wt, 'feat/unmerged');
+    writeFileSync(join(wt, 'b.txt'), 'edited\n');
+    writeFileSync(join(wt, 'scratch.tmp'), 'untracked\n');
+
+    const line = lineFor(report(), 'WORKTREE', 'feat/unmerged') ?? '';
+    expect(line).toContain('DIRTY');
+    expect(line).toContain('1 modified');
+    expect(line).toContain('1 untracked');
+    expect(line).toContain('do NOT remove');
+    expect(line).toContain(wt);
+  });
+
+  test('a clean worktree is reported without the warning', () => {
+    const wt = join(box.root, 'wt-clean');
+    git(repo, box, 'worktree', 'add', '-q', wt, 'feat/unmerged');
+    const line = lineFor(report(), 'WORKTREE', 'feat/unmerged') ?? '';
+    expect(line).toContain('clean');
+    expect(line).not.toContain('DIRTY');
+  });
+
+  test('the primary checkout is not listed as a worktree of itself', () => {
+    expect(report()).not.toContain('WORKTREE');
+  });
+});
+
+describe('plans', () => {
+  test('a plan with an unclosed gap is surfaced read-only', () => {
+    mkdirSync(join(repo, 'plans'), { recursive: true });
+    writeFileSync(
+      join(repo, 'plans', '057.md'),
+      '# P\n\n## Known gaps\n\n- no UI for exec_mode\n- tracked one #4\n',
+    );
+    const line = lineFor(report(), 'PLAN', 'plans/057.md') ?? '';
+    expect(line).toContain('1 gap(s) unclosed');
+  });
+});
+
+describe('forge degradation', () => {
+  test('a repository whose forge CLI is absent says so instead of showing nothing', () => {
+    const out = report([], { PATH: restrictedPath(box, BARE_TOOLS) });
+    expect(out).toContain('NOTE');
+    expect(out).toContain('not checked');
+    expect(lineFor(out, 'BRANCH', 'feat/unmerged')).toBeDefined();
+  });
+
+  test('a github repository without gh names gh as the missing piece', () => {
+    git(repo, box, 'remote', 'set-url', 'origin', 'git@github.com:acme/fixture.git');
+    const out = report([], { PATH: restrictedPath(box, BARE_TOOLS) });
+    expect(out).toContain('gh is not installed');
+  });
+
+  test('a gitlab repository without glab names glab as the missing piece', () => {
+    git(repo, box, 'remote', 'set-url', 'origin', 'git@gitlab.example.com:acme/fixture.git');
+    const out = report([], { PATH: restrictedPath(box, BARE_TOOLS) });
+    expect(out).toContain('glab is unavailable or unauthenticated');
+  });
+
+  test('--no-forge names itself as the reason the sections are missing', () => {
+    expect(report()).toContain('skipped (--no-forge)');
+  });
+
+  test('a repository with no origin remote is reported, not crashed on', () => {
+    git(repo, box, 'remote', 'remove', 'origin');
+    const result = run([wip, repo], box, box.root, { PATH: restrictedPath(box, BARE_TOOLS) });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('no origin remote');
+  });
+
+  test('a path that is not a repository fails loudly', () => {
+    const result = run([wip, box.home], box, box.root);
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('not a git repository');
+  });
+});
+
+describe('forge sections', () => {
+  function installFakeGh(prs: unknown[], issues: unknown[]): void {
+    writeExecutable(
+      join(box.binDir, 'gh'),
+      [
+        '#!/usr/bin/env bash',
+        // Listing resolves the repository from gh's own working directory, so a
+        // caller that queries from elsewhere silently gets nothing back. Auth
+        // status reads config and works anywhere, as the real gh does.
+        `inrepo() { [[ "$PWD" == "${repo}" ]] || exit 1; }`,
+        'case "$*" in',
+        '  *"auth status"*) exit 0 ;;',
+        `  *"pr list"*) inrepo; printf '%s' '${JSON.stringify(prs)}' ;;`,
+        `  *"issue list"*) inrepo; printf '%s' '${JSON.stringify(issues)}' ;;`,
+        '  *) exit 1 ;;',
+        'esac',
+      ].join('\n'),
+    );
+  }
+
+  test('an open change reports what holds it, and binds to its branch', () => {
+    installFakeGh(
+      [{
+        number: 42,
+        headRefName: 'feat/unmerged',
+        isDraft: true,
+        mergeable: 'CONFLICTING',
+        reviewDecision: '',
+        statusCheckRollup: [{ conclusion: 'FAILURE' }],
+      }],
+      [],
+    );
+    const out = report([]);
+    const change = lineFor(out, 'MR/PR', '#42') ?? '';
+    expect(change).toContain('draft');
+    expect(change).toContain('conflicts');
+    expect(change).toContain('checks failing');
+    expect(change).toContain('no approving review');
+    expect(lineFor(out, 'BRANCH', 'feat/unmerged')).toContain('#42');
+  });
+
+  test('a branch with no change of its own says so', () => {
+    installFakeGh([], []);
+    expect(lineFor(report([]), 'BRANCH', 'feat/unmerged')).toContain('no MR/PR');
+  });
+
+  test('an approved, clean change reports nothing holding it', () => {
+    installFakeGh(
+      [{
+        number: 7,
+        headRefName: 'feat/unmerged',
+        isDraft: false,
+        mergeable: 'MERGEABLE',
+        reviewDecision: 'APPROVED',
+        statusCheckRollup: [{ conclusion: 'SUCCESS' }],
+      }],
+      [],
+    );
+    expect(lineFor(report([]), 'MR/PR', '#7')).toContain('nothing — ready');
+  });
+
+  test('issues carved out of other work are separated from the rest', () => {
+    installFakeGh([], [
+      { number: 11, title: 'plain bug', body: 'it breaks' },
+      { number: 12, title: 'exec UI', body: 'Split out of #10 so that plan can close.' },
+    ]);
+    const out = report([]);
+    expect(lineFor(out, 'FILED', '#11')).toBeDefined();
+    expect(lineFor(out, 'DEFERRED', '#12')).toBeDefined();
+    expect(lineFor(out, 'FILED', '#12')).toBeUndefined();
+  });
+
+  test('the merged-cleanup list is bounded and says how many it dropped', () => {
+    for (let i = 0; i < 8; i += 1) {
+      git(repo, box, 'branch', `merged/${i}`, 'main');
+    }
+    const out = report(['--limit', '3']);
+    expect(lineFor(out, 'MERGED', '+')).toContain('more (--limit 0 for all)');
+  });
+
+  test('a bounded list says how many it dropped', () => {
+    const many = Array.from({ length: 30 }, (_, i) => ({ number: i + 1, title: 't', body: 'b' }));
+    installFakeGh([], many);
+    const out = report(['--limit', '5']);
+    expect(lineFor(out, 'FILED', '+25 more')).toBeDefined();
+    expect(out).toContain('--limit 0 for all');
+  });
+});
+
+describe('several repositories', () => {
+  test('each repository gets its own heading and count', () => {
+    const second = join(box.root, 'second');
+    mkdirSync(second, { recursive: true });
+    git(second, box, 'init', '-q', '-b', 'main');
+    commitFile(second, box, 'x.md', 'x\n', 'init');
+
+    const result = run([wip, '--no-forge', repo, second], box, box.root);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('repo — ');
+    expect(result.stdout).toContain('second — 0 half-done');
+  });
+});

--- a/tests/wip/wip.test.ts
+++ b/tests/wip/wip.test.ts
@@ -40,53 +40,107 @@ function lineFor(output: string, label: string, needle: string): string | undefi
   return output.split('\n').find((line) => line.includes(` ${label} `) && line.includes(needle));
 }
 
-describe('merged-ness is decided by content, not ancestry', () => {
-  test('a squash-merged branch is reported as merged, not as work in progress', () => {
-    const out = report();
+const PR = (number: number, headRefName: string, state: string) => ({ number, headRefName, state });
+
+// The forge is the only authority on a squash merge. `feat/squashed` in this
+// fixture is squash-merged in git terms — its content is on main and its
+// commits are not ancestors of anything — so every classification below is a
+// statement about what the forge says, not about git topology.
+function installFakeGh(
+  prs: unknown[],
+  issues: unknown[] = [],
+  byHead: Record<string, unknown[]> = {},
+): void {
+  writeExecutable(
+    join(box.binDir, 'gh'),
+    [
+      '#!/usr/bin/env bash',
+      // Listing resolves the repository from gh's own working directory, so a
+      // caller that queries from elsewhere silently gets nothing back. Auth
+      // status reads config and works anywhere, as the real gh does.
+      `inrepo() { [[ "$PWD" == "${repo}" ]] || exit 1; }`,
+      'case "$*" in',
+      '  *"auth status"*) exit 0 ;;',
+      ...Object.entries(byHead).map(([branch, rows]) =>
+        `  *"--head ${branch}"*) inrepo; printf '%s' '${JSON.stringify(rows)}' ;;`
+      ),
+      `  *"--head "*) inrepo; printf '%s' '[]' ;;`,
+      `  *"pr list"*) inrepo; printf '%s' '${JSON.stringify(prs)}' ;;`,
+      `  *"issue list"*) inrepo; printf '%s' '${JSON.stringify(issues)}' ;;`,
+      '  *) exit 1 ;;',
+      'esac',
+    ].join('\n'),
+  );
+}
+
+function withForge(prs: unknown[], byHead: Record<string, unknown[]> = {}) {
+  installFakeGh(prs, [], byHead);
+  return run([wip, '--limit', '0', repo], box, box.root).stdout;
+}
+
+describe('branch state comes from the forge, not from git topology', () => {
+  test('a squash-merged branch the forge calls merged is cleanup, not unfinished work', () => {
+    const out = withForge([PR(1, 'feat/squashed', 'MERGED')]);
     expect(lineFor(out, 'BRANCH', 'feat/squashed')).toBeUndefined();
-    expect(out).toContain('MERGED');
     expect(lineFor(out, 'MERGED', 'feat/squashed')).toBeDefined();
+    expect(out).toContain('cleanup, not unfinished work');
   });
 
-  test('a branch whose content is not on the default branch is still reported', () => {
-    const out = report();
-    expect(lineFor(out, 'BRANCH', 'feat/unmerged')).toBeDefined();
+  test('a branch with an open change is in flight and names its reference', () => {
+    const line = lineFor(withForge([PR(7, 'feat/unmerged', 'OPEN')]), 'BRANCH', 'feat/unmerged') ?? '';
+    expect(line).toContain('#7 open');
   });
 
-  test('the default branch advancing does not turn a merged branch back into work', () => {
-    commitFile(repo, box, 'later.txt', 'later\n', 'main moves on');
-    git(repo, box, 'update-ref', 'refs/remotes/origin/main', 'main');
-    const out = report();
+  test('a branch closed without merging is abandoned, not outstanding and not merged', () => {
+    const out = withForge([PR(9, 'feat/unmerged', 'CLOSED')]);
+    const line = lineFor(out, 'ABANDONED', 'feat/unmerged') ?? '';
+    expect(line).toContain('#9 closed without merging');
+    expect(lineFor(out, 'BRANCH', 'feat/unmerged')).toBeUndefined();
+    expect(lineFor(out, 'MERGED', 'feat/unmerged')).toBeUndefined();
+  });
+
+  test('a branch the forge has never seen is the genuinely interesting case', () => {
+    const line = lineFor(withForge([]), 'BRANCH', 'feat/unmerged') ?? '';
+    expect(line).toContain('no MR/PR ever opened');
+  });
+
+  test('one merged change outranks a closed one on the same branch', () => {
+    const out = withForge([PR(2, 'feat/squashed', 'CLOSED'), PR(3, 'feat/squashed', 'MERGED')]);
+    expect(lineFor(out, 'MERGED', 'feat/squashed')).toBeDefined();
+    expect(lineFor(out, 'ABANDONED', 'feat/squashed')).toBeUndefined();
+  });
+
+  test('a branch older than the bulk listing window is asked for by name', () => {
+    // The bulk query is capped, so a branch missing from it must be queried
+    // directly rather than silently reported as never having had a change.
+    const out = withForge([], { 'feat/squashed': [PR(4, 'feat/squashed', 'MERGED')] });
+    expect(lineFor(out, 'MERGED', 'feat/squashed')).toBeDefined();
     expect(lineFor(out, 'BRANCH', 'feat/squashed')).toBeUndefined();
-    expect(lineFor(out, 'MERGED', 'feat/squashed')).toBeDefined();
-    expect(lineFor(out, 'BRANCH', 'feat/unmerged')).toBeDefined();
   });
 
-  test('git without merge-tree --write-tree still answers both cases correctly', () => {
-    const realGit = spawnSync('sh', ['-c', 'command -v git'], { encoding: 'utf8' }).stdout.trim();
-    writeExecutable(
-      join(box.binDir, 'git'),
-      ['#!/usr/bin/env bash', 'for a in "$@"; do', '  if [[ "$a" == "merge-tree" ]]; then exit 129; fi', 'done', `exec ${realGit} "$@"`]
-        .join('\n'),
-    );
-    const out = report();
-    expect(lineFor(out, 'MERGED', 'feat/squashed')).toBeDefined();
-    expect(lineFor(out, 'BRANCH', 'feat/unmerged')).toBeDefined();
-    expect(lineFor(out, 'BRANCH', 'feat/squashed')).toBeUndefined();
-  });
-
-  test('an unmerged branch reports its age and commit count', () => {
-    const line = lineFor(report(), 'BRANCH', 'feat/unmerged') ?? '';
-    expect(line).toMatch(/\d+d/);
-    expect(line).toMatch(/1 commits/);
-  });
-
-  test('a branch whose upstream is gone but whose content is not merged says so', () => {
+  test('a deleted upstream branch is annotated, not treated as an answer', () => {
     git(repo, box, 'update-ref', 'refs/remotes/origin/feat/unmerged', 'feat/unmerged');
     git(repo, box, 'branch', '--set-upstream-to=origin/feat/unmerged', 'feat/unmerged');
     git(repo, box, 'update-ref', '-d', 'refs/remotes/origin/feat/unmerged');
-    const line = lineFor(report(), 'BRANCH', 'feat/unmerged') ?? '';
-    expect(line).toContain('upstream gone but content NOT merged');
+    const line = lineFor(withForge([]), 'BRANCH', 'feat/unmerged') ?? '';
+    expect(line).toContain('upstream branch deleted');
+    expect(line).toContain('no MR/PR ever opened');
+  });
+
+  test('an unreachable forge says the state is unknown instead of guessing', () => {
+    const out = report([], { PATH: restrictedPath(box, BARE_TOOLS) });
+    expect(lineFor(out, 'BRANCH', 'feat/squashed')).toContain('state UNKNOWN');
+    expect(out).toContain('branch state is DEGRADED');
+    // The alarming direction: never claim work is outstanding, or finished,
+    // when nothing could answer.
+    expect(out).not.toContain('cleanup, not unfinished work');
+    expect(out).not.toContain('no MR/PR ever opened');
+  });
+
+  test('an unmerged branch reports its age and commit count', () => {
+    const line = lineFor(withForge([]), 'BRANCH', 'feat/unmerged') ?? '';
+    expect(line).toMatch(/\d+d/);
+    expect(line).toMatch(/1 commits/);
   });
 });
 
@@ -111,6 +165,15 @@ describe('worktrees', () => {
     const line = lineFor(report(), 'WORKTREE', 'feat/unmerged') ?? '';
     expect(line).toContain('clean');
     expect(line).not.toContain('DIRTY');
+  });
+
+  test('a worktree on a merged branch is marked cleanup, not unfinished work', () => {
+    const wt = join(box.root, 'wt-merged');
+    git(repo, box, 'worktree', 'add', '-q', wt, 'feat/squashed');
+    const out = withForge([PR(1, 'feat/squashed', 'MERGED')]);
+    const line = lineFor(out, 'WORKTREE', 'feat/squashed') ?? '';
+    expect(line).toContain('branch already merged — cleanup');
+    expect(lineFor(out, 'BRANCH', 'feat/squashed')).toBeUndefined();
   });
 
   test('the primary checkout is not listed as a worktree of itself', () => {
@@ -169,30 +232,12 @@ describe('forge degradation', () => {
 });
 
 describe('forge sections', () => {
-  function installFakeGh(prs: unknown[], issues: unknown[]): void {
-    writeExecutable(
-      join(box.binDir, 'gh'),
-      [
-        '#!/usr/bin/env bash',
-        // Listing resolves the repository from gh's own working directory, so a
-        // caller that queries from elsewhere silently gets nothing back. Auth
-        // status reads config and works anywhere, as the real gh does.
-        `inrepo() { [[ "$PWD" == "${repo}" ]] || exit 1; }`,
-        'case "$*" in',
-        '  *"auth status"*) exit 0 ;;',
-        `  *"pr list"*) inrepo; printf '%s' '${JSON.stringify(prs)}' ;;`,
-        `  *"issue list"*) inrepo; printf '%s' '${JSON.stringify(issues)}' ;;`,
-        '  *) exit 1 ;;',
-        'esac',
-      ].join('\n'),
-    );
-  }
-
   test('an open change reports what holds it, and binds to its branch', () => {
     installFakeGh(
       [{
         number: 42,
         headRefName: 'feat/unmerged',
+        state: 'OPEN',
         isDraft: true,
         mergeable: 'CONFLICTING',
         reviewDecision: '',
@@ -219,6 +264,7 @@ describe('forge sections', () => {
       [{
         number: 7,
         headRefName: 'feat/unmerged',
+        state: 'OPEN',
         isDraft: false,
         mergeable: 'MERGEABLE',
         reviewDecision: 'APPROVED',
@@ -241,11 +287,15 @@ describe('forge sections', () => {
   });
 
   test('the merged-cleanup list is bounded and says how many it dropped', () => {
+    const merged: unknown[] = [];
     for (let i = 0; i < 8; i += 1) {
       git(repo, box, 'branch', `merged/${i}`, 'main');
+      merged.push({ number: 100 + i, headRefName: `merged/${i}`, state: 'MERGED' });
     }
+    installFakeGh(merged, []);
     const out = report(['--limit', '3']);
-    expect(lineFor(out, 'MERGED', '+')).toContain('more (--limit 0 for all)');
+    const line = lineFor(out, 'MERGED', '+') ?? '';
+    expect(line).toContain('more (--limit 0 for all)');
   });
 
   test('a bounded list says how many it dropped', () => {

--- a/tests/wip/wip.test.ts
+++ b/tests/wip/wip.test.ts
@@ -148,6 +148,59 @@ describe('branch state comes from the forge, not from git topology', () => {
   });
 });
 
+describe('branches that were never started', () => {
+  // A harness that makes a branch per worktree leaves dozens of empty ones.
+  // They crowd out the rows that matter, and a count that is loudly wrong in
+  // the alarming direction trains a reader to skim past the whole report.
+  test('nothing committed, no worktree and no change ever opened is hidden and counted', () => {
+    for (let i = 0; i < 3; i += 1) git(repo, box, 'branch', `worktree-agent-${i}`, 'main');
+    const out = withForge([]);
+    for (let i = 0; i < 3; i += 1) {
+      expect(lineFor(out, 'BRANCH', `worktree-agent-${i}`)).toBeUndefined();
+    }
+    expect(out).toContain('3 branch(es) hidden');
+    expect(out).toContain('nothing committed, no worktree, no change ever opened');
+  });
+
+  test('a branch with no commits but a worktree is NOT hidden — uncommitted work lives there', () => {
+    git(repo, box, 'branch', 'fix/uncommitted', 'main');
+    git(repo, box, 'worktree', 'add', '-q', join(box.root, 'wt-unc'), 'fix/uncommitted');
+    const out = withForge([]);
+    expect(lineFor(out, 'BRANCH', 'fix/uncommitted')).toBeDefined();
+    expect(out).not.toContain('branch(es) hidden');
+  });
+
+  test('a branch with commits is never hidden, whatever it is called', () => {
+    git(repo, box, 'checkout', '-q', '-b', 'worktree-agent-busy', 'main');
+    commitFile(repo, box, 'agent.txt', 'work\n', 'agent did something');
+    git(repo, box, 'checkout', '-q', 'main');
+    expect(lineFor(withForge([]), 'BRANCH', 'worktree-agent-busy')).toBeDefined();
+  });
+
+  test('a branch with an open change is never hidden, even with no commits', () => {
+    git(repo, box, 'branch', 'feat/empty-but-open', 'main');
+    const out = withForge([PR(5, 'feat/empty-but-open', 'OPEN')]);
+    expect(lineFor(out, 'BRANCH', 'feat/empty-but-open')).toContain('#5 open');
+  });
+
+  test('hiding still happens when the forge cannot be asked', () => {
+    for (let i = 0; i < 2; i += 1) git(repo, box, 'branch', `worktree-agent-${i}`, 'main');
+    const out = report([], { PATH: restrictedPath(box, BARE_TOOLS) });
+    expect(out).toContain('2 branch(es) hidden');
+    expect(lineFor(out, 'BRANCH', 'worktree-agent-0')).toBeUndefined();
+  });
+});
+
+describe('the headline says what it counts', () => {
+  test('it counts unfinished branches, and breaks the rest out separately', () => {
+    const out = withForge([PR(1, 'feat/squashed', 'MERGED'), PR(2, 'feat/unmerged', 'CLOSED')]);
+    // One branch row would be left; merged is cleanup and closed is abandoned.
+    expect(out).toMatch(/^repo — \d+ unfinished branch\(es\)/m);
+    expect(out).toContain('COUNTS');
+    expect(out).toMatch(/1 abandoned · \d+ worktree\(s\)/);
+  });
+});
+
 describe('worktrees', () => {
   test('a dirty worktree is flagged and warned against removing', () => {
     const wt = join(box.root, 'wt-dirty');
@@ -321,6 +374,6 @@ describe('several repositories', () => {
     const result = run([wip, '--no-forge', repo, second], box, box.root);
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('repo — ');
-    expect(result.stdout).toContain('second — 0 half-done');
+    expect(result.stdout).toContain('second — 0 unfinished branch(es)');
   });
 });

--- a/tests/wip/wip.test.ts
+++ b/tests/wip/wip.test.ts
@@ -75,7 +75,11 @@ function installFakeGh(
 
 function withForge(prs: unknown[], byHead: Record<string, unknown[]> = {}) {
   installFakeGh(prs, [], byHead);
-  return run([wip, '--limit', '0', repo], box, box.root).stdout;
+  const result = run([wip, '--limit', '0', repo], box, box.root);
+  // A crashed run prints fewer rows, which reads exactly like a clean report.
+  // Assert the status, or every absence-assertion below can pass vacuously.
+  expect(result.status, result.stderr).toBe(0);
+  return result.stdout;
 }
 
 describe('branch state comes from the forge, not from git topology', () => {

--- a/tools/plan-gate
+++ b/tools/plan-gate
@@ -132,16 +132,32 @@ discover_plans() {
 	return 0
 }
 
+# The physical path of a file that need not exist yet: its directory is resolved
+# through symlinks, its name kept. Both sides of the comparison below must be
+# physical or the match fails wherever a symlink sits above the repository —
+# macOS reaches every temporary directory through /var -> /private/var, and git
+# reports the resolved form while the harness passes the unresolved one. The
+# failure is silent and open: the path stops looking like a plan, and the gate
+# waves the edit through.
+physical_path() {
+	local path="$1" dir base
+	base="${path##*/}"
+	dir="${path%/*}"
+	[[ "$dir" == "$path" ]] && dir="."
+	if dir="$(cd "$dir" 2>/dev/null && pwd -P)"; then
+		printf '%s/%s' "$dir" "$base"
+		return 0
+	fi
+	printf '%s' "$path"
+	return 0
+}
+
 # Whether a path would be judged as a plan. plan-police asks rather than
 # matching for itself, so the hook and the gate cannot disagree.
 path_is_plan() {
-	local path="$1" repo="$2" entry candidate dir
+	local path="$1" repo="$2" entry candidate
 	[[ "$path" == *.md ]] || return 1
-	if [[ "$path" != /* ]]; then
-		dir="${path%/*}"
-		[[ "$dir" == "$path" ]] && dir="."
-		path="$(cd "$dir" 2>/dev/null && pwd)/${path##*/}" || return 1
-	fi
+	path="$(physical_path "$path")"
 	while IFS= read -r entry; do
 		[[ -n "$entry" ]] || continue
 		candidate="$repo/$entry"
@@ -355,7 +371,7 @@ if [[ -n "$MATCH_PATH" && "$REPO_GIVEN" == 0 ]]; then
 	[[ "$MATCH_DIR" == "$MATCH_PATH" ]] && MATCH_DIR="."
 	REPO="$(git -C "$MATCH_DIR" rev-parse --show-toplevel 2>/dev/null || printf '%s' "$PWD")"
 fi
-if ! REPO="$(cd "$REPO" 2>/dev/null && pwd)"; then
+if ! REPO="$(cd "$REPO" 2>/dev/null && pwd -P)"; then
 	printf 'plan-gate: unreadable repo\n' >&2
 	exit 3
 fi

--- a/tools/plan-gate
+++ b/tools/plan-gate
@@ -1,0 +1,420 @@
+#!/usr/bin/env bash
+# plan-gate — judge whether a plan may be treated as done.
+#
+# A plan's own gaps section is the most honest record of what is outstanding,
+# and nothing reads it. This is the single parser for that section: `wip` calls
+# it to report, plan-police calls it to refuse an edit that declares a plan done
+# while a gap stands. A second scanner would eventually disagree with this one.
+#
+# A gap stops blocking when the author ticks it or names the issue that now
+# carries it — nothing bespoke to remember.
+#
+# Exit: 0 nothing blocking, 1 blocking gaps, 2 usage, 3 fault (unreadable input).
+set -euo pipefail
+
+VERSION=1
+
+usage() {
+	cat <<'EOF'
+Usage: plan-gate [options] [PLAN...]
+
+  PLAN               plan file or directory. Default: plans discovered under --repo.
+
+  --repo DIR         repository root to discover plans in (default: cwd)
+  --stdin NAME       read one plan's content from stdin; NAME is the path to report
+  --matches PATH     exit 0 if PATH would be judged as a plan, 1 if not
+  --require-done     only report blocking gaps for plans that mark themselves done
+  --all              also list gaps that are closed or tracked
+  --tsv              machine output: STATUS<TAB>PLAN<TAB>LINE<TAB>TEXT
+  --quiet            no output; exit status only
+  --list-plans       print the plan files that would be judged, then exit
+  --version          print the tool version
+  -h, --help         this text
+
+Exit: 0 nothing blocking, 1 blocking gaps, 2 usage, 3 fault.
+EOF
+}
+
+# Defaults, each overridable from the `wip:` section of the agentkit config.
+GAP_HEADINGS='(known|open|remaining|outstanding|unresolved|deferred) *(gaps?|work|items?)?|gaps?|not done|follow.?ups?|todo'
+DONE_MARKERS='^[[:space:]]*(#+[[:space:]]*)?(\*\*|__)?status(\*\*|__)?[[:space:]]*[:=][[:space:]]*[^[:alnum:]]*(done|complete|completed|shipped|delivered|finished|closed)\b'
+PLAN_PATHS=""
+
+# A forge issue reference: GitHub/GitLab number, GitLab MR, or an issue/MR/PR
+# URL. A Jira-style KEY-123 is deliberately absent — nothing tells it apart from
+# UTF-8 or SHA-256, and a false "tracked" is the direction that loses a gap.
+# Jira shops add the pattern back through the `issue-refs` config key.
+ISSUE_REFS='(^|[^[:alnum:]_/])(#[0-9]+|![0-9]+|[Gg][Hh]-[0-9]+)([^[:alnum:]]|$)|https?://[^[:space:]]*(/issues/|/-/issues/|/merge_requests/|/pull/|/browse/)'
+
+# Emits the `wip:` section as key=value lines, so no caller re-parses YAML.
+read_wip_section() {
+	local file="$1"
+	[[ -f "$file" ]] || return 0
+	awk '
+		/^[^[:space:]#]/ { in_section = ($0 ~ /^wip:/); in_paths = 0; next }
+		!in_section { next }
+		{
+			line = $0
+			sub(/^[[:space:]]+/, "", line)
+			if (line ~ /^#/ || line == "") next
+			if (in_paths) {
+				if (line ~ /^-[[:space:]]*./) {
+					value = line
+					sub(/^-[[:space:]]*/, "", value)
+					gsub(/["'\'']/, "", value)
+					sub(/[[:space:]]+#.*$/, "", value)
+					print "plan-path=" value
+					next
+				}
+				in_paths = 0
+			}
+			if (line ~ /^plan-paths:[[:space:]]*$/) { in_paths = 1; next }
+			if (line !~ /^(gap-headings|done-markers|issue-refs):[[:space:]]*./) next
+			key = line
+			sub(/:.*/, "", key)
+			sub(/^[^:]*:[[:space:]]*/, "", line)
+			gsub(/^["'\'']|["'\'']$/, "", line)
+			if (line == "") next
+			print key "=" line
+		}
+	' "$file"
+	return 0
+}
+
+# Global config first, then the repository's, so a repository setting wins.
+load_config() {
+	local repo="$1" file key value
+	local global="${AGENTKIT_CONFIG:-${XDG_CONFIG_HOME:-$HOME/.config}/agentkit/config.yaml}"
+	for file in "$global" "$repo/.agentkit/config.yaml"; do
+		while IFS='=' read -r key value; do
+			case "$key" in
+			gap-headings) GAP_HEADINGS="$value" ;;
+			done-markers) DONE_MARKERS="$value" ;;
+			issue-refs) ISSUE_REFS="$value" ;;
+			plan-path) PLAN_PATHS="$PLAN_PATHS$value"$'\n' ;;
+			esac
+		done < <(read_wip_section "$file")
+	done
+	return 0
+}
+
+# Conventions vary, so the default is a list of candidate roots rather than one
+# layout, and `wip.plan-paths` replaces the list outright.
+default_plan_paths() {
+	printf '%s\n' plans docs/plans doc/plans .omc/plans PLAN.md PLANS.md
+}
+
+configured_plan_paths() {
+	if [[ -n "$PLAN_PATHS" ]]; then
+		printf '%s' "$PLAN_PATHS"
+	else
+		default_plan_paths
+	fi
+	return 0
+}
+
+find_plan_files() {
+	find "$1" -type f -name '*.md' \
+		-not -path '*/node_modules/*' -not -path '*/.git/*' 2>/dev/null | sort
+}
+
+discover_plans() {
+	local repo="$1" entry candidate
+	while IFS= read -r entry; do
+		[[ -n "$entry" ]] || continue
+		candidate="$repo/$entry"
+		if [[ -d "$candidate" ]]; then
+			find_plan_files "$candidate"
+		elif [[ -f "$candidate" ]]; then
+			printf '%s\n' "$candidate"
+		fi
+	done < <(configured_plan_paths)
+	return 0
+}
+
+# Whether a path would be judged as a plan. plan-police asks rather than
+# matching for itself, so the hook and the gate cannot disagree.
+path_is_plan() {
+	local path="$1" repo="$2" entry candidate dir
+	[[ "$path" == *.md ]] || return 1
+	if [[ "$path" != /* ]]; then
+		dir="${path%/*}"
+		[[ "$dir" == "$path" ]] && dir="."
+		path="$(cd "$dir" 2>/dev/null && pwd)/${path##*/}" || return 1
+	fi
+	while IFS= read -r entry; do
+		[[ -n "$entry" ]] || continue
+		candidate="$repo/$entry"
+		if [[ "$path" == "$candidate" || "$path" == "$candidate"/* ]]; then
+			return 0
+		fi
+	done < <(configured_plan_paths)
+	return 1
+}
+
+# Emits STATUS<TAB>LINE<TAB>TEXT for every gap entry in the content on stdin.
+parse_gaps() {
+	awk -v gapre="$GAP_HEADINGS" -v refre="$ISSUE_REFS" '
+		BEGIN { fence = 0; insec = 0; seclvl = 0; baseind = -1; n = 0 }
+		{
+			raw = $0
+			sub(/\r$/, "", raw)
+			trimmed = raw
+			sub(/^[[:space:]]+/, "", trimmed)
+
+			# A heading inside a fenced block is sample text, not structure.
+			if (trimmed ~ /^(```|~~~)/) { fence = 1 - fence; next }
+			if (fence) next
+
+			if (trimmed ~ /^#+[[:space:]]/) {
+				lvl = 0
+				while (substr(trimmed, lvl + 1, 1) == "#") lvl++
+				htext = substr(trimmed, lvl + 1)
+				sub(/^[[:space:]]+/, "", htext)
+				sub(/[[:space:]]*#+[[:space:]]*$/, "", htext)
+				if (insec && lvl <= seclvl) insec = 0
+				if (!insec && tolower(htext) ~ ("^(" gapre ")$")) {
+					insec = 1; seclvl = lvl; baseind = -1
+				}
+				next
+			}
+			if (!insec) next
+
+			i = 1; ind = 0
+			while (1) {
+				c = substr(raw, i, 1)
+				if (c == " ") { ind++; i++ }
+				else if (c == "\t") { ind += 4; i++ }
+				else break
+			}
+			rest = substr(raw, i)
+
+			if (rest ~ /^([-*+]|[0-9]+[.)])[[:space:]]/) {
+				if (baseind < 0) baseind = ind
+				if (ind <= baseind) {
+					n++
+					body = rest
+					sub(/^([-*+]|[0-9]+[.)])[[:space:]]+/, "", body)
+					ln[n] = FNR; first[n] = body; full[n] = body
+				} else if (n > 0) {
+					full[n] = full[n] " " rest
+				}
+				next
+			}
+			if (rest == "") next
+			# Indented prose belongs to the entry above it; unindented prose is
+			# section commentary and belongs to none.
+			if (ind > 0 && n > 0) full[n] = full[n] " " rest
+			next
+		}
+		END {
+			for (k = 1; k <= n; k++) {
+				text = first[k]
+				closed = 0
+				if (text ~ /^\[[xX]\][[:space:]]/) closed = 1
+				sub(/^\[[ xX]\][[:space:]]+/, "", text)
+				if (text ~ /^~~.*~~[[:space:]]*$/) closed = 1
+				status = "OPEN"
+				if (closed) status = "CLOSED"
+				else if (full[k] ~ refre) status = "TRACKED"
+				printf "%s\t%d\t%s\n", status, ln[k], text
+			}
+		}
+	'
+}
+
+marks_done() {
+	grep -qiE "$DONE_MARKERS" <<<"$1"
+}
+
+TRUNCATE_AT=110
+
+report_plan() {
+	local plan="$1" content="$2"
+	local gaps blocking status line text shown
+	gaps="$(printf '%s\n' "$content" | parse_gaps)"
+	blocking=0
+	if [[ -n "$gaps" ]]; then
+		blocking=$(grep -c '^OPEN	' <<<"$gaps" || true)
+	fi
+
+	if [[ "$REQUIRE_DONE" == 1 ]] && ! marks_done "$content"; then
+		return 0
+	fi
+	if [[ "$blocking" -gt 0 ]]; then
+		FOUND_BLOCKING=$((FOUND_BLOCKING + blocking))
+	fi
+	if [[ "$QUIET" == 1 || -z "$gaps" ]]; then
+		return 0
+	fi
+
+	shown=0
+	while IFS=$'\t' read -r status line text; do
+		[[ -n "$status" ]] || continue
+		if [[ "$SHOW_ALL" != 1 && "$status" != "OPEN" ]]; then
+			continue
+		fi
+		if [[ "$TSV" == 1 ]]; then
+			printf '%s\t%s\t%s\t%s\n' "$status" "$plan" "$line" "$text"
+			shown=$((shown + 1))
+			continue
+		fi
+		if [[ "$shown" == 0 ]]; then
+			printf '%s — %d gap(s) unclosed\n' "$plan" "$blocking"
+		fi
+		if [[ "${#text}" -gt "$TRUNCATE_AT" ]]; then
+			text="${text:0:$TRUNCATE_AT}… [truncated for display; full text in the plan]"
+		fi
+		printf '  %-8s L%-5s %s\n' "$status" "$line" "$text"
+		shown=$((shown + 1))
+	done <<<"$gaps"
+	return 0
+}
+
+REPO="$PWD"
+REPO_GIVEN=0
+STDIN_NAME=""
+MATCH_PATH=""
+REQUIRE_DONE=0
+SHOW_ALL=0
+TSV=0
+QUIET=0
+LIST_ONLY=0
+TARGETS=""
+
+need_value() {
+	if [[ "$1" -lt 2 ]]; then
+		usage >&2
+		exit 2
+	fi
+	return 0
+}
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--repo)
+		need_value $#
+		REPO="$2"
+		REPO_GIVEN=1
+		shift 2
+		;;
+	--stdin)
+		need_value $#
+		STDIN_NAME="$2"
+		shift 2
+		;;
+	--matches)
+		need_value $#
+		MATCH_PATH="$2"
+		shift 2
+		;;
+	--require-done)
+		REQUIRE_DONE=1
+		shift
+		;;
+	--all)
+		SHOW_ALL=1
+		shift
+		;;
+	--tsv)
+		TSV=1
+		shift
+		;;
+	--quiet)
+		QUIET=1
+		shift
+		;;
+	--list-plans)
+		LIST_ONLY=1
+		shift
+		;;
+	--version)
+		printf 'plan-gate %s\n' "$VERSION"
+		exit 0
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	-*)
+		printf 'plan-gate: unknown option %s\n' "$1" >&2
+		usage >&2
+		exit 2
+		;;
+	*)
+		TARGETS="$TARGETS$1"$'\n'
+		shift
+		;;
+	esac
+done
+
+# A bare --matches is asked from wherever the harness happens to be, so the
+# repository comes from the path under judgement rather than from the cwd.
+if [[ -n "$MATCH_PATH" && "$REPO_GIVEN" == 0 ]]; then
+	MATCH_DIR="${MATCH_PATH%/*}"
+	[[ "$MATCH_DIR" == "$MATCH_PATH" ]] && MATCH_DIR="."
+	REPO="$(git -C "$MATCH_DIR" rev-parse --show-toplevel 2>/dev/null || printf '%s' "$PWD")"
+fi
+if ! REPO="$(cd "$REPO" 2>/dev/null && pwd)"; then
+	printf 'plan-gate: unreadable repo\n' >&2
+	exit 3
+fi
+
+load_config "$REPO"
+
+if [[ -n "$MATCH_PATH" ]]; then
+	if path_is_plan "$MATCH_PATH" "$REPO"; then
+		exit 0
+	fi
+	exit 1
+fi
+
+FOUND_BLOCKING=0
+
+collect_targets() {
+	local target
+	while IFS= read -r target; do
+		[[ -n "$target" ]] || continue
+		if [[ -d "$target" ]]; then
+			find_plan_files "$target"
+		elif [[ -f "$target" ]]; then
+			printf '%s\n' "$target"
+		else
+			printf 'plan-gate: no such plan: %s\n' "$target" >&2
+			return 3
+		fi
+	done <<<"$TARGETS"
+	return 0
+}
+
+if [[ -n "$STDIN_NAME" ]]; then
+	CONTENT="$(cat)"
+	report_plan "$STDIN_NAME" "$CONTENT"
+else
+	if [[ -n "$TARGETS" ]]; then
+		PLAN_LIST="$(collect_targets)" || exit 3
+	else
+		PLAN_LIST="$(discover_plans "$REPO")"
+	fi
+
+	if [[ "$LIST_ONLY" == 1 ]]; then
+		if [[ -n "$PLAN_LIST" ]]; then
+			printf '%s\n' "$PLAN_LIST"
+		fi
+		exit 0
+	fi
+
+	while IFS= read -r plan; do
+		[[ -n "$plan" ]] || continue
+		if [[ ! -r "$plan" ]]; then
+			printf 'plan-gate: unreadable: %s\n' "$plan" >&2
+			exit 3
+		fi
+		report_plan "$plan" "$(cat "$plan")"
+	done <<<"$PLAN_LIST"
+fi
+
+if [[ "$FOUND_BLOCKING" -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/tools/wip
+++ b/tools/wip
@@ -302,6 +302,34 @@ emit_class() {
 	return 0
 }
 
+# Branches that have a worktree attached. A branch with nothing committed still
+# holds work if a checkout is sitting on it — that is where uncommitted work
+# lives — so this is what separates "nothing started" from "started, uncommitted".
+worktree_branches() {
+	git_in worktree list --porcelain 2>/dev/null |
+		awk '$1 == "branch" { sub(/^refs\/heads\//, "", $2); print $2 }'
+	return 0
+}
+
+# Nothing committed, nowhere checked out, and no change ever opened: nothing was
+# started. A harness that creates a branch per worktree leaves dozens of these,
+# and they crowd out the rows that matter — being loudly wrong about the size of
+# your backlog trains a reader to skim past it.
+#
+# The test is structural rather than by name deliberately. A name pattern would
+# hide a harness branch that DOES carry commits, which is real unfinished work;
+# this cannot, because having commits disqualifies a branch from being hidden.
+# Only ever asked about a branch the forge has no change for; the call sites are
+# the single place that decides, so there is no state guard duplicated here.
+branch_is_unstarted() {
+	local branch="$1"
+	[[ "$(git_in rev-list --count "$BASE..$branch" 2>/dev/null || printf '1')" == "0" ]] || return 1
+	case "$WORKTREE_BRANCHES" in
+	*"|$branch|"*) return 1 ;;
+	esac
+	return 0
+}
+
 # STATE<TAB>BRANCH<TAB>REF<TAB>TRACK, judged once. A caller that classified
 # inside a command substitution would lose the result to the subshell.
 # STATE is merged / opened / closed / none / unknown, where `none` means the
@@ -313,7 +341,11 @@ classify_branches() {
 		[[ -n "$branch" ]] || continue
 		[[ "$branch" == "$DEFAULT" ]] && continue
 		if [[ -z "$FORGE" ]]; then
-			emit_class 'unknown' "$branch" '' "$track"
+			if branch_is_unstarted "$branch"; then
+				emit_class 'unstarted' "$branch" '' "$track"
+			else
+				emit_class 'unknown' "$branch" '' "$track"
+			fi
 			continue
 		fi
 		answer=$(best_state_for "$branch" "$FORGE_STATES")
@@ -321,12 +353,26 @@ classify_branches() {
 			answer=$(best_state_for "$branch" "$(forge_branch_state_one "$branch")")
 		fi
 		if [[ -z "$answer" ]]; then
-			emit_class 'none' "$branch" '' "$track"
+			if branch_is_unstarted "$branch"; then
+				emit_class 'unstarted' "$branch" '' "$track"
+			else
+				emit_class 'none' "$branch" '' "$track"
+			fi
 			continue
 		fi
 		IFS=$'\t' read -r state ref <<<"$answer"
 		emit_class "$state" "$branch" "$ref" "$track"
 	done < <(git_in for-each-ref --format='%(refname:short)%09%(upstream:track)' refs/heads 2>/dev/null)
+	return 0
+}
+
+unstarted_count() {
+	local state
+	local n=0
+	while IFS=$'\t' read -r state _ _ _; do
+		[[ "$state" == "unstarted" ]] && n=$((n + 1))
+	done <<<"$BRANCH_CLASS"
+	printf '%d' "$n"
 	return 0
 }
 
@@ -490,7 +536,7 @@ count_lines() {
 }
 
 report_repo() {
-	local branches abandoned worktrees changes issues plans total
+	local branches abandoned worktrees changes issues plans hidden
 
 	DEFAULT="$(default_branch)"
 	BASE="$(base_ref "$DEFAULT")"
@@ -508,6 +554,7 @@ report_repo() {
 	if [[ -n "$FORGE" ]]; then
 		FORGE_STATES="$(forge_branch_states)"
 	fi
+	WORKTREE_BRANCHES="|$(worktree_branches | tr '\n' '|')"
 	BRANCH_CLASS="$(classify_branches)"
 	CLEANUP="$(merged_branch_names)"
 
@@ -518,10 +565,7 @@ report_repo() {
 	issues="$(section_issues)" || fail_section section_issues
 	plans="$(section_plans)" || fail_section section_plans
 
-	total=$(($(count_lines "$branches") + $(count_lines "$abandoned") + $(count_lines "$worktrees") +
-		$(count_lines "$CHANGES") + $(count_lines "$ISSUES") + $(count_lines "$plans")))
-
-	printf '%s — %d half-done\n' "${REPO##*/}" "$total"
+	printf '%s — %d unfinished branch(es)\n' "${REPO##*/}" "$(count_lines "$branches")"
 	emit_bounded 'branch(es)' "$branches"
 	emit_bounded 'abandoned branch(es)' "$abandoned"
 	emit_bounded 'worktree(s)' "$worktrees"
@@ -529,6 +573,13 @@ report_repo() {
 	emit_bounded 'issue line(s)' "$issues"
 	emit_bounded 'plan(s)' "$plans"
 
+	printf ' %-9s %s abandoned · %s worktree(s) · %s open change(s) · %s filed issue(s) · %s plan(s) with gaps\n' \
+		'COUNTS' "$(count_lines "$abandoned")" "$(count_lines "$worktrees")" \
+		"$(count_lines "$CHANGES")" "$(count_lines "$ISSUES")" "$(count_lines "$plans")"
+	hidden="$(unstarted_count)"
+	if [[ "$hidden" -gt 0 ]]; then
+		printf ' %-9s %s\n' 'NOTE' "$hidden branch(es) hidden: nothing committed, no worktree, no change ever opened"
+	fi
 	if [[ -n "$CLEANUP" ]]; then
 		printf ' %-9s %s\n' 'MERGED' "$(bound_list "$CLEANUP") — merged on the forge; cleanup, not unfinished work"
 	fi

--- a/tools/wip
+++ b/tools/wip
@@ -1,0 +1,510 @@
+#!/usr/bin/env bash
+# wip — what was started and not finished, for one repository or several.
+#
+# Read-only: it blocks nothing and changes nothing. It exists so a human never
+# has to take an agent's summary of its own work on trust.
+#
+# The one thing here worth knowing: merged-ness is decided by CONTENT, never by
+# ancestry. See branch_is_merged for why every cheaper rule gets it wrong.
+set -euo pipefail
+
+VERSION=1
+LIMIT=20
+FORGE_ENABLED=1
+
+usage() {
+	cat <<'EOF'
+Usage: wip [options] [REPO...]
+
+  REPO           repository path. Default: the current directory's repository.
+
+  --limit N      rows per section before the rest is summarised (default 20; 0 = all)
+  --no-forge     skip merge-request/pull-request and issue lookups
+  --version      print the tool version
+  -h, --help     this text
+
+Exit: 0 always, unless a repository argument is unusable (2).
+EOF
+}
+
+# ── git ─────────────────────────────────────────────────────────────────────
+git_in() { git -C "$REPO" "$@"; }
+
+# origin/HEAD names the default branch when the clone recorded it; the probes
+# after it are for clones that never did.
+default_branch() {
+	local ref candidate
+	ref=$(git_in symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null || true)
+	if [[ -n "$ref" ]]; then
+		printf '%s' "${ref##*/}"
+		return 0
+	fi
+	for candidate in main master trunk develop; do
+		if git_in show-ref --verify --quiet "refs/remotes/origin/$candidate"; then
+			printf '%s' "$candidate"
+			return 0
+		fi
+	done
+	for candidate in main master trunk develop; do
+		if git_in show-ref --verify --quiet "refs/heads/$candidate"; then
+			printf '%s' "$candidate"
+			return 0
+		fi
+	done
+	git_in rev-parse --abbrev-ref HEAD 2>/dev/null || printf '%s' 'main'
+}
+
+base_ref() {
+	if git_in show-ref --verify --quiet "refs/remotes/origin/$1"; then
+		printf 'origin/%s' "$1"
+	else
+		printf '%s' "$1"
+	fi
+}
+
+# Merging the branch into the default branch and getting the default branch's
+# own tree back means its content is already there — however it arrived, and
+# whatever the default branch has done since.
+#
+# Every cheaper rule was tried against a squash-merge fixture and fails:
+# `rev-list --count base..branch` counts a squashed branch as ahead forever,
+# because the squashed commit is not an ancestor of anything. A two-dot diff
+# reports the default branch's own later commits as deletions on the branch. A
+# three-dot diff answers a different question entirely — the branch's changes
+# since the merge base — which is non-empty for every branch that did anything.
+branch_is_merged() {
+	local merged_tree base_tree merge_base files
+	local -a paths=()
+
+	if ! base_tree=$(git_in rev-parse "$BASE^{tree}" 2>/dev/null); then
+		return 1
+	fi
+	if merged_tree=$(git_in merge-tree --write-tree "$BASE" "$1" 2>/dev/null); then
+		if [[ "$merged_tree" == "$base_tree" ]]; then
+			return 0
+		fi
+		return 1
+	fi
+
+	# Older git has no --write-tree. Comparing only the files the branch touched
+	# keeps the default branch's unrelated progress out of the answer.
+	if ! merge_base=$(git_in merge-base "$BASE" "$1" 2>/dev/null); then
+		return 1
+	fi
+	files=$(git_in diff --name-only "$merge_base" "$1" 2>/dev/null || true)
+	if [[ -z "$files" ]]; then
+		return 0
+	fi
+	while IFS= read -r line; do
+		[[ -n "$line" ]] && paths+=("$line")
+	done <<<"$files"
+	if git_in diff --quiet "$BASE" "$1" -- "${paths[@]}" 2>/dev/null; then
+		return 0
+	fi
+	return 1
+}
+
+age_days() {
+	local when now
+	when=$(git_in log -1 --format=%ct "$1" 2>/dev/null || printf '0')
+	now=$(date +%s)
+	printf '%d' $(((now - when) / 86400))
+}
+
+# ── forge ───────────────────────────────────────────────────────────────────
+# Resolved per repository, never assumed. A repository whose forge cannot be
+# reached reports that fact rather than an empty section, because an empty
+# section reads as "nothing outstanding".
+FORGE=""
+FORGE_NOTE=""
+
+detect_forge() {
+	FORGE=""
+	FORGE_NOTE=""
+	if [[ "$FORGE_ENABLED" != 1 ]]; then
+		FORGE_NOTE="skipped (--no-forge)"
+		return 0
+	fi
+	local url host
+	url=$(git_in remote get-url origin 2>/dev/null || true)
+	if [[ -z "$url" ]]; then
+		FORGE_NOTE="no origin remote — merge requests and issues not checked"
+		return 0
+	fi
+	host=$(printf '%s' "$url" | sed -E 's#^(git\+)?(ssh://)?(git@|https?://)?([^:/]+).*#\4#')
+
+	if [[ "$host" == "github.com" ]] || (command -v gh >/dev/null 2>&1 && gh auth status --hostname "$host" >/dev/null 2>&1); then
+		if command -v gh >/dev/null 2>&1; then
+			FORGE="github"
+			GH_HOSTNAME="$host"
+			return 0
+		fi
+		FORGE_NOTE="github repo but gh is not installed — merge requests and issues not checked"
+		return 0
+	fi
+	if command -v glab >/dev/null 2>&1; then
+		if (cd "$REPO" && GITLAB_HOST="$host" glab api /version >/dev/null 2>&1); then
+			FORGE="gitlab"
+			GITLAB_HOSTNAME="$host"
+			return 0
+		fi
+	fi
+	if [[ "$host" == *gitlab* ]]; then
+		FORGE_NOTE="gitlab repo but glab is unavailable or unauthenticated — merge requests and issues not checked"
+		return 0
+	fi
+	FORGE_NOTE="unrecognised forge host '$host' — merge requests and issues not checked"
+	return 0
+}
+
+# One row per open change authored by the current user:
+# NUMBER<TAB>HEAD_BRANCH<TAB>HOLDS
+open_changes() {
+	case "$FORGE" in
+	github)
+		(cd "$REPO" && GH_HOST="$GH_HOSTNAME" gh pr list --author '@me' --state open --limit 100 \
+			--json number,headRefName,isDraft,mergeable,reviewDecision,statusCheckRollup 2>/dev/null) |
+			jq -r '.[] | [
+				("#" + (.number | tostring)),
+				.headRefName,
+				([ (if .isDraft then "draft" else empty end),
+				   (if .mergeable == "CONFLICTING" then "conflicts" else empty end),
+				   (if ([.statusCheckRollup[]? | select(.conclusion == "FAILURE" or .conclusion == "TIMED_OUT" or .state == "FAILURE")] | length) > 0
+				      then "checks failing" else empty end),
+				   (if .reviewDecision == "CHANGES_REQUESTED" then "changes requested"
+				    elif .reviewDecision == "APPROVED" then empty
+				    else "no approving review" end)
+				 ] | join(", "))
+			] | @tsv' || true
+		;;
+	gitlab)
+		(cd "$REPO" && GITLAB_HOST="$GITLAB_HOSTNAME" glab mr list --author '@me' --output json --per-page 100 2>/dev/null) |
+			jq -r '(if type == "array" then . else (.merge_requests // []) end)[] | [
+				("!" + (.iid | tostring)),
+				.source_branch,
+				([ (if (.draft // .work_in_progress // false) then "draft" else empty end),
+				   (if .has_conflicts then "conflicts" else empty end),
+				   (if (.upvotes // 0) == 0 then "no approving review" else empty end)
+				 ] | join(", "))
+			] | @tsv' || true
+		;;
+	esac
+	return 0
+}
+
+# NUMBER<TAB>FLAG — FLAG marks an issue whose body says it was carved out of
+# other work. Filing one of those is a deferral, and deferrals should be visible.
+SPLIT_HINT='split out of|split from|carved out|carved from|extracted from|broken out of|deferred from|follow-?up (to|from)|descoped from|out of scope for'
+
+open_authored_issues() {
+	case "$FORGE" in
+	github)
+		(cd "$REPO" && GH_HOST="$GH_HOSTNAME" gh issue list --author '@me' --state open --limit 100 \
+			--json number,body,title 2>/dev/null) |
+			jq -r --arg re "$SPLIT_HINT" '.[] |
+				[ ("#" + (.number | tostring)),
+				  (if ((.body // "") + " " + (.title // "") | test($re; "i")) then "split" else "" end)
+				] | @tsv' || true
+		;;
+	gitlab)
+		(cd "$REPO" && GITLAB_HOST="$GITLAB_HOSTNAME" glab issue list --author '@me' --output json --per-page 100 2>/dev/null) |
+			jq -r --arg re "$SPLIT_HINT" '(if type == "array" then . else (.issues // []) end)[] |
+				[ ("#" + (.iid | tostring)),
+				  (if ((.description // "") + " " + (.title // "") | test($re; "i")) then "split" else "" end)
+				] | @tsv' || true
+		;;
+	esac
+	return 0
+}
+
+# ── output ──────────────────────────────────────────────────────────────────
+# Bounded sections say what they dropped. A silent cap reads as "nothing else
+# to see", which is the failure this whole tool exists to prevent.
+emit_bounded() {
+	local label="$1" body="$2" total shown
+	[[ -n "$body" ]] || return 0
+	total=$(grep -c . <<<"$body" || true)
+	if [[ "$LIMIT" -gt 0 && "$total" -gt "$LIMIT" ]]; then
+		shown="$LIMIT"
+	else
+		shown="$total"
+	fi
+	printf '%s' "$(head -n "$shown" <<<"$body")"
+	printf '\n'
+	if [[ "$shown" -lt "$total" ]]; then
+		printf ' %-9s %s\n' "…" "$((total - shown)) more $label not shown (--limit 0 for all)"
+	fi
+	return 0
+}
+
+# An inline list of identifiers, capped the same way and just as loudly.
+bound_list() {
+	local items="${1# }" total kept
+	total=$(wc -w <<<"$items" | tr -d ' ')
+	if [[ "$LIMIT" -le 0 || "$total" -le "$LIMIT" ]]; then
+		printf '%s' "$items"
+		return 0
+	fi
+	kept=$(cut -d' ' -f"1-$LIMIT" <<<"$items")
+	printf '%s +%d more (--limit 0 for all)' "$kept" "$((total - LIMIT))"
+	return 0
+}
+
+# ── sections ────────────────────────────────────────────────────────────────
+CHANGES=""
+CLEANUP=""
+
+change_for_branch() {
+	local head number
+	while IFS=$'\t' read -r number head _; do
+		if [[ -n "$head" && "$head" == "$1" ]]; then
+			printf '%s' "$number"
+			return 0
+		fi
+	done <<<"$CHANGES"
+	return 0
+}
+
+# STATUS<TAB>BRANCH<TAB>UPSTREAM_TRACK, judged once. A caller that classified
+# inside a command substitution would lose the merged list to the subshell.
+classify_branches() {
+	local branch track
+	while IFS=$'\t' read -r branch track; do
+		[[ -n "$branch" ]] || continue
+		[[ "$branch" == "$DEFAULT" ]] && continue
+		if branch_is_merged "$branch"; then
+			printf 'MERGED\t%s\t%s\n' "$branch" "$track"
+		else
+			printf 'OPEN\t%s\t%s\n' "$branch" "$track"
+		fi
+	done < <(git_in for-each-ref --format='%(refname:short)%09%(upstream:track)' refs/heads 2>/dev/null)
+	return 0
+}
+
+merged_branch_names() {
+	local status branch
+	while IFS=$'\t' read -r status branch _; do
+		[[ "$status" == "MERGED" ]] && printf ' %s' "$branch"
+	done <<<"$BRANCH_CLASS"
+	return 0
+}
+
+section_branches() {
+	local status branch track ahead days change note body=""
+	while IFS=$'\t' read -r status branch track; do
+		[[ "$status" == "OPEN" ]] || continue
+		ahead=$(git_in rev-list --count "$BASE..$branch" 2>/dev/null || printf '0')
+		days=$(age_days "$branch")
+		change=$(change_for_branch "$branch")
+		if [[ -n "$change" ]]; then
+			note="$change"
+		elif [[ -n "$FORGE" ]]; then
+			note="no MR/PR"
+		else
+			note="MR/PR unknown"
+		fi
+		if [[ "$track" == *gone* ]]; then
+			note="$note; upstream gone but content NOT merged"
+		fi
+		body="$body$(printf ' %-9s %-34s %3sd  %3s commits  %s' 'BRANCH' "$branch" "$days" "$ahead" "$note")"$'\n'
+	done <<<"$BRANCH_CLASS"
+	printf '%s' "$body"
+	return 0
+}
+
+# A dirty worktree is called out because removing one destroys the uncommitted
+# and untracked files in it; the branch ref does not carry them.
+section_worktrees() {
+	local path branch modified untracked state body=""
+	while IFS= read -r line; do
+		case "$line" in
+		"worktree "*)
+			path="${line#worktree }"
+			branch=""
+			;;
+		"branch "*) branch="${line#branch refs/heads/}" ;;
+		"detached") branch="(detached)" ;;
+		"")
+			[[ -n "${path:-}" ]] || continue
+			[[ "$path" == "$REPO" ]] && {
+				path=""
+				continue
+			}
+			modified=$(git -C "$path" status --porcelain 2>/dev/null | grep -cv '^??' || true)
+			untracked=$(git -C "$path" status --porcelain 2>/dev/null | grep -c '^??' || true)
+			if [[ "$modified" -gt 0 || "$untracked" -gt 0 ]]; then
+				state=$(printf 'DIRTY %s modified, %s untracked — do NOT remove' "$modified" "$untracked")
+			else
+				state="clean"
+			fi
+			body="$body$(printf ' %-9s %-34s %s at %s' 'WORKTREE' "${branch:-(no branch)}" "$state" "${path/#$HOME/\~}")"$'\n'
+				path=""
+			;;
+		esac
+	done < <(
+		git_in worktree list --porcelain 2>/dev/null
+		printf '\n'
+	)
+	printf '%s' "$body"
+	return 0
+}
+
+section_changes() {
+	local number head holds body=""
+	while IFS=$'\t' read -r number head holds; do
+		[[ -n "$number" ]] || continue
+		body="$body$(printf ' %-9s %-34s held: %s' 'MR/PR' "$number ($head)" "${holds:-nothing — ready}")"$'\n'
+	done <<<"$CHANGES"
+	printf '%s' "$body"
+	return 0
+}
+
+section_issues() {
+	local number flag plain="" split="" body=""
+	while IFS=$'\t' read -r number flag; do
+		[[ -n "$number" ]] || continue
+		if [[ "$flag" == "split" ]]; then
+			split="$split $number"
+		else
+			plain="$plain $number"
+		fi
+	done <<<"$ISSUES"
+	if [[ -n "$plain" ]]; then
+		body="$body$(printf ' %-9s %s' 'FILED' "$(bound_list "$plain") — authored, open, unfixed")"$'\n'
+	fi
+	if [[ -n "$split" ]]; then
+		body="$body$(printf ' %-9s %s' 'DEFERRED' "$(bound_list "$split") — carved out of other work")"$'\n'
+	fi
+	printf '%s' "$body"
+	return 0
+}
+
+section_plans() {
+	local plan open name body="" seen=""
+	[[ -n "$PLAN_GATE" ]] || return 0
+	while IFS=$'\t' read -r _ plan _ _; do
+		[[ -n "$plan" ]] || continue
+		case " $seen " in *" $plan "*) continue ;; esac
+		seen="$seen $plan"
+		open=$(grep -cF "	$plan	" <<<"$PLAN_ROWS" || true)
+		name="${plan#"$REPO"/}"
+		body="$body$(printf ' %-9s %-34s %s gap(s) unclosed' 'PLAN' "$name" "$open")"$'\n'
+	done <<<"$PLAN_ROWS"
+	printf '%s' "$body"
+	return 0
+}
+
+count_lines() {
+	if [[ -z "$1" ]]; then
+		printf '0'
+		return 0
+	fi
+	grep -c . <<<"$1" || true
+}
+
+report_repo() {
+	local branches worktrees changes issues plans total
+
+	DEFAULT="$(default_branch)"
+	BASE="$(base_ref "$DEFAULT")"
+	detect_forge
+	CHANGES="$(open_changes)"
+	ISSUES=""
+	if [[ -n "$FORGE" ]]; then
+		ISSUES="$(open_authored_issues)"
+	fi
+	PLAN_ROWS=""
+	if [[ -n "$PLAN_GATE" ]]; then
+		PLAN_ROWS="$("$PLAN_GATE" --repo "$REPO" --tsv 2>/dev/null | grep '^OPEN	' || true)"
+	fi
+	BRANCH_CLASS="$(classify_branches)"
+	CLEANUP="$(merged_branch_names)"
+
+	branches="$(section_branches)"
+	worktrees="$(section_worktrees)"
+	changes="$(section_changes)"
+	issues="$(section_issues)"
+	plans="$(section_plans)"
+
+	total=$(($(count_lines "$branches") + $(count_lines "$worktrees") +
+		$(count_lines "$CHANGES") + $(count_lines "$ISSUES") + $(count_lines "$plans")))
+
+	printf '%s — %d half-done\n' "${REPO##*/}" "$total"
+	emit_bounded 'branch(es)' "$branches"
+	emit_bounded 'worktree(s)' "$worktrees"
+	emit_bounded 'change(s)' "$changes"
+	emit_bounded 'issue line(s)' "$issues"
+	emit_bounded 'plan(s)' "$plans"
+
+	if [[ -n "$CLEANUP" ]]; then
+		printf ' %-9s %s\n' 'MERGED' "$(bound_list "$CLEANUP") — content already on $DEFAULT; safe to delete"
+	fi
+	if [[ -n "$FORGE_NOTE" ]]; then
+		printf ' %-9s %s\n' 'NOTE' "$FORGE_NOTE"
+	fi
+	if [[ -z "$PLAN_GATE" ]]; then
+		printf ' %-9s %s\n' 'NOTE' 'plan-gate not found beside this tool — plans not checked'
+	fi
+	return 0
+}
+
+# ── arguments ───────────────────────────────────────────────────────────────
+TARGETS=""
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--limit)
+		if [[ $# -lt 2 || ! "$2" =~ ^[0-9]+$ ]]; then
+			usage >&2
+			exit 2
+		fi
+		LIMIT="$2"
+		shift 2
+		;;
+	--no-forge)
+		FORGE_ENABLED=0
+		shift
+		;;
+	--version)
+		printf 'wip %s\n' "$VERSION"
+		exit 0
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	-*)
+		printf 'wip: unknown option %s\n' "$1" >&2
+		usage >&2
+		exit 2
+		;;
+	*)
+		TARGETS="$TARGETS$1"$'\n'
+		shift
+		;;
+	esac
+done
+
+[[ -n "$TARGETS" ]] || TARGETS="$PWD"$'\n'
+
+TOOL_DIR="${BASH_SOURCE[0]%/*}"
+PLAN_GATE=""
+for candidate in "$TOOL_DIR/plan-gate" "$TOOL_DIR/../tools/plan-gate"; do
+	if [[ -x "$candidate" ]]; then
+		PLAN_GATE="$candidate"
+		break
+	fi
+done
+
+FIRST=1
+while IFS= read -r target; do
+	[[ -n "$target" ]] || continue
+	if ! REPO="$(git -C "$target" rev-parse --show-toplevel 2>/dev/null)"; then
+		printf 'wip: not a git repository: %s\n' "$target" >&2
+		exit 2
+	fi
+	[[ "$FIRST" == 1 ]] || printf '\n'
+	FIRST=0
+	report_repo
+done <<<"$TARGETS"
+exit 0

--- a/tools/wip
+++ b/tools/wip
@@ -350,7 +350,7 @@ branch_is_cleanup() {
 
 # Merged branches are cleanup, not unfinished work, and leave this section.
 section_branches() {
-	local state branch track ref ahead days note body=""
+	local state branch track ref ahead days body="" note=""
 	while IFS=$'\t' read -r state branch ref track; do
 		[[ "$ref" == "-" ]] && ref=""
 		[[ "$track" == "-" ]] && track=""
@@ -470,6 +470,17 @@ section_plans() {
 	return 0
 }
 
+# A section builds its rows in a command substitution, so a failure inside one
+# yields an empty string — indistinguishable from "nothing to report" in a tool
+# whose whole purpose is that work does not disappear quietly. Each capture is
+# guarded so a failure is loud and non-zero instead. The calls stay direct:
+# dispatching through a variable would blind shellcheck's dead-code check, which
+# has already caught real dead code in this file.
+fail_section() {
+	printf 'wip: the %s section failed — this report is INCOMPLETE\n' "$1" >&2
+	exit 3
+}
+
 count_lines() {
 	if [[ -z "$1" ]]; then
 		printf '0'
@@ -500,12 +511,12 @@ report_repo() {
 	BRANCH_CLASS="$(classify_branches)"
 	CLEANUP="$(merged_branch_names)"
 
-	branches="$(section_branches)"
-	abandoned="$(section_abandoned)"
-	worktrees="$(section_worktrees)"
-	changes="$(section_changes)"
-	issues="$(section_issues)"
-	plans="$(section_plans)"
+	branches="$(section_branches)" || fail_section section_branches
+	abandoned="$(section_abandoned)" || fail_section section_abandoned
+	worktrees="$(section_worktrees)" || fail_section section_worktrees
+	changes="$(section_changes)" || fail_section section_changes
+	issues="$(section_issues)" || fail_section section_issues
+	plans="$(section_plans)" || fail_section section_plans
 
 	total=$(($(count_lines "$branches") + $(count_lines "$abandoned") + $(count_lines "$worktrees") +
 		$(count_lines "$CHANGES") + $(count_lines "$ISSUES") + $(count_lines "$plans")))

--- a/tools/wip
+++ b/tools/wip
@@ -4,8 +4,9 @@
 # Read-only: it blocks nothing and changes nothing. It exists so a human never
 # has to take an agent's summary of its own work on trust.
 #
-# The one thing here worth knowing: merged-ness is decided by CONTENT, never by
-# ancestry. See branch_is_merged for why every cheaper rule gets it wrong.
+# The one thing here worth knowing: whether a branch is finished is answered by
+# the FORGE, never by git topology. See forge_branch_states for the measurement
+# behind that, and for why there is no local rule to fall back to.
 set -euo pipefail
 
 VERSION=1
@@ -62,46 +63,84 @@ base_ref() {
 	fi
 }
 
-# Merging the branch into the default branch and getting the default branch's
-# own tree back means its content is already there — however it arrived, and
-# whatever the default branch has done since.
+# A squash merge destroys the topological evidence by design: the squashed
+# commit is not an ancestor of the branch, and the merge base stays before the
+# squash forever. Only the forge records that a change from this branch merged.
 #
-# Every cheaper rule was tried against a squash-merge fixture and fails:
-# `rev-list --count base..branch` counts a squashed branch as ahead forever,
-# because the squashed commit is not an ancestor of anything. A two-dot diff
-# reports the default branch's own later commits as deletions on the branch. A
-# three-dot diff answers a different question entirely — the branch's changes
-# since the merge base — which is non-empty for every branch that did anything.
-branch_is_merged() {
-	local merged_tree base_tree merge_base files
-	local -a paths=()
+# Measured against nine branches of known outcome, every git-only rule reported
+# all seven merged ones as outstanding: ancestry counts, a two-dot diff, a
+# three-dot diff, and an in-memory merge-tree comparison alike. The last of
+# those passed a two-commit fixture and still failed here, because a fixture
+# whose default branch has not moved cannot distinguish the case it exists to
+# prove. There is no local rule to fall back to, so when the forge cannot
+# answer, this reports that it does not know rather than guessing loudly.
 
-	if ! base_tree=$(git_in rev-parse "$BASE^{tree}" 2>/dev/null); then
-		return 1
+# BRANCH<TAB>STATE<TAB>REF for every change the forge knows of. States are
+# normalised to merged / opened / closed.
+forge_branch_states() {
+	case "$FORGE" in
+	github)
+		(cd "$REPO" && GH_HOST="$GH_HOSTNAME" gh pr list --state all --limit 200 \
+			--json headRefName,number,state 2>/dev/null) |
+			jq -r '.[] | [.headRefName, (.state | ascii_downcase), ("#" + (.number | tostring))] | @tsv' || true
+		;;
+	gitlab)
+		(cd "$REPO" && GITLAB_HOST="$GITLAB_HOSTNAME" \
+			glab api "projects/:fullpath/merge_requests?state=all&per_page=100&order_by=updated_at" 2>/dev/null) |
+			jq -r 'if type == "array" then .[] else empty end
+				| [.source_branch, .state, ("!" + (.iid | tostring))] | @tsv' || true
+		;;
+	esac
+	return 0
+}
+
+# The bulk listing is capped, so a branch older than the window needs asking for
+# by name rather than being silently called untracked.
+forge_branch_state_one() {
+	case "$FORGE" in
+	github)
+		(cd "$REPO" && GH_HOST="$GH_HOSTNAME" gh pr list --head "$1" --state all --limit 10 \
+			--json headRefName,number,state 2>/dev/null) |
+			jq -r '.[] | [.headRefName, (.state | ascii_downcase), ("#" + (.number | tostring))] | @tsv' || true
+		;;
+	gitlab)
+		(cd "$REPO" && GITLAB_HOST="$GITLAB_HOSTNAME" \
+			glab api "projects/:fullpath/merge_requests?source_branch=$1&state=all" 2>/dev/null) |
+			jq -r 'if type == "array" then .[] else empty end
+				| [.source_branch, .state, ("!" + (.iid | tostring))] | @tsv' || true
+		;;
+	esac
+	return 0
+}
+
+# A branch may carry several changes over its life. Merged wins: one merged
+# change means the work landed, whatever was closed alongside it.
+best_state_for() {
+	local branch="$1" rows name state ref
+	local open_ref="" closed_ref=""
+	rows=$(printf '%s\n' "$2" | grep -F "$branch	" || true)
+	if [[ -z "$rows" ]]; then
+		printf ''
+		return 0
 	fi
-	if merged_tree=$(git_in merge-tree --write-tree "$BASE" "$1" 2>/dev/null); then
-		if [[ "$merged_tree" == "$base_tree" ]]; then
+	while IFS=$'\t' read -r name state ref; do
+		[[ "$name" == "$branch" ]] || continue
+		case "$state" in
+		merged)
+			printf 'merged\t%s' "$ref"
 			return 0
-		fi
-		return 1
+			;;
+		# GitHub says OPEN, GitLab says opened; merged and closed coincide.
+		open | opened | locked) [[ -n "$open_ref" ]] || open_ref="$ref" ;;
+		closed) [[ -n "$closed_ref" ]] || closed_ref="$ref" ;;
+		esac
+	done <<<"$rows"
+	if [[ -n "$open_ref" ]]; then
+		printf 'opened\t%s' "$open_ref"
+	elif [[ -n "$closed_ref" ]]; then
+		printf 'closed\t%s' "$closed_ref"
 	fi
-
-	# Older git has no --write-tree. Comparing only the files the branch touched
-	# keeps the default branch's unrelated progress out of the answer.
-	if ! merge_base=$(git_in merge-base "$BASE" "$1" 2>/dev/null); then
-		return 1
-	fi
-	files=$(git_in diff --name-only "$merge_base" "$1" 2>/dev/null || true)
-	if [[ -z "$files" ]]; then
-		return 0
-	fi
-	while IFS= read -r line; do
-		[[ -n "$line" ]] && paths+=("$line")
-	done <<<"$files"
-	if git_in diff --quiet "$BASE" "$1" -- "${paths[@]}" 2>/dev/null; then
-		return 0
-	fi
-	return 1
+	return 0
 }
 
 age_days() {
@@ -254,57 +293,80 @@ bound_list() {
 CHANGES=""
 CLEANUP=""
 
-change_for_branch() {
-	local head number
-	while IFS=$'\t' read -r number head _; do
-		if [[ -n "$head" && "$head" == "$1" ]]; then
-			printf '%s' "$number"
-			return 0
-		fi
-	done <<<"$CHANGES"
+# Tab counts as IFS whitespace, so `read` collapses a run of them: an empty
+# field silently shifts every later field one place left, and the reference
+# lands in the variable meant for the upstream marker. A placeholder keeps the
+# columns aligned; consumers turn it back into an empty string.
+emit_class() {
+	printf '%s\t%s\t%s\t%s\n' "$1" "$2" "${3:--}" "${4:--}"
 	return 0
 }
 
-# STATUS<TAB>BRANCH<TAB>UPSTREAM_TRACK, judged once. A caller that classified
-# inside a command substitution would lose the merged list to the subshell.
+# STATE<TAB>BRANCH<TAB>REF<TAB>TRACK, judged once. A caller that classified
+# inside a command substitution would lose the result to the subshell.
+# STATE is merged / opened / closed / none / unknown, where `none` means the
+# forge answered and has never seen a change from this branch — the genuinely
+# interesting case — and `unknown` means nobody could answer.
 classify_branches() {
-	local branch track
+	local branch track answer state ref
 	while IFS=$'\t' read -r branch track; do
 		[[ -n "$branch" ]] || continue
 		[[ "$branch" == "$DEFAULT" ]] && continue
-		if branch_is_merged "$branch"; then
-			printf 'MERGED\t%s\t%s\n' "$branch" "$track"
-		else
-			printf 'OPEN\t%s\t%s\n' "$branch" "$track"
+		if [[ -z "$FORGE" ]]; then
+			emit_class 'unknown' "$branch" '' "$track"
+			continue
 		fi
+		answer=$(best_state_for "$branch" "$FORGE_STATES")
+		if [[ -z "$answer" ]]; then
+			answer=$(best_state_for "$branch" "$(forge_branch_state_one "$branch")")
+		fi
+		if [[ -z "$answer" ]]; then
+			emit_class 'none' "$branch" '' "$track"
+			continue
+		fi
+		IFS=$'\t' read -r state ref <<<"$answer"
+		emit_class "$state" "$branch" "$ref" "$track"
 	done < <(git_in for-each-ref --format='%(refname:short)%09%(upstream:track)' refs/heads 2>/dev/null)
 	return 0
 }
 
 merged_branch_names() {
-	local status branch
-	while IFS=$'\t' read -r status branch _; do
-		[[ "$status" == "MERGED" ]] && printf ' %s' "$branch"
+	local state branch
+	while IFS=$'\t' read -r state branch _ _; do
+		[[ "$state" == "merged" ]] && printf ' %s' "$branch"
 	done <<<"$BRANCH_CLASS"
 	return 0
 }
 
+branch_is_cleanup() {
+	local state branch
+	while IFS=$'\t' read -r state branch _ _; do
+		if [[ "$branch" == "$1" && "$state" == "merged" ]]; then
+			return 0
+		fi
+	done <<<"$BRANCH_CLASS"
+	return 1
+}
+
+# Merged branches are cleanup, not unfinished work, and leave this section.
 section_branches() {
-	local status branch track ahead days change note body=""
-	while IFS=$'\t' read -r status branch track; do
-		[[ "$status" == "OPEN" ]] || continue
+	local state branch track ref ahead days note body=""
+	while IFS=$'\t' read -r state branch ref track; do
+		[[ "$ref" == "-" ]] && ref=""
+		[[ "$track" == "-" ]] && track=""
+		case "$state" in
+		opened | none | unknown) ;;
+		*) continue ;;
+		esac
 		ahead=$(git_in rev-list --count "$BASE..$branch" 2>/dev/null || printf '0')
 		days=$(age_days "$branch")
-		change=$(change_for_branch "$branch")
-		if [[ -n "$change" ]]; then
-			note="$change"
-		elif [[ -n "$FORGE" ]]; then
-			note="no MR/PR"
-		else
-			note="MR/PR unknown"
-		fi
+		case "$state" in
+		opened) note="$ref open" ;;
+		none) note="no MR/PR ever opened" ;;
+		unknown) note="state UNKNOWN — forge could not be asked" ;;
+		esac
 		if [[ "$track" == *gone* ]]; then
-			note="$note; upstream gone but content NOT merged"
+			note="$note; upstream branch deleted"
 		fi
 		body="$body$(printf ' %-9s %-34s %3sd  %3s commits  %s' 'BRANCH' "$branch" "$days" "$ahead" "$note")"$'\n'
 	done <<<"$BRANCH_CLASS"
@@ -312,8 +374,20 @@ section_branches() {
 	return 0
 }
 
-# A dirty worktree is called out because removing one destroys the uncommitted
-# and untracked files in it; the branch ref does not carry them.
+# A change closed without merging is a decision, not an oversight. It reads
+# differently from work nobody ever opened, so it gets its own row.
+section_abandoned() {
+	local state branch track ref days body=""
+	while IFS=$'\t' read -r state branch ref track; do
+		[[ "$state" == "closed" ]] || continue
+		[[ "$ref" == "-" ]] && ref=""
+		days=$(age_days "$branch")
+		body="$body$(printf ' %-9s %-34s %3sd  %s closed without merging' 'ABANDONED' "$branch" "$days" "$ref")"$'\n'
+	done <<<"$BRANCH_CLASS"
+	printf '%s' "$body"
+	return 0
+}
+
 section_worktrees() {
 	local path branch modified untracked state body=""
 	while IFS= read -r line; do
@@ -334,6 +408,8 @@ section_worktrees() {
 			untracked=$(git -C "$path" status --porcelain 2>/dev/null | grep -c '^??' || true)
 			if [[ "$modified" -gt 0 || "$untracked" -gt 0 ]]; then
 				state=$(printf 'DIRTY %s modified, %s untracked — do NOT remove' "$modified" "$untracked")
+			elif [[ -n "$branch" ]] && branch_is_cleanup "$branch"; then
+				state="clean; branch already merged — cleanup"
 			else
 				state="clean"
 			fi
@@ -403,7 +479,7 @@ count_lines() {
 }
 
 report_repo() {
-	local branches worktrees changes issues plans total
+	local branches abandoned worktrees changes issues plans total
 
 	DEFAULT="$(default_branch)"
 	BASE="$(base_ref "$DEFAULT")"
@@ -417,30 +493,37 @@ report_repo() {
 	if [[ -n "$PLAN_GATE" ]]; then
 		PLAN_ROWS="$("$PLAN_GATE" --repo "$REPO" --tsv 2>/dev/null | grep '^OPEN	' || true)"
 	fi
+	FORGE_STATES=""
+	if [[ -n "$FORGE" ]]; then
+		FORGE_STATES="$(forge_branch_states)"
+	fi
 	BRANCH_CLASS="$(classify_branches)"
 	CLEANUP="$(merged_branch_names)"
 
 	branches="$(section_branches)"
+	abandoned="$(section_abandoned)"
 	worktrees="$(section_worktrees)"
 	changes="$(section_changes)"
 	issues="$(section_issues)"
 	plans="$(section_plans)"
 
-	total=$(($(count_lines "$branches") + $(count_lines "$worktrees") +
+	total=$(($(count_lines "$branches") + $(count_lines "$abandoned") + $(count_lines "$worktrees") +
 		$(count_lines "$CHANGES") + $(count_lines "$ISSUES") + $(count_lines "$plans")))
 
 	printf '%s — %d half-done\n' "${REPO##*/}" "$total"
 	emit_bounded 'branch(es)' "$branches"
+	emit_bounded 'abandoned branch(es)' "$abandoned"
 	emit_bounded 'worktree(s)' "$worktrees"
 	emit_bounded 'change(s)' "$changes"
 	emit_bounded 'issue line(s)' "$issues"
 	emit_bounded 'plan(s)' "$plans"
 
 	if [[ -n "$CLEANUP" ]]; then
-		printf ' %-9s %s\n' 'MERGED' "$(bound_list "$CLEANUP") — content already on $DEFAULT; safe to delete"
+		printf ' %-9s %s\n' 'MERGED' "$(bound_list "$CLEANUP") — merged on the forge; cleanup, not unfinished work"
 	fi
 	if [[ -n "$FORGE_NOTE" ]]; then
 		printf ' %-9s %s\n' 'NOTE' "$FORGE_NOTE"
+		printf ' %-9s %s\n' 'NOTE' 'branch state is DEGRADED: only the forge can tell a squash-merged branch from an unfinished one, so no branch above is known to be outstanding'
 	fi
 	if [[ -z "$PLAN_GATE" ]]; then
 		printf ' %-9s %s\n' 'NOTE' 'plan-gate not found beside this tool — plans not checked'


### PR DESCRIPTION
Closes #250.

## What ships

| Unit | Kind | Role |
| --- | --- | --- |
| `tools/wip` | tool | read-only "what is half done", one repo or several |
| `tools/plan-gate` | tool | the single parser for a plan's gaps section |
| `hooks/claude/plan-police.sh` | PreToolUse `Edit\|Write` | refuses an edit that marks a plan done while a bare gap stands |
| `skills/wip` | skill (core kit) | when to run them, how to read the output |

```
agentkit — 7 half-done
 BRANCH    feat/render-emit-html                3d    6 commits  no MR/PR
 WORKTREE  fix/core-name                      DIRTY 11 modified, 2 untracked — do NOT remove at ~/wt/x
 MR/PR     #249 (feat/page-diagram)           held: no approving review
 FILED     #250 #248 #247 +38 more (--limit 0 for all) — authored, open, unfixed
 DEFERRED  #245 #75 #41 — carved out of other work
 PLAN      plans/057.md                       2 gap(s) unclosed
 MERGED    fix/old — content already on main; safe to delete
 NOTE      unrecognised forge host 'git.example.com' — merge requests and issues not checked
```

## The merged-ness rule, and why the obvious ones are wrong

Probed against a real squash-merge fixture rather than reasoned about:

| Rule | Squash-merged branch | Merged, then default branch advanced | Genuinely unmerged |
| --- | --- | --- | --- |
| `rev-list --count base..head` | **ahead forever** | ahead forever | ahead ✓ |
| `git diff base..head` | empty ✓ | **1 file changed (a deletion)** | non-empty ✓ |
| `git diff base...head` | **1 file changed** | 1 file changed | non-empty ✓ |
| `merge-tree --write-tree`, tree compare | merged ✓ | merged ✓ | unmerged ✓ |

`wip` merges into the default branch in memory and compares trees. Older git
without `--write-tree` falls back to a two-dot diff restricted to the files the
branch touched, which keeps the default branch's unrelated progress out of the
answer; that fallback is tested by denying the hook a `merge-tree` subcommand.

## Design decisions

| Decision | Choice | Why |
| --- | --- | --- |
| Gap closed | `- [x]`, or struck through | markdown an author already writes |
| Gap tracked | `#123`, `!123`, `GH-123`, or an issue/MR/PR URL | filing the issue and pasting the number is the natural fix |
| Referenced issue's state | not checked | keeps the gate offline and deterministic; `/wip` reports open authored issues separately |
| Jira `PROJ-123` | **off** by default, `issue-refs` turns it on | nothing tells a Jira key from a hex digest or a UTF-8 label, and a false "tracked" loses the gap silently |
| Hook vs tool | both | the hook catches the moment; the tool serves CI and manual use |
| PreToolUse, not PostToolUse | refuse the edit | PostToolUse must `exit 2` to be heard, and by then the claim is written |
| Plan layout | discovered, then configurable | six common paths by default; `wip.plan-paths` replaces them, repo config beats global |
| One parser, two callers | `wip` and the hook both shell out to `plan-gate` | a second scanner eventually disagrees with the first |

## Verification

- `scripts/preflight --slice wip` — all checks pass, 56 pass / 0 fail
- full suite: **1788 pass, 15 fail**. The 15 are `publish-page/mermaid-runtime`,
  `product-intelligence/portable`, `publish-page/deck-template`, which fail
  **identically** (1 pass / 15 fail / 2 errors) on a detached `origin/main`
  worktree — measured, not assumed
- real GitLab: run against a bizfoundry repo, returning live MRs with holds,
  authored issues, deferred issues, and plan gaps
- **16 mutations, all CAUGHT.** Including: `merge-tree` swapped for each of the
  two rules the brief prescribed; the literal `split/join` swapped back to jq
  `index` (jq reports a BYTE offset while `.[a:b]` slices codepoints, so one em
  dash shifted every replacement two characters); the plan-path filter, the kill
  switch, the deployed-shape resolution, dirty detection, the forge-absent
  notes, and both bounded-list announcements

Two defects were found this way during the build, not after: forge queries ran
in the caller's cwd rather than the target repo, so `gh` returned nothing and
every branch was labelled "no MR/PR"; and the jq codepoint bug above. Both now
have tests that fail without the fix.

## Not done

- `mr-police` remains GitLab-only. Out of scope here, but it is the one
  remaining forge asymmetry in the hook set.
