### PR TITLE
fix(designer): round-3 fixes from the third acceptance run

### DIFF
--- a/plugins-cc/agentkit/skills/designer/SKILL.md
+++ b/plugins-cc/agentkit/skills/designer/SKILL.md
@@ -82,6 +82,9 @@ content and a reviewer cannot tell which needed a designer.
   AND on its own `--x-soft`) and `--x-soft` (its background ground). The
   soft-ground requirement is the binding one — light-theme accents that look
   right usually land near 3:1 there and must be darkened.
+- A family painted as a **large-area fill** (a band, a zone, a canvas region)
+  gets a third, calmer value (`--x-band`): soft grounds are badge-scale, and
+  at hundreds of pixels wide they shout, especially in dark.
 - Three theme blocks, token-level only: base `:root`, then
   `@media (prefers-color-scheme: dark)`, then BOTH `:root[data-theme="dark"]`
   and `:root[data-theme="light"]` so a host's toggle overrides the OS in both
@@ -159,12 +162,16 @@ and still lose to a plainer one that reads faster. Clarity outranks detail.
   reader can follow beats a denser one they must decode.
 
 Escalate beyond the grammar when the concept outgrows it: hand-drawn
-architecture and anything with loop-backs or trust boundaries → the `diagram`
-skill (inline its SVG in a figure block); message exchanges of >6 participants,
-alt/loop fragments, or state machines → mermaid where the host renders it, else
-the `diagram` skill. Inventing a component above the grammar's floor is
-encouraged when the subject demands one — keep it on the page's tokens. Never
-ASCII art.
+architecture → the `diagram` skill (inline its SVG in a figure block); message
+exchanges of >6 participants, alt/loop fragments, or state machines → mermaid
+where the host renders it, else the `diagram` skill. A trust/boundary figure
+stays **in-grammar** when it must share the page's measured type and node
+geometry: build it bespoke on the page's tokens — banded zones (`--x-band`
+grounds), dashed boundary rules, numbered crossings, refused crossings in the
+failure family — and escalate to the `diagram` skill only when it needs
+hand-drawn semantics no page CSS carries. Inventing a component above the
+grammar's floor is encouraged when the subject demands one — keep it on the
+page's tokens. Never ASCII art.
 
 ## Do not ship the templated look
 

--- a/plugins-cc/agentkit/skills/designer/references/scaffold.html
+++ b/plugins-cc/agentkit/skills/designer/references/scaffold.html
@@ -208,7 +208,7 @@ try {
     background: var(--core-soft); border: 1.5px solid var(--core); font-size: 12px; line-height: 1.4;
   }
   .fbox b { display: block; font-size: 12.5px; font-weight: 650; }
-  .fbox code { background: transparent; padding: 0; font-size: 10.5px; color: var(--muted); display: block; margin-top: 2px; }
+  .fbox code { background: transparent; padding: 0; font-size: 10.5px; color: var(--muted); display: block; margin-top: 2px; overflow-wrap: anywhere; }
   .fbox.is-new { background: var(--new-soft); border-style: dashed; border-color: var(--new); }
   .fbox.is-gate { background: var(--gate-soft); border-color: var(--gate); }
   .fbox.is-ext { background: var(--surface); border-color: var(--line); }
