### PR TITLE
chore: cut v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ top and ships with the next tag.
 
 ## [Unreleased]
 
+## v0.8.0 — 2026-08-05
+
+- docs(designer): the altitude rule — clarity outranks detail. The centerpiece
+  figure carries every stage of its story at a glance, headline + centerpiece
+  must pass a ten-second newcomer test, zooms come after the overview and are
+  labeled as zooms, and evidence supports a figure the reader already
+  understands rather than leading it. Distilled from an owner review where the
+  measured-richer page read worse than a plainer one. (#292)
 - fix(designer): standalone pages carry their own persisted theme toggle. The
   scaffold themed correctly through `prefers-color-scheme` and `data-theme`
   overrides, but a page hosted without chrome (a product repo, a raw publish)


### PR DESCRIPTION
Moves the designer-skill work (#286–#294) from Unreleased under v0.8.0 — 2026-08-05, adding the altitude-rule entry the refinement rounds folded in silently. Tag v0.8.0 follows the merge.