### PR TITLE
fix(taste): stage each scope separately so two scopes may declare the same source name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,20 @@ release PR — "publish this" authorizes a release, never the tier.
 
 ## [Unreleased]
 
+- fix(taste): **a sync stages each scope separately, so both may declare a source of the same
+  name.** Staging was keyed on the source name alone, so a machine source and a repository
+  source sharing a name were fetched into one checkout and the second died on
+  `remote origin already exists` — taking the whole run with it, both scopes left unvendored.
+  The owner hit it running the shipped release: a machine-level `public` and this repository's
+  own `public` are two subscriptions to one upstream, which the scopes are built to allow.
+- test(taste): the GitLab arm of the visibility prober is covered in the positive direction —
+  a private `origin` beside a public `upstream` must read _private_. The public-side case
+  passes just as well when the arm asks about the wrong repository, so only this one shows the
+  URL reaching `glab` is the one being written into. The GitHub arm already had its counterpart.
+
 ## v0.7.10 — 2026-08-06
 
-- feat(taste)!: **a taste source installs at the machine level or at the repository level**, and
+- feat(taste): **a taste source installs at the machine level or at the repository level**, and
   both apply. Declared in `~/.config/agentkit/config.yaml` a source vendors into
   `~/.agentkit/tastes/external/` with `~/.agentkit/tastes.lock`, and every repository on the
   machine reads it — declare it once, nothing copied into any checkout. Declared in a
@@ -26,7 +37,9 @@ release PR — "publish this" authorizes a release, never the tier.
 - feat(taste): **vendoring a private source into a public repository is refused.** A source
   carries `visibility: public | private`, required of any source a repository vendors because
   that snapshot is committed there; the target's visibility is read from its forge with `gh` or
-  `glab`. It fails closed — a target that cannot be shown to be private is refused too, and an
+  `glab`. Upgrading: an existing repository-level source must add `visibility:` to its entry in
+  `.agentkit/config.yaml`, and a sync names the source and refuses until it does. A
+  machine-level source needs no such key, since nothing of it is committed anywhere. It fails closed — a target that cannot be shown to be private is refused too, and an
   internal repository counts as public. `AGENTKIT_TASTE_TARGET_PRIVATE=1` asserts only the fact
   the tool could not establish: a target the forge answered _public_ for stays refused with it
   set. The machine level is gated only where it publishes — see the work-tree fix below.

--- a/plugins-cc/agentkit/skills/taste/scripts/sync.ts
+++ b/plugins-cc/agentkit/skills/taste/scripts/sync.ts
@@ -133,15 +133,18 @@ function lintSource(source: TasteSource, dir: string): string[] {
   return errors.map((error) => `${source.name}: ${error}`);
 }
 