@@ -269,7 +269,7 @@ try {
   .msg.k.fwd .hd { border-left-color: var(--ok); }
   .msg.k.rev .hd { border-right-color: var(--ok); }
   .seq-n {
-    position: absolute; left: 0; top: 3px; transform: translateX(-100%); padding-right: 10px;
+    position: absolute; left: 0; width: 34px;
     font-family: var(--mono); font-size: 10px; color: var(--muted); font-variant-numeric: tabular-nums;
   }
 
@@ -455,9 +455,12 @@ try {
           <div class="lifeline" style="left:12%"></div>
           <div class="lifeline" style="left:50%"></div>
           <div class="lifeline" style="left:88%"></div>
-          <div class="msg fwd" style="left:12%; right:50%; top:8px"><span class="seq-n">01</span><span class="ln"></span><span class="lbl">request · payload</span><span class="hd"></span></div>
-          <div class="msg fwd g dash" style="left:50%; right:12%; top:52px"><span class="seq-n">02</span><span class="ln"></span><span class="lbl">check · parks durably</span><span class="hd"></span></div>
-          <div class="msg rev k" style="left:12%; right:50%; top:96px"><span class="seq-n">03</span><span class="ln"></span><span class="lbl">result · audit row</span><span class="hd"></span></div>
+          <span class="seq-n" style="top:11px">01</span>
+          <span class="seq-n" style="top:55px">02</span>
+          <span class="seq-n" style="top:99px">03</span>
+          <div class="msg fwd" style="left:12%; right:50%; top:8px"><span class="ln"></span><span class="lbl">request · payload</span><span class="hd"></span></div>
+          <div class="msg fwd g dash" style="left:50%; right:12%; top:52px"><span class="ln"></span><span class="lbl">check · parks durably</span><span class="hd"></span></div>
+          <div class="msg rev k" style="left:12%; right:50%; top:96px"><span class="ln"></span><span class="lbl">result · audit row</span><span class="hd"></span></div>
         </div>
       </div>
     </div>

--- a/skills/designer/SKILL.md
+++ b/skills/designer/SKILL.md
@@ -82,6 +82,9 @@ content and a reviewer cannot tell which needed a designer.
   AND on its own `--x-soft`) and `--x-soft` (its background ground). The
   soft-ground requirement is the binding one — light-theme accents that look
   right usually land near 3:1 there and must be darkened.
+- A family painted as a **large-area fill** (a band, a zone, a canvas region)
+  gets a third, calmer value (`--x-band`): soft grounds are badge-scale, and
+  at hundreds of pixels wide they shout, especially in dark.
 - Three theme blocks, token-level only: base `:root`, then
   `@media (prefers-color-scheme: dark)`, then BOTH `:root[data-theme="dark"]`
   and `:root[data-theme="light"]` so a host's toggle overrides the OS in both
@@ -159,12 +162,16 @@ and still lose to a plainer one that reads faster. Clarity outranks detail.
   reader can follow beats a denser one they must decode.
 
 Escalate beyond the grammar when the concept outgrows it: hand-drawn
-architecture and anything with loop-backs or trust boundaries → the `diagram`
-skill (inline its SVG in a figure block); message exchanges of >6 participants,
-alt/loop fragments, or state machines → mermaid where the host renders it, else
-the `diagram` skill. Inventing a component above the grammar's floor is
-encouraged when the subject demands one — keep it on the page's tokens. Never
-ASCII art.
+architecture → the `diagram` skill (inline its SVG in a figure block); message
+exchanges of >6 participants, alt/loop fragments, or state machines → mermaid
+where the host renders it, else the `diagram` skill. A trust/boundary figure
+stays **in-grammar** when it must share the page's measured type and node
+geometry: build it bespoke on the page's tokens — banded zones (`--x-band`
+grounds), dashed boundary rules, numbered crossings, refused crossings in the
+failure family — and escalate to the `diagram` skill only when it needs
+hand-drawn semantics no page CSS carries. Inventing a component above the
+grammar's floor is encouraged when the subject demands one — keep it on the
+page's tokens. Never ASCII art.
 
 ## Do not ship the templated look
 

--- a/skills/designer/references/scaffold.html
+++ b/skills/designer/references/scaffold.html
@@ -208,7 +208,7 @@ try {
     background: var(--core-soft); border: 1.5px solid var(--core); font-size: 12px; line-height: 1.4;
   }
   .fbox b { display: block; font-size: 12.5px; font-weight: 650; }
-  .fbox code { background: transparent; padding: 0; font-size: 10.5px; color: var(--muted); display: block; margin-top: 2px; }
+  .fbox code { background: transparent; padding: 0; font-size: 10.5px; color: var(--muted); display: block; margin-top: 2px; overflow-wrap: anywhere; }
   .fbox.is-new { background: var(--new-soft); border-style: dashed; border-color: var(--new); }
   .fbox.is-gate { background: var(--gate-soft); border-color: var(--gate); }
   .fbox.is-ext { background: var(--surface); border-color: var(--line); }
@@ -269,7 +269,7 @@ try {
   .msg.k.fwd .hd { border-left-color: var(--ok); }
   .msg.k.rev .hd { border-right-color: var(--ok); }
   .seq-n {
-    position: absolute; left: 0; top: 3px; transform: translateX(-100%); padding-right: 10px;
+    position: absolute; left: 0; width: 34px;
     font-family: var(--mono); font-size: 10px; color: var(--muted); font-variant-numeric: tabular-nums;
   }
 
@@ -455,9 +455,12 @@ try {
           <div class="lifeline" style="left:12%"></div>
           <div class="lifeline" style="left:50%"></div>
           <div class="lifeline" style="left:88%"></div>
-          <div class="msg fwd" style="left:12%; right:50%; top:8px"><span class="seq-n">01</span><span class="ln"></span><span class="lbl">request · payload</span><span class="hd"></span></div>
-          <div class="msg fwd g dash" style="left:50%; right:12%; top:52px"><span class="seq-n">02</span><span class="ln"></span><span class="lbl">check · parks durably</span><span class="hd"></span></div>
-          <div class="msg rev k" style="left:12%; right:50%; top:96px"><span class="seq-n">03</span><span class="ln"></span><span class="lbl">result · audit row</span><span class="hd"></span></div>
+          <span class="seq-n" style="top:11px">01</span>
+          <span class="seq-n" style="top:55px">02</span>
+          <span class="seq-n" style="top:99px">03</span>
+          <div class="msg fwd" style="left:12%; right:50%; top:8px"><span class="ln"></span><span class="lbl">request · payload</span><span class="hd"></span></div>
+          <div class="msg fwd g dash" style="left:50%; right:12%; top:52px"><span class="ln"></span><span class="lbl">check · parks durably</span><span class="hd"></span></div>
+          <div class="msg rev k" style="left:12%; right:50%; top:96px"><span class="ln"></span><span class="lbl">result · audit row</span><span class="hd"></span></div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
The four gaps surfaced by the pages-accounts design run: seq-number gutter (render-verified — numbers stay left even when a message spans inner lanes), fbox code overflow-wrap, --x-band large-area token guidance, and the in-grammar boundary-figure rule resolving the tension between 'trust boundaries → diagram skill' and 'invent above the floor'. Mirror synced. Refs #286.