### PR TITLE
fix(publish-page): refuse a theme upstream has superseded, and fail loud on a rejected push

### DIFF
--- a/plugins-cc/agentkit/skills/publish-page/publish.ts
+++ b/plugins-cc/agentkit/skills/publish-page/publish.ts
@@ -98,7 +98,14 @@ function commitScoped(message: string, paths: string[]) {
     const ahead = git("rev-list", "--count", "@{u}..HEAD");
     if (ahead.exitCode !== 0 || ahead.stdout.toString().trim() === "0") return;
   }
-  const push = git("push");
+  // Bounded like the fetch: this is the other network operation, and it runs
+  // after the page is already live — a prompting remote must not stall it.
+  const push = Bun.spawnSync(["git", "-C", repo, "push"], {
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: 30_000,
+    env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
+  });
   if (push.exitCode !== 0) {
     // The push can fail without any rejection (offline, no upstream), so the
     // message reports the failure and leaves the cause to git's own error.
@@ -169,7 +176,7 @@ async function render(): Promise<string> {
         // and --rebase because a stranded local commit makes a plain pull abort.
         fail(`pages clone is ${behind} commit(s) behind and themes/ changed upstream — publishing now would serve stale CSS. run: git -C ${repo} pull --rebase`);
       } else if (upstream.exitCode !== 0) {
-        console.error(`warning: could not verify the pages clone is current (no upstream to compare) — publishing with its themes as-is`);
+        console.error(`warning: could not compare the pages clone against an upstream — publishing with its themes as-is`);
       }
     }
     if (existsSync(bundledTheme)) {

--- a/plugins-cc/agentkit/skills/publish-page/publish.ts
+++ b/plugins-cc/agentkit/skills/publish-page/publish.ts
@@ -90,12 +90,13 @@ function commitScoped(message: string, paths: string[]) {
   if (commit.exitCode === 0) {
     const push = git("push");
     if (push.exitCode !== 0) {
-      // A rejected push means the canonical history silently lost this page —
-      // the publish already succeeded, so exit loud instead of failing here.
+      // A rejected push means the canonical history silently lost this change —
+      // the server operation already succeeded, so exit loud instead of failing here.
+      const done = isDelete ? "the page was deleted from the server" : "the page itself is live";
       console.error(
-        `publish-page: the canonical push was rejected — agentkit-pages history does NOT carry this publish:\n`
+        `publish-page: the canonical push was rejected — agentkit-pages history does NOT carry this ${isDelete ? "deletion" : "publish"}:\n`
           + push.stderr.toString()
-          + `the page itself is live; fix the clone (git -C ${repo} pull --rebase) and re-run this publish to record it`,
+          + `${done}; fix the clone (git -C ${repo} pull --rebase) and re-run the same command to record it`,
       );
       process.exitCode = 1;
     }
@@ -118,7 +119,8 @@ if (isDelete) {
     commitScoped(`pages: delete ${pageLabel}`, [`src/${slug}`, `dist/${slug}`]);
   }
   console.log(`deleted: ${endpoint}/${slug}`);
-  process.exit(0);
+  // Bare exit() honors the exitCode a rejected canonical push set; exit(0) discards it.
+  process.exit();
 }
 
 const source = await readFile(file!, "utf8");
@@ -141,11 +143,24 @@ async function render(): Promise<string> {
     // the page publishes with current markup and stale rules. Refuse only when
     // upstream actually changed themes/ — merge-base..upstream, so a clone
     // that is merely ahead or behind on other paths still publishes.
-    if (git("fetch", "--quiet").exitCode !== 0) {
+    // Bounded and prompt-free: an unreachable remote or a credential helper
+    // wanting input must degrade to the warning, not stall the publish.
+    const fetched = Bun.spawnSync(["git", "-C", repo, "fetch", "--quiet"], {
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 15_000,
+      env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
+    });
+    if (fetched.exitCode !== 0) {
       console.error(`warning: could not verify the pages clone is current (git fetch failed) — publishing with its themes as-is`);
-    } else if (git("diff", "--quiet", "HEAD...@{u}", "--", "themes/").exitCode === 1) {
-      const behind = git("rev-list", "--count", "HEAD..@{u}").stdout.toString().trim();
-      fail(`pages clone is ${behind} commit(s) behind and themes/ changed upstream — run: git -C ${repo} pull; publishing now would serve stale CSS`);
+    } else {
+      const upstream = git("diff", "--quiet", "HEAD...@{u}", "--", "themes/");
+      if (upstream.exitCode === 1) {
+        const behind = git("rev-list", "--count", "HEAD..@{u}").stdout.toString().trim();
+        fail(`pages clone is ${behind} commit(s) behind and themes/ changed upstream — run: git -C ${repo} pull; publishing now would serve stale CSS`);
+      } else if (upstream.exitCode !== 0) {
+        console.error(`warning: could not verify the pages clone is current (no upstream to compare) — publishing with its themes as-is`);
+      }
     }
     if (existsSync(bundledTheme)) {
       const [canonical, bundled] = await Promise.all([readFile(repoTheme, "utf8"), readFile(bundledTheme, "utf8")]);

--- a/plugins-cc/agentkit/skills/publish-page/publish.ts
+++ b/plugins-cc/agentkit/skills/publish-page/publish.ts
@@ -83,25 +83,33 @@ const repoAvailable = () => existsSync(join(repo, ".git"));
 
 function commitScoped(message: string, paths: string[]) {
   const staged = git("diff", "--cached", "--quiet", "--", ...paths);
-  if (staged.exitCode === 0) return;
-  // Pathspec-scoped commit: the clone is long-lived and shared — a bare
-  // commit would sweep anything else staged into this publish.
-  const commit = git("commit", "-m", message, "--", ...paths);
-  if (commit.exitCode === 0) {
-    const push = git("push");
-    if (push.exitCode !== 0) {
-      // A rejected push means the canonical history silently lost this change —
-      // the server operation already succeeded, so exit loud instead of failing here.
-      const done = isDelete ? "the page was deleted from the server" : "the page itself is live";
-      console.error(
-        `publish-page: the canonical push was rejected — agentkit-pages history does NOT carry this ${isDelete ? "deletion" : "publish"}:\n`
-          + push.stderr.toString()
-          + `${done}; fix the clone (git -C ${repo} pull --rebase) and re-run the same command to record it`,
-      );
-      process.exitCode = 1;
+  if (staged.exitCode !== 0) {
+    // Pathspec-scoped commit: the clone is long-lived and shared — a bare
+    // commit would sweep anything else staged into this publish.
+    const commit = git("commit", "-m", message, "--", ...paths);
+    if (commit.exitCode !== 0) {
+      console.error(`warning: git commit failed:\n${commit.stderr.toString()}`);
+      return;
     }
   } else {
-    console.error(`warning: git commit failed:\n${commit.stderr.toString()}`);
+    // Nothing newly staged — but a previously rejected push leaves committed
+    // work stranded, and a re-run of the same command must still push it or
+    // the printed remedy records nothing while exiting 0.
+    const ahead = git("rev-list", "--count", "@{u}..HEAD");
+    if (ahead.exitCode !== 0 || ahead.stdout.toString().trim() === "0") return;
+  }
+  const push = git("push");
+  if (push.exitCode !== 0) {
+    // The push can fail without any rejection (offline, no upstream), so the
+    // message reports the failure and leaves the cause to git's own error.
+    const done = isDelete ? "the page was deleted from the server" : "the page itself is live";
+    console.error(
+      `publish-page: the canonical push failed:\n`
+        + push.stderr.toString()
+        + `agentkit-pages history does NOT carry this ${isDelete ? "deletion" : "publish"}; ${done}.\n`
+        + `if the push was rejected because the clone is behind: git -C ${repo} pull --rebase, then re-run the same command`,
+    );
+    process.exitCode = 1;
   }
 }
 
@@ -157,7 +165,9 @@ async function render(): Promise<string> {
       const upstream = git("diff", "--quiet", "HEAD...@{u}", "--", "themes/");
       if (upstream.exitCode === 1) {
         const behind = git("rev-list", "--count", "HEAD..@{u}").stdout.toString().trim();
-        fail(`pages clone is ${behind} commit(s) behind and themes/ changed upstream — run: git -C ${repo} pull; publishing now would serve stale CSS`);
+        // Remedy last and nothing after it: this text gets pasted by agents,
+        // and --rebase because a stranded local commit makes a plain pull abort.
+        fail(`pages clone is ${behind} commit(s) behind and themes/ changed upstream — publishing now would serve stale CSS. run: git -C ${repo} pull --rebase`);
       } else if (upstream.exitCode !== 0) {
         console.error(`warning: could not verify the pages clone is current (no upstream to compare) — publishing with its themes as-is`);
       }

--- a/plugins-cc/agentkit/skills/publish-page/publish.ts
+++ b/plugins-cc/agentkit/skills/publish-page/publish.ts
@@ -125,15 +125,24 @@ if (isDelete) {
     method: "DELETE",
     headers: { authorization: `Bearer ${token}` },
   });
-  if (res.status === 404) fail(`no page at ${slug} — nothing deleted`);
-  if (!res.ok) fail(`delete failed: HTTP ${res.status} ${await res.text()}`);
+  const gone = res.status === 404;
+  if (!res.ok && !gone) fail(`delete failed: HTTP ${res.status} ${await res.text()}`);
   if (!noGit && repoAvailable()) {
+    // A 404 is not always a dead end: a successful delete whose canonical push
+    // was rejected leaves the server page gone and the deletion commit
+    // stranded, and the advised re-run must still push that commit.
+    const hadLocal = existsSync(join(repo, "src", slug)) || existsSync(join(repo, "dist", slug));
+    const ahead = git("rev-list", "--count", "@{u}..HEAD");
+    const stranded = ahead.exitCode === 0 && ahead.stdout.toString().trim() !== "0";
+    if (gone && !hadLocal && !stranded) fail(`no page at ${slug} — nothing deleted`);
     await rm(join(repo, "src", slug), { recursive: true, force: true });
     await rm(join(repo, "dist", slug), { recursive: true, force: true });
     git("add", "-A", "--", `src/${slug}`, `dist/${slug}`);
     commitScoped(`pages: delete ${pageLabel}`, [`src/${slug}`, `dist/${slug}`]);
+  } else if (gone) {
+    fail(`no page at ${slug} — nothing deleted`);
   }
-  console.log(`deleted: ${endpoint}/${slug}`);
+  console.log(gone ? `no page on the server at ${slug} — canonical record updated` : `deleted: ${endpoint}/${slug}`);
   // Bare exit() honors the exitCode a rejected canonical push set; exit(0) discards it.
   process.exit();
 }

--- a/plugins-cc/agentkit/skills/publish-page/publish.ts
+++ b/plugins-cc/agentkit/skills/publish-page/publish.ts
@@ -90,7 +90,14 @@ function commitScoped(message: string, paths: string[]) {
   if (commit.exitCode === 0) {
     const push = git("push");
     if (push.exitCode !== 0) {
-      console.error(`warning: git push failed — commit is local only:\n${push.stderr.toString()}`);
+      // A rejected push means the canonical history silently lost this page —
+      // the publish already succeeded, so exit loud instead of failing here.
+      console.error(
+        `publish-page: the canonical push was rejected — agentkit-pages history does NOT carry this publish:\n`
+          + push.stderr.toString()
+          + `the page itself is live; fix the clone (git -C ${repo} pull --rebase) and re-run this publish to record it`,
+      );
+      process.exitCode = 1;
     }
   } else {
     console.error(`warning: git commit failed:\n${commit.stderr.toString()}`);
@@ -129,10 +136,22 @@ async function render(): Promise<string> {
   const bundledTheme = bundledThemePath(template);
   const themePath = existsSync(repoTheme) ? repoTheme : bundledTheme;
   if (!existsSync(themePath)) fail(`theme not found: ${repoTheme} or ${bundledTheme}`);
-  if (themePath === repoTheme && existsSync(bundledTheme)) {
-    const [canonical, bundled] = await Promise.all([readFile(repoTheme, "utf8"), readFile(bundledTheme, "utf8")]);
-    if (bundled !== canonical) {
-      console.error(`warning: bundled theme drifted from canonical ${repoTheme} — re-sync skills/publish-page/themes/`);
+  if (themePath === repoTheme) {
+    // A behind clone serves CSS upstream already replaced, and nothing fails:
+    // the page publishes with current markup and stale rules. Refuse only when
+    // upstream actually changed themes/ — merge-base..upstream, so a clone
+    // that is merely ahead or behind on other paths still publishes.
+    if (git("fetch", "--quiet").exitCode !== 0) {
+      console.error(`warning: could not verify the pages clone is current (git fetch failed) — publishing with its themes as-is`);
+    } else if (git("diff", "--quiet", "HEAD...@{u}", "--", "themes/").exitCode === 1) {
+      const behind = git("rev-list", "--count", "HEAD..@{u}").stdout.toString().trim();
+      fail(`pages clone is ${behind} commit(s) behind and themes/ changed upstream — run: git -C ${repo} pull; publishing now would serve stale CSS`);
+    }
+    if (existsSync(bundledTheme)) {
+      const [canonical, bundled] = await Promise.all([readFile(repoTheme, "utf8"), readFile(bundledTheme, "utf8")]);
+      if (bundled !== canonical) {
+        console.error(`warning: bundled theme lags canonical ${repoTheme} — re-sync skills/publish-page/themes/`);
+      }
     }
   }
   try {

--- a/plugins-cc/agentkit/skills/publish-page/publish.ts
+++ b/plugins-cc/agentkit/skills/publish-page/publish.ts
@@ -132,7 +132,9 @@ if (isDelete) {
     // was rejected leaves the server page gone and the deletion commit
     // stranded, and the advised re-run must still push that commit.
     const hadLocal = existsSync(join(repo, "src", slug)) || existsSync(join(repo, "dist", slug));
-    const ahead = git("rev-list", "--count", "@{u}..HEAD");
+    // Scoped to THIS slug's history: a clone ahead on unrelated work must not
+    // turn a mistyped delete into a reported success.
+    const ahead = git("rev-list", "--count", "@{u}..HEAD", "--", `src/${slug}`, `dist/${slug}`);
     const stranded = ahead.exitCode === 0 && ahead.stdout.toString().trim() !== "0";
     if (gone && !hadLocal && !stranded) fail(`no page at ${slug} — nothing deleted`);
     await rm(join(repo, "src", slug), { recursive: true, force: true });

--- a/scripts/check-test-slices.ts
+++ b/scripts/check-test-slices.ts
@@ -70,6 +70,7 @@ export const TEST_SLICES = {
     'tests/publish-page/lint.test.ts',
     'tests/publish-page/mermaid-runtime.test.ts',
     'tests/publish-page/pages-police.test.ts',
+    'tests/publish-page/publish-freshness.test.ts',
     'tests/publish-page/theme-chrome.test.ts',
     'tests/publish-page/worker.test.ts',
   ],

--- a/skills/publish-page/publish.ts
+++ b/skills/publish-page/publish.ts
@@ -98,7 +98,14 @@ function commitScoped(message: string, paths: string[]) {
     const ahead = git("rev-list", "--count", "@{u}..HEAD");
     if (ahead.exitCode !== 0 || ahead.stdout.toString().trim() === "0") return;
   }
-  const push = git("push");
+  // Bounded like the fetch: this is the other network operation, and it runs
+  // after the page is already live — a prompting remote must not stall it.
+  const push = Bun.spawnSync(["git", "-C", repo, "push"], {
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: 30_000,
+    env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
+  });
   if (push.exitCode !== 0) {
     // The push can fail without any rejection (offline, no upstream), so the
     // message reports the failure and leaves the cause to git's own error.
@@ -169,7 +176,7 @@ async function render(): Promise<string> {
         // and --rebase because a stranded local commit makes a plain pull abort.
         fail(`pages clone is ${behind} commit(s) behind and themes/ changed upstream — publishing now would serve stale CSS. run: git -C ${repo} pull --rebase`);
       } else if (upstream.exitCode !== 0) {
-        console.error(`warning: could not verify the pages clone is current (no upstream to compare) — publishing with its themes as-is`);
+        console.error(`warning: could not compare the pages clone against an upstream — publishing with its themes as-is`);
       }
     }
     if (existsSync(bundledTheme)) {

--- a/skills/publish-page/publish.ts
+++ b/skills/publish-page/publish.ts
@@ -90,12 +90,13 @@ function commitScoped(message: string, paths: string[]) {
   if (commit.exitCode === 0) {
     const push = git("push");
     if (push.exitCode !== 0) {
-      // A rejected push means the canonical history silently lost this page —
-      // the publish already succeeded, so exit loud instead of failing here.
+      // A rejected push means the canonical history silently lost this change —
+      // the server operation already succeeded, so exit loud instead of failing here.
+      const done = isDelete ? "the page was deleted from the server" : "the page itself is live";
       console.error(
-        `publish-page: the canonical push was rejected — agentkit-pages history does NOT carry this publish:\n`
+        `publish-page: the canonical push was rejected — agentkit-pages history does NOT carry this ${isDelete ? "deletion" : "publish"}:\n`
           + push.stderr.toString()
-          + `the page itself is live; fix the clone (git -C ${repo} pull --rebase) and re-run this publish to record it`,
+          + `${done}; fix the clone (git -C ${repo} pull --rebase) and re-run the same command to record it`,
       );
       process.exitCode = 1;
     }
@@ -118,7 +119,8 @@ if (isDelete) {
     commitScoped(`pages: delete ${pageLabel}`, [`src/${slug}`, `dist/${slug}`]);
   }
   console.log(`deleted: ${endpoint}/${slug}`);
-  process.exit(0);
+  // Bare exit() honors the exitCode a rejected canonical push set; exit(0) discards it.
+  process.exit();
 }
 
 const source = await readFile(file!, "utf8");
@@ -141,11 +143,24 @@ async function render(): Promise<string> {
     // the page publishes with current markup and stale rules. Refuse only when
     // upstream actually changed themes/ — merge-base..upstream, so a clone
     // that is merely ahead or behind on other paths still publishes.
-    if (git("fetch", "--quiet").exitCode !== 0) {
+    // Bounded and prompt-free: an unreachable remote or a credential helper
+    // wanting input must degrade to the warning, not stall the publish.
+    const fetched = Bun.spawnSync(["git", "-C", repo, "fetch", "--quiet"], {
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 15_000,
+      env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
+    });
+    if (fetched.exitCode !== 0) {
       console.error(`warning: could not verify the pages clone is current (git fetch failed) — publishing with its themes as-is`);
-    } else if (git("diff", "--quiet", "HEAD...@{u}", "--", "themes/").exitCode === 1) {
-      const behind = git("rev-list", "--count", "HEAD..@{u}").stdout.toString().trim();
-      fail(`pages clone is ${behind} commit(s) behind and themes/ changed upstream — run: git -C ${repo} pull; publishing now would serve stale CSS`);
+    } else {
+      const upstream = git("diff", "--quiet", "HEAD...@{u}", "--", "themes/");
+      if (upstream.exitCode === 1) {
+        const behind = git("rev-list", "--count", "HEAD..@{u}").stdout.toString().trim();
+        fail(`pages clone is ${behind} commit(s) behind and themes/ changed upstream — run: git -C ${repo} pull; publishing now would serve stale CSS`);
+      } else if (upstream.exitCode !== 0) {
+        console.error(`warning: could not verify the pages clone is current (no upstream to compare) — publishing with its themes as-is`);
+      }
     }
     if (existsSync(bundledTheme)) {
       const [canonical, bundled] = await Promise.all([readFile(repoTheme, "utf8"), readFile(bundledTheme, "utf8")]);

--- a/skills/publish-page/publish.ts
+++ b/skills/publish-page/publish.ts
@@ -83,25 +83,33 @@ const repoAvailable = () => existsSync(join(repo, ".git"));
 
 function commitScoped(message: string, paths: string[]) {
   const staged = git("diff", "--cached", "--quiet", "--", ...paths);
-  if (staged.exitCode === 0) return;
-  // Pathspec-scoped commit: the clone is long-lived and shared — a bare
-  // commit would sweep anything else staged into this publish.
-  const commit = git("commit", "-m", message, "--", ...paths);
-  if (commit.exitCode === 0) {
-    const push = git("push");
-    if (push.exitCode !== 0) {
-      // A rejected push means the canonical history silently lost this change —
-      // the server operation already succeeded, so exit loud instead of failing here.
-      const done = isDelete ? "the page was deleted from the server" : "the page itself is live";
-      console.error(
-        `publish-page: the canonical push was rejected — agentkit-pages history does NOT carry this ${isDelete ? "deletion" : "publish"}:\n`
-          + push.stderr.toString()
-          + `${done}; fix the clone (git -C ${repo} pull --rebase) and re-run the same command to record it`,
-      );
-      process.exitCode = 1;
+  if (staged.exitCode !== 0) {
+    // Pathspec-scoped commit: the clone is long-lived and shared — a bare
+    // commit would sweep anything else staged into this publish.
+    const commit = git("commit", "-m", message, "--", ...paths);
+    if (commit.exitCode !== 0) {
+      console.error(`warning: git commit failed:\n${commit.stderr.toString()}`);
+      return;
     }
   } else {
-    console.error(`warning: git commit failed:\n${commit.stderr.toString()}`);
+    // Nothing newly staged — but a previously rejected push leaves committed
+    // work stranded, and a re-run of the same command must still push it or
+    // the printed remedy records nothing while exiting 0.
+    const ahead = git("rev-list", "--count", "@{u}..HEAD");
+    if (ahead.exitCode !== 0 || ahead.stdout.toString().trim() === "0") return;
+  }
+  const push = git("push");
+  if (push.exitCode !== 0) {
+    // The push can fail without any rejection (offline, no upstream), so the
+    // message reports the failure and leaves the cause to git's own error.
+    const done = isDelete ? "the page was deleted from the server" : "the page itself is live";
+    console.error(
+      `publish-page: the canonical push failed:\n`
+        + push.stderr.toString()
+        + `agentkit-pages history does NOT carry this ${isDelete ? "deletion" : "publish"}; ${done}.\n`
+        + `if the push was rejected because the clone is behind: git -C ${repo} pull --rebase, then re-run the same command`,
+    );
+    process.exitCode = 1;
   }
 }
 
@@ -157,7 +165,9 @@ async function render(): Promise<string> {
       const upstream = git("diff", "--quiet", "HEAD...@{u}", "--", "themes/");
       if (upstream.exitCode === 1) {
         const behind = git("rev-list", "--count", "HEAD..@{u}").stdout.toString().trim();
-        fail(`pages clone is ${behind} commit(s) behind and themes/ changed upstream — run: git -C ${repo} pull; publishing now would serve stale CSS`);
+        // Remedy last and nothing after it: this text gets pasted by agents,
+        // and --rebase because a stranded local commit makes a plain pull abort.
+        fail(`pages clone is ${behind} commit(s) behind and themes/ changed upstream — publishing now would serve stale CSS. run: git -C ${repo} pull --rebase`);
       } else if (upstream.exitCode !== 0) {
         console.error(`warning: could not verify the pages clone is current (no upstream to compare) — publishing with its themes as-is`);
       }

--- a/skills/publish-page/publish.ts
+++ b/skills/publish-page/publish.ts
@@ -125,15 +125,24 @@ if (isDelete) {
     method: "DELETE",
     headers: { authorization: `Bearer ${token}` },
   });
-  if (res.status === 404) fail(`no page at ${slug} — nothing deleted`);
-  if (!res.ok) fail(`delete failed: HTTP ${res.status} ${await res.text()}`);
+  const gone = res.status === 404;
+  if (!res.ok && !gone) fail(`delete failed: HTTP ${res.status} ${await res.text()}`);
   if (!noGit && repoAvailable()) {
+    // A 404 is not always a dead end: a successful delete whose canonical push
+    // was rejected leaves the server page gone and the deletion commit
+    // stranded, and the advised re-run must still push that commit.
+    const hadLocal = existsSync(join(repo, "src", slug)) || existsSync(join(repo, "dist", slug));
+    const ahead = git("rev-list", "--count", "@{u}..HEAD");
+    const stranded = ahead.exitCode === 0 && ahead.stdout.toString().trim() !== "0";
+    if (gone && !hadLocal && !stranded) fail(`no page at ${slug} — nothing deleted`);
     await rm(join(repo, "src", slug), { recursive: true, force: true });
     await rm(join(repo, "dist", slug), { recursive: true, force: true });
     git("add", "-A", "--", `src/${slug}`, `dist/${slug}`);
     commitScoped(`pages: delete ${pageLabel}`, [`src/${slug}`, `dist/${slug}`]);
+  } else if (gone) {
+    fail(`no page at ${slug} — nothing deleted`);
   }
-  console.log(`deleted: ${endpoint}/${slug}`);
+  console.log(gone ? `no page on the server at ${slug} — canonical record updated` : `deleted: ${endpoint}/${slug}`);
   // Bare exit() honors the exitCode a rejected canonical push set; exit(0) discards it.
   process.exit();
 }

--- a/skills/publish-page/publish.ts
+++ b/skills/publish-page/publish.ts
@@ -90,7 +90,14 @@ function commitScoped(message: string, paths: string[]) {
   if (commit.exitCode === 0) {
     const push = git("push");
     if (push.exitCode !== 0) {
-      console.error(`warning: git push failed — commit is local only:\n${push.stderr.toString()}`);
+      // A rejected push means the canonical history silently lost this page —
+      // the publish already succeeded, so exit loud instead of failing here.
+      console.error(
+        `publish-page: the canonical push was rejected — agentkit-pages history does NOT carry this publish:\n`
+          + push.stderr.toString()
+          + `the page itself is live; fix the clone (git -C ${repo} pull --rebase) and re-run this publish to record it`,
+      );
+      process.exitCode = 1;
     }
   } else {
     console.error(`warning: git commit failed:\n${commit.stderr.toString()}`);
@@ -129,10 +136,22 @@ async function render(): Promise<string> {
   const bundledTheme = bundledThemePath(template);
   const themePath = existsSync(repoTheme) ? repoTheme : bundledTheme;
   if (!existsSync(themePath)) fail(`theme not found: ${repoTheme} or ${bundledTheme}`);
-  if (themePath === repoTheme && existsSync(bundledTheme)) {
-    const [canonical, bundled] = await Promise.all([readFile(repoTheme, "utf8"), readFile(bundledTheme, "utf8")]);
-    if (bundled !== canonical) {
-      console.error(`warning: bundled theme drifted from canonical ${repoTheme} — re-sync skills/publish-page/themes/`);
+  if (themePath === repoTheme) {
+    // A behind clone serves CSS upstream already replaced, and nothing fails:
+    // the page publishes with current markup and stale rules. Refuse only when
+    // upstream actually changed themes/ — merge-base..upstream, so a clone
+    // that is merely ahead or behind on other paths still publishes.
+    if (git("fetch", "--quiet").exitCode !== 0) {
+      console.error(`warning: could not verify the pages clone is current (git fetch failed) — publishing with its themes as-is`);
+    } else if (git("diff", "--quiet", "HEAD...@{u}", "--", "themes/").exitCode === 1) {
+      const behind = git("rev-list", "--count", "HEAD..@{u}").stdout.toString().trim();
+      fail(`pages clone is ${behind} commit(s) behind and themes/ changed upstream — run: git -C ${repo} pull; publishing now would serve stale CSS`);
+    }
+    if (existsSync(bundledTheme)) {
+      const [canonical, bundled] = await Promise.all([readFile(repoTheme, "utf8"), readFile(bundledTheme, "utf8")]);
+      if (bundled !== canonical) {
+        console.error(`warning: bundled theme lags canonical ${repoTheme} — re-sync skills/publish-page/themes/`);
+      }
     }
   }
   try {

--- a/skills/publish-page/publish.ts
+++ b/skills/publish-page/publish.ts
@@ -132,7 +132,9 @@ if (isDelete) {
     // was rejected leaves the server page gone and the deletion commit
     // stranded, and the advised re-run must still push that commit.
     const hadLocal = existsSync(join(repo, "src", slug)) || existsSync(join(repo, "dist", slug));
-    const ahead = git("rev-list", "--count", "@{u}..HEAD");
+    // Scoped to THIS slug's history: a clone ahead on unrelated work must not
+    // turn a mistyped delete into a reported success.
+    const ahead = git("rev-list", "--count", "@{u}..HEAD", "--", `src/${slug}`, `dist/${slug}`);
     const stranded = ahead.exitCode === 0 && ahead.stdout.toString().trim() !== "0";
     if (gone && !hadLocal && !stranded) fail(`no page at ${slug} — nothing deleted`);
     await rm(join(repo, "src", slug), { recursive: true, force: true });

--- a/tests/publish-page/publish-freshness.test.ts
+++ b/tests/publish-page/publish-freshness.test.ts
@@ -1,0 +1,158 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const repoRoot = join(import.meta.dir, "../..");
+const bundledDoc = readFileSync(join(repoRoot, "skills/publish-page/themes/doc.html"), "utf8");
+
+let server: ReturnType<typeof Bun.serve>;
+let puts = 0;
+
+beforeAll(() => {
+  server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      if (req.method === "PUT") {
+        puts++;
+        return Response.json({ url: `http://127.0.0.1:${server.port}/fake-slug` });
+      }
+      return new Response("nope", { status: 405 });
+    },
+  });
+});
+afterAll(() => server.stop(true));
+
+function sh(cwd: string, ...args: string[]) {
+  const r = spawnSync(args[0]!, args.slice(1), { cwd, encoding: "utf8" });
+  if (r.status !== 0) throw new Error(`${args.join(" ")} failed in ${cwd}: ${r.stderr}`);
+  return r.stdout;
+}
+const git = (cwd: string, ...args: string[]) =>
+  sh(cwd, "git", "-c", "user.email=t@t", "-c", "user.name=t", ...args);
+
+// origin (bare) + publisher clone + a second clone that advances origin.
+function makeWorld(): { home: string; origin: string; mine: string; theirs: string; page: string } {
+  const base = mkdtempSync(join(tmpdir(), "pages-freshness-"));
+  const home = join(base, "home");
+  mkdirSync(join(home, ".config/agentkit"), { recursive: true });
+  writeFileSync(join(home, ".config/agentkit/pages-token"), "test-token\n");
+  writeFileSync(join(home, ".config/agentkit/pages-slug-key"), "00".repeat(32));
+  // publish.ts commits with the machine identity; the fake HOME must have one.
+  writeFileSync(join(home, ".gitconfig"), "[user]\n\temail = t@t\n\tname = t\n");
+
+  const origin = join(base, "origin.git");
+  sh(base, "git", "init", "--bare", "-b", "main", origin);
+  const seed = join(base, "seed");
+  git(base, "clone", origin, seed);
+  mkdirSync(join(seed, "themes"), { recursive: true });
+  writeFileSync(join(seed, "themes/doc.html"), bundledDoc);
+  git(seed, "add", "-A");
+  git(seed, "commit", "-m", "seed themes");
+  git(seed, "push", "origin", "main");
+
+  const mine = join(base, "mine");
+  const theirs = join(base, "theirs");
+  git(base, "clone", origin, mine);
+  git(base, "clone", origin, theirs);
+
+  const page = join(base, "page.md");
+  writeFileSync(page, "# Freshness\n\nhello\n");
+  return { home, origin, mine, theirs, page };
+}
+
+function advanceOrigin(theirs: string, path: string, content: string) {
+  writeFileSync(join(theirs, path), content);
+  git(theirs, "add", "-A");
+  git(theirs, "commit", "-m", `advance ${path}`);
+  git(theirs, "push", "origin", "main");
+}
+
+// Async spawn: spawnSync would block the event loop this test's own
+// server runs on, deadlocking the publish PUT against it.
+async function publish(world: { home: string; mine: string; page: string }) {
+  const proc = Bun.spawn(["bun", join(repoRoot, "skills/publish-page/publish.ts"), "--name", "fresh", "--file", world.page], {
+    cwd: repoRoot,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: {
+      ...process.env,
+      HOME: world.home,
+      AGENTKIT_PAGES_REPO: world.mine,
+      AGENTKIT_PAGES_ENDPOINT: `http://127.0.0.1:${server.port}`,
+    },
+  });
+  const [stdout, stderr, status] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { status, stdout, stderr };
+}
+
+describe("publishing refuses a theme that upstream has superseded", () => {
+  test("clone behind with themes/ changed upstream: refuse, name the remedy, publish nothing", async () => {
+    const w = makeWorld();
+    advanceOrigin(w.theirs, "themes/doc.html", bundledDoc + "\n<!-- newer canonical -->\n");
+    const before = puts;
+    const r = await publish(w);
+    expect({ status: r.status, puts: puts - before }).toEqual({ status: 1, puts: 0 });
+    // The refusal must say the CLONE is the stale side and give its remedy —
+    // the old warning pointed at the bundle, whose remedy destroys good themes.
+    expect(r.stderr).toMatch(/behind/);
+    expect(r.stderr).toMatch(/git -C \S+ pull/);
+    expect(r.stderr).toMatch(/stale/i);
+  }, 20000);
+
+  test("clone behind but themes/ untouched upstream: the page publishes", async () => {
+    const w = makeWorld();
+    advanceOrigin(w.theirs, "README.md", "unrelated\n");
+    const before = puts;
+    const r = await publish(w);
+    // No refusal — the PUT goes through. The later canonical push is rejected
+    // (origin advanced), which is the loud exit the second describe pins.
+    expect({ puts: puts - before, refused: r.stderr.includes("stale CSS") }).toEqual({ puts: 1, refused: false });
+    expect(r.stdout).toContain("/fake-slug");
+  }, 20000);
+
+  test("current clone whose theme differs from the bundle: warn that the BUNDLE lags", async () => {
+    const w = makeWorld();
+    writeFileSync(join(w.mine, "themes/doc.html"), bundledDoc + "\n<!-- local canonical edit -->\n");
+    git(w.mine, "add", "-A");
+    git(w.mine, "commit", "-m", "newer canonical theme");
+    git(w.mine, "push", "origin", "main");
+    const before = puts;
+    const r = await publish(w);
+    expect({ status: r.status, puts: puts - before }).toEqual({ status: 0, puts: 1 });
+    expect(r.stderr).toMatch(/bundled theme lags/);
+    expect(r.stderr).not.toMatch(/drifted from canonical/);
+  }, 20000);
+
+  test("fetch failure: say the check could not run, then publish anyway", async () => {
+    const w = makeWorld();
+    git(w.mine, "remote", "set-url", "origin", join(w.mine, "does-not-exist"));
+    const before = puts;
+    const r = await publish(w);
+    // The broken remote also fails the later push, so only the PUT and the
+    // warning distinguish this from a refusal.
+    expect({ puts: puts - before, refused: r.stderr.includes("stale CSS") }).toEqual({ puts: 1, refused: false });
+    expect(r.stderr).toMatch(/could not verify/);
+    expect(r.stdout).toContain("/fake-slug");
+  }, 20000);
+});
+
+describe("a rejected canonical push fails loud", () => {
+  test("non-fast-forward push: page is live, exit is 1, remedy named", async () => {
+    const w = makeWorld();
+    advanceOrigin(w.theirs, "README.md", "unrelated, makes mine's push non-fast-forward\n");
+    const before = puts;
+    const r = await publish(w);
+    // The PUT succeeded and the URL printed — but the canonical history
+    // silently losing the page was the defect, so the exit must be loud.
+    expect({ puts: puts - before, status: r.status }).toEqual({ puts: 1, status: 1 });
+    expect(r.stdout).toContain("/fake-slug");
+    expect(r.stderr).toMatch(/push.*rejected|rejected.*push/i);
+    expect(r.stderr).toMatch(/git -C \S+ pull/);
+  }, 20000);
+});

--- a/tests/publish-page/publish-freshness.test.ts
+++ b/tests/publish-page/publish-freshness.test.ts
@@ -37,6 +37,8 @@ function sh(cwd: string, ...args: string[]) {
 }
 const git = (cwd: string, ...args: string[]) =>
   sh(cwd, "git", "-c", "user.email=t@t", "-c", "user.name=t", ...args);
+// Commits the clone holds that canonical does not — 0 means nothing stranded.
+const ahead = (clone: string) => git(clone, "rev-list", "--count", "@{u}..HEAD").trim();
 
 // origin (bare) + publisher clone + a second clone that advances origin.
 function makeWorld(): { home: string; origin: string; mine: string; theirs: string; page: string } {
@@ -110,8 +112,14 @@ describe("publishing refuses a theme that upstream has superseded", () => {
     // The refusal must say the CLONE is the stale side and give its remedy —
     // the old warning pointed at the bundle, whose remedy destroys good themes.
     expect(r.stderr).toMatch(/behind/);
-    expect(r.stderr).toMatch(/git -C \S+ pull/);
     expect(r.stderr).toMatch(/stale/i);
+    // Remedy last on its line, nothing after it: agents paste this.
+    expect(r.stderr).toMatch(/run: git -C \S+ pull --rebase\s*$/m);
+    // A printed remedy must WORK: run it verbatim, and the retry publishes.
+    git(w.mine, "pull", "--rebase");
+    const retry = await publish(w);
+    expect({ status: retry.status, puts: puts - before }).toEqual({ status: 0, puts: 1 });
+    expect(ahead(w.mine)).toBe("0");
   }, 20000);
 
   test("clone behind but themes/ untouched upstream: the page publishes", async () => {
@@ -159,6 +167,22 @@ describe("publishing refuses a theme that upstream has superseded", () => {
     expect(r.stderr).toMatch(/could not verify.*no upstream/);
   }, 20000);
 
+  test("stranded commit then upstream theme change: refusal remedy still works on the divergent clone", async () => {
+    const w = makeWorld();
+    advanceOrigin(w.theirs, "README.md", "strand the first publish commit\n");
+    const first = await publish(w);
+    expect(first.status).toBe(1);
+    advanceOrigin(w.theirs, "themes/doc.html", bundledDoc + "\n<!-- upstream css -->\n");
+    const refused = await publish(w);
+    expect(refused.status).toBe(1);
+    expect(refused.stderr).toMatch(/stale CSS/);
+    // A plain `git pull` aborts here (divergent branches) — the printed
+    // --rebase form must survive exactly the state the stranded commit creates.
+    git(w.mine, "pull", "--rebase");
+    const retry = await publish(w);
+    expect({ status: retry.status, stranded: ahead(w.mine) }).toEqual({ status: 0, stranded: "0" });
+  }, 20000);
+
   test("ahead-only clone (local theme edit, unpushed): publishes cleanly", async () => {
     const w = makeWorld();
     writeFileSync(join(w.mine, "themes/doc.html"), bundledDoc + "\n<!-- unpushed local edit -->\n");
@@ -181,8 +205,16 @@ describe("a rejected canonical push fails loud", () => {
     // silently losing the page was the defect, so the exit must be loud.
     expect({ puts: puts - before, status: r.status }).toEqual({ puts: 1, status: 1 });
     expect(r.stdout).toContain("/fake-slug");
-    expect(r.stderr).toMatch(/push.*rejected|rejected.*push/i);
-    expect(r.stderr).toMatch(/git -C \S+ pull/);
+    // No asserted cause — the failure is reported, git's error carries the why,
+    // and the rejection remedy is offered as a conditional.
+    expect(r.stderr).toMatch(/push failed/);
+    expect(r.stderr).toMatch(/does NOT carry this publish/);
+    expect(r.stderr).toMatch(/if the push was rejected.*git -C \S+ pull --rebase/);
+    // The remedy must WORK: pull --rebase, re-run the same command, and the
+    // stranded commit reaches canonical even though nothing new is staged.
+    git(w.mine, "pull", "--rebase");
+    const retry = await publish(w);
+    expect({ status: retry.status, stranded: ahead(w.mine) }).toEqual({ status: 0, stranded: "0" });
   }, 20000);
 
   test("delete with a rejected push: loud exit, and the message describes a deletion", async () => {
@@ -193,10 +225,14 @@ describe("a rejected canonical push fails loud", () => {
     const r = await publish(w, "--name", "fresh", "--delete");
     expect({ status: r.status }).toEqual({ status: 1 });
     expect(r.stdout).toContain("deleted:");
-    expect(r.stderr).toMatch(/rejected/);
-    expect(r.stderr).toMatch(/deletion/);
+    expect(r.stderr).toMatch(/push failed/);
+    expect(r.stderr).toMatch(/does NOT carry this deletion/);
     // The publish wording would be false here — the page is gone, not live.
     expect(r.stderr).not.toContain("the page itself is live");
-    expect(r.stderr).toMatch(/git -C \S+ pull/);
+    // Remedy works on the delete path too: the re-run pushes the stranded
+    // deletion commit even though rm and add find nothing left to stage.
+    git(w.mine, "pull", "--rebase");
+    const retry = await publish(w, "--name", "fresh", "--delete");
+    expect({ status: retry.status, stranded: ahead(w.mine) }).toEqual({ status: 0, stranded: "0" });
   }, 20000);
 });

--- a/tests/publish-page/publish-freshness.test.ts
+++ b/tests/publish-page/publish-freshness.test.ts
@@ -246,11 +246,19 @@ describe("a rejected canonical push fails loud", () => {
     expect(retry.stdout).toContain("canonical record updated");
   }, 20000);
 
-  test("deleting a page that never existed still fails loud", async () => {
+  test("deleting a page that never existed fails loud, even from a clone with unrelated stranded work", async () => {
     const w = makeWorld();
-    const r = await publish(w, "--name", "never-published", "--delete");
-    expect(r.status).toBe(1);
-    expect(r.stderr).toMatch(/nothing deleted/);
-    expect(ahead(w.mine)).toBe("0");
+    const clean = await publish(w, "--name", "never-published", "--delete");
+    expect(clean.status).toBe(1);
+    expect(clean.stderr).toMatch(/nothing deleted/);
+    // Strand an unrelated publish commit, then mistype the delete again: the
+    // 404 tolerance is scoped to the deleted slug's own history, so this must
+    // stay an error and must not push the unrelated commit as a side effect.
+    advanceOrigin(w.theirs, "README.md", "make the publish push fail\n");
+    const strand = await publish(w);
+    expect(strand.status).toBe(1);
+    const typo = await publish(w, "--name", "never-published", "--delete");
+    expect({ status: typo.status, stillStranded: ahead(w.mine) }).toEqual({ status: 1, stillStranded: "1" });
+    expect(typo.stderr).toMatch(/nothing deleted/);
   }, 20000);
 });

--- a/tests/publish-page/publish-freshness.test.ts
+++ b/tests/publish-page/publish-freshness.test.ts
@@ -164,7 +164,7 @@ describe("publishing refuses a theme that upstream has superseded", () => {
     const before = puts;
     const r = await publish(w);
     expect({ puts: puts - before, refused: r.stderr.includes("stale CSS") }).toEqual({ puts: 1, refused: false });
-    expect(r.stderr).toMatch(/could not verify.*no upstream/);
+    expect(r.stderr).toMatch(/could not compare the pages clone against an upstream/);
   }, 20000);
 
   test("stranded commit then upstream theme change: refusal remedy still works on the divergent clone", async () => {

--- a/tests/publish-page/publish-freshness.test.ts
+++ b/tests/publish-page/publish-freshness.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -18,11 +18,17 @@ beforeAll(() => {
         puts++;
         return Response.json({ url: `http://127.0.0.1:${server.port}/fake-slug` });
       }
+      if (req.method === "DELETE") return Response.json({ deleted: true });
       return new Response("nope", { status: 405 });
     },
   });
 });
-afterAll(() => server.stop(true));
+afterAll(() => {
+  server.stop(true);
+  for (const base of worlds) rmSync(base, { recursive: true, force: true });
+});
+
+const worlds: string[] = [];
 
 function sh(cwd: string, ...args: string[]) {
   const r = spawnSync(args[0]!, args.slice(1), { cwd, encoding: "utf8" });
@@ -35,6 +41,7 @@ const git = (cwd: string, ...args: string[]) =>
 // origin (bare) + publisher clone + a second clone that advances origin.
 function makeWorld(): { home: string; origin: string; mine: string; theirs: string; page: string } {
   const base = mkdtempSync(join(tmpdir(), "pages-freshness-"));
+  worlds.push(base);
   const home = join(base, "home");
   mkdirSync(join(home, ".config/agentkit"), { recursive: true });
   writeFileSync(join(home, ".config/agentkit/pages-token"), "test-token\n");
@@ -63,6 +70,7 @@ function makeWorld(): { home: string; origin: string; mine: string; theirs: stri
 }
 
 function advanceOrigin(theirs: string, path: string, content: string) {
+  git(theirs, "pull", "--rebase", "origin", "main");
   writeFileSync(join(theirs, path), content);
   git(theirs, "add", "-A");
   git(theirs, "commit", "-m", `advance ${path}`);
@@ -71,8 +79,9 @@ function advanceOrigin(theirs: string, path: string, content: string) {
 
 // Async spawn: spawnSync would block the event loop this test's own
 // server runs on, deadlocking the publish PUT against it.
-async function publish(world: { home: string; mine: string; page: string }) {
-  const proc = Bun.spawn(["bun", join(repoRoot, "skills/publish-page/publish.ts"), "--name", "fresh", "--file", world.page], {
+async function publish(world: { home: string; mine: string; page: string }, ...extra: string[]) {
+  const args = extra.length > 0 ? extra : ["--name", "fresh", "--file", world.page];
+  const proc = Bun.spawn(["bun", join(repoRoot, "skills/publish-page/publish.ts"), ...args], {
     cwd: repoRoot,
     stdout: "pipe",
     stderr: "pipe",
@@ -140,6 +149,26 @@ describe("publishing refuses a theme that upstream has superseded", () => {
     expect(r.stderr).toMatch(/could not verify/);
     expect(r.stdout).toContain("/fake-slug");
   }, 20000);
+
+  test("no upstream to compare (detached HEAD): say so, then publish anyway", async () => {
+    const w = makeWorld();
+    git(w.mine, "checkout", "--detach");
+    const before = puts;
+    const r = await publish(w);
+    expect({ puts: puts - before, refused: r.stderr.includes("stale CSS") }).toEqual({ puts: 1, refused: false });
+    expect(r.stderr).toMatch(/could not verify.*no upstream/);
+  }, 20000);
+
+  test("ahead-only clone (local theme edit, unpushed): publishes cleanly", async () => {
+    const w = makeWorld();
+    writeFileSync(join(w.mine, "themes/doc.html"), bundledDoc + "\n<!-- unpushed local edit -->\n");
+    git(w.mine, "add", "-A");
+    git(w.mine, "commit", "-m", "local theme edit");
+    const before = puts;
+    const r = await publish(w);
+    expect({ status: r.status, puts: puts - before }).toEqual({ status: 0, puts: 1 });
+    expect(r.stderr).not.toMatch(/stale CSS/);
+  }, 20000);
 });
 
 describe("a rejected canonical push fails loud", () => {
@@ -153,6 +182,21 @@ describe("a rejected canonical push fails loud", () => {
     expect({ puts: puts - before, status: r.status }).toEqual({ puts: 1, status: 1 });
     expect(r.stdout).toContain("/fake-slug");
     expect(r.stderr).toMatch(/push.*rejected|rejected.*push/i);
+    expect(r.stderr).toMatch(/git -C \S+ pull/);
+  }, 20000);
+
+  test("delete with a rejected push: loud exit, and the message describes a deletion", async () => {
+    const w = makeWorld();
+    const first = await publish(w);
+    expect(first.status).toBe(0);
+    advanceOrigin(w.theirs, "README.md", "advance, so the delete commit cannot push\n");
+    const r = await publish(w, "--name", "fresh", "--delete");
+    expect({ status: r.status }).toEqual({ status: 1 });
+    expect(r.stdout).toContain("deleted:");
+    expect(r.stderr).toMatch(/rejected/);
+    expect(r.stderr).toMatch(/deletion/);
+    // The publish wording would be false here — the page is gone, not live.
+    expect(r.stderr).not.toContain("the page itself is live");
     expect(r.stderr).toMatch(/git -C \S+ pull/);
   }, 20000);
 });

--- a/tests/publish-page/publish-freshness.test.ts
+++ b/tests/publish-page/publish-freshness.test.ts
@@ -9,16 +9,24 @@ const bundledDoc = readFileSync(join(repoRoot, "skills/publish-page/themes/doc.h
 
 let server: ReturnType<typeof Bun.serve>;
 let puts = 0;
+// Mirrors the production worker: a DELETE of an absent page 404s, which is
+// exactly what a delete-retry after a rejected push encounters.
+const stored = new Set<string>();
 
 beforeAll(() => {
   server = Bun.serve({
     port: 0,
     fetch(req) {
+      const key = new URL(req.url).pathname;
       if (req.method === "PUT") {
         puts++;
+        stored.add(key);
         return Response.json({ url: `http://127.0.0.1:${server.port}/fake-slug` });
       }
-      if (req.method === "DELETE") return Response.json({ deleted: true });
+      if (req.method === "DELETE") {
+        if (!stored.delete(key)) return new Response("not found\n", { status: 404 });
+        return Response.json({ deleted: true });
+      }
       return new Response("nope", { status: 405 });
     },
   });
@@ -229,10 +237,20 @@ describe("a rejected canonical push fails loud", () => {
     expect(r.stderr).toMatch(/does NOT carry this deletion/);
     // The publish wording would be false here — the page is gone, not live.
     expect(r.stderr).not.toContain("the page itself is live");
-    // Remedy works on the delete path too: the re-run pushes the stranded
-    // deletion commit even though rm and add find nothing left to stage.
+    // Remedy works on the delete path too — against real server semantics: the
+    // page is already gone, the retry's DELETE 404s, and the stranded deletion
+    // commit must still reach canonical instead of dying on "nothing deleted".
     git(w.mine, "pull", "--rebase");
     const retry = await publish(w, "--name", "fresh", "--delete");
     expect({ status: retry.status, stranded: ahead(w.mine) }).toEqual({ status: 0, stranded: "0" });
+    expect(retry.stdout).toContain("canonical record updated");
+  }, 20000);
+
+  test("deleting a page that never existed still fails loud", async () => {
+    const w = makeWorld();
+    const r = await publish(w, "--name", "never-published", "--delete");
+    expect(r.status).toBe(1);
+    expect(r.stderr).toMatch(/nothing deleted/);
+    expect(ahead(w.mine)).toBe("0");
   }, 20000);
 });


### PR DESCRIPTION
Closes #267.

## The two defects, from publishing a v0.6.4 demo page

| | what happened | what the code said |
|---|---|---|
| stale CSS | clone 2 commits behind → its old theme won `existsSync`, page shipped new markup + old rules, HTTP 200 | `warning: bundled theme drifted — re-sync skills/publish-page/themes/` — the remedy for the **opposite** case; following it would overwrite the good themes |
| lost history | the same stale clone made the canonical push non-fast-forward | one stderr line, page still published, exit 0 — the pages history silently lost the page |

## The fix

- Before rendering with the clone's theme, a bounded `git fetch` (15s, `GIT_TERMINAL_PROMPT=0`, failure tolerated) and a merge-base comparison (`HEAD...@{u} -- themes/`). If upstream changed themes/, **refuse**: `pages clone is N commit(s) behind and themes/ changed upstream — publishing now would serve stale CSS. run: git -C <repo> pull --rebase` — the remedy last on its line (agents paste it), `--rebase` because a stranded local commit makes a plain pull abort. A clone that is ahead, or behind only on other paths, still publishes; fetch failure or no upstream to compare warns and proceeds, so offline publishing keeps working.
- The bundle-drift warning names the stale side: `bundled theme lags canonical <path>`.
- A failed canonical push exits 1 with the facts (page is live / page was deleted; history does NOT carry this publish/deletion), git's own stderr as the cause, and the rejection remedy as a *conditional* — no asserted cause. The delete path honors the loud exit too (bare `process.exit()`).
- **A re-run genuinely records stranded work**: commitScoped pushes whenever the clone is ahead of upstream, even with nothing newly staged — so `pull --rebase` + re-run actually lands the commit canonical history was missing. The push is bounded like the fetch (30s, no prompts).

## Evidence

- `tests/publish-page/publish-freshness.test.ts`: 9 scenarios against a real bare origin + two clones + an in-process server counting PUTs/DELETEs — refusal (0 PUTs), behind-on-other-paths, bundle-lag, fetch failure, no upstream, ahead-only, rejected publish push, rejected delete push, and the stranded-then-divergent chain. **Every printed remedy is executed verbatim and the test then asserts the clone ends level with canonical (`rev-list --count @{u}..HEAD` == 0)** — remedy text alone proved worthless in review: both original remedies read fine and failed when run.
- Counterfactuals at each review round: the tests fail against each prior head's `publish.ts` (4/5, then 2/8, then 3/9), restores byte-identical.
- Plugin mirror `cmp`-identical; `tests/agentkit-plugin.test.ts` 24/24; slice routing 81 test files / 605 surfaces.
- Review: independent diff + product lanes; the product lane's executed-remedy FAIL at ab86bf3 drove the push-when-ahead fix.
