### PR TITLE
fix(designer): standalone pages carry their own persisted theme toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ top and ships with the next tag.
 
 ## [Unreleased]
 
+- fix(designer): standalone pages carry their own persisted theme toggle. The
+  scaffold themed correctly through `prefers-color-scheme` and `data-theme`
+  overrides, but a page hosted without chrome (a product repo, a raw publish)
+  had nothing stamping `data-theme`, so viewers could never flip themes and the
+  second theme went unseen. (#288)
+
 - feat(skills): `designer` — bespoke, artifact-grade design pages. Carries the
   per-subject design method (semantic color families over a three-level surface
   stack, dual token-level theming, a chosen type system) and a component

--- a/plugins-cc/agentkit/skills/designer/SKILL.md
+++ b/plugins-cc/agentkit/skills/designer/SKILL.md
@@ -75,6 +75,10 @@ content and a reviewer cannot tell which needed a designer.
   directions. Components never restyle inside the color-scheme media query —
   theme changes travel through tokens only; layout media queries (responsive
   collapse, `prefers-reduced-motion`) are a different matter and fine.
+- **Standalone pages ship the scaffold's `.theme-toggle`** (persisted, stamps
+  `data-theme`) — without host chrome a viewer can never flip themes, so the
+  second theme goes unseen and unjudged. Keep it only when the host has no
+  toggle of its own; a host that stamps `data-theme` composes with it anyway.
 - Dark values are re-picked, not inverted: soft grounds go deep and desaturated,
   accents brighten to hold contrast.
 

