### PR TITLE
fix(designer): icon-only theme toggle

### DIFF
--- a/plugins-cc/agentkit/skills/designer/SKILL.md
+++ b/plugins-cc/agentkit/skills/designer/SKILL.md
@@ -93,7 +93,8 @@ content and a reviewer cannot tell which needed a designer.
   collapse, `prefers-reduced-motion`) are a different matter and fine.
 - **Standalone pages ship the scaffold's `.theme-toggle`** (persisted, stamps
   `data-theme`) — without host chrome a viewer can never flip themes, so the
-  second theme goes unseen and unjudged. Keep it only when the host has no
+  second theme goes unseen and unjudged. The button shows the ◐ glyph only;
+  the words live in `aria-label`, not on the page. Keep it only when the host has no
   toggle of its own; a host that stamps `data-theme` composes with it anyway.
 - Dark values are re-picked, not inverted: soft grounds go deep and desaturated,
   accents brighten to hold contrast.

--- a/plugins-cc/agentkit/skills/designer/references/scaffold.html
+++ b/plugins-cc/agentkit/skills/designer/references/scaffold.html
@@ -308,7 +308,7 @@ try {
 
   .theme-toggle {
     position: fixed; top: 14px; right: 14px; z-index: 10;
-    font-family: var(--mono); font-size: 11.5px; padding: 5px 12px;
+    font-size: 15px; line-height: 1; padding: 7px 9px;
     border: 1px solid var(--line); border-radius: 99px;
     background: var(--surface); color: var(--muted); cursor: pointer;
   }
@@ -317,7 +317,7 @@ try {
 </style>
 </head>
 <body>
-<button class="theme-toggle" type="button" aria-label="Switch color theme" aria-pressed="false">◐ theme</button>
+<button class="theme-toggle" type="button" aria-label="Switch color theme" aria-pressed="false">◐</button>
 <script>
 (() => {
   const root = document.documentElement;

--- a/skills/designer/SKILL.md
+++ b/skills/designer/SKILL.md
@@ -93,7 +93,8 @@ content and a reviewer cannot tell which needed a designer.
   collapse, `prefers-reduced-motion`) are a different matter and fine.
 - **Standalone pages ship the scaffold's `.theme-toggle`** (persisted, stamps
   `data-theme`) — without host chrome a viewer can never flip themes, so the
-  second theme goes unseen and unjudged. Keep it only when the host has no
+  second theme goes unseen and unjudged. The button shows the ◐ glyph only;
+  the words live in `aria-label`, not on the page. Keep it only when the host has no
   toggle of its own; a host that stamps `data-theme` composes with it anyway.
 - Dark values are re-picked, not inverted: soft grounds go deep and desaturated,
   accents brighten to hold contrast.

--- a/skills/designer/references/scaffold.html
+++ b/skills/designer/references/scaffold.html
@@ -308,7 +308,7 @@ try {
 
   .theme-toggle {
     position: fixed; top: 14px; right: 14px; z-index: 10;
-    font-family: var(--mono); font-size: 11.5px; padding: 5px 12px;
+    font-size: 15px; line-height: 1; padding: 7px 9px;
     border: 1px solid var(--line); border-radius: 99px;
     background: var(--surface); color: var(--muted); cursor: pointer;
   }
@@ -317,7 +317,7 @@ try {
 </style>
 </head>
 <body>
-<button class="theme-toggle" type="button" aria-label="Switch color theme" aria-pressed="false">◐ theme</button>
+<button class="theme-toggle" type="button" aria-label="Switch color theme" aria-pressed="false">◐</button>
 <script>
 (() => {
   const root = document.documentElement;


### PR DESCRIPTION
Owner feedback: the toggle should show the ◐ glyph only. Words move to aria-label; glyph sized up to keep the target obvious. Mirror synced. Refs #288.