### PR TITLE
chore: cut v0.7.4 — tastes phase 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ release PR — "publish this" authorizes a release, never the tier.
 
 ## [Unreleased]
 
+## v0.7.4 — 2026-08-05
+
 - feat(skills): `taste` — one markdown file per convention, read by every
   harness agentkit installs to. A taste carries frontmatter an agent can filter
   on (`name` as the key, `scope`, `strength`, `enforce`, an optional declarative


### PR DESCRIPTION
Patch release per the tier rule: the taste skill, format contract, and lint (#304, refs #301).