-async function stage(sources: readonly TasteSource[], workspace: string, timeoutMs: number): Promise<{
+// Staged under the declaring scope: a source name is unique only within its own
+// store, so one checkout keyed on the name would fetch the machine's source
+// onto the repository's.
+async function stage(store: Store, workspace: string, timeoutMs: number): Promise<{
   staged: Staged[];
   errors: string[];
 }> {
   const staged: Staged[] = [];
   const errors: string[] = [];
 
-  for (const source of sources) {
-    const checkout = join(workspace, source.name);
+  for (const source of store.sources) {
+    const checkout = join(workspace, store.scope, source.name);
     const fetched = await fetchSource(source, checkout, timeoutMs);
     if (fetched.sha === undefined) {
       errors.push(fetched.error as string);
@@ -283,7 +286,7 @@ export async function syncSources(request: SyncRequest): Promise<SyncResult> {
     const staged = new Map<SourceScope, Staged[]>();
     const refused: string[] = [];
     for (const store of scoped) {
-      const run = await stage(store.sources, workspace, request.timeoutMs ?? STEP_TIMEOUT_MS);
+      const run = await stage(store, workspace, request.timeoutMs ?? STEP_TIMEOUT_MS);
       staged.set(store.scope, run.staged);
       refused.push(...run.errors);
     }

--- a/skills/taste/scripts/sync.ts
+++ b/skills/taste/scripts/sync.ts
@@ -133,15 +133,18 @@ function lintSource(source: TasteSource, dir: string): string[] {
   return errors.map((error) => `${source.name}: ${error}`);
 }
 
-async function stage(sources: readonly TasteSource[], workspace: string, timeoutMs: number): Promise<{
+// Staged under the declaring scope: a source name is unique only within its own
+// store, so one checkout keyed on the name would fetch the machine's source
+// onto the repository's.
+async function stage(store: Store, workspace: string, timeoutMs: number): Promise<{
   staged: Staged[];
   errors: string[];
 }> {
   const staged: Staged[] = [];
   const errors: string[] = [];
 
-  for (const source of sources) {
-    const checkout = join(workspace, source.name);
+  for (const source of store.sources) {
+    const checkout = join(workspace, store.scope, source.name);
     const fetched = await fetchSource(source, checkout, timeoutMs);
     if (fetched.sha === undefined) {
       errors.push(fetched.error as string);
@@ -283,7 +286,7 @@ export async function syncSources(request: SyncRequest): Promise<SyncResult> {
     const staged = new Map<SourceScope, Staged[]>();
     const refused: string[] = [];
     for (const store of scoped) {
-      const run = await stage(store.sources, workspace, request.timeoutMs ?? STEP_TIMEOUT_MS);
+      const run = await stage(store, workspace, request.timeoutMs ?? STEP_TIMEOUT_MS);
       staged.set(store.scope, run.staged);
       refused.push(...run.errors);
     }

--- a/tests/taste/scopes.test.ts
+++ b/tests/taste/scopes.test.ts
@@ -335,6 +335,35 @@ describe('sync refreshes each scope into its own store', () => {
     });
   });
 
+  // Staging keyed on the source name alone gave both scopes one checkout, so
+  // the second store's fetch ran against the first store's git directory and
+  // the whole sync died. A name is only unique within the scope that declared
+  // it, which is the same reason the two stores hold separate locks.
+  test('two scopes may name a source alike, and each lands its own upstream', async () => {
+    const of = (body: string) => taste('release-tier', {}, body);
+    const at = both(
+      [source(upstream({ 'release-tier.md': of('the repository\'s own upstream') }).url, {
+        ref: 'v1',
+        name: 'shared',
+        visibility: 'public',
+      })],
+      [source(upstream({ 'release-tier.md': of('the machine\'s own upstream') }).url, {
+        ref: 'v1',
+        name: 'shared',
+      })],
+    );
+
+    const result = await at.run();
+
+    expect(result.errors).toEqual([]);
+    expect(treeOf(vendored(at.cwd, 'shared'))).toEqual({
+      'release-tier.md': of('the repository\'s own upstream'),
+    });
+    expect(treeOf(vendored(at.home, 'shared'))).toEqual({
+      'release-tier.md': of('the machine\'s own upstream'),
+    });
+  });
+
   test('a source the lint refuses at one scope leaves the other store untouched', async () => {
     const broken = upstream({
       'commit-style.md': taste('commit-style').replace('name: commit-style', 'name: Commit_Style'),

--- a/tests/taste/visibility.test.ts
+++ b/tests/taste/visibility.test.ts
@@ -335,6 +335,21 @@ describe('the forge is asked about the repository being written into', () => {
     expect(existsSync(vendoredInto(at.cwd))).toBe(true);
   });
 
+  // The direction the public-side pair cannot catch: an arm that answers about
+  // anything other than origin still reads "public" when origin is public, so
+  // only a private origin proves the URL reaching glab is the one being read.
+  test('a private origin reads as private on gitlab, whatever the other remote is', async () => {
+    const at = checkoutWith([
+      ['origin', 'git@gitlab.com:group/private-notes.git'],
+      ['upstream', 'git@gitlab.com:group/public-site.git'],
+    ], { glab: GLAB_LIKE });
+
+    const read = await repoVisibility(at.cwd, at.env);
+
+    expect(read.visibility).toBe('private');
+    expect(read.detail).toContain('private-notes');
+  });
+
   test('a remote url that reads as an option is refused before a CLI sees it', async () => {
     const at = checkoutWith([], { gh: GH_LIKE });
     Bun.spawnSync({ cmd: ['git', 'config', 'remote.origin.url', '--upload-pack=id'], cwd: at.cwd });


### PR DESCRIPTION
Found by running the shipped v0.7.10 against the owner's own machine, where a
machine-level source and this repository's source are both named `public`.

### The collision

`syncSources` makes one staging workspace and calls `stage()` once per store,
which keyed the checkout on `source.name` alone. Two scopes naming a source
alike therefore fetched into one git directory:

```
public: could not fetch ref "main" from git@github.com:developerinlondon/agentkit-tastes.git
        — error: remote origin already exists.
```

Nothing is vendored for **either** scope — every source is staged before
anything lands, so a total failure, not a partial one. Fixed by staging under
`join(workspace, store.scope, source.name)`. Landing paths, locks and the guard
are untouched.

Live, same config both sides:

| | shipped v0.7.10 | this branch |
| --- | --- | --- |
| exit | 1 | 0 |
| repository store | nothing | `public main b032f90 — 8 tastes` |
| machine store | nothing | `public main b032f90 — 8 tastes` |

### Regression test

Two stores declare `shared` against two different fixture remotes, and the test
asserts the **content** each scope lands, not merely that the run succeeded.
Mutation-verified twice:

- name-only keying restored → red (`remote origin already exists`), and it was
  the only red in 521 — the case was genuinely uncovered.
- name-only keying *plus* tolerating the failed `remote add`, i.e. a "fix" that
  lets both scopes share one checkout → run succeeds, and the content assertion
  still catches it: the machine store receives `the repository's own upstream`.
  A success-only test would have passed this.

### GitLab arm of the visibility prober

The GitHub arm has "a private target on origin still vendors"; the `glab` arm
had no positive-direction counterpart, so its public-side test passes just as
well when the arm asks about the wrong repository. Added: private `origin`
beside public `upstream`, asserting `private`. Mutation — `glab` handed a
constant URL-shaped decoy — went from 0 red to 1 red.

### Release hygiene

v0.7.10's headline entry was `feat(taste)!`, conventional-commit BREAKING under
a patch tag, without the owner having agreed a tier. The `!` is dropped and the
upgrade requirement stated in prose in the entry body instead — the only
repo-level source in existence was updated in the same PR, so nothing broke for
a consumer. No entry moved release.

### Verification

- `scripts/preflight --base origin/main` in a fresh clone: all checks passed
- full suite in that clone: **2626 pass, 0 fail**, 7 pre-existing skips
- plugin mirror and docs facts synced; dprint clean
