### PR TITLE
docs(pages): document callouts, and correct two things the site now gets wrong

### DIFF
--- a/docs/site/src/content/docs/concepts/pages.md
+++ b/docs/site/src/content/docs/concepts/pages.md
@@ -150,3 +150,9 @@ Without that clone, publishing still works — it warns once that it is using th
 which can lag the canonical ones, and that no history is being recorded. That warning matters: a
 republish under an existing name overwrites silently, and on a machine with no clone there is nothing
 to recover from.
+
+Staleness runs both ways, and the clone is the side that goes stale quietly. Publishing prefers the
+clone's themes whenever a clone exists, so a clone left behind its upstream serves older chrome than
+the installed skill carries — while the renderer, which ships with the skill, stays current. The two
+disagree inside a single page, and nothing fails: the upload succeeds and the page loads. Pull the
+clone before publishing after an upgrade.

--- a/docs/site/src/content/docs/concepts/pages.md
+++ b/docs/site/src/content/docs/concepts/pages.md
@@ -151,8 +151,9 @@ which can lag the canonical ones, and that no history is being recorded. That wa
 republish under an existing name overwrites silently, and on a machine with no clone there is nothing
 to recover from.
 
-Staleness runs both ways, and the clone is the side that goes stale quietly. Publishing prefers the
+Staleness runs both ways, and the clone is the side that is easiest to miss. Publishing prefers the
 clone's themes whenever a clone exists, so a clone left behind its upstream serves older chrome than
 the installed skill carries — while the renderer, which ships with the skill, stays current. The two
-disagree inside a single page, and nothing fails: the upload succeeds and the page loads. Pull the
-clone before publishing after an upgrade.
+disagree inside a single page, and nothing fails: the upload succeeds and the page loads. A drift
+warning does fire, but it names the bundled copy as the stale one either way, so in this direction
+its advice is backwards. Pull the clone before publishing after an upgrade.

--- a/docs/site/src/content/docs/cookbook/publish-a-page.md
+++ b/docs/site/src/content/docs/cookbook/publish-a-page.md
@@ -49,14 +49,52 @@ bun ~/.agentkit/skills/publish-page/publish.ts \
 | `deck`   | slides — markdown split on `---` lines        |
 | `raw`    | complete self-contained HTML, published as-is |
 
+## Callouts
+
+A callout is an aside with a coloured rail and a label. Pick the severity by consequence, not by
+mood: `warn` for a cost or a constraint, `alarm` for something that breaks or exposes if ignored,
+`ok` for a confirmed-good result, `note` for a quiet aside, and no class at all for a neutral one.
+
+```html
+<div class="callout warn"><strong>Heads up.</strong> body text</div>
+```
+
+The label is whatever **opens** the callout, and four spellings mean the same thing — they render
+identically, at the same height, with the label taking the colour of its own rail:
+
+| Spelling   | What you write                                                                           |
+| ---------- | ---------------------------------------------------------------------------------------- |
+| Inline     | `<div class="callout"><strong>Label.</strong> body</div>`                                |
+| Blank line | a blank line inside the div, then `**Label.** body` — markdown wraps the body in a `<p>` |
+| Wrapped    | you supply the `<p>` yourself                                                            |
+| Heading    | a leading `<h3>`                                                                         |
+
+Bold that does **not** open the callout stays body text: a phrase mid-sentence, a phrase after a
+plain opening, a second `<h3>` further down. That distinction is made when the page is rendered,
+not by a CSS selector — `:first-child` counts element children, so it cannot see the text sitting
+in front of a bold phrase and would promote it to a title.
+
+:::note[The corollary]
+Whatever opens a callout becomes its label. Do not open one with emphasis you did not intend as a
+title — put the plain words first instead.
+:::
+
+Severity rides the rail and the label only. Body text stays in ink in both palettes, and every
+pairing the themes actually paint is contrast-checked at 4.5:1.
+
 ## Constraints worth knowing before you write
 
 - **Self-contained only.** The serving CSP blocks every external request. Inline the CSS and JS,
   embed images as data URIs.
 - **5 MB cap** on the rendered page.
-- The `doc` and `deck` themes carry the house style, a persisted dark/light toggle, a TOC dot rail
-  on docs with three or more `h2` sections, click-to-expand figures, and deck navigation. Do not
-  re-implement any of it.
+- The `doc` and `deck` themes carry the house style, a persisted dark/light toggle, a labelled
+  section nav on docs with three or more `h2` sections, click-to-expand figures, and deck
+  navigation. Do not re-implement any of it.
+- The section nav names each tab from its `h2`. A title longer than about 28 characters is
+  shortened and marked with an ellipsis to say the label was derived rather than chosen — write
+  `<h2 data-nav="Estimate">Two to four weeks, not two months</h2>` to name it yourself.
+- The nav's left slot is opt-in: a `<div class="brand">Name</div>` anywhere in the page is hoisted
+  into the bar, with its accent mark drawn for you. Without one the slot stays empty.
 
 :::tip[Verify before you report the URL]
 The skill's own instruction is to load the printed URL in headless Chromium at ~1280 px, screenshot

--- a/docs/site/src/content/docs/cookbook/publish-a-page.md
+++ b/docs/site/src/content/docs/cookbook/publish-a-page.md
@@ -93,7 +93,7 @@ pairing the themes actually paint is contrast-checked at 4.5:1.
 - The section nav names each tab from its `h2`. A title longer than about 28 characters is
   shortened and marked with an ellipsis to say the label was derived rather than chosen — write
   `<h2 data-nav="Estimate">Two to four weeks, not two months</h2>` to name it yourself.
-- The nav's left slot is opt-in: a `<div class="brand">Name</div>` anywhere in the page is hoisted
+- The nav's left slot is opt-in: a `<div class="brand">Name</div>` anywhere in your content is hoisted
   into the bar, with its accent mark drawn for you. Without one the slot stays empty.
 
 :::tip[Verify before you report the URL]


### PR DESCRIPTION
Found by publishing a v0.6.4 demo page and reading the docs against it.

| Gap | State |
| --- | --- |
| Callouts | documented **nowhere** on the site — only in the skill's `SKILL.md`, which agents read |
| "TOC dot rail" | replaced by the labelled section nav in #249; the cookbook still promised the rail |
| `<div class="brand">` | the nav's left slot is opt-in and was documented nowhere |
| Theme staleness | described in one direction only — the direction that bites is the other one |

## The staleness correction

`concepts/pages.md` warned that *bundled* themes can lag the canonical ones. Publishing prefers the **clone's** themes whenever a clone exists, so the failure that actually happens is the reverse: a clone behind its upstream serves older chrome than the installed skill carries, while the renderer — which ships with the skill — stays current. The two disagree inside one page and nothing fails; the upload succeeds and the page loads.

That is exactly what happened publishing the v0.6.4 demo: labels were marked by the new renderer and left unstyled by the stale CSS. Tracked as #267 for the tooling fix; this corrects the mental model the docs were teaching.

## Also

The empty brand slot in that demo was a direct consequence of the third row — I had no way to know the slot existed without reading the theme's JavaScript.

`bun test tests/docs/` — 121 pass, 0 fail. No `:::caution` added, so the editorial allowlist is untouched.