### PR TITLE
chore: cut v0.7.10 — taste install scopes and the vendor guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ release PR — "publish this" authorizes a release, never the tier.
 
 ## [Unreleased]
 
+## v0.7.10 — 2026-08-06
+
 - feat(taste)!: **a taste source installs at the machine level or at the repository level**, and
   both apply. Declared in `~/.config/agentkit/config.yaml` a source vendors into
   `~/.agentkit/tastes/external/` with `~/.agentkit/tastes.lock`, and every repository on the


### PR DESCRIPTION
Patch release: machine-level and repo-level taste installs, and a fail-closed refusal to vendor a private source into a public repository (#323).