--- a/plugins-cc/agentkit/skills/designer/references/scaffold.html
+++ b/plugins-cc/agentkit/skills/designer/references/scaffold.html
@@ -4,6 +4,12 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Page title — Design</title>
+<script>
+try {
+  const saved = localStorage.getItem("designer-theme");
+  if (saved === "dark" || saved === "light") document.documentElement.dataset.theme = saved;
+} catch {}
+</script>
 <style>
   /* Tokens. Rename the four semantic families to THIS page's own distinctions
      (exists/build/gate/ok is one worked example) and re-derive every value from
@@ -16,6 +22,7 @@
     --muted: #5b6678;
     --line: #d3dae6;
     --line-soft: #e2e8f2;
+    color-scheme: light;
     --core: #0b6f80;      --core-soft: #e0f2f5;
     --new: #6250d8;       --new-soft: #eceafb;
     --gate: #8a5c04;      --gate-soft: #f7ecd6;
@@ -28,6 +35,7 @@
     :root {
       --bg: #0c1018; --surface: #141a26; --surface-2: #1a2233;
       --ink: #e4eaf4; --muted: #8b96aa; --line: #2a3448; --line-soft: #202939;
+      color-scheme: dark;
       --core: #56cfe0; --core-soft: #10333c;
       --new: #a293ff; --new-soft: #2a2650;
       --gate: #e6a63d; --gate-soft: #3a2c10;
@@ -38,6 +46,7 @@
   :root[data-theme="light"] {
     --bg: #f4f6fa; --surface: #ffffff; --surface-2: #eaeef5;
     --ink: #1a2230; --muted: #5b6678; --line: #d3dae6; --line-soft: #e2e8f2;
+    color-scheme: light;
     --core: #0b6f80; --core-soft: #e0f2f5;
     --new: #6250d8; --new-soft: #eceafb;
     --gate: #8a5c04; --gate-soft: #f7ecd6;
@@ -47,6 +56,7 @@
   :root[data-theme="dark"] {
     --bg: #0c1018; --surface: #141a26; --surface-2: #1a2233;
     --ink: #e4eaf4; --muted: #8b96aa; --line: #2a3448; --line-soft: #202939;
+    color-scheme: dark;
     --core: #56cfe0; --core-soft: #10333c;
     --new: #a293ff; --new-soft: #2a2650;
     --gate: #e6a63d; --gate-soft: #3a2c10;
@@ -307,18 +317,19 @@
 </style>
 </head>
 <body>
-<button class="theme-toggle" aria-label="Switch color theme">◐ theme</button>
+<button class="theme-toggle" type="button" aria-label="Switch color theme" aria-pressed="false">◐ theme</button>
 <script>
 (() => {
   const root = document.documentElement;
-  const saved = localStorage.getItem("theme");
-  if (saved === "dark" || saved === "light") root.dataset.theme = saved;
-  document.querySelector(".theme-toggle").addEventListener("click", () => {
-    const current = root.dataset.theme
-      || (matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
-    const next = current === "dark" ? "light" : "dark";
+  const btn = document.querySelector(".theme-toggle");
+  const isDark = () => (root.dataset.theme
+    || (matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light")) === "dark";
+  btn.setAttribute("aria-pressed", String(isDark()));
+  btn.addEventListener("click", () => {
+    const next = isDark() ? "light" : "dark";
     root.dataset.theme = next;
-    localStorage.setItem("theme", next);
+    btn.setAttribute("aria-pressed", String(next === "dark"));
+    try { localStorage.setItem("designer-theme", next); } catch {}
   });
 })();
 </script>

--- a/plugins-cc/agentkit/skills/designer/references/scaffold.html
+++ b/plugins-cc/agentkit/skills/designer/references/scaffold.html
@@ -295,9 +295,33 @@
   }
 
   footer { margin-top: 60px; border-top: 1px solid var(--line); padding-top: 16px; font-size: 12px; color: var(--muted); font-family: var(--mono); line-height: 1.7; }
+
+  .theme-toggle {
+    position: fixed; top: 14px; right: 14px; z-index: 10;
+    font-family: var(--mono); font-size: 11.5px; padding: 5px 12px;
+    border: 1px solid var(--line); border-radius: 99px;
+    background: var(--surface); color: var(--muted); cursor: pointer;
+  }
+  .theme-toggle:hover { color: var(--ink); border-color: var(--muted); }
+  .theme-toggle:focus-visible { outline: 2px solid var(--ink); outline-offset: 2px; }
 </style>
 </head>
 <body>
+<button class="theme-toggle" aria-label="Switch color theme">◐ theme</button>
+<script>
+(() => {
+  const root = document.documentElement;
+  const saved = localStorage.getItem("theme");
+  if (saved === "dark" || saved === "light") root.dataset.theme = saved;
+  document.querySelector(".theme-toggle").addEventListener("click", () => {
+    const current = root.dataset.theme
+      || (matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
+    const next = current === "dark" ? "light" : "dark";
+    root.dataset.theme = next;
+    localStorage.setItem("theme", next);
+  });
+})();
+</script>
 <main>
   <header class="page">
     <div class="eyebrow">project · document kind · 2026-01-01</div>

--- a/skills/designer/SKILL.md
+++ b/skills/designer/SKILL.md
@@ -75,6 +75,10 @@ content and a reviewer cannot tell which needed a designer.
   directions. Components never restyle inside the color-scheme media query —
   theme changes travel through tokens only; layout media queries (responsive
   collapse, `prefers-reduced-motion`) are a different matter and fine.
+- **Standalone pages ship the scaffold's `.theme-toggle`** (persisted, stamps
+  `data-theme`) — without host chrome a viewer can never flip themes, so the
+  second theme goes unseen and unjudged. Keep it only when the host has no
+  toggle of its own; a host that stamps `data-theme` composes with it anyway.
 - Dark values are re-picked, not inverted: soft grounds go deep and desaturated,
   accents brighten to hold contrast.
 

--- a/skills/designer/references/scaffold.html
+++ b/skills/designer/references/scaffold.html
@@ -4,6 +4,12 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Page title — Design</title>
+<script>
+try {
+  const saved = localStorage.getItem("designer-theme");
+  if (saved === "dark" || saved === "light") document.documentElement.dataset.theme = saved;
+} catch {}
+</script>
 <style>
   /* Tokens. Rename the four semantic families to THIS page's own distinctions
      (exists/build/gate/ok is one worked example) and re-derive every value from
@@ -16,6 +22,7 @@
     --muted: #5b6678;
     --line: #d3dae6;
     --line-soft: #e2e8f2;
+    color-scheme: light;
     --core: #0b6f80;      --core-soft: #e0f2f5;
     --new: #6250d8;       --new-soft: #eceafb;
     --gate: #8a5c04;      --gate-soft: #f7ecd6;
@@ -28,6 +35,7 @@
     :root {
       --bg: #0c1018; --surface: #141a26; --surface-2: #1a2233;
       --ink: #e4eaf4; --muted: #8b96aa; --line: #2a3448; --line-soft: #202939;
+      color-scheme: dark;
       --core: #56cfe0; --core-soft: #10333c;
       --new: #a293ff; --new-soft: #2a2650;
       --gate: #e6a63d; --gate-soft: #3a2c10;
@@ -38,6 +46,7 @@
   :root[data-theme="light"] {
     --bg: #f4f6fa; --surface: #ffffff; --surface-2: #eaeef5;
     --ink: #1a2230; --muted: #5b6678; --line: #d3dae6; --line-soft: #e2e8f2;
+    color-scheme: light;
     --core: #0b6f80; --core-soft: #e0f2f5;
     --new: #6250d8; --new-soft: #eceafb;
     --gate: #8a5c04; --gate-soft: #f7ecd6;
@@ -47,6 +56,7 @@
   :root[data-theme="dark"] {
     --bg: #0c1018; --surface: #141a26; --surface-2: #1a2233;
     --ink: #e4eaf4; --muted: #8b96aa; --line: #2a3448; --line-soft: #202939;
+    color-scheme: dark;
     --core: #56cfe0; --core-soft: #10333c;
     --new: #a293ff; --new-soft: #2a2650;
     --gate: #e6a63d; --gate-soft: #3a2c10;
@@ -307,18 +317,19 @@
 </style>
 </head>
 <body>
-<button class="theme-toggle" aria-label="Switch color theme">◐ theme</button>
+<button class="theme-toggle" type="button" aria-label="Switch color theme" aria-pressed="false">◐ theme</button>
 <script>
 (() => {
   const root = document.documentElement;
-  const saved = localStorage.getItem("theme");
-  if (saved === "dark" || saved === "light") root.dataset.theme = saved;
-  document.querySelector(".theme-toggle").addEventListener("click", () => {
-    const current = root.dataset.theme
-      || (matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
-    const next = current === "dark" ? "light" : "dark";
+  const btn = document.querySelector(".theme-toggle");
+  const isDark = () => (root.dataset.theme
+    || (matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light")) === "dark";
+  btn.setAttribute("aria-pressed", String(isDark()));
+  btn.addEventListener("click", () => {
+    const next = isDark() ? "light" : "dark";
     root.dataset.theme = next;
-    localStorage.setItem("theme", next);
+    btn.setAttribute("aria-pressed", String(next === "dark"));
+    try { localStorage.setItem("designer-theme", next); } catch {}
   });
 })();
 </script>

--- a/skills/designer/references/scaffold.html
+++ b/skills/designer/references/scaffold.html
@@ -295,9 +295,33 @@
   }
 
   footer { margin-top: 60px; border-top: 1px solid var(--line); padding-top: 16px; font-size: 12px; color: var(--muted); font-family: var(--mono); line-height: 1.7; }
+
+  .theme-toggle {
+    position: fixed; top: 14px; right: 14px; z-index: 10;
+    font-family: var(--mono); font-size: 11.5px; padding: 5px 12px;
+    border: 1px solid var(--line); border-radius: 99px;
+    background: var(--surface); color: var(--muted); cursor: pointer;
+  }
+  .theme-toggle:hover { color: var(--ink); border-color: var(--muted); }
+  .theme-toggle:focus-visible { outline: 2px solid var(--ink); outline-offset: 2px; }
 </style>
 </head>
 <body>
+<button class="theme-toggle" aria-label="Switch color theme">◐ theme</button>
+<script>
+(() => {
+  const root = document.documentElement;
+  const saved = localStorage.getItem("theme");
+  if (saved === "dark" || saved === "light") root.dataset.theme = saved;
+  document.querySelector(".theme-toggle").addEventListener("click", () => {
+    const current = root.dataset.theme
+      || (matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
+    const next = current === "dark" ? "light" : "dark";
+    root.dataset.theme = next;
+    localStorage.setItem("theme", next);
+  });
+})();
+</script>
 <main>
   <header class="page">
     <div class="eyebrow">project · document kind · 2026-01-01</div>


### PR DESCRIPTION
Closes #288. Scaffold gains a fixed `.theme-toggle` (persisted, stamps `data-theme`, focus-visible state, composes with host-stamped themes); SKILL.md token contract teaches when it ships. Verified: probe shows unset→dark→light across two clicks with localStorage persistence; post-click render paints the dark ground. Mirror synced.