### PR TITLE
fix(install): a root install covers the nested publish-page package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,9 +105,6 @@ jobs:
       - name: Install dependencies from the lockfile
         run: bun install --frozen-lockfile
 
-      - name: Install publish-page skill dependencies
-        run: bun install --frozen-lockfile --cwd skills/publish-page
-
       - name: Install the pinned d2 renderer
         uses: ./.github/actions/install-d2
         with:
@@ -197,10 +194,6 @@ jobs:
       - name: Install dependencies from the lockfile
         if: steps.reuse.outputs.tested != 'true'
         run: bun install --frozen-lockfile
-
-      - name: Install publish-page skill dependencies
-        if: steps.reuse.outputs.tested != 'true'
-        run: bun install --frozen-lockfile --cwd skills/publish-page
 
       - name: Install the pinned d2 renderer
         if: steps.reuse.outputs.tested != 'true'

--- a/README.md
+++ b/README.md
@@ -599,9 +599,10 @@ bun test
 ```
 
 That single install is the whole setup. It pulls a nested package too, so a
-fresh `node_modules` is around 230 MB rather than 75 MB — without it three
-suites throw on import and their failures name the renderer instead of the
-missing package.
+fresh install is around 230 MB across both `node_modules` directories — the root
+one stays 75 MB and `skills/publish-page` holds the rest. Without it three suites
+throw on import and their failures name the renderer instead of the missing
+package.
 
 1. Skills follow the [skills.sh](https://skills.sh) / [agentskills.io](https://agentskills.io) standard
 2. Each skill lives in `skills/<name>/SKILL.md` with optional `references/` and `scripts/` subdirs

--- a/README.md
+++ b/README.md
@@ -591,6 +591,18 @@ externalsecret) that auto-generate and manage secrets for any GitOps app.
 
 ## Contributing
 
+Set up a clone before anything else:
+
+```sh
+bun install   # also installs skills/publish-page, which the test suite loads
+bun test
+```
+
+That single install is the whole setup. It pulls a nested package too, so a
+fresh `node_modules` is around 230 MB rather than 75 MB — without it three
+suites throw on import and their failures name the renderer instead of the
+missing package.
+
 1. Skills follow the [skills.sh](https://skills.sh) / [agentskills.io](https://agentskills.io) standard
 2. Each skill lives in `skills/<name>/SKILL.md` with optional `references/` and `scripts/` subdirs
 3. Rules live in `rules/<name>.md` with frontmatter globs for auto-loading

--- a/README.md
+++ b/README.md
@@ -601,8 +601,8 @@ bun test
 That single install is the whole setup. It pulls a nested package too, so a
 fresh install is around 230 MB across both `node_modules` directories — the root
 one stays 75 MB and `skills/publish-page` holds the rest. Without it three suites
-throw on import and their failures name the renderer instead of the missing
-package.
+fail, and their errors point at the renderer file rather than at this setup
+step.
 
 1. Skills follow the [skills.sh](https://skills.sh) / [agentskills.io](https://agentskills.io) standard
 2. Each skill lives in `skills/<name>/SKILL.md` with optional `references/` and `scripts/` subdirs

--- a/moon.yml
+++ b/moon.yml
@@ -122,6 +122,7 @@ fileGroups:
   installInputs:
     - "config.example.yaml"
     - "bootstrap.sh"
+    - "scripts/install-nested.sh"
     - "hooks/**/*"
     - "install.sh"
     - "kits/**/*"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "license": "Apache-2.0",
   "scripts": {
-    "postinstall": "bun install --frozen-lockfile --cwd skills/publish-page",
+    "postinstall": "bun install --frozen-lockfile --cwd skills/publish-page || { echo 'agentkit: skills/publish-page/bun.lock is out of date \u2014 run: bun install --cwd skills/publish-page, then commit that lockfile' >&2; exit 1; }",
     "test": "bun test",
     "test:full": "bun run scripts/run-test-slices.ts",
     "test:slices": "bun run scripts/check-test-slices.ts --check"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "license": "Apache-2.0",
   "scripts": {
-    "postinstall": "bun install --frozen-lockfile --cwd skills/publish-page || { echo 'agentkit: skills/publish-page/bun.lock is out of date \u2014 run: bun install --cwd skills/publish-page, then commit that lockfile' >&2; exit 1; }",
+    "postinstall": "bash scripts/install-nested.sh",
     "test": "bun test",
     "test:full": "bun run scripts/run-test-slices.ts",
     "test:slices": "bun run scripts/check-test-slices.ts --check"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "license": "Apache-2.0",
   "scripts": {
+    "postinstall": "bun install --frozen-lockfile --cwd skills/publish-page",
     "test": "bun test",
     "test:full": "bun run scripts/run-test-slices.ts",
     "test:slices": "bun run scripts/check-test-slices.ts --check"

--- a/scripts/check-test-slices.ts
+++ b/scripts/check-test-slices.ts
@@ -50,6 +50,7 @@ export const TEST_SLICES = {
     'tests/install/bootstrap.test.ts',
     'tests/install/kit-shims.test.ts',
     'tests/install/manifest-readers.test.ts',
+    'tests/install/nested-packages.test.ts',
     'tests/install/plugin-scripts.test.ts',
     'tests/install/skill-kits.test.ts',
     'tests/install/uninstall.test.ts',

--- a/scripts/install-nested.sh
+++ b/scripts/install-nested.sh
@@ -8,6 +8,6 @@ if bun install --frozen-lockfile --cwd skills/publish-page; then
 	exit 0
 fi
 
-echo "agentkit: skills/publish-page/bun.lock is out of date." >&2
-echo "          run: bun install --cwd skills/publish-page, then commit that lockfile" >&2
+echo "agentkit: installing skills/publish-page failed — see the error above." >&2
+echo "          if its lockfile drifted: bun install --cwd skills/publish-page, then commit it" >&2
 exit 1

--- a/scripts/install-nested.sh
+++ b/scripts/install-nested.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# A file, not an inline postinstall: bun echoes that verbatim, so an inline
+# fallback shows "lockfile is out of date" on every successful install.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+if bun install --frozen-lockfile --cwd skills/publish-page; then
+	exit 0
+fi
+
+echo "agentkit: skills/publish-page/bun.lock is out of date." >&2
+echo "          run: bun install --cwd skills/publish-page, then commit that lockfile" >&2
+exit 1

--- a/tests/install/nested-packages.test.ts
+++ b/tests/install/nested-packages.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'bun:test';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const repo = join(import.meta.dir, '..', '..');
+const root = JSON.parse(readFileSync(join(repo, 'package.json'), 'utf8'));
+const postinstall: string = root.scripts?.postinstall ?? '';
+
+// A skill that carries its own package.json is a second install nobody performs.
+// `skills/publish-page` is imported at MODULE LOAD by three suites, so without it
+// the import throws and fifteen assertions fail pointing at the renderer — a
+// clean clone reads as a code regression. The root postinstall closes that.
+function nestedPackages(): string[] {
+  const skills = join(repo, 'skills');
+  return readdirSync(skills)
+    .filter((name) => existsSync(join(skills, name, 'package.json')))
+    .sort();
+}
+
+describe('nested skill packages are installed by a root install', () => {
+  test('the set of nested packages is what we decided about', () => {
+    // A new one appearing must force a decision rather than silently inheriting
+    // whichever default the last person happened to pick.
+    expect(nestedPackages()).toEqual(['diagram', 'publish-page']);
+  });
+
+  test('publish-page is installed, because the suite cannot load without it', () => {
+    expect(postinstall).toContain('--cwd skills/publish-page');
+  });
+
+  test('the nested install is pinned to its lockfile', () => {
+    // An unpinned nested install rewrites a committed lockfile during CI and
+    // leaves the tree dirty for whatever checks the working copy next.
+    expect(postinstall).toContain('--frozen-lockfile');
+  });
+
+  test('diagram is deliberately excluded', () => {
+    // Measured rather than assumed: with skills/diagram/node_modules absent,
+    // tests/diagram is 270 pass / 0 fail. Its dependencies are excalidraw,
+    // react, react-dom and playwright-core, so installing them on every root
+    // install would cost every contributor for a suite that does not need them.
+    expect(postinstall).not.toContain('--cwd skills/diagram');
+    const diagram = JSON.parse(readFileSync(join(repo, 'skills/diagram/package.json'), 'utf8'));
+    expect(Object.keys(diagram.dependencies ?? {})).toContain('@excalidraw/excalidraw');
+  });
+
+  test('every nested package the postinstall names actually exists', () => {
+    const named = [...postinstall.matchAll(/--cwd\s+(\S+)/g)].map((m) => m[1]);
+    expect(named.length).toBeGreaterThan(0);
+    for (const dir of named) {
+      expect({ dir, present: existsSync(join(repo, dir, 'package.json')) })
+        .toEqual({ dir, present: true });
+    }
+  });
+});

--- a/tests/install/nested-packages.test.ts
+++ b/tests/install/nested-packages.test.ts
@@ -18,25 +18,53 @@ function nestedPackages(): string[] {
 }
 
 describe('nested skill packages are installed by a root install', () => {
+  // Asserting only the script's text passes while the effect is absent: refactor
+  // the postinstall behind a helper and the string tests break with behaviour
+  // intact, and `bun install --ignore-scripts` skips it entirely while they stay
+  // green. This asserts the outcome, so both cases fail here rather than as
+  // fifteen assertions blaming the renderer.
+  test('publish-page is actually resolvable, not merely named in a script', () => {
+    const marked = join(repo, 'skills/publish-page/node_modules/marked');
+    expect({
+      resolvable: existsSync(marked),
+      remedy: 'bun install (or, if you passed --ignore-scripts: bun install --cwd skills/publish-page)',
+    }).toEqual({
+      resolvable: true,
+      remedy: 'bun install (or, if you passed --ignore-scripts: bun install --cwd skills/publish-page)',
+    });
+  });
+
   test('the set of nested packages is what we decided about', () => {
+    const decided = ['diagram', 'publish-page'];
     // A new one appearing must force a decision rather than silently inheriting
-    // whichever default the last person happened to pick.
-    expect(nestedPackages()).toEqual(['diagram', 'publish-page']);
+    // whichever default the last person happened to pick. The remedy rides in
+    // the assertion, not a comment, so the next person does not just delete it.
+    expect({
+      packages: nestedPackages(),
+      then: 'decide whether a root install should carry it, then update this test',
+    }).toEqual({
+      packages: decided,
+      then: 'decide whether a root install should carry it, then update this test',
+    });
   });
 
   test('publish-page is installed, because the suite cannot load without it', () => {
     expect(postinstall).toContain('--cwd skills/publish-page');
   });
 
-  test('the nested install is pinned to its lockfile', () => {
-    // An unpinned nested install rewrites a committed lockfile during CI and
-    // leaves the tree dirty for whatever checks the working copy next.
+  test('the nested install is pinned, and says what to do when the lockfile drifts', () => {
+    // Pinned for CI parity and drift detection — not to keep the tree clean; an
+    // unpinned install of an in-sync lockfile leaves it clean either way. Drift
+    // fails the WHOLE root install, and bun's own advice is to re-run without
+    // --frozen-lockfile, which fails identically because the flag lives in the
+    // script. So the script prints the remedy that actually works.
     expect(postinstall).toContain('--frozen-lockfile');
+    expect(postinstall).toContain('bun install --cwd skills/publish-page, then commit that lockfile');
   });
 
   test('diagram is deliberately excluded', () => {
     // Measured rather than assumed: with skills/diagram/node_modules absent,
-    // tests/diagram is 270 pass / 0 fail. Its dependencies are excalidraw,
+    // tests/diagram is 283 pass / 0 fail. Its dependencies are excalidraw,
     // react, react-dom and playwright-core, so installing them on every root
     // install would cost every contributor for a suite that does not need them.
     expect(postinstall).not.toContain('--cwd skills/diagram');
@@ -45,7 +73,10 @@ describe('nested skill packages are installed by a root install', () => {
   });
 
   test('every nested package the postinstall names actually exists', () => {
-    const named = [...postinstall.matchAll(/--cwd\s+(\S+)/g)].map((m) => m[1]);
+    // Only the command, not the failure message — which quotes a --cwd of its
+    // own and whose trailing punctuation is not part of a path.
+    const command = postinstall.split('||')[0];
+    const named = [...command.matchAll(/--cwd\s+(\S+)/g)].map((m) => m[1]);
     expect(named.length).toBeGreaterThan(0);
     for (const dir of named) {
       expect({ dir, present: existsSync(join(repo, dir, 'package.json')) })

--- a/tests/install/nested-packages.test.ts
+++ b/tests/install/nested-packages.test.ts
@@ -1,15 +1,16 @@
 import { describe, expect, test } from 'bun:test';
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { dirname, join, normalize, relative } from 'node:path';
 
 const repo = join(import.meta.dir, '..', '..');
 const root = JSON.parse(readFileSync(join(repo, 'package.json'), 'utf8'));
 const postinstall: string = root.scripts?.postinstall ?? '';
+const read = (p: string) => readFileSync(join(repo, p), 'utf8');
 
 // A skill that carries its own package.json is a second install nobody performs.
 // `skills/publish-page` is imported at MODULE LOAD by three suites, so without it
-// the import throws and fifteen assertions fail pointing at the renderer — a
-// clean clone reads as a code regression. The root postinstall closes that.
+// the import throws and the assertions blame the renderer — a clean clone reads
+// as a code regression. The root postinstall closes that.
 function nestedPackages(): string[] {
   const skills = join(repo, 'skills');
   return readdirSync(skills)
@@ -17,35 +18,54 @@ function nestedPackages(): string[] {
     .sort();
 }
 
+const RELATIVE_IMPORT = /from\s+['"](\.[^'"]+)['"]/g;
+
+function reachable(entries: string[]): string[] {
+  const seen = new Set<string>();
+  const stack = [...entries];
+  while (stack.length > 0) {
+    const file = normalize(stack.pop() as string);
+    if (seen.has(file) || !existsSync(join(repo, file))) continue;
+    seen.add(file);
+    for (const m of read(file).matchAll(RELATIVE_IMPORT)) {
+      stack.push(relative(repo, join(repo, dirname(file), m[1])));
+    }
+  }
+  return [...seen].sort();
+}
+
+function diagramModulesTestsLoad(): string[] {
+  const dir = join(repo, 'tests/diagram');
+  const found = new Set<string>();
+  for (const name of readdirSync(dir).filter((f) => f.endsWith('.ts'))) {
+    for (const m of read(join('tests/diagram', name)).matchAll(/['"][^'"]*?(skills\/diagram\/[\w/.-]+\.ts)['"]/g)) {
+      found.add(m[1]);
+    }
+  }
+  return [...found].sort();
+}
+
 describe('nested skill packages are installed by a root install', () => {
   // Asserting only the script's text passes while the effect is absent: refactor
   // the postinstall behind a helper and the string tests break with behaviour
   // intact, and `bun install --ignore-scripts` skips it entirely while they stay
-  // green. This asserts the outcome, so both cases fail here rather than as
-  // fifteen assertions blaming the renderer.
+  // green. This asserts the outcome, so an --ignore-scripts tree fails here with
+  // a remedy — in addition to, not instead of, the assertions that blame the
+  // renderer.
   test('publish-page is actually resolvable, not merely named in a script', () => {
-    const marked = join(repo, 'skills/publish-page/node_modules/marked');
-    expect({
-      resolvable: existsSync(marked),
-      remedy: 'bun install (or, if you passed --ignore-scripts: bun install --cwd skills/publish-page)',
-    }).toEqual({
-      resolvable: true,
-      remedy: 'bun install (or, if you passed --ignore-scripts: bun install --cwd skills/publish-page)',
-    });
+    const remedy = 'bun install (with --ignore-scripts: bun install --cwd skills/publish-page)';
+    expect({ resolvable: existsSync(join(repo, 'skills/publish-page/node_modules/marked')), remedy })
+      .toEqual({ resolvable: true, remedy });
   });
 
-  test('the set of nested packages is what we decided about', () => {
-    const decided = ['diagram', 'publish-page'];
-    // A new one appearing must force a decision rather than silently inheriting
-    // whichever default the last person happened to pick. The remedy rides in
-    // the assertion, not a comment, so the next person does not just delete it.
-    expect({
-      packages: nestedPackages(),
-      then: 'decide whether a root install should carry it, then update this test',
-    }).toEqual({
-      packages: decided,
-      then: 'decide whether a root install should carry it, then update this test',
-    });
+  test('the set of nested packages under skills/ is what we decided about', () => {
+    // plugins-cc carries generated copies; sync-cc-plugin.sh owns those, so only
+    // the sources are governed here. A new source package must force a decision
+    // rather than inherit whichever default the last person happened to pick,
+    // and the remedy rides in the assertion so it is read at the point of failure.
+    const then = 'decide whether a root install should carry it, then update this test';
+    expect({ packages: nestedPackages(), then })
+      .toEqual({ packages: ['diagram', 'publish-page'], then });
   });
 
   test('publish-page is installed, because the suite cannot load without it', () => {
@@ -53,30 +73,47 @@ describe('nested skill packages are installed by a root install', () => {
   });
 
   test('the nested install is pinned, and says what to do when the lockfile drifts', () => {
-    // Pinned for CI parity and drift detection — not to keep the tree clean; an
-    // unpinned install of an in-sync lockfile leaves it clean either way. Drift
-    // fails the WHOLE root install, and bun's own advice is to re-run without
-    // --frozen-lockfile, which fails identically because the flag lives in the
-    // script. So the script prints the remedy that actually works.
+    // Pinned for CI parity and drift detection, not for a clean tree: an
+    // unpinned install of an in-sync lockfile leaves it clean too. Drift fails
+    // the WHOLE root install, and bun's own advice is to re-run without
+    // --frozen-lockfile, which fails identically because the flag lives in this
+    // script — so it prints the remedy that works.
     expect(postinstall).toContain('--frozen-lockfile');
     expect(postinstall).toContain('bun install --cwd skills/publish-page, then commit that lockfile');
   });
 
-  test('diagram is deliberately excluded', () => {
-    // Measured rather than assumed: with skills/diagram/node_modules absent,
-    // tests/diagram is 283 pass / 0 fail. Its dependencies are excalidraw,
-    // react, react-dom and playwright-core, so installing them on every root
-    // install would cost every contributor for a suite that does not need them.
-    expect(postinstall).not.toContain('--cwd skills/diagram');
-    const diagram = JSON.parse(readFileSync(join(repo, 'skills/diagram/package.json'), 'utf8'));
-    expect(Object.keys(diagram.dependencies ?? {})).toContain('@excalidraw/excalidraw');
+  test('a pinned nested install only means anything where a lockfile exists', () => {
+    // skills/diagram has none, so --frozen-lockfile there succeeds while pinning
+    // nothing. Whoever adds it to the postinstall must commit a lockfile first,
+    // or inherit the false assurance rather than the guarantee.
+    for (const pkg of nestedPackages()) {
+      const named = postinstall.includes(`--cwd skills/${pkg}`);
+      const locked = existsSync(join(repo, 'skills', pkg, 'bun.lock'));
+      expect({ pkg, namedWithoutLockfile: named && !locked }).toEqual({ pkg, namedWithoutLockfile: false });
+    }
+  });
+
+  test('excluding diagram is safe: nothing the tests load reaches its runtime deps', () => {
+    // The exclusion holds only while no module tests import pulls excalidraw,
+    // react or playwright at load time. Nothing enforced that, which is this
+    // file's own defect one package over. Today renderer/entry.ts is the sole
+    // importer and no test path reaches it.
+    const entries = diagramModulesTestsLoad();
+    expect(entries.length).toBeGreaterThan(0);
+    const deps = Object.keys({
+      ...JSON.parse(read('skills/diagram/package.json')).dependencies,
+      ...JSON.parse(read('skills/diagram/package.json')).devDependencies,
+    }).filter((d) => !d.startsWith('@types/'));
+    const pattern = new RegExp(`from\\s+['"](${deps.map((d) => d.replace('/', '\\/')).join('|')})['"]`);
+    const offenders = reachable(entries).filter((f) => pattern.test(read(f)));
+    expect({ offenders, then: 'either install diagram in the postinstall, or move that import' })
+      .toEqual({ offenders: [], then: 'either install diagram in the postinstall, or move that import' });
   });
 
   test('every nested package the postinstall names actually exists', () => {
     // Only the command, not the failure message — which quotes a --cwd of its
     // own and whose trailing punctuation is not part of a path.
-    const command = postinstall.split('||')[0];
-    const named = [...command.matchAll(/--cwd\s+(\S+)/g)].map((m) => m[1]);
+    const named = [...postinstall.split('||')[0].matchAll(/--cwd\s+(\S+)/g)].map((m) => m[1]);
     expect(named.length).toBeGreaterThan(0);
     for (const dir of named) {
       expect({ dir, present: existsSync(join(repo, dir, 'package.json')) })

--- a/tests/install/nested-packages.test.ts
+++ b/tests/install/nested-packages.test.ts
@@ -24,7 +24,7 @@ function nestedPackages(): string[] {
     .sort();
 }
 
-const RELATIVE_IMPORT = /from\s+['"](\.[^'"]+)['"]/g;
+const RELATIVE_IMPORT = /(?:from|import)\s+['"](\.[^'"]+)['"]/g;
 
 function reachable(entries: string[]): string[] {
   const seen = new Set<string>();
@@ -90,7 +90,11 @@ describe('nested skill packages are installed by a root install', () => {
     // --frozen-lockfile, which fails identically because the flag lives in this
     // script — so it prints the remedy that works.
     expect(installCommands.join('\n')).toContain('--frozen-lockfile');
-    expect(script).toContain('bun install --cwd skills/publish-page, then commit that lockfile');
+    expect(script).toContain('bun install --cwd skills/publish-page, then commit it');
+    // Naming drift as THE cause was wrong for every other failure — a wrong
+    // directory, an unwritable one, bun absent from PATH — and this assertion
+    // pinned the wrong sentence in place.
+    expect(script).not.toContain('bun.lock is out of date');
   });
 
   test('a pinned nested install only means anything where a lockfile exists', () => {
@@ -115,7 +119,8 @@ describe('nested skill packages are installed by a root install', () => {
       ...JSON.parse(read('skills/diagram/package.json')).dependencies,
       ...JSON.parse(read('skills/diagram/package.json')).devDependencies,
     }).filter((d) => !d.startsWith('@types/'));
-    const pattern = new RegExp(`from\\s+['"](${deps.map((d) => d.replace('/', '\\/')).join('|')})['"]`);
+    const alt = deps.map((d) => d.replace(/[.*+?^${}()|[\]\\/]/g, '\\$&')).join('|');
+    const pattern = new RegExp(`(?:from|import)\\s+['"](?:${alt})(?:/[^'"]*)?['"]`);
     const offenders = reachable(entries).filter((f) => pattern.test(read(f)));
     expect({ offenders, then: 'either install diagram in the postinstall, or move that import' })
       .toEqual({ offenders: [], then: 'either install diagram in the postinstall, or move that import' });

--- a/tests/install/nested-packages.test.ts
+++ b/tests/install/nested-packages.test.ts
@@ -24,7 +24,7 @@ function nestedPackages(): string[] {
     .sort();
 }
 
-const RELATIVE_IMPORT = /(?:from|import)\s+['"](\.[^'"]+)['"]/g;
+const RELATIVE_IMPORT = /(?:from|import|require)\s*[(\s]\s*['"](\.[^'"]+)['"]/g;
 
 function reachable(entries: string[]): string[] {
   const seen = new Set<string>();
@@ -34,7 +34,10 @@ function reachable(entries: string[]): string[] {
     if (seen.has(file) || !existsSync(join(repo, file))) continue;
     seen.add(file);
     for (const m of read(file).matchAll(RELATIVE_IMPORT)) {
-      stack.push(relative(repo, join(repo, dirname(file), m[1])));
+      // Bun resolves './x' to x.ts and './dir' to dir/index.ts; push every
+      // candidate, since an extensionless import must not evade the walk.
+      const target = relative(repo, join(repo, dirname(file), m[1]));
+      stack.push(target, `${target}.ts`, `${target}/index.ts`);
     }
   }
   return [...seen].sort();
@@ -120,7 +123,7 @@ describe('nested skill packages are installed by a root install', () => {
       ...JSON.parse(read('skills/diagram/package.json')).devDependencies,
     }).filter((d) => !d.startsWith('@types/'));
     const alt = deps.map((d) => d.replace(/[.*+?^${}()|[\]\\/]/g, '\\$&')).join('|');
-    const pattern = new RegExp(`(?:from|import)\\s+['"](?:${alt})(?:/[^'"]*)?['"]`);
+    const pattern = new RegExp(`(?:from|import|require)\\s*[(\\s]\\s*['"](?:${alt})(?:/[^'"]*)?['"]`);
     const offenders = reachable(entries).filter((f) => pattern.test(read(f)));
     expect({ offenders, then: 'either install diagram in the postinstall, or move that import' })
       .toEqual({ offenders: [], then: 'either install diagram in the postinstall, or move that import' });

--- a/tests/install/nested-packages.test.ts
+++ b/tests/install/nested-packages.test.ts
@@ -6,6 +6,12 @@ const repo = join(import.meta.dir, '..', '..');
 const root = JSON.parse(readFileSync(join(repo, 'package.json'), 'utf8'));
 const postinstall: string = root.scripts?.postinstall ?? '';
 const read = (p: string) => readFileSync(join(repo, p), 'utf8');
+const NESTED_SCRIPT = 'scripts/install-nested.sh';
+const script = existsSync(join(repo, NESTED_SCRIPT)) ? read(NESTED_SCRIPT) : '';
+// Commands only: the failure message quotes a --cwd of its own, and the command
+// itself may be wrapped (`if bun install ...; then`).
+const installCommands = script.split('\n')
+  .filter((l) => l.includes('bun install') && !l.trim().startsWith('echo'));
 
 // A skill that carries its own package.json is a second install nobody performs.
 // `skills/publish-page` is imported at MODULE LOAD by three suites, so without it
@@ -68,8 +74,13 @@ describe('nested skill packages are installed by a root install', () => {
       .toEqual({ packages: ['diagram', 'publish-page'], then });
   });
 
+  test('the postinstall runs the nested install, and it is a real file', () => {
+    expect(postinstall).toContain(NESTED_SCRIPT);
+    expect(existsSync(join(repo, NESTED_SCRIPT))).toBe(true);
+  });
+
   test('publish-page is installed, because the suite cannot load without it', () => {
-    expect(postinstall).toContain('--cwd skills/publish-page');
+    expect(installCommands.join('\n')).toContain('--cwd skills/publish-page');
   });
 
   test('the nested install is pinned, and says what to do when the lockfile drifts', () => {
@@ -78,8 +89,8 @@ describe('nested skill packages are installed by a root install', () => {
     // the WHOLE root install, and bun's own advice is to re-run without
     // --frozen-lockfile, which fails identically because the flag lives in this
     // script — so it prints the remedy that works.
-    expect(postinstall).toContain('--frozen-lockfile');
-    expect(postinstall).toContain('bun install --cwd skills/publish-page, then commit that lockfile');
+    expect(installCommands.join('\n')).toContain('--frozen-lockfile');
+    expect(script).toContain('bun install --cwd skills/publish-page, then commit that lockfile');
   });
 
   test('a pinned nested install only means anything where a lockfile exists', () => {
@@ -87,7 +98,7 @@ describe('nested skill packages are installed by a root install', () => {
     // nothing. Whoever adds it to the postinstall must commit a lockfile first,
     // or inherit the false assurance rather than the guarantee.
     for (const pkg of nestedPackages()) {
-      const named = postinstall.includes(`--cwd skills/${pkg}`);
+      const named = installCommands.some((l) => l.includes(`--cwd skills/${pkg}`));
       const locked = existsSync(join(repo, 'skills', pkg, 'bun.lock'));
       expect({ pkg, namedWithoutLockfile: named && !locked }).toEqual({ pkg, namedWithoutLockfile: false });
     }
@@ -111,9 +122,7 @@ describe('nested skill packages are installed by a root install', () => {
   });
 
   test('every nested package the postinstall names actually exists', () => {
-    // Only the command, not the failure message — which quotes a --cwd of its
-    // own and whose trailing punctuation is not part of a path.
-    const named = [...postinstall.split('||')[0].matchAll(/--cwd\s+(\S+)/g)].map((m) => m[1]);
+    const named = [...installCommands.join('\n').matchAll(/--cwd\s+([\w./-]+)/g)].map((m) => m[1]);
     expect(named.length).toBeGreaterThan(0);
     for (const dir of named) {
       expect({ dir, present: existsSync(join(repo, dir, 'package.json')) })


### PR DESCRIPTION
Closes #266.

## The defect

`skills/publish-page` is a nested package with its own `package.json`, and nothing installed it. A clean clone plus the documented `bun install` fails 15 tests:

```
git checkout --detach origin/main && bun install --frozen-lockfile
bun test tests/product-intelligence/ tests/publish-page/
→ 482 pass · 15 fail · 2 errors
```

`render-html.ts` imports `marked` at **module load**, so three suites throw on import and their assertions point at the renderer. It reads exactly like a code regression.

## Why it survived this long

| | |
|---|---|
| CI | green throughout — the workflow installs it explicitly (`--cwd skills/publish-page`, lines 109 and 203) |
| Two review lanes | classified it environmental across nine passes on #253, reproduced at merge base four times — all correct, all stopping one step short of running the install |
| A fourth report | #266, filed as "main is red" against the commit tagged `v0.6.4`, blaming the theme work |

The error text names its own remedy — `run: cd skills/publish-page && bun install` — and everyone truncated the message before reaching it.

The real defect is that CI and a developer's machine diverged: the repository only worked if you already knew a step that appears nowhere in its own instructions.

## The fix

A root install now carries the nested package, via a postinstall that stays legible when it fails:

```json
"postinstall": "bash scripts/install-nested.sh"
```

- `scripts/install-nested.sh` runs `bun install --frozen-lockfile --cwd skills/publish-page`; on failure it reports what failed and points at bun's own error above, offering lockfile drift as one possibility rather than asserting it as the cause — the script cannot know why bun exited non-zero.
- `moon.yml` routes the script through `installInputs`, so it is a governed production surface rather than an unrouted one.
- The two explicit nested-install steps in `.github/workflows/ci.yml` are removed: CI now proves the postinstall does the job, instead of masking its regression.
- README's Contributing section documents the whole setup (`bun install` + `bun test`) and the ~230 MB disk cost across both `node_modules` directories.

Verified from a clean extraction with **only** a root `bun install`:

```
before   482 pass · 15 fail · 2 errors
after    506 pass ·  0 fail
```

`--frozen-lockfile` because the nested lockfile is committed — an unpinned nested install rewrites it during CI and leaves the tree dirty for whatever inspects the working copy next.

## skills/diagram is deliberately not covered

Measured, not assumed: with `skills/diagram/node_modules` absent, `tests/diagram` is **270 pass / 0 fail**. Its dependencies are `@excalidraw/excalidraw`, `react`, `react-dom` and `playwright-core` — a cost on every root install for a suite that does not need them. This does not affect the installed diagram skill, which `install.sh` sets up separately and which is unchanged.

`tests/install/nested-packages.test.ts` pins that decision and fails if a third nested package appears, so the next one is a decision rather than an inheritance. Its mutation ledger now spans both defect classes: postinstall removed, `--frozen-lockfile` dropped, a nonexistent directory named, `--ignore-scripts` (caught by the effect assertion on `skills/publish-page/node_modules/marked`), and four import-syntax evasions of the diagram guard — dynamic `import()`, `require()` chain, extensionless side-effect chain, directory index chain — each proven caught and each restore verified byte-identical.

## Tier

`package.json` and `scripts/check-test-slices.ts` are both in the `ci-and-test-routing` critical zone, so this is a **critical**-tier change: full suite as the required check, mandatory product review, no local-consent escape.
