### PR TITLE
docs(site): make the deck's reproduction instruction executable

### DIFF
--- a/docs/site/src/content/docs/cookbook/publish-a-page.md
+++ b/docs/site/src/content/docs/cookbook/publish-a-page.md
@@ -65,9 +65,11 @@ keys, space and swipe move between slides; the toggle in the nav bar flips the t
 source is
 [`docs/site/examples/publish-freshness-deck.md`](https://github.com/developerinlondon/agentkit/blob/main/docs/site/examples/publish-freshness-deck.md).
 Rendering it through the `deck` template with `--title "The Publish Freshness Architecture"`
-reproduces the published file byte for byte — the title has to be given, because a deck's cover
-headline is HTML rather than a markdown `#` heading, so there is nothing for the title to be
-derived from.
+reproduces the published file byte for byte. The title has to be given: a deck's cover headline is
+HTML rather than a markdown `#` heading, so there is nothing to derive one from. The bytes come from
+`renderThemed` in `skills/publish-page/render-html.ts` against this repo's copy of the theme —
+`publish.ts` prefers a pages clone's theme when you have one, and a different theme renders
+different bytes.
 
 ## Callouts
 

--- a/docs/site/src/content/docs/cookbook/publish-a-page.md
+++ b/docs/site/src/content/docs/cookbook/publish-a-page.md
@@ -63,8 +63,11 @@ A rendered deck is worth more than a description of one:
 `deck` template — a cover with a stat row, a severity callout, legend rails, and column cards. Arrow
 keys, space and swipe move between slides; the toggle in the nav bar flips the theme. Its markdown
 source is
-[`docs/site/examples/publish-freshness-deck.md`](https://github.com/developerinlondon/agentkit/blob/main/docs/site/examples/publish-freshness-deck.md),
-and re-rendering it reproduces the published file byte for byte.
+[`docs/site/examples/publish-freshness-deck.md`](https://github.com/developerinlondon/agentkit/blob/main/docs/site/examples/publish-freshness-deck.md).
+Rendering it through the `deck` template with `--title "The Publish Freshness Architecture"`
+reproduces the published file byte for byte — the title has to be given, because a deck's cover
+headline is HTML rather than a markdown `#` heading, so there is nothing for the title to be
+derived from.
 
 ## Callouts
 

--- a/tests/docs/example-deck.test.ts
+++ b/tests/docs/example-deck.test.ts
@@ -8,18 +8,26 @@ const source = join(repo, 'docs/site/examples/publish-freshness-deck.md');
 const published = join(repo, 'docs/site/public/examples/publish-freshness-deck.html');
 const cookbook = join(repo, 'docs/site/src/content/docs/cookbook/publish-a-page.md');
 
-// Taken from the sentence a reader follows, not hardcoded: a deck's cover
-// headline is HTML, so publish.ts can derive no title from the source and the
-// render only reproduces when the documented --title is the one given.
-function documentedTitle(): string {
-  // Anchored on the deck's own paragraph: the page documents other --title
-  // examples earlier, and the first match in the file is one of those.
+const SOURCE_PATH = 'docs/site/examples/publish-freshness-deck.md';
+
+// Read from the paragraph a reader follows rather than hardcoded, because
+// anything the sentence states and the guard assumes can drift apart silently:
+// the title did exactly that, and the template and the link can too.
+function documented(): { title: string; template: string; link: string } {
   const prose = readFileSync(cookbook, 'utf8');
-  const at = prose.indexOf('publish-freshness-deck.md');
-  if (at < 0) throw new Error('the cookbook no longer points at the example deck source');
-  const found = prose.slice(at).match(/--title "([^"]+)"/);
-  if (!found) throw new Error('the cookbook no longer documents a --title for the example deck');
-  return found[1] as string;
+  // Scoped to the deck's own paragraph — the page documents other templates and
+  // other --title examples, and an unanchored match binds to one of those.
+  const from = prose.indexOf('A rendered deck is worth more');
+  const to = prose.indexOf('## Callouts', from);
+  if (from < 0 || to < 0) throw new Error('the cookbook no longer carries the example deck paragraph');
+  const para = prose.slice(from, to);
+  const title = para.match(/--title "([^"]+)"/);
+  const template = para.match(/through the `([a-z]+)` template/);
+  const link = para.match(/\]\((https?:\/\/[^)]+)\)/);
+  if (!title) throw new Error('the cookbook no longer documents a --title for the example deck');
+  if (!template) throw new Error('the cookbook no longer documents which template the example uses');
+  if (!link) throw new Error('the cookbook no longer links the example deck source');
+  return { title: title[1] as string, template: template[1] as string, link: link[1] as string };
 }
 
 describe('the published example deck', () => {
@@ -28,15 +36,24 @@ describe('the published example deck', () => {
   // about, reintroduced as a build artifact. The cookbook promises the
   // re-render reproduces it; this is what makes that a fact.
   test('re-renders byte-for-byte by following the cookbook', async () => {
+    const { title, template } = documented();
     const rendered = await renderThemed({
       source: readFileSync(source, 'utf8'),
       isMd: true,
-      template: 'deck',
-      title: documentedTitle(),
+      template,
+      title,
       themePath: join(repo, 'skills/publish-page/themes/deck.html'),
     });
     const then = 'stale example: re-render it through skills/publish-page/render-html.ts and commit the result';
     expect({ matches: rendered === readFileSync(published, 'utf8'), then })
       .toEqual({ matches: true, then });
+  });
+
+  test('the source the cookbook links is the source it was rendered from', () => {
+    // The render above proves the title and the template; the link is the one
+    // documented thing a reader can follow away from the file under test.
+    const then = `point the link at ${SOURCE_PATH}, which is the file this guard renders`;
+    expect({ linksTheSource: documented().link.endsWith(SOURCE_PATH), then })
+      .toEqual({ linksTheSource: true, then });
   });
 });

--- a/tests/docs/example-deck.test.ts
+++ b/tests/docs/example-deck.test.ts
@@ -18,8 +18,9 @@ function documented(): { title: string; template: string; link: string } {
   // Scoped to the deck's own paragraph — the page documents other templates and
   // other --title examples, and an unanchored match binds to one of those.
   const from = prose.indexOf('A rendered deck is worth more');
+  if (from < 0) throw new Error(`no line opening "A rendered deck is worth more" in ${cookbook}`);
   const to = prose.indexOf('## Callouts', from);
-  if (from < 0 || to < 0) throw new Error('the cookbook no longer carries the example deck paragraph');
+  if (to < 0) throw new Error(`no "## Callouts" heading after that line in ${cookbook}`);
   const para = prose.slice(from, to);
   const title = para.match(/--title "([^"]+)"/);
   const template = para.match(/through the `([a-z]+)` template/);

--- a/tests/docs/example-deck.test.ts
+++ b/tests/docs/example-deck.test.ts
@@ -6,18 +6,33 @@ import { renderThemed } from '../../skills/publish-page/render-html.ts';
 const repo = join(import.meta.dir, '..', '..');
 const source = join(repo, 'docs/site/examples/publish-freshness-deck.md');
 const published = join(repo, 'docs/site/public/examples/publish-freshness-deck.html');
+const cookbook = join(repo, 'docs/site/src/content/docs/cookbook/publish-a-page.md');
+
+// Taken from the sentence a reader follows, not hardcoded: a deck's cover
+// headline is HTML, so publish.ts can derive no title from the source and the
+// render only reproduces when the documented --title is the one given.
+function documentedTitle(): string {
+  // Anchored on the deck's own paragraph: the page documents other --title
+  // examples earlier, and the first match in the file is one of those.
+  const prose = readFileSync(cookbook, 'utf8');
+  const at = prose.indexOf('publish-freshness-deck.md');
+  if (at < 0) throw new Error('the cookbook no longer points at the example deck source');
+  const found = prose.slice(at).match(/--title "([^"]+)"/);
+  if (!found) throw new Error('the cookbook no longer documents a --title for the example deck');
+  return found[1] as string;
+}
 
 describe('the published example deck', () => {
   // The deck is a committed render, so a theme change leaves it serving
   // superseded CSS with nothing to notice — the defect the deck itself is
   // about, reintroduced as a build artifact. The cookbook promises the
   // re-render reproduces it; this is what makes that a fact.
-  test('re-renders byte-for-byte from its committed source', async () => {
+  test('re-renders byte-for-byte by following the cookbook', async () => {
     const rendered = await renderThemed({
       source: readFileSync(source, 'utf8'),
       isMd: true,
       template: 'deck',
-      title: 'The Publish Freshness Architecture',
+      title: documentedTitle(),
       themePath: join(repo, 'skills/publish-page/themes/deck.html'),
     });
     const then = 'stale example: re-render it through skills/publish-page/render-html.ts and commit the result';


### PR DESCRIPTION
Closes the LOW the product lane raised on #277.

The cookbook said the example deck's source "re-renders byte for byte". It does not — not from what the page tells you. A deck's cover headline is HTML, not a markdown `#` heading, so `publish.ts` finds nothing in its title chain and falls through to the page name. The published file's title, `The Publish Freshness Architecture`, appears **nowhere** in the linked source. A reader following the sentence literally produced a different file, and `tests/docs/example-deck.test.ts` stayed green only because it hardcoded the title the reader was never told.

That is the same shape as the defect the deck itself documents: an instruction that fails when executed.

## The fix

- The sentence names the title and says why one must be given.
- The guard **reads the title out of that sentence** instead of hardcoding it, so the documented instruction is the thing under test.

## Mutation evidence

| Mutation | Guard |
|---|---|
| cookbook documents a different title | fails |
| cookbook documents no title | fails |
| source edited, not re-rendered | fails |
| theme changed, not re-rendered | fails |
| clean tree | passes |

Restores byte-identical. Note the first version of this fix passed *nothing* — the cookbook documents an earlier `--title "Q3 roadmap"` example and `.match()` took it; the extraction is now anchored to the deck's own paragraph. Mutation testing is what surfaced that.