### PR TITLE
feat(taste): a rule-kind registry, and git-tag-sequence as the second kind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ release PR — "publish this" authorizes a release, never the tier.
 
 ## [Unreleased]
 
+- feat(taste): **a rule declares a kind agentkit implements, and parameterises it** (#328). The
+  rule vocabulary was one regular expression over the command string, which cannot answer a
+  question about state. It is now a registry of named predicates: each kind declares the fields
+  it needs, the validation the lint runs, and the evaluator the hook runs. `kind: command` is
+  the first entry with exactly its previous behaviour. An unknown kind is refused by the lint
+  naming the kinds that exist, and **skipped with a warning by the hook** rather than crashing
+  it, so a taste vendored from a source on a newer agentkit cannot brick an older one. Taste
+  data still executes nothing: a hostile source can pick a check and word a refusal, and at
+  worst over-block you.
+- feat(taste): **`kind: git-tag-sequence` refuses a release tag that does not follow the tags
+  already in the repository** (#328). `policy` picks the ordering — `no-duplicate`,
+  `no-backwards-in-line` (a tag below the highest on its own major.minor line, so v0.6.5 while
+  v0.7.11 exists stays a legitimate maintenance release), or `strict-successor` (only the
+  immediate next patch of the highest tag). Non-semver tags are ignored throughout. The
+  proposed tag is read from `git tag`, `git push` and `gh release create`; `match` overrides
+  that reading, its first capture group being the tag. It deliberately does **not** fail closed
+  like the vendoring guard: outside a repository or with no tags there is nothing to check and
+  the command passes silently, and where git cannot answer it reports `UNCHECKED` and allows —
+  never a silent allow. The reasoning for the asymmetry is in the skill, bound to tests.
+
 ## v0.7.11 — 2026-08-06
 
 - fix(taste): **a sync stages each scope separately, so both may declare a source of the same

--- a/plugins-cc/agentkit/skills/taste/SKILL.md
+++ b/plugins-cc/agentkit/skills/taste/SKILL.md
@@ -339,9 +339,10 @@ A preference that no kind can express stays at `enforce: check`. **A new kind is
 agentkit**, proposed and reviewed like one — never bespoke code smuggled into a taste folder.
 `references/format.md` carries each kind's fields, the three tag policies, and worked examples.
 
-**A kind this agentkit does not implement is skipped, loudly.** The lint refuses the file, and
-the hook names it, warns, and keeps enforcing every other taste — a taste written against a
-newer agentkit must not brick an older hook.
+**A kind this agentkit does not implement is skipped, loudly.** The lint refuses such a file, and
+the hook runs that same lint as it loads the folder — so the taste is dropped there, named in a
+warning that lists the kinds this agentkit does have, while every other taste keeps enforcing. A
+taste written against a newer agentkit must not brick an older hook.
 
 ### What it does at the edges, so you can answer for it
 

--- a/plugins-cc/agentkit/skills/taste/SKILL.md
+++ b/plugins-cc/agentkit/skills/taste/SKILL.md
@@ -318,11 +318,32 @@ is read the same way, for one release of grace.
 
 `block` is carried out by one generic hook — `taste-police`, in the core kit, on every harness
 agentkit installs to. It resolves the same folders this skill does, takes the tastes at
-`enforce: block` whose `rule` the lint accepts, and tests `rule.match` against the command in
+`enforce: block` whose `rule` the lint accepts, and runs that rule's kind against the command in
 process. Nothing in a taste is ever executed. Adding a blocking taste changes no code
 anywhere: it is a file.
 
-What it does at the edges, so you can answer for it:
+### What a rule can check: the kinds
+
+**The enforcement vocabulary is extensible by agentkit and parameterised by tastes.** A
+`rule.kind` names a check agentkit implements; the taste supplies the data it runs on and the
+words it refuses with. The taste never carries the code, which is the whole reason a taste from
+somewhere else is safe to load: **a hostile source can at worst over-block you**, because
+picking a check and wording a refusal is all a taste can do.
+
+| `kind`             | The taste supplies                     | agentkit inspects                     |
+| ------------------ | -------------------------------------- | ------------------------------------- |
+| `command`          | `match`, a regular expression          | the text of the command about to run  |
+| `git-tag-sequence` | `policy`, one of three named orderings | the tags in the repository it runs in |
+
+A preference that no kind can express stays at `enforce: check`. **A new kind is a change to
+agentkit**, proposed and reviewed like one — never bespoke code smuggled into a taste folder.
+`references/format.md` carries each kind's fields, the three tag policies, and worked examples.
+
+**A kind this agentkit does not implement is skipped, loudly.** The lint refuses the file, and
+the hook names it, warns, and keeps enforcing every other taste — a taste written against a
+newer agentkit must not brick an older hook.
+
+### What it does at the edges, so you can answer for it
 
 - **Refusal** names the taste, its file, its own `remedy`, and its own `override`.
 - **The override** is that taste's named variable, set inline on the command (`NAME=1 …`) or
@@ -332,14 +353,33 @@ What it does at the edges, so you can answer for it:
   pattern that outruns the match deadline — it is named, skipped, and the rest still bind.
 - **An unrunnable hook** (no `bun`, no evaluator) says `UNCHECKED` and allows. It never
   refuses on its own uncertainty, and it never goes quiet where there were tastes to read.
+- **A check that cannot read what it needs** says `UNCHECKED` for that one taste and allows the
+  command — `git-tag-sequence` where git will not answer, for instance. Silence there would be
+  worse than either verdict: the session would read enforcement into a guard that never ran.
 - **Bounds**: `rule.match` is capped at 200 characters, only the first 4000 characters of a
   command are examined, and the match itself is abandoned after 250ms — length is not safety,
   since a short pattern can still backtrack forever. `references/format.md` carries the
   reasoning.
 
+### Why this does not fail closed, when the vendoring guard does
+
+The two guards sit on opposite sides of one question — what does the tool do when it cannot see?
+— and they answer differently because **the cost of each mistake is different**:
+
+- **Vendoring fails closed.** A private source wrongly let into a public repository is words
+  published under someone's name, and no later commit takes them back. Refusing costs one
+  environment variable.
+- **A rule kind fails open, and says so.** Refusing every tag command in a repository whose tags
+  cannot be read would cost real work, to prevent a mis-ordered tag that `git tag -d` undoes in
+  a second. And **nothing to check is not a failure at all**: outside a git repository, or in one
+  with no tags, `git-tag-sequence` passes silently, because there is no sequence to violate.
+
+Do not "fix" this into symmetry. The rule is that a guard fails towards whichever error is
+recoverable, and it is `UNCHECKED` — never a silent allow — whenever it could not look.
+
 If someone asks why a `block` taste did not stop something, check those in order: the taste is
-`advise`, the pattern did not match, the override was set, the file failed the lint, or the
-hook reported `UNCHECKED`.
+`advise`, the rule did not fire, the override was set, the file failed the lint, the kind is one
+this agentkit does not implement, or the hook reported `UNCHECKED`.
 
 Never raise `enforce` yourself. Observed violations are evidence for a proposal the owner
 merges — the diff is how it changes.

--- a/plugins-cc/agentkit/skills/taste/references/format.md
+++ b/plugins-cc/agentkit/skills/taste/references/format.md
@@ -54,10 +54,11 @@ anything.
 A key belongs to one kind: `policy` inside a `command` rule is an unknown key, and the lint says
 so naming what that kind does carry.
 
-**An unknown kind is refused by the lint**, naming the kinds that exist. The hook treats it
-differently on purpose: it **skips that taste with a warning and keeps enforcing every other
-one**, because a taste vendored from a source running a newer agentkit must not brick an older
-hook. Upgrade agentkit, or keep the taste at `enforce: check` until you have.
+**An unknown kind is refused by the lint**, naming the kinds that exist — and the hook runs that
+same lint as it loads the folder, so at enforcement time the file is **skipped with a warning
+while every other taste keeps enforcing**, rather than taking the hook down with it. That is what
+lets a taste vendored from a source running a newer agentkit be safe to load at all. Upgrade
+agentkit, or keep the taste at `enforce: check` until you have.
 
 A preference no registered kind can express stays at `enforce: check` rather than growing
 bespoke code in someone's taste folder. A new kind is a change to agentkit, reviewed like one.

--- a/plugins-cc/agentkit/skills/taste/references/format.md
+++ b/plugins-cc/agentkit/skills/taste/references/format.md
@@ -116,6 +116,13 @@ because `v0.6.5` already is. `strict-successor` refuses both — it is for a pro
 line and nothing else. A prerelease sorts below the release it leads to, so `v0.8.0-rc1` then
 `v0.8.0` is an ascending pair under every policy.
 
+**`strict-successor` cannot open a new line, prerelease included.** On a repository at `v0.7.11`
+it refuses `v0.8.0-rc1` exactly as it refuses `v0.8.0`, saying the next tag is `v0.7.12` — the
+next patch is the only thing it accepts, and a release candidate for a new minor is not one.
+That follows from the name, but it is worth knowing before a release rather than during one: a
+project that cuts minor release candidates wants `no-backwards-in-line`, or the taste's own
+override for the one tag that opens the line.
+
 The proposed tag is read from the command in the shapes agentkit recognises: `git tag <tag>`,
 `git push <remote> <tag>` (including `refs/tags/` and `<src>:<dst>` refspecs), and
 `gh release create <tag>`. Listing, verifying and deleting are not proposals — `git tag --list`,

--- a/plugins-cc/agentkit/skills/taste/references/format.md
+++ b/plugins-cc/agentkit/skills/taste/references/format.md
@@ -15,7 +15,7 @@ override across scopes.
 | `provenance` | yes      | a date and where it came from              | When the preference was stated, so a stale one is visible            |
 | `category`   | no       | free text                                  | Lets a skill load only the tastes an action can touch                |
 | `enforce`    | no       | `advise` \| `check` \| `block`             | How hard it binds. Defaults to `advise`, where most tastes stay      |
-| `rule`       | no       | `kind` / `match` / `remedy` / `override`   | Only with `enforce: check` or `block`. Declarative data — never code |
+| `rule`       | no       | `kind` plus that kind's own fields         | Only with `enforce: check` or `block`. Declarative data — never code |
 
 No other top-level key is accepted. A typo is a rejection, not a silently ignored field.
 
@@ -27,16 +27,45 @@ violation is evidence for a proposal the owner merges — never an automatic pro
 Present only when `enforce` is `check` or `block`. It is data the generic `taste-police` hook
 reads; nothing in it is ever executed as a command.
 
+Three keys are the same in every rule:
+
 | Key        | Required | Value                                                                   |
 | ---------- | -------- | ----------------------------------------------------------------------- |
-| `kind`     | yes      | `command` — the action class the pattern matches                        |
-| `match`    | yes      | a regular expression that must compile, at most 200 characters          |
+| `kind`     | yes      | which check agentkit runs — one of the registered kinds below           |
 | `remedy`   | yes      | the sentence an agent is shown instead of the refused action            |
 | `override` | no       | the name of one environment variable that lets it through, deliberately |
 
 Every value is a string. No nesting, no lists, and no shell metacharacters — `override` is an
-environment-variable name and nothing else. A preference no pattern can capture stays at
-`enforce: check` rather than growing bespoke code.
+environment-variable name and nothing else.
+
+### The rule-kind registry
+
+A `kind` is a **named predicate agentkit implements**. The taste chooses which check runs and
+supplies the data it needs; the code that inspects anything is always agentkit's. That is what
+keeps a taste data rather than a program, and it is why the trust property holds: a hostile
+source can pick a check and word a refusal, so at worst it over-blocks you — it can never run
+anything.
+
+| `kind`             | Its own keys                      | What it inspects                               |
+| ------------------ | --------------------------------- | ---------------------------------------------- |
+| `command`          | `match` (required)                | the text of the command about to run           |
+| `git-tag-sequence` | `policy` (required), `match` (no) | the tags in the repository the command runs in |
+
+A key belongs to one kind: `policy` inside a `command` rule is an unknown key, and the lint says
+so naming what that kind does carry.
+
+**An unknown kind is refused by the lint**, naming the kinds that exist. The hook treats it
+differently on purpose: it **skips that taste with a warning and keeps enforcing every other
+one**, because a taste vendored from a source running a newer agentkit must not brick an older
+hook. Upgrade agentkit, or keep the taste at `enforce: check` until you have.
+
+A preference no registered kind can express stays at `enforce: check` rather than growing
+bespoke code in someone's taste folder. A new kind is a change to agentkit, reviewed like one.
+
+### `kind: command`
+
+`match` is a regular expression tested against the command string — at most 200 characters, and
+it must compile.
 
 **A remedy is plain prose.** It is a sentence an agent reads, never a command anything runs, so
 name the command in words — `Cut a patch tag` rather than a backticked or `$()`-wrapped
@@ -66,6 +95,49 @@ unenforced, rather than taking the session down with it.
 
 The subject bound is the honest trade: a command long enough to hit it is a script, and a
 taste is not a way to audit one. Write the pattern against what an agent actually types.
+
+### `kind: git-tag-sequence`
+
+Refuses a release tag that does not follow the tags already in the repository. A pattern cannot
+do this — the answer is not in the command string — which is what a named predicate is for.
+
+`policy` names which sequence rule applies. All three ignore any tag that is not semver, in the
+proposal and among the existing tags alike, because a tag with no version carries no order:
+
+| `policy`               | Refuses                                                                          |
+| ---------------------- | -------------------------------------------------------------------------------- |
+| `no-duplicate`         | a tag that already exists                                                        |
+| `no-backwards-in-line` | that, plus a tag lower than the highest existing tag **sharing its major.minor** |
+| `strict-successor`     | that, plus anything but the immediate next patch of the highest tag **overall**  |
+
+`no-backwards-in-line` is the one that keeps maintenance possible: on a repository at `v0.7.11`,
+`v0.6.5` is allowed because nothing on the `0.6` line is above it, while `v0.6.2` is refused
+because `v0.6.5` already is. `strict-successor` refuses both — it is for a project that cuts one
+line and nothing else. A prerelease sorts below the release it leads to, so `v0.8.0-rc1` then
+`v0.8.0` is an ascending pair under every policy.
+
+The proposed tag is read from the command in the shapes agentkit recognises: `git tag <tag>`,
+`git push <remote> <tag>` (including `refs/tags/` and `<src>:<dst>` refspecs), and
+`gh release create <tag>`. Listing, verifying and deleting are not proposals — `git tag --list`,
+`git tag -d v1.2.3` and `git push --delete` all pass. Where that reading is wrong for your
+workflow, `match` overrides it: **its first capture group is the tag**, and it is held to the
+same 200-character, must-compile, no-substitution bounds as a `command` rule.
+
+**It does not fail closed, and that is deliberate.** The vendoring guard refuses whatever it
+cannot verify, because the error it prevents is a leak that cannot be undone. This one is a
+convention guard, so the two errors are the other way round:
+
+| Situation                             | What happens                                      |
+| ------------------------------------- | ------------------------------------------------- |
+| the command proposes no semver tag    | passes, and git is never run                      |
+| the directory is not a git repository | passes silently — there is no sequence to violate |
+| the repository has no tags            | passes silently — there is nothing to be behind   |
+| git cannot be run, or cannot list     | **`UNCHECKED`, and the command is allowed**       |
+
+Failing closed here would refuse every tag command in every repository whose tags cannot be
+read, to prevent a mis-ordered tag that `git tag` itself makes trivial to delete. But a silent
+allow would be worse than either: the session would read enforcement into a guard that never
+ran. So it says `UNCHECKED`, names the taste and the reason, and lets the command through.
 
 ### What counts as using an override
 
@@ -104,6 +176,34 @@ semver alone will tag a minor for any feature-shaped diff.
 
 How to apply: propose the patch version in the release PR. If the diff looks
 minor-worthy, say so and ask — do not tag it.
+```
+
+And `.agentkit/tastes/tag-sequence.md`, the same shape with the other kind — no pattern, because
+what it checks is not in the command:
+
+```markdown
+---
+name: tag-sequence
+scope: project
+category: release
+strength: require
+enforce: block
+rule:
+  kind: git-tag-sequence
+  policy: no-backwards-in-line
+  remedy: Read the tags first and cut the next patch on the line you are releasing.
+  override: AGENTKIT_TAG_SEQUENCE
+provenance: 2026-08-06 · issue 328
+---
+
+A release tag goes forwards on its own line. A lower line is maintenance and is
+fine; a tag below one that already exists on the same line is not.
+
+Why: version numbers are read as a sequence by everything downstream — a
+backwards tag makes "latest" mean two different commits.
+
+How to apply: list the tags before tagging. If the tag you want is already
+there, or is behind one on its line, pick the next patch instead.
 ```
 
 ## The source contract

--- a/plugins-cc/agentkit/skills/taste/scripts/lint.ts
+++ b/plugins-cc/agentkit/skills/taste/scripts/lint.ts
@@ -2,31 +2,24 @@ import { YAML } from 'bun';
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { basename, join, relative, resolve } from 'node:path';
 import { EXTERNAL_DIR, LEGACY_EXTERNAL_ROOT } from './layout.ts';
+import { type RuleKind, ruleKeys, ruleKind, RULE_KINDS } from './rules/kinds.ts';
+import { carriesSubstitution } from './rules/pattern.ts';
 
 const REQUIRED_KEYS = ['name', 'provenance', 'scope', 'strength'];
 const OPTIONAL_KEYS = ['category', 'enforce', 'rule'];
 export const SCOPES = ['project', 'external', 'user'];
 export const STRENGTHS = ['prefer', 'require'];
 export const ENFORCEMENTS = ['advise', 'check', 'block'];
-const RULE_KEYS = ['kind', 'match', 'remedy', 'override'];
-const RULE_KINDS = ['command'];
 
 // `external` is read by position, not by name: it is the one directory at a
 // tastes root that a sync writes and the resolver treats as a stack of sources.
 const RESERVED = `${JSON.stringify(EXTERNAL_DIR)} is reserved — it names the subtree holding the `
   + 'snapshot of each declared source, at the root of a tastes tree and nowhere else';
 
-// A rule is tested in-process against every command an agent runs, and a
-// regular expression can be made to backtrack for longer than anyone will wait.
-// The subject is bounded where the matching happens (police.ts); the pattern is
-// bounded here, so an unrunnable rule fails the lint rather than a session.
-export const MAX_MATCH_LENGTH = 200;
-
 // Unnumbered as well as kebab: position carries no meaning in a taste folder, so
 // a leading number is a record's habit leaking into a dictionary.
 const NAME = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/;
 const ENV_NAME = /^[A-Z][A-Z0-9_]*$/;
-const SHELL_SUBSTITUTION = /\$\(|`/;
 const FRONTMATTER = /^---\r?\n([\s\S]*?)\r?\n---\r?\n([\s\S]*)$/;
 
 type Frontmatter = Record<string, unknown>;
@@ -93,40 +86,45 @@ function checkEnums(front: Frontmatter): string[] {
   return errors.filter((error): error is string => error !== undefined);
 }
 
-function checkRuleFields(rule: Frontmatter): string[] {
-  const errors: string[] = [];
-  const unknown = Object.keys(rule).filter((key) => !RULE_KEYS.includes(key)).sort();
-  if (unknown.length > 0) {
-    errors.push(`unknown rule key: ${unknown.join(', ')} — a rule carries ${RULE_KEYS.join(', ')}`);
+// The kind decides which keys mean anything, so an unknown kind names the ones
+// agentkit implements instead of judging the rest of the block against a
+// vocabulary nobody chose.
+function checkKind(rule: Frontmatter, kind: RuleKind | undefined): string[] {
+  if (typeof rule.kind !== 'string') return [];
+  if (kind === undefined) {
+    return [`rule.kind: ${JSON.stringify(rule.kind)} is not one of ${RULE_KINDS.join(', ')}`];
   }
-  for (const key of ['kind', 'match', 'remedy']) {
+  const keys = ruleKeys(kind);
+  const unknown = Object.keys(rule).filter((key) => !keys.includes(key)).sort();
+  if (unknown.length === 0) return [];
+  return [
+    `unknown rule key: ${unknown.join(', ')} — a rule of kind ${kind.name} carries `
+      + keys.join(', '),
+  ];
+}
+
+// Every value in the block is a string, which is what makes a rule data rather
+// than structure. Which strings have to be there is the kind's business.
+function stringFields(rule: Frontmatter): Record<string, string> {
+  const fields: Record<string, string> = {};
+  for (const [key, value] of Object.entries(rule)) {
+    if (typeof value === 'string') fields[key] = value;
+  }
+  return fields;
+}
+
+function checkRuleFields(rule: Frontmatter): string[] {
+  const kind = typeof rule.kind === 'string' ? ruleKind(rule.kind) : undefined;
+  const errors = checkKind(rule, kind);
+
+  for (const key of ['kind', 'remedy', ...(kind?.required ?? [])]) {
     if (typeof rule[key] !== 'string') {
       errors.push(`rule.${key} must be a string — the rule is data, not structure`);
     }
   }
-  if (typeof rule.kind === 'string' && !RULE_KINDS.includes(rule.kind)) {
-    errors.push(`rule.kind: ${JSON.stringify(rule.kind)} is not one of ${RULE_KINDS.join(', ')}`);
-  }
-  if (typeof rule.match === 'string') {
-    if (rule.match.length > MAX_MATCH_LENGTH) {
-      errors.push(
-        `rule.match is ${rule.match.length} characters — the cap is ${MAX_MATCH_LENGTH}, because `
-          + 'the hook runs it against every command. Narrow the pattern, or keep the taste at check.',
-      );
-    }
-    try {
-      new RegExp(rule.match);
-    } catch (error) {
-      errors.push(`rule.match is not a valid regular expression: ${(error as Error).message}`);
-    }
-    if (SHELL_SUBSTITUTION.test(rule.match)) {
-      errors.push(
-        'rule.match carries a command substitution — a rule is data; escape it as \\$\\( to '
-          + 'match those characters literally. A backtick cannot appear in a match at all.',
-      );
-    }
-  }
-  if (typeof rule.remedy === 'string' && SHELL_SUBSTITUTION.test(rule.remedy)) {
+  if (kind !== undefined) errors.push(...kind.validate(stringFields(rule)));
+
+  if (typeof rule.remedy === 'string' && carriesSubstitution(rule.remedy)) {
     errors.push(
       'rule.remedy carries a command substitution — a remedy is plain prose; name the command '
         + 'without backticks or $()',
@@ -148,7 +146,10 @@ function checkRule(front: Frontmatter): string[] {
     return ['enforce: block needs a rule — taste-police would have nothing to read'];
   }
   if (!hasRule) return [];
-  if (!isRecord(front.rule)) return ['rule must be a block of kind, match, remedy, override'];
+  if (!isRecord(front.rule)) {
+    return [`rule must be a block of kind, remedy, override and what the kind requires — the `
+      + `kinds are ${RULE_KINDS.join(', ')}`];
+  }
   return checkRuleFields(front.rule);
 }
 

--- a/plugins-cc/agentkit/skills/taste/scripts/match.ts
+++ b/plugins-cc/agentkit/skills/taste/scripts/match.ts
@@ -1,12 +1,36 @@
 declare const self: Worker;
 
+// A rule that reads a value out of the command gets it from here too, rather
+// than compiling the pattern a second time somewhere the deadline cannot reach.
+const MAX_CAPTURES = 20;
+
+function captured(pattern: string, subject: string): { matched: boolean; captures: string[] } {
+  const regex = new RegExp(pattern, 'g');
+  const captures: string[] = [];
+  let found = regex.exec(subject);
+  while (found !== null && captures.length < MAX_CAPTURES) {
+    captures.push(found[1] ?? found[0]);
+    if (found[0] === '') regex.lastIndex += 1;
+    found = regex.exec(subject);
+  }
+  return { matched: captures.length > 0, captures };
+}
+
 // One rule's pattern against one command, on a thread that can be terminated.
 // A regular expression cannot be interrupted once it starts backtracking, so the
 // only way to bound it is to run it somewhere abandonable.
 self.onmessage = (event: MessageEvent) => {
-  const { pattern, subject } = event.data as { pattern: string; subject: string };
+  const { pattern, subject, capture } = event.data as {
+    pattern: string;
+    subject: string;
+    capture?: boolean;
+  };
   try {
-    postMessage({ matched: new RegExp(pattern).test(subject) });
+    postMessage(
+      capture === true
+        ? captured(pattern, subject)
+        : { matched: new RegExp(pattern).test(subject), captures: [] },
+    );
   } catch (error) {
     postMessage({ failed: (error as Error).message });
   }

--- a/plugins-cc/agentkit/skills/taste/scripts/police.ts
+++ b/plugins-cc/agentkit/skills/taste/scripts/police.ts
@@ -1,6 +1,7 @@
 import { homedir } from 'node:os';
 import { offValueLine, type Override, readOverride, unquote } from './override.ts';
-import { type ResolvedTaste, resolveTastes } from './resolve.ts';
+import { type ResolvedTaste, resolveTastes, type TasteRule } from './resolve.ts';
+import { evaluateRule, type MatchOutcome } from './rules/kinds.ts';
 import { configFiles, tasteSection } from './sources.ts';
 
 // The rule's pattern is capped where the lint can refuse it; the subject is
@@ -54,15 +55,13 @@ function overrideState(
   return readOverride(assignedInline(command, name) ?? env[name]);
 }
 
-type MatchOutcome = { matched: boolean } | { skipped: string };
-
 // The deadline has to live here rather than in either adapter: the OpenCode lane
 // runs the match in the editor's own process, where a pattern that backtracks
 // takes the session with it and no outer timeout can reach.
 class BoundedMatcher {
   private worker: Worker | undefined;
 
-  async test(pattern: string, command: string): Promise<MatchOutcome> {
+  async test(pattern: string, command: string, capture?: boolean): Promise<MatchOutcome> {
     const worker = (this.worker ??= new Worker(new URL('./match.ts', import.meta.url).href));
     const subject = command.slice(0, MAX_SUBJECT_LENGTH);
 
@@ -77,10 +76,10 @@ class BoundedMatcher {
 
       worker.onmessage = (event: MessageEvent) => {
         clearTimeout(timer);
-        const result = event.data as { matched?: boolean; failed?: string };
+        const result = event.data as { matched?: boolean; captures?: string[]; failed?: string };
         resolve(
           result.failed === undefined
-            ? { matched: result.matched === true }
+            ? { matched: result.matched === true, captures: result.captures ?? [] }
             : { skipped: `its rule.match could not be run: ${result.failed}` },
         );
       };
@@ -90,7 +89,7 @@ class BoundedMatcher {
         resolve({ skipped: `its rule.match could not be run: ${event.message}` });
       };
 
-      worker.postMessage({ pattern, subject });
+      worker.postMessage({ pattern, subject, capture: capture === true });
     });
   }
 
@@ -121,13 +120,14 @@ function overrideLine(taste: ResolvedTaste, override: Override): string {
 // enforcement happened while some of it silently did not.
 function refusal(
   taste: ResolvedTaste,
+  finding: string,
   override: Override,
   cwd: string,
   home: string,
   notices: string[],
 ): string {
   const lines = [
-    `BLOCKED by taste ${taste.name} (enforce: block): this command matches rule.match in `
+    `BLOCKED by taste ${taste.name} (enforce: block): ${finding} in `
       + `${displayPath(taste.path, cwd, home)}.`,
     taste.rule?.remedy ?? '',
     overrideLine(taste, override),
@@ -137,7 +137,7 @@ function refusal(
 }
 
 function blocking(taste: ResolvedTaste): boolean {
-  return taste.enforce === 'block' && taste.rule?.kind === 'command';
+  return taste.enforce === 'block' && taste.rule !== undefined;
 }
 
 export async function evaluateCommand(request: Request): Promise<Verdict> {
@@ -151,23 +151,39 @@ export async function evaluateCommand(request: Request): Promise<Verdict> {
 
   try {
     for (const taste of tastes.filter(blocking)) {
-      const outcome = await matcher.test(taste.rule?.match as string, request.command);
-      if ('skipped' in outcome) {
-        notices.push(`taste ${taste.name} was not applied — ${outcome.skipped} (${taste.path}).`);
+      const rule = taste.rule as TasteRule;
+      const outcome = await evaluateRule(rule.kind, rule.fields, {
+        command: request.command,
+        cwd: request.cwd,
+        env,
+        match: (pattern, capture) => matcher.test(pattern, request.command, capture),
+      });
+
+      if (outcome.verdict === 'skipped') {
+        notices.push(`taste ${taste.name} was not applied — ${outcome.detail} (${taste.path}).`);
         continue;
       }
-      if (!outcome.matched) continue;
+      // Allowed, and said so. A guard that could not read the state it needed
+      // is not a guard that found nothing.
+      if (outcome.verdict === 'unchecked') {
+        notices.push(
+          `UNCHECKED: taste ${taste.name} could not check this command — ${outcome.detail}. `
+            + `The command was allowed (${taste.path}).`,
+        );
+        continue;
+      }
+      if (outcome.verdict === 'passes') continue;
 
-      const override = overrideState(taste.rule?.override, request.command, env);
+      const override = overrideState(rule.override, request.command, env);
       if (override.state === 'granted') {
         notices.push(
-          `taste ${taste.name} allowed this command: ${taste.rule?.override} is set deliberately.`,
+          `taste ${taste.name} allowed this command: ${rule.override} is set deliberately.`,
         );
         continue;
       }
       return {
         decision: 'deny',
-        reason: refusal(taste, override, request.cwd, home, notices),
+        reason: refusal(taste, outcome.finding, override, request.cwd, home, notices),
         notices,
       };
     }

--- a/plugins-cc/agentkit/skills/taste/scripts/resolve.ts
+++ b/plugins-cc/agentkit/skills/taste/scripts/resolve.ts
@@ -12,9 +12,12 @@ export type Layer = 'project' | 'project-external' | 'user' | 'user-external';
 
 export interface TasteRule {
   kind: string;
-  match: string;
   remedy: string;
   override?: string;
+  // Everything else in the block, kind by kind: `match` for a command rule,
+  // `policy` for a tag-sequence one. The resolver stays out of the vocabulary
+  // so a kind can be added without it learning anything.
+  fields: Record<string, string>;
 }
 
 export interface ResolvedTaste {
@@ -156,12 +159,17 @@ function isDirectory(path: string): boolean {
 function readRule(front: Record<string, unknown>): TasteRule | undefined {
   const rule = front.rule;
   if (typeof rule !== 'object' || rule === null || Array.isArray(rule)) return undefined;
-  const fields = rule as Record<string, unknown>;
-  const kind = scalar(fields.kind);
-  const match = scalar(fields.match);
-  const remedy = scalar(fields.remedy);
-  if (kind === undefined || match === undefined || remedy === undefined) return undefined;
-  return { kind, match, remedy, override: scalar(fields.override) };
+  const block = rule as Record<string, unknown>;
+  const kind = scalar(block.kind);
+  const remedy = scalar(block.remedy);
+  if (kind === undefined || remedy === undefined) return undefined;
+
+  const fields: Record<string, string> = {};
+  for (const [key, value] of Object.entries(block)) {
+    const text = scalar(value);
+    if (text !== undefined) fields[key] = text;
+  }
+  return { kind, remedy, override: scalar(block.override), fields };
 }
 
 function load(path: string, where: Directory): { taste?: ResolvedTaste; warning?: string } {

--- a/plugins-cc/agentkit/skills/taste/scripts/rules/kinds.ts
+++ b/plugins-cc/agentkit/skills/taste/scripts/rules/kinds.ts
@@ -67,10 +67,10 @@ export function ruleKeys(kind: RuleKind): string[] {
   return ['kind', ...kind.required, ...kind.optional, 'remedy', 'override'];
 }
 
-// A taste written against a newer agentkit names a kind this one has never
-// heard of. It is skipped and said out loud — never a throw, because one taste
-// from the future must not take the whole hook down with it, and never silence,
-// because an enforcement that stopped happening has to be visible.
+// Depth, not the path. A taste naming a kind this agentkit lacks is already
+// dropped by resolve.ts, whose load-time lint refuses the kind and names it in a
+// warning — that is what delivers the guarantee. This branch exists because the
+// lookup can return nothing, and the answer to that must never be a throw.
 export async function evaluateRule(
   name: string,
   fields: Record<string, string>,

--- a/plugins-cc/agentkit/skills/taste/scripts/rules/kinds.ts
+++ b/plugins-cc/agentkit/skills/taste/scripts/rules/kinds.ts
@@ -1,0 +1,89 @@
+import { matchErrors } from './pattern.ts';
+import { GIT_TAG_SEQUENCE } from './tag-sequence.ts';
+
+export type MatchOutcome = { matched: boolean; captures: string[] } | { skipped: string };
+
+// The bounded matcher, supplied by whoever is running the rule. A kind never
+// compiles a taste's pattern itself: the deadline that makes a hostile pattern
+// survivable lives in one place, and every kind borrows it.
+export type Matcher = (pattern: string, capture?: boolean) => Promise<MatchOutcome>;
+
+export interface KindRequest {
+  command: string;
+  cwd: string;
+  env: Record<string, string | undefined>;
+  match: Matcher;
+}
+
+// `fires` refuses and says what was found; `skipped` and `unchecked` both allow
+// and both say so. They are separate because they answer different questions:
+// skipped means this taste could not be applied, unchecked means the state the
+// check needed could not be read.
+export type KindOutcome =
+  | { verdict: 'fires'; finding: string }
+  | { verdict: 'passes' }
+  | { verdict: 'skipped'; detail: string }
+  | { verdict: 'unchecked'; detail: string };
+
+// One entry per enforcement vocabulary agentkit implements. A taste names the
+// kind and parameterises it; the code is always agentkit's, which is what keeps
+// a taste data rather than a program.
+export interface RuleKind {
+  name: string;
+  // Beyond `kind`, `remedy` and `override`, which every kind carries.
+  required: readonly string[];
+  optional: readonly string[];
+  validate(fields: Record<string, string>): string[];
+  evaluate(fields: Record<string, string>, request: KindRequest): Promise<KindOutcome>;
+}
+
+const COMMAND: RuleKind = {
+  name: 'command',
+  required: ['match'],
+  optional: [],
+  validate(fields: Record<string, string>): string[] {
+    return fields.match === undefined ? [] : matchErrors(fields.match);
+  },
+  async evaluate(fields: Record<string, string>, request: KindRequest): Promise<KindOutcome> {
+    const outcome = await request.match(fields.match as string);
+    if ('skipped' in outcome) return { verdict: 'skipped', detail: outcome.skipped };
+    return outcome.matched
+      ? { verdict: 'fires', finding: 'this command matches rule.match' }
+      : { verdict: 'passes' };
+  },
+};
+
+const KINDS: readonly RuleKind[] = [COMMAND, GIT_TAG_SEQUENCE];
+
+export const RULE_KINDS: readonly string[] = KINDS.map((kind) => kind.name);
+
+export function ruleKind(name: string): RuleKind | undefined {
+  return KINDS.find((kind) => kind.name === name);
+}
+
+// What the lint accepts inside a rule of this kind, in reading order: what it
+// is, what it needs, what it may have, what it says, and how to get past it.
+export function ruleKeys(kind: RuleKind): string[] {
+  return ['kind', ...kind.required, ...kind.optional, 'remedy', 'override'];
+}
+
+// A taste written against a newer agentkit names a kind this one has never
+// heard of. It is skipped and said out loud — never a throw, because one taste
+// from the future must not take the whole hook down with it, and never silence,
+// because an enforcement that stopped happening has to be visible.
+export async function evaluateRule(
+  name: string,
+  fields: Record<string, string>,
+  request: KindRequest,
+): Promise<KindOutcome> {
+  const kind = ruleKind(name);
+  if (kind === undefined) {
+    return {
+      verdict: 'skipped',
+      detail: `its rule.kind ${JSON.stringify(name)} is not implemented by this version of `
+        + `agentkit, which has ${RULE_KINDS.join(', ')}. Upgrade agentkit, or keep the taste at `
+        + 'enforce: check',
+    };
+  }
+  return await kind.evaluate(fields, request);
+}

--- a/plugins-cc/agentkit/skills/taste/scripts/rules/pattern.ts
+++ b/plugins-cc/agentkit/skills/taste/scripts/rules/pattern.ts
@@ -1,0 +1,36 @@
+// A rule is tested in-process against every command an agent runs, and a
+// regular expression can be made to backtrack for longer than anyone will wait.
+// The subject is bounded where the matching happens (police.ts); the pattern is
+// bounded here, so an unrunnable rule fails the lint rather than a session.
+export const MAX_MATCH_LENGTH = 200;
+
+const SHELL_SUBSTITUTION = /\$\(|`/;
+
+// Every kind that reads a pattern out of a taste holds it to the same bounds:
+// a second kind's `match` is the same string in the same file, evaluated by the
+// same worker, so a looser one would be a way around the first.
+export function matchErrors(pattern: string): string[] {
+  const errors: string[] = [];
+  if (pattern.length > MAX_MATCH_LENGTH) {
+    errors.push(
+      `rule.match is ${pattern.length} characters — the cap is ${MAX_MATCH_LENGTH}, because `
+        + 'the hook runs it against every command. Narrow the pattern, or keep the taste at check.',
+    );
+  }
+  try {
+    new RegExp(pattern);
+  } catch (error) {
+    errors.push(`rule.match is not a valid regular expression: ${(error as Error).message}`);
+  }
+  if (SHELL_SUBSTITUTION.test(pattern)) {
+    errors.push(
+      'rule.match carries a command substitution — a rule is data; escape it as \\$\\( to '
+        + 'match those characters literally. A backtick cannot appear in a match at all.',
+    );
+  }
+  return errors;
+}
+
+export function carriesSubstitution(value: string): boolean {
+  return SHELL_SUBSTITUTION.test(value);
+}

--- a/plugins-cc/agentkit/skills/taste/scripts/rules/semver.ts
+++ b/plugins-cc/agentkit/skills/taste/scripts/rules/semver.ts
@@ -1,0 +1,67 @@
+export interface Version {
+  major: number;
+  minor: number;
+  patch: number;
+  // Dot-separated identifiers, empty for a release. A release outranks every
+  // prerelease of the same core, which is what makes rc1 -> rc2 -> final an
+  // ascending sequence rather than three unrelated tags.
+  prerelease: string[];
+}
+
+// A leading `v` is the tag convention rather than the grammar, and build
+// metadata is ignored for precedence — both per semver itself.
+const SEMVER =
+  /^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/;
+
+export function parseVersion(tag: string): Version | undefined {
+  const parts = SEMVER.exec(tag.trim());
+  if (parts === null) return undefined;
+  const prerelease = parts[4];
+  return {
+    major: Number(parts[1]),
+    minor: Number(parts[2]),
+    patch: Number(parts[3]),
+    prerelease: prerelease === undefined ? [] : prerelease.split('.'),
+  };
+}
+
+function compareIdentifiers(left: string, right: string): number {
+  const leftNumeric = /^\d+$/.test(left);
+  const rightNumeric = /^\d+$/.test(right);
+  if (leftNumeric && rightNumeric) return Number(left) - Number(right);
+  if (leftNumeric) return -1;
+  if (rightNumeric) return 1;
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function comparePrerelease(left: string[], right: string[]): number {
+  if (left.length === 0 && right.length === 0) return 0;
+  if (left.length === 0) return 1;
+  if (right.length === 0) return -1;
+  for (let index = 0; index < Math.max(left.length, right.length); index += 1) {
+    const one = left[index];
+    const other = right[index];
+    if (one === undefined) return -1;
+    if (other === undefined) return 1;
+    const order = compareIdentifiers(one, other);
+    if (order !== 0) return order;
+  }
+  return 0;
+}
+
+export function compareVersions(left: Version, right: Version): number {
+  if (left.major !== right.major) return left.major - right.major;
+  if (left.minor !== right.minor) return left.minor - right.minor;
+  if (left.patch !== right.patch) return left.patch - right.patch;
+  return comparePrerelease(left.prerelease, right.prerelease);
+}
+
+// The major.minor a tag belongs to. A release line is what makes a lower tag
+// maintenance rather than a mistake.
+export function sameLine(left: Version, right: Version): boolean {
+  return left.major === right.major && left.minor === right.minor;
+}
+
+export function sameCore(left: Version, right: Version): boolean {
+  return sameLine(left, right) && left.patch === right.patch;
+}

--- a/plugins-cc/agentkit/skills/taste/scripts/rules/tag-command.ts
+++ b/plugins-cc/agentkit/skills/taste/scripts/rules/tag-command.ts
@@ -1,0 +1,160 @@
+import { unquote } from '../override.ts';
+import { parseVersion } from './semver.ts';
+
+// Quoted runs are one token, so a separator inside a tag message does not end
+// the command and hide the tag that follows it.
+const TOKEN = /"[^"]*"|'[^']*'|[;&|\n]+|[^\s;&|]+/g;
+const SEPARATOR = /^[;&|\n]+$/;
+const ASSIGNMENT = /^[A-Za-z_][A-Za-z0-9_]*=/;
+
+interface Shape {
+  // An option that means this command lists, verifies or removes a tag rather
+  // than proposing one. Its presence ends the reading.
+  skip: readonly string[];
+  // An option whose value is the next word, which is therefore not a tag.
+  valued: readonly string[];
+  // git push names the remote first; only what follows it is a refspec.
+  dropFirst: boolean;
+}
+
+const GIT_TAG: Shape = {
+  skip: [
+    '-d',
+    '--delete',
+    '-l',
+    '--list',
+    '-v',
+    '--verify',
+    '-n',
+    '--contains',
+    '--no-contains',
+    '--points-at',
+    '--merged',
+    '--no-merged',
+    '--column',
+  ],
+  valued: ['-m', '--message', '-F', '--file', '-u', '--local-user', '--sort', '--format', '--cleanup'],
+  dropFirst: false,
+};
+
+const GIT_PUSH: Shape = {
+  skip: ['-d', '--delete', '--prune', '--mirror'],
+  valued: ['--repo', '-o', '--push-option', '--receive-pack', '--exec'],
+  dropFirst: true,
+};
+
+const GH_RELEASE_CREATE: Shape = {
+  skip: [],
+  valued: [
+    '-t',
+    '--title',
+    '-n',
+    '--notes',
+    '-F',
+    '--notes-file',
+    '--target',
+    '--discussion-category',
+    '-R',
+    '--repo',
+    '--notes-start-tag',
+  ],
+  dropFirst: false,
+};
+
+const GIT_GLOBAL_VALUED = ['-C', '-c', '--git-dir', '--work-tree', '--namespace', '--exec-path'];
+const GH_GLOBAL_VALUED = ['-R', '--repo'];
+
+function segments(command: string): string[][] {
+  const found: string[][] = [[]];
+  for (const token of command.match(TOKEN) ?? []) {
+    if (SEPARATOR.test(token)) {
+      found.push([]);
+      continue;
+    }
+    (found[found.length - 1] as string[]).push(unquote(token));
+  }
+  return found;
+}
+
+function named(word: string, program: string): boolean {
+  return word === program || word.endsWith(`/${program}`);
+}
+
+function dropOptions(words: string[], valued: readonly string[]): void {
+  while (words.length > 0 && (words[0] as string).startsWith('-')) {
+    const option = words.shift() as string;
+    if (valued.includes(option)) words.shift();
+  }
+}
+
+interface Reading {
+  shape: Shape;
+  words: string[];
+}
+
+function readingOf(segment: string[]): Reading | undefined {
+  const words = [...segment];
+  while (words.length > 0 && ASSIGNMENT.test(words[0] as string)) words.shift();
+  const program = words.shift();
+  if (program === undefined) return undefined;
+
+  if (named(program, 'git')) {
+    dropOptions(words, GIT_GLOBAL_VALUED);
+    const subcommand = words.shift();
+    if (subcommand === 'tag') return { shape: GIT_TAG, words };
+    if (subcommand === 'push') return { shape: GIT_PUSH, words };
+    return undefined;
+  }
+
+  if (named(program, 'gh')) {
+    dropOptions(words, GH_GLOBAL_VALUED);
+    if (words.shift() !== 'release') return undefined;
+    if (words.shift() !== 'create') return undefined;
+    return { shape: GH_RELEASE_CREATE, words };
+  }
+
+  return undefined;
+}
+
+function positionals(reading: Reading): string[] | undefined {
+  const found: string[] = [];
+  const words = reading.words;
+  for (let index = 0; index < words.length; index += 1) {
+    const word = words[index] as string;
+    if (word === '--') {
+      found.push(...words.slice(index + 1));
+      break;
+    }
+    if (word.startsWith('-') && word.length > 1) {
+      const option = word.split('=')[0] as string;
+      if (reading.shape.skip.includes(option)) return undefined;
+      if (reading.shape.valued.includes(option) && !word.includes('=')) index += 1;
+      continue;
+    }
+    found.push(word);
+  }
+  return reading.shape.dropFirst ? found.slice(1) : found;
+}
+
+function refName(word: string): string {
+  const target = word.replace(/^\+/, '').split(':').pop() as string;
+  return target.replace(/^refs\/tags\//, '');
+}
+
+// Every version-shaped tag this command would create, in the shapes agentkit
+// recognises. Anything that is not semver is not a tag this can reason about,
+// so it never becomes a proposal.
+export function proposedTags(command: string): string[] {
+  const tags: string[] = [];
+  for (const segment of segments(command)) {
+    const reading = readingOf(segment);
+    if (reading === undefined) continue;
+    const words = positionals(reading);
+    if (words === undefined) continue;
+    for (const word of words) {
+      const tag = refName(word);
+      if (parseVersion(tag) !== undefined && !tags.includes(tag)) tags.push(tag);
+    }
+  }
+  return tags;
+}

--- a/plugins-cc/agentkit/skills/taste/scripts/rules/tag-command.ts
+++ b/plugins-cc/agentkit/skills/taste/scripts/rules/tag-command.ts
@@ -1,11 +1,13 @@
 import { unquote } from '../override.ts';
 import { parseVersion } from './semver.ts';
 
-// Quoted runs are one token, so a separator inside a tag message does not end
-// the command and hide the tag that follows it. A quote may open partway
-// through a word — `-m"a;b"` is one argument to git, and reading it as two
-// would put the tag in a segment that no longer starts with a program name.
-const TOKEN = /(?:"[^"]*"|'[^']*'|[^\s;&|"']+)+|[;&|\n]+/g;
+// Quoted and escaped runs are one token: a separator inside a tag message must
+// not end the command and hide the tag after it, and a quote may open partway
+// through a word — `-m"a;b"` is one argument to git.
+// The double-quoted arm is unrolled rather than `(?:\\.|[^"\\])*`, which matches
+// the same language but backtracks through every position of an unterminated
+// quote — and this runs in the hook's own process, with no deadline around it.
+const TOKEN = /(?:"[^"\\]*(?:\\.[^"\\]*)*"|'[^']*'|\\.|[^\s;&|"'\\]+)+|[;&|\n]+/g;
 const SEPARATOR = /^[;&|\n]+$/;
 const ASSIGNMENT = /^[A-Za-z_][A-Za-z0-9_]*=/;
 

--- a/plugins-cc/agentkit/skills/taste/scripts/rules/tag-command.ts
+++ b/plugins-cc/agentkit/skills/taste/scripts/rules/tag-command.ts
@@ -2,8 +2,10 @@ import { unquote } from '../override.ts';
 import { parseVersion } from './semver.ts';
 
 // Quoted runs are one token, so a separator inside a tag message does not end
-// the command and hide the tag that follows it.
-const TOKEN = /"[^"]*"|'[^']*'|[;&|\n]+|[^\s;&|]+/g;
+// the command and hide the tag that follows it. A quote may open partway
+// through a word — `-m"a;b"` is one argument to git, and reading it as two
+// would put the tag in a segment that no longer starts with a program name.
+const TOKEN = /(?:"[^"]*"|'[^']*'|[^\s;&|"']+)+|[;&|\n]+/g;
 const SEPARATOR = /^[;&|\n]+$/;
 const ASSIGNMENT = /^[A-Za-z_][A-Za-z0-9_]*=/;
 

--- a/plugins-cc/agentkit/skills/taste/scripts/rules/tag-sequence.ts
+++ b/plugins-cc/agentkit/skills/taste/scripts/rules/tag-sequence.ts
@@ -91,9 +91,12 @@ export function judgeTag(
   tag: string,
   existing: readonly string[],
 ): string | undefined {
-  const judge = POLICIES[policy];
+  // Checked against the registered names rather than by looking the key up:
+  // `constructor` and `toString` resolve to functions on any plain object, and
+  // the hook's safety must not rest on the lint two modules away.
   const version = parseVersion(tag);
-  if (judge === undefined || version === undefined) return undefined;
+  if (!TAG_POLICIES.includes(policy) || version === undefined) return undefined;
+  const judge = POLICIES[policy] as Judge;
   return judge({ text: tag, version }, knownTags(existing));
 }
 
@@ -103,18 +106,37 @@ function firstLine(text: string): string {
 
 type Tags = { names: string[] } | { unchecked: string };
 
+// The one failure that means "there is nothing here to check". Exit 128 alone
+// does not: dubious ownership under a CI uid, a permission error and a corrupt
+// repository all use it, and reading those as not-a-repository would delete the
+// guard in exactly the environments that most need it.
+// Both of git's discovery-failed phrasings, and neither of the ones it uses for
+// a repository it found but could not use.
+const NOT_A_REPOSITORY = /not a git repository \(or any /;
+
+// git is asked in C, because the sentence above is what tells a directory with
+// no repository apart from a repository that cannot be read, and a translated
+// git would answer in another language.
+function askedInC(env: Record<string, string | undefined>): Record<string, string | undefined> {
+  return { ...env, LC_ALL: 'C', LANGUAGE: 'C', LANG: 'C' };
+}
+
 // Asymmetric on purpose, and the asymmetry is the design: a directory that is
 // not a repository has no sequence to violate, so it passes silently; git that
 // cannot answer is an unread guard, so it says UNCHECKED and still allows.
 async function repositoryTags(
   cwd: string,
-  env: Record<string, string | undefined>,
+  callerEnv: Record<string, string | undefined>,
 ): Promise<Tags> {
+  const env = askedInC(callerEnv);
   const inside = await runBounded(['git', '-C', cwd, 'rev-parse', '--git-dir'], cwd, env, GIT_TIMEOUT_MS);
   if (inside.code === null || inside.timedOut) {
     return { unchecked: `git could not be run in ${cwd} — ${firstLine(inside.err)}` };
   }
-  if (!inside.ok) return { names: [] };
+  if (!inside.ok) {
+    if (NOT_A_REPOSITORY.test(inside.err)) return { names: [] };
+    return { unchecked: `git could not read the repository at ${cwd} — ${firstLine(inside.err)}` };
+  }
 
   const listed = await runBounded(['git', '-C', cwd, 'tag', '--list'], cwd, env, GIT_TIMEOUT_MS);
   if (!listed.ok) {
@@ -153,6 +175,17 @@ export const GIT_TAG_SEQUENCE: RuleKind = {
   },
 
   async evaluate(fields: Record<string, string>, request: KindRequest): Promise<KindOutcome> {
+    // The lint refuses a policy that is not registered, so reaching this means
+    // the taste was never checked. Said out loud rather than allowed quietly,
+    // for the same reason an unimplemented kind is.
+    if (!TAG_POLICIES.includes(fields.policy as string)) {
+      return {
+        verdict: 'skipped',
+        detail: `its rule.policy ${JSON.stringify(fields.policy ?? null)} is not one of `
+          + TAG_POLICIES.join(', '),
+      };
+    }
+
     const proposals = await proposalsFor(fields, request);
     if (!Array.isArray(proposals)) return { verdict: 'skipped', detail: proposals.skipped };
     if (proposals.length === 0) return { verdict: 'passes' };

--- a/plugins-cc/agentkit/skills/taste/scripts/rules/tag-sequence.ts
+++ b/plugins-cc/agentkit/skills/taste/scripts/rules/tag-sequence.ts
@@ -1,0 +1,172 @@
+import { runBounded } from '../run.ts';
+import type { KindOutcome, KindRequest, RuleKind } from './kinds.ts';
+import { matchErrors } from './pattern.ts';
+import { compareVersions, parseVersion, sameCore, sameLine, type Version } from './semver.ts';
+import { proposedTags } from './tag-command.ts';
+
+// Long enough for a cold repository, short enough that a wedged git costs the
+// session a moment rather than the hook's whole budget.
+export const GIT_TIMEOUT_MS = 3000;
+
+interface Tag {
+  text: string;
+  version: Version;
+}
+
+type Judge = (proposed: Tag, existing: Tag[]) => string | undefined;
+
+function highestOf(tags: Tag[]): Tag | undefined {
+  return tags.reduce<Tag | undefined>(
+    (highest, tag) =>
+      highest === undefined || compareVersions(tag.version, highest.version) > 0 ? tag : highest,
+    undefined,
+  );
+}
+
+function duplicate(proposed: Tag, existing: Tag[]): string | undefined {
+  const clash = existing.find((tag) => compareVersions(tag.version, proposed.version) === 0);
+  if (clash === undefined) return undefined;
+  return clash.text === proposed.text
+    ? `${proposed.text} already exists in this repository`
+    : `${proposed.text} already exists as ${clash.text}`;
+}
+
+// A lower line is maintenance, not a mistake: what a tag may not do is go
+// backwards among the tags it shares a major.minor with.
+function backwardsInLine(proposed: Tag, existing: Tag[]): string | undefined {
+  const line = existing.filter((tag) => sameLine(tag.version, proposed.version));
+  const highest = highestOf(line);
+  if (highest === undefined || compareVersions(highest.version, proposed.version) < 0) {
+    return undefined;
+  }
+  return `${proposed.text} is behind ${highest.text}, the highest tag on the `
+    + `${proposed.version.major}.${proposed.version.minor} line`;
+}
+
+function nextPatchOf(highest: Tag): string {
+  const prefix = highest.text.startsWith('v') ? 'v' : '';
+  const { major, minor, patch } = highest.version;
+  return `${prefix}${major}.${minor}.${patch + 1}`;
+}
+
+// The immediate next patch of the highest tag overall — or the same core, which
+// is how a prerelease reaches its release without the line restarting.
+function notTheSuccessor(proposed: Tag, existing: Tag[]): string | undefined {
+  const highest = highestOf(existing);
+  if (highest === undefined) return undefined;
+  if (compareVersions(proposed.version, highest.version) < 0) {
+    return `${proposed.text} is not above ${highest.text}, the highest tag in this repository`;
+  }
+  const next = { ...highest.version, patch: highest.version.patch + 1, prerelease: [] };
+  if (sameCore(proposed.version, highest.version) || sameCore(proposed.version, next)) {
+    return undefined;
+  }
+  return `${proposed.text} is not the next patch after ${highest.text} — that would be `
+    + nextPatchOf(highest);
+}
+
+const POLICIES: Record<string, Judge> = {
+  'no-duplicate': duplicate,
+  'no-backwards-in-line': (proposed, existing) =>
+    duplicate(proposed, existing) ?? backwardsInLine(proposed, existing),
+  'strict-successor': (proposed, existing) =>
+    duplicate(proposed, existing) ?? notTheSuccessor(proposed, existing),
+};
+
+export const TAG_POLICIES: readonly string[] = Object.keys(POLICIES);
+
+// A tag that is not semver carries no order, so no policy has anything to say
+// about it — as a proposal or as one of the tags already there.
+function knownTags(names: readonly string[]): Tag[] {
+  const tags: Tag[] = [];
+  for (const text of names) {
+    const version = parseVersion(text);
+    if (version !== undefined) tags.push({ text, version });
+  }
+  return tags;
+}
+
+export function judgeTag(
+  policy: string,
+  tag: string,
+  existing: readonly string[],
+): string | undefined {
+  const judge = POLICIES[policy];
+  const version = parseVersion(tag);
+  if (judge === undefined || version === undefined) return undefined;
+  return judge({ text: tag, version }, knownTags(existing));
+}
+
+function firstLine(text: string): string {
+  return text.split('\n').find((line) => line.trim() !== '')?.trim() ?? 'no output';
+}
+
+type Tags = { names: string[] } | { unchecked: string };
+
+// Asymmetric on purpose, and the asymmetry is the design: a directory that is
+// not a repository has no sequence to violate, so it passes silently; git that
+// cannot answer is an unread guard, so it says UNCHECKED and still allows.
+async function repositoryTags(
+  cwd: string,
+  env: Record<string, string | undefined>,
+): Promise<Tags> {
+  const inside = await runBounded(['git', '-C', cwd, 'rev-parse', '--git-dir'], cwd, env, GIT_TIMEOUT_MS);
+  if (inside.code === null || inside.timedOut) {
+    return { unchecked: `git could not be run in ${cwd} — ${firstLine(inside.err)}` };
+  }
+  if (!inside.ok) return { names: [] };
+
+  const listed = await runBounded(['git', '-C', cwd, 'tag', '--list'], cwd, env, GIT_TIMEOUT_MS);
+  if (!listed.ok) {
+    return { unchecked: `git could not list the tags in ${cwd} — ${firstLine(listed.err)}` };
+  }
+  return { names: listed.out.split('\n').map((name) => name.trim()).filter((name) => name !== '') };
+}
+
+async function proposalsFor(
+  fields: Record<string, string>,
+  request: KindRequest,
+): Promise<string[] | { skipped: string }> {
+  const pattern = fields.match;
+  if (pattern === undefined) return proposedTags(request.command);
+
+  const outcome = await request.match(pattern, true);
+  if ('skipped' in outcome) return outcome;
+  return outcome.captures.filter((capture) => parseVersion(capture) !== undefined);
+}
+
+export const GIT_TAG_SEQUENCE: RuleKind = {
+  name: 'git-tag-sequence',
+  required: ['policy'],
+  optional: ['match'],
+
+  validate(fields: Record<string, string>): string[] {
+    const errors: string[] = [];
+    const policy = fields.policy;
+    if (policy !== undefined && !TAG_POLICIES.includes(policy)) {
+      errors.push(
+        `rule.policy: ${JSON.stringify(policy)} is not one of ${TAG_POLICIES.join(', ')}`,
+      );
+    }
+    if (fields.match !== undefined) errors.push(...matchErrors(fields.match));
+    return errors;
+  },
+
+  async evaluate(fields: Record<string, string>, request: KindRequest): Promise<KindOutcome> {
+    const proposals = await proposalsFor(fields, request);
+    if (!Array.isArray(proposals)) return { verdict: 'skipped', detail: proposals.skipped };
+    if (proposals.length === 0) return { verdict: 'passes' };
+
+    const tags = await repositoryTags(request.cwd, request.env);
+    if ('unchecked' in tags) return { verdict: 'unchecked', detail: tags.unchecked };
+    if (tags.names.length === 0) return { verdict: 'passes' };
+
+    for (const proposal of proposals) {
+      const finding = judgeTag(fields.policy as string, proposal, tags.names);
+      if (finding !== undefined) {
+        return { verdict: 'fires', finding: `${finding}, and rule.policy is ${fields.policy}` };
+      }
+    }
+    return { verdict: 'passes' };
+  },
+};

--- a/plugins-cc/agentkit/skills/taste/scripts/run.ts
+++ b/plugins-cc/agentkit/skills/taste/scripts/run.ts
@@ -3,6 +3,10 @@ export interface Run {
   out: string;
   err: string;
   timedOut: boolean;
+  // null when the process never started at all. A caller that treats a failing
+  // exit code as an answer needs to tell that apart from a missing program,
+  // which is no answer.
+  code: number | null;
 }
 
 // Spawned asynchronously so the deadline is a timer on a running event loop: a
@@ -20,7 +24,7 @@ export async function runBounded(
   try {
     child = Bun.spawn({ cmd, cwd, env, stdout: 'pipe', stderr: 'pipe' });
   } catch (error) {
-    return { ok: false, out: '', err: (error as Error).message, timedOut: false };
+    return { ok: false, out: '', err: (error as Error).message, timedOut: false, code: null };
   }
 
   let timedOut = false;
@@ -35,7 +39,13 @@ export async function runBounded(
       new Response(child.stderr).text(),
     ]);
     await child.exited;
-    return { ok: child.exitCode === 0, out: out.trim(), err: err.trim(), timedOut };
+    return {
+      ok: child.exitCode === 0,
+      out: out.trim(),
+      err: err.trim(),
+      timedOut,
+      code: child.exitCode,
+    };
   } finally {
     clearTimeout(deadline);
   }

--- a/scripts/check-test-slices.ts
+++ b/scripts/check-test-slices.ts
@@ -97,6 +97,7 @@ export const TEST_SLICES = {
   ],
   session: ['tests/session/agent-session.test.ts', 'tests/session/install-session-slice.test.ts'],
   taste: [
+    'tests/taste/kinds.test.ts',
     'tests/taste/layout.test.ts',
     'tests/taste/lint.test.ts',
     'tests/taste/police-lanes.test.ts',
@@ -105,6 +106,7 @@ export const TEST_SLICES = {
     'tests/taste/skill.test.ts',
     'tests/taste/sources.test.ts',
     'tests/taste/sync.test.ts',
+    'tests/taste/tag-sequence.test.ts',
     'tests/taste/visibility.test.ts',
   ],
   wip: [

--- a/skills/taste/SKILL.md
+++ b/skills/taste/SKILL.md
@@ -339,9 +339,10 @@ A preference that no kind can express stays at `enforce: check`. **A new kind is
 agentkit**, proposed and reviewed like one — never bespoke code smuggled into a taste folder.
 `references/format.md` carries each kind's fields, the three tag policies, and worked examples.
 
-**A kind this agentkit does not implement is skipped, loudly.** The lint refuses the file, and
-the hook names it, warns, and keeps enforcing every other taste — a taste written against a
-newer agentkit must not brick an older hook.
+**A kind this agentkit does not implement is skipped, loudly.** The lint refuses such a file, and
+the hook runs that same lint as it loads the folder — so the taste is dropped there, named in a
+warning that lists the kinds this agentkit does have, while every other taste keeps enforcing. A
+taste written against a newer agentkit must not brick an older hook.
 
 ### What it does at the edges, so you can answer for it
 

--- a/skills/taste/SKILL.md
+++ b/skills/taste/SKILL.md
@@ -318,11 +318,32 @@ is read the same way, for one release of grace.
 
 `block` is carried out by one generic hook — `taste-police`, in the core kit, on every harness
 agentkit installs to. It resolves the same folders this skill does, takes the tastes at
-`enforce: block` whose `rule` the lint accepts, and tests `rule.match` against the command in
+`enforce: block` whose `rule` the lint accepts, and runs that rule's kind against the command in
 process. Nothing in a taste is ever executed. Adding a blocking taste changes no code
 anywhere: it is a file.
 
-What it does at the edges, so you can answer for it:
+### What a rule can check: the kinds
+
+**The enforcement vocabulary is extensible by agentkit and parameterised by tastes.** A
+`rule.kind` names a check agentkit implements; the taste supplies the data it runs on and the
+words it refuses with. The taste never carries the code, which is the whole reason a taste from
+somewhere else is safe to load: **a hostile source can at worst over-block you**, because
+picking a check and wording a refusal is all a taste can do.
+
+| `kind`             | The taste supplies                     | agentkit inspects                     |
+| ------------------ | -------------------------------------- | ------------------------------------- |
+| `command`          | `match`, a regular expression          | the text of the command about to run  |
+| `git-tag-sequence` | `policy`, one of three named orderings | the tags in the repository it runs in |
+
+A preference that no kind can express stays at `enforce: check`. **A new kind is a change to
+agentkit**, proposed and reviewed like one — never bespoke code smuggled into a taste folder.
+`references/format.md` carries each kind's fields, the three tag policies, and worked examples.
+
+**A kind this agentkit does not implement is skipped, loudly.** The lint refuses the file, and
+the hook names it, warns, and keeps enforcing every other taste — a taste written against a
+newer agentkit must not brick an older hook.
+
+### What it does at the edges, so you can answer for it
 
 - **Refusal** names the taste, its file, its own `remedy`, and its own `override`.
 - **The override** is that taste's named variable, set inline on the command (`NAME=1 …`) or
@@ -332,14 +353,33 @@ What it does at the edges, so you can answer for it:
   pattern that outruns the match deadline — it is named, skipped, and the rest still bind.
 - **An unrunnable hook** (no `bun`, no evaluator) says `UNCHECKED` and allows. It never
   refuses on its own uncertainty, and it never goes quiet where there were tastes to read.
+- **A check that cannot read what it needs** says `UNCHECKED` for that one taste and allows the
+  command — `git-tag-sequence` where git will not answer, for instance. Silence there would be
+  worse than either verdict: the session would read enforcement into a guard that never ran.
 - **Bounds**: `rule.match` is capped at 200 characters, only the first 4000 characters of a
   command are examined, and the match itself is abandoned after 250ms — length is not safety,
   since a short pattern can still backtrack forever. `references/format.md` carries the
   reasoning.
 
+### Why this does not fail closed, when the vendoring guard does
+
+The two guards sit on opposite sides of one question — what does the tool do when it cannot see?
+— and they answer differently because **the cost of each mistake is different**:
+
+- **Vendoring fails closed.** A private source wrongly let into a public repository is words
+  published under someone's name, and no later commit takes them back. Refusing costs one
+  environment variable.
+- **A rule kind fails open, and says so.** Refusing every tag command in a repository whose tags
+  cannot be read would cost real work, to prevent a mis-ordered tag that `git tag -d` undoes in
+  a second. And **nothing to check is not a failure at all**: outside a git repository, or in one
+  with no tags, `git-tag-sequence` passes silently, because there is no sequence to violate.
+
+Do not "fix" this into symmetry. The rule is that a guard fails towards whichever error is
+recoverable, and it is `UNCHECKED` — never a silent allow — whenever it could not look.
+
 If someone asks why a `block` taste did not stop something, check those in order: the taste is
-`advise`, the pattern did not match, the override was set, the file failed the lint, or the
-hook reported `UNCHECKED`.
+`advise`, the rule did not fire, the override was set, the file failed the lint, the kind is one
+this agentkit does not implement, or the hook reported `UNCHECKED`.
 
 Never raise `enforce` yourself. Observed violations are evidence for a proposal the owner
 merges — the diff is how it changes.

--- a/skills/taste/references/format.md
+++ b/skills/taste/references/format.md
@@ -54,10 +54,11 @@ anything.
 A key belongs to one kind: `policy` inside a `command` rule is an unknown key, and the lint says
 so naming what that kind does carry.
 
-**An unknown kind is refused by the lint**, naming the kinds that exist. The hook treats it
-differently on purpose: it **skips that taste with a warning and keeps enforcing every other
-one**, because a taste vendored from a source running a newer agentkit must not brick an older
-hook. Upgrade agentkit, or keep the taste at `enforce: check` until you have.
+**An unknown kind is refused by the lint**, naming the kinds that exist — and the hook runs that
+same lint as it loads the folder, so at enforcement time the file is **skipped with a warning
+while every other taste keeps enforcing**, rather than taking the hook down with it. That is what
+lets a taste vendored from a source running a newer agentkit be safe to load at all. Upgrade
+agentkit, or keep the taste at `enforce: check` until you have.
 
 A preference no registered kind can express stays at `enforce: check` rather than growing
 bespoke code in someone's taste folder. A new kind is a change to agentkit, reviewed like one.

--- a/skills/taste/references/format.md
+++ b/skills/taste/references/format.md
@@ -116,6 +116,13 @@ because `v0.6.5` already is. `strict-successor` refuses both — it is for a pro
 line and nothing else. A prerelease sorts below the release it leads to, so `v0.8.0-rc1` then
 `v0.8.0` is an ascending pair under every policy.
 
+**`strict-successor` cannot open a new line, prerelease included.** On a repository at `v0.7.11`
+it refuses `v0.8.0-rc1` exactly as it refuses `v0.8.0`, saying the next tag is `v0.7.12` — the
+next patch is the only thing it accepts, and a release candidate for a new minor is not one.
+That follows from the name, but it is worth knowing before a release rather than during one: a
+project that cuts minor release candidates wants `no-backwards-in-line`, or the taste's own
+override for the one tag that opens the line.
+
 The proposed tag is read from the command in the shapes agentkit recognises: `git tag <tag>`,
 `git push <remote> <tag>` (including `refs/tags/` and `<src>:<dst>` refspecs), and
 `gh release create <tag>`. Listing, verifying and deleting are not proposals — `git tag --list`,

--- a/skills/taste/references/format.md
+++ b/skills/taste/references/format.md
@@ -15,7 +15,7 @@ override across scopes.
 | `provenance` | yes      | a date and where it came from              | When the preference was stated, so a stale one is visible            |
 | `category`   | no       | free text                                  | Lets a skill load only the tastes an action can touch                |
 | `enforce`    | no       | `advise` \| `check` \| `block`             | How hard it binds. Defaults to `advise`, where most tastes stay      |
-| `rule`       | no       | `kind` / `match` / `remedy` / `override`   | Only with `enforce: check` or `block`. Declarative data — never code |
+| `rule`       | no       | `kind` plus that kind's own fields         | Only with `enforce: check` or `block`. Declarative data — never code |
 
 No other top-level key is accepted. A typo is a rejection, not a silently ignored field.
 
@@ -27,16 +27,45 @@ violation is evidence for a proposal the owner merges — never an automatic pro
 Present only when `enforce` is `check` or `block`. It is data the generic `taste-police` hook
 reads; nothing in it is ever executed as a command.
 
+Three keys are the same in every rule:
+
 | Key        | Required | Value                                                                   |
 | ---------- | -------- | ----------------------------------------------------------------------- |
-| `kind`     | yes      | `command` — the action class the pattern matches                        |
-| `match`    | yes      | a regular expression that must compile, at most 200 characters          |
+| `kind`     | yes      | which check agentkit runs — one of the registered kinds below           |
 | `remedy`   | yes      | the sentence an agent is shown instead of the refused action            |
 | `override` | no       | the name of one environment variable that lets it through, deliberately |
 
 Every value is a string. No nesting, no lists, and no shell metacharacters — `override` is an
-environment-variable name and nothing else. A preference no pattern can capture stays at
-`enforce: check` rather than growing bespoke code.
+environment-variable name and nothing else.
+
+### The rule-kind registry
+
+A `kind` is a **named predicate agentkit implements**. The taste chooses which check runs and
+supplies the data it needs; the code that inspects anything is always agentkit's. That is what
+keeps a taste data rather than a program, and it is why the trust property holds: a hostile
+source can pick a check and word a refusal, so at worst it over-blocks you — it can never run
+anything.
+
+| `kind`             | Its own keys                      | What it inspects                               |
+| ------------------ | --------------------------------- | ---------------------------------------------- |
+| `command`          | `match` (required)                | the text of the command about to run           |
+| `git-tag-sequence` | `policy` (required), `match` (no) | the tags in the repository the command runs in |
+
+A key belongs to one kind: `policy` inside a `command` rule is an unknown key, and the lint says
+so naming what that kind does carry.
+
+**An unknown kind is refused by the lint**, naming the kinds that exist. The hook treats it
+differently on purpose: it **skips that taste with a warning and keeps enforcing every other
+one**, because a taste vendored from a source running a newer agentkit must not brick an older
+hook. Upgrade agentkit, or keep the taste at `enforce: check` until you have.
+
+A preference no registered kind can express stays at `enforce: check` rather than growing
+bespoke code in someone's taste folder. A new kind is a change to agentkit, reviewed like one.
+
+### `kind: command`
+
+`match` is a regular expression tested against the command string — at most 200 characters, and
+it must compile.
 
 **A remedy is plain prose.** It is a sentence an agent reads, never a command anything runs, so
 name the command in words — `Cut a patch tag` rather than a backticked or `$()`-wrapped
@@ -66,6 +95,49 @@ unenforced, rather than taking the session down with it.
 
 The subject bound is the honest trade: a command long enough to hit it is a script, and a
 taste is not a way to audit one. Write the pattern against what an agent actually types.
+
+### `kind: git-tag-sequence`
+
+Refuses a release tag that does not follow the tags already in the repository. A pattern cannot
+do this — the answer is not in the command string — which is what a named predicate is for.
+
+`policy` names which sequence rule applies. All three ignore any tag that is not semver, in the
+proposal and among the existing tags alike, because a tag with no version carries no order:
+
+| `policy`               | Refuses                                                                          |
+| ---------------------- | -------------------------------------------------------------------------------- |
+| `no-duplicate`         | a tag that already exists                                                        |
+| `no-backwards-in-line` | that, plus a tag lower than the highest existing tag **sharing its major.minor** |
+| `strict-successor`     | that, plus anything but the immediate next patch of the highest tag **overall**  |
+
+`no-backwards-in-line` is the one that keeps maintenance possible: on a repository at `v0.7.11`,
+`v0.6.5` is allowed because nothing on the `0.6` line is above it, while `v0.6.2` is refused
+because `v0.6.5` already is. `strict-successor` refuses both — it is for a project that cuts one
+line and nothing else. A prerelease sorts below the release it leads to, so `v0.8.0-rc1` then
+`v0.8.0` is an ascending pair under every policy.
+
+The proposed tag is read from the command in the shapes agentkit recognises: `git tag <tag>`,
+`git push <remote> <tag>` (including `refs/tags/` and `<src>:<dst>` refspecs), and
+`gh release create <tag>`. Listing, verifying and deleting are not proposals — `git tag --list`,
+`git tag -d v1.2.3` and `git push --delete` all pass. Where that reading is wrong for your
+workflow, `match` overrides it: **its first capture group is the tag**, and it is held to the
+same 200-character, must-compile, no-substitution bounds as a `command` rule.
+
+**It does not fail closed, and that is deliberate.** The vendoring guard refuses whatever it
+cannot verify, because the error it prevents is a leak that cannot be undone. This one is a
+convention guard, so the two errors are the other way round:
+
+| Situation                             | What happens                                      |
+| ------------------------------------- | ------------------------------------------------- |
+| the command proposes no semver tag    | passes, and git is never run                      |
+| the directory is not a git repository | passes silently — there is no sequence to violate |
+| the repository has no tags            | passes silently — there is nothing to be behind   |
+| git cannot be run, or cannot list     | **`UNCHECKED`, and the command is allowed**       |
+
+Failing closed here would refuse every tag command in every repository whose tags cannot be
+read, to prevent a mis-ordered tag that `git tag` itself makes trivial to delete. But a silent
+allow would be worse than either: the session would read enforcement into a guard that never
+ran. So it says `UNCHECKED`, names the taste and the reason, and lets the command through.
 
 ### What counts as using an override
 
@@ -104,6 +176,34 @@ semver alone will tag a minor for any feature-shaped diff.
 
 How to apply: propose the patch version in the release PR. If the diff looks
 minor-worthy, say so and ask — do not tag it.
+```
+
+And `.agentkit/tastes/tag-sequence.md`, the same shape with the other kind — no pattern, because
+what it checks is not in the command:
+
+```markdown
+---
+name: tag-sequence
+scope: project
+category: release
+strength: require
+enforce: block
+rule:
+  kind: git-tag-sequence
+  policy: no-backwards-in-line
+  remedy: Read the tags first and cut the next patch on the line you are releasing.
+  override: AGENTKIT_TAG_SEQUENCE
+provenance: 2026-08-06 · issue 328
+---
+
+A release tag goes forwards on its own line. A lower line is maintenance and is
+fine; a tag below one that already exists on the same line is not.
+
+Why: version numbers are read as a sequence by everything downstream — a
+backwards tag makes "latest" mean two different commits.
+
+How to apply: list the tags before tagging. If the tag you want is already
+there, or is behind one on its line, pick the next patch instead.
 ```
 
 ## The source contract

--- a/skills/taste/scripts/lint.ts
+++ b/skills/taste/scripts/lint.ts
@@ -2,31 +2,24 @@ import { YAML } from 'bun';
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { basename, join, relative, resolve } from 'node:path';
 import { EXTERNAL_DIR, LEGACY_EXTERNAL_ROOT } from './layout.ts';
+import { type RuleKind, ruleKeys, ruleKind, RULE_KINDS } from './rules/kinds.ts';
+import { carriesSubstitution } from './rules/pattern.ts';
 
 const REQUIRED_KEYS = ['name', 'provenance', 'scope', 'strength'];
 const OPTIONAL_KEYS = ['category', 'enforce', 'rule'];
 export const SCOPES = ['project', 'external', 'user'];
 export const STRENGTHS = ['prefer', 'require'];
 export const ENFORCEMENTS = ['advise', 'check', 'block'];
-const RULE_KEYS = ['kind', 'match', 'remedy', 'override'];
-const RULE_KINDS = ['command'];
 
 // `external` is read by position, not by name: it is the one directory at a
 // tastes root that a sync writes and the resolver treats as a stack of sources.
 const RESERVED = `${JSON.stringify(EXTERNAL_DIR)} is reserved — it names the subtree holding the `
   + 'snapshot of each declared source, at the root of a tastes tree and nowhere else';
 
-// A rule is tested in-process against every command an agent runs, and a
-// regular expression can be made to backtrack for longer than anyone will wait.
-// The subject is bounded where the matching happens (police.ts); the pattern is
-// bounded here, so an unrunnable rule fails the lint rather than a session.
-export const MAX_MATCH_LENGTH = 200;
-
 // Unnumbered as well as kebab: position carries no meaning in a taste folder, so
 // a leading number is a record's habit leaking into a dictionary.
 const NAME = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/;
 const ENV_NAME = /^[A-Z][A-Z0-9_]*$/;
-const SHELL_SUBSTITUTION = /\$\(|`/;
 const FRONTMATTER = /^---\r?\n([\s\S]*?)\r?\n---\r?\n([\s\S]*)$/;
 
 type Frontmatter = Record<string, unknown>;
@@ -93,40 +86,45 @@ function checkEnums(front: Frontmatter): string[] {
   return errors.filter((error): error is string => error !== undefined);
 }
 
-function checkRuleFields(rule: Frontmatter): string[] {
-  const errors: string[] = [];
-  const unknown = Object.keys(rule).filter((key) => !RULE_KEYS.includes(key)).sort();
-  if (unknown.length > 0) {
-    errors.push(`unknown rule key: ${unknown.join(', ')} — a rule carries ${RULE_KEYS.join(', ')}`);
+// The kind decides which keys mean anything, so an unknown kind names the ones
+// agentkit implements instead of judging the rest of the block against a
+// vocabulary nobody chose.
+function checkKind(rule: Frontmatter, kind: RuleKind | undefined): string[] {
+  if (typeof rule.kind !== 'string') return [];
+  if (kind === undefined) {
+    return [`rule.kind: ${JSON.stringify(rule.kind)} is not one of ${RULE_KINDS.join(', ')}`];
   }
-  for (const key of ['kind', 'match', 'remedy']) {
+  const keys = ruleKeys(kind);
+  const unknown = Object.keys(rule).filter((key) => !keys.includes(key)).sort();
+  if (unknown.length === 0) return [];
+  return [
+    `unknown rule key: ${unknown.join(', ')} — a rule of kind ${kind.name} carries `
+      + keys.join(', '),
+  ];
+}
+
+// Every value in the block is a string, which is what makes a rule data rather
+// than structure. Which strings have to be there is the kind's business.
+function stringFields(rule: Frontmatter): Record<string, string> {
+  const fields: Record<string, string> = {};
+  for (const [key, value] of Object.entries(rule)) {
+    if (typeof value === 'string') fields[key] = value;
+  }
+  return fields;
+}
+
+function checkRuleFields(rule: Frontmatter): string[] {
+  const kind = typeof rule.kind === 'string' ? ruleKind(rule.kind) : undefined;
+  const errors = checkKind(rule, kind);
+
+  for (const key of ['kind', 'remedy', ...(kind?.required ?? [])]) {
     if (typeof rule[key] !== 'string') {
       errors.push(`rule.${key} must be a string — the rule is data, not structure`);
     }
   }
-  if (typeof rule.kind === 'string' && !RULE_KINDS.includes(rule.kind)) {
-    errors.push(`rule.kind: ${JSON.stringify(rule.kind)} is not one of ${RULE_KINDS.join(', ')}`);
-  }
-  if (typeof rule.match === 'string') {
-    if (rule.match.length > MAX_MATCH_LENGTH) {
-      errors.push(
-        `rule.match is ${rule.match.length} characters — the cap is ${MAX_MATCH_LENGTH}, because `
-          + 'the hook runs it against every command. Narrow the pattern, or keep the taste at check.',
-      );
-    }
-    try {
-      new RegExp(rule.match);
-    } catch (error) {
-      errors.push(`rule.match is not a valid regular expression: ${(error as Error).message}`);
-    }
-    if (SHELL_SUBSTITUTION.test(rule.match)) {
-      errors.push(
-        'rule.match carries a command substitution — a rule is data; escape it as \\$\\( to '
-          + 'match those characters literally. A backtick cannot appear in a match at all.',
-      );
-    }
-  }
-  if (typeof rule.remedy === 'string' && SHELL_SUBSTITUTION.test(rule.remedy)) {
+  if (kind !== undefined) errors.push(...kind.validate(stringFields(rule)));
+
+  if (typeof rule.remedy === 'string' && carriesSubstitution(rule.remedy)) {
     errors.push(
       'rule.remedy carries a command substitution — a remedy is plain prose; name the command '
         + 'without backticks or $()',
@@ -148,7 +146,10 @@ function checkRule(front: Frontmatter): string[] {
     return ['enforce: block needs a rule — taste-police would have nothing to read'];
   }
   if (!hasRule) return [];
-  if (!isRecord(front.rule)) return ['rule must be a block of kind, match, remedy, override'];
+  if (!isRecord(front.rule)) {
+    return [`rule must be a block of kind, remedy, override and what the kind requires — the `
+      + `kinds are ${RULE_KINDS.join(', ')}`];
+  }
   return checkRuleFields(front.rule);
 }
 

--- a/skills/taste/scripts/match.ts
+++ b/skills/taste/scripts/match.ts
@@ -1,12 +1,36 @@
 declare const self: Worker;
 
+// A rule that reads a value out of the command gets it from here too, rather
+// than compiling the pattern a second time somewhere the deadline cannot reach.
+const MAX_CAPTURES = 20;
+
+function captured(pattern: string, subject: string): { matched: boolean; captures: string[] } {
+  const regex = new RegExp(pattern, 'g');
+  const captures: string[] = [];
+  let found = regex.exec(subject);
+  while (found !== null && captures.length < MAX_CAPTURES) {
+    captures.push(found[1] ?? found[0]);
+    if (found[0] === '') regex.lastIndex += 1;
+    found = regex.exec(subject);
+  }
+  return { matched: captures.length > 0, captures };
+}
+
 // One rule's pattern against one command, on a thread that can be terminated.
 // A regular expression cannot be interrupted once it starts backtracking, so the
 // only way to bound it is to run it somewhere abandonable.
 self.onmessage = (event: MessageEvent) => {
-  const { pattern, subject } = event.data as { pattern: string; subject: string };
+  const { pattern, subject, capture } = event.data as {
+    pattern: string;
+    subject: string;
+    capture?: boolean;
+  };
   try {
-    postMessage({ matched: new RegExp(pattern).test(subject) });
+    postMessage(
+      capture === true
+        ? captured(pattern, subject)
+        : { matched: new RegExp(pattern).test(subject), captures: [] },
+    );
   } catch (error) {
     postMessage({ failed: (error as Error).message });
   }

--- a/skills/taste/scripts/police.ts
+++ b/skills/taste/scripts/police.ts
@@ -1,6 +1,7 @@
 import { homedir } from 'node:os';
 import { offValueLine, type Override, readOverride, unquote } from './override.ts';
-import { type ResolvedTaste, resolveTastes } from './resolve.ts';
+import { type ResolvedTaste, resolveTastes, type TasteRule } from './resolve.ts';
+import { evaluateRule, type MatchOutcome } from './rules/kinds.ts';
 import { configFiles, tasteSection } from './sources.ts';
 
 // The rule's pattern is capped where the lint can refuse it; the subject is
@@ -54,15 +55,13 @@ function overrideState(
   return readOverride(assignedInline(command, name) ?? env[name]);
 }
 
-type MatchOutcome = { matched: boolean } | { skipped: string };
-
 // The deadline has to live here rather than in either adapter: the OpenCode lane
 // runs the match in the editor's own process, where a pattern that backtracks
 // takes the session with it and no outer timeout can reach.
 class BoundedMatcher {
   private worker: Worker | undefined;
 
-  async test(pattern: string, command: string): Promise<MatchOutcome> {
+  async test(pattern: string, command: string, capture?: boolean): Promise<MatchOutcome> {
     const worker = (this.worker ??= new Worker(new URL('./match.ts', import.meta.url).href));
     const subject = command.slice(0, MAX_SUBJECT_LENGTH);
 
@@ -77,10 +76,10 @@ class BoundedMatcher {
 
       worker.onmessage = (event: MessageEvent) => {
         clearTimeout(timer);
-        const result = event.data as { matched?: boolean; failed?: string };
+        const result = event.data as { matched?: boolean; captures?: string[]; failed?: string };
         resolve(
           result.failed === undefined
-            ? { matched: result.matched === true }
+            ? { matched: result.matched === true, captures: result.captures ?? [] }
             : { skipped: `its rule.match could not be run: ${result.failed}` },
         );
       };
@@ -90,7 +89,7 @@ class BoundedMatcher {
         resolve({ skipped: `its rule.match could not be run: ${event.message}` });
       };
 
-      worker.postMessage({ pattern, subject });
+      worker.postMessage({ pattern, subject, capture: capture === true });
     });
   }
 
@@ -121,13 +120,14 @@ function overrideLine(taste: ResolvedTaste, override: Override): string {
 // enforcement happened while some of it silently did not.
 function refusal(
   taste: ResolvedTaste,
+  finding: string,
   override: Override,
   cwd: string,
   home: string,
   notices: string[],
 ): string {
   const lines = [
-    `BLOCKED by taste ${taste.name} (enforce: block): this command matches rule.match in `
+    `BLOCKED by taste ${taste.name} (enforce: block): ${finding} in `
       + `${displayPath(taste.path, cwd, home)}.`,
     taste.rule?.remedy ?? '',
     overrideLine(taste, override),
@@ -137,7 +137,7 @@ function refusal(
 }
 
 function blocking(taste: ResolvedTaste): boolean {
-  return taste.enforce === 'block' && taste.rule?.kind === 'command';
+  return taste.enforce === 'block' && taste.rule !== undefined;
 }
 
 export async function evaluateCommand(request: Request): Promise<Verdict> {
@@ -151,23 +151,39 @@ export async function evaluateCommand(request: Request): Promise<Verdict> {
 
   try {
     for (const taste of tastes.filter(blocking)) {
-      const outcome = await matcher.test(taste.rule?.match as string, request.command);
-      if ('skipped' in outcome) {
-        notices.push(`taste ${taste.name} was not applied — ${outcome.skipped} (${taste.path}).`);
+      const rule = taste.rule as TasteRule;
+      const outcome = await evaluateRule(rule.kind, rule.fields, {
+        command: request.command,
+        cwd: request.cwd,
+        env,
+        match: (pattern, capture) => matcher.test(pattern, request.command, capture),
+      });
+
+      if (outcome.verdict === 'skipped') {
+        notices.push(`taste ${taste.name} was not applied — ${outcome.detail} (${taste.path}).`);
         continue;
       }
-      if (!outcome.matched) continue;
+      // Allowed, and said so. A guard that could not read the state it needed
+      // is not a guard that found nothing.
+      if (outcome.verdict === 'unchecked') {
+        notices.push(
+          `UNCHECKED: taste ${taste.name} could not check this command — ${outcome.detail}. `
+            + `The command was allowed (${taste.path}).`,
+        );
+        continue;
+      }
+      if (outcome.verdict === 'passes') continue;
 
-      const override = overrideState(taste.rule?.override, request.command, env);
+      const override = overrideState(rule.override, request.command, env);
       if (override.state === 'granted') {
         notices.push(
-          `taste ${taste.name} allowed this command: ${taste.rule?.override} is set deliberately.`,
+          `taste ${taste.name} allowed this command: ${rule.override} is set deliberately.`,
         );
         continue;
       }
       return {
         decision: 'deny',
-        reason: refusal(taste, override, request.cwd, home, notices),
+        reason: refusal(taste, outcome.finding, override, request.cwd, home, notices),
         notices,
       };
     }

--- a/skills/taste/scripts/resolve.ts
+++ b/skills/taste/scripts/resolve.ts
@@ -12,9 +12,12 @@ export type Layer = 'project' | 'project-external' | 'user' | 'user-external';
 
 export interface TasteRule {
   kind: string;
-  match: string;
   remedy: string;
   override?: string;
+  // Everything else in the block, kind by kind: `match` for a command rule,
+  // `policy` for a tag-sequence one. The resolver stays out of the vocabulary
+  // so a kind can be added without it learning anything.
+  fields: Record<string, string>;
 }
 
 export interface ResolvedTaste {
@@ -156,12 +159,17 @@ function isDirectory(path: string): boolean {
 function readRule(front: Record<string, unknown>): TasteRule | undefined {
   const rule = front.rule;
   if (typeof rule !== 'object' || rule === null || Array.isArray(rule)) return undefined;
-  const fields = rule as Record<string, unknown>;
-  const kind = scalar(fields.kind);
-  const match = scalar(fields.match);
-  const remedy = scalar(fields.remedy);
-  if (kind === undefined || match === undefined || remedy === undefined) return undefined;
-  return { kind, match, remedy, override: scalar(fields.override) };
+  const block = rule as Record<string, unknown>;
+  const kind = scalar(block.kind);
+  const remedy = scalar(block.remedy);
+  if (kind === undefined || remedy === undefined) return undefined;
+
+  const fields: Record<string, string> = {};
+  for (const [key, value] of Object.entries(block)) {
+    const text = scalar(value);
+    if (text !== undefined) fields[key] = text;
+  }
+  return { kind, remedy, override: scalar(block.override), fields };
 }
 
 function load(path: string, where: Directory): { taste?: ResolvedTaste; warning?: string } {

--- a/skills/taste/scripts/rules/kinds.ts
+++ b/skills/taste/scripts/rules/kinds.ts
@@ -67,10 +67,10 @@ export function ruleKeys(kind: RuleKind): string[] {
   return ['kind', ...kind.required, ...kind.optional, 'remedy', 'override'];
 }
 
-// A taste written against a newer agentkit names a kind this one has never
-// heard of. It is skipped and said out loud — never a throw, because one taste
-// from the future must not take the whole hook down with it, and never silence,
-// because an enforcement that stopped happening has to be visible.
+// Depth, not the path. A taste naming a kind this agentkit lacks is already
+// dropped by resolve.ts, whose load-time lint refuses the kind and names it in a
+// warning — that is what delivers the guarantee. This branch exists because the
+// lookup can return nothing, and the answer to that must never be a throw.
 export async function evaluateRule(
   name: string,
   fields: Record<string, string>,

--- a/skills/taste/scripts/rules/kinds.ts
+++ b/skills/taste/scripts/rules/kinds.ts
@@ -1,0 +1,89 @@
+import { matchErrors } from './pattern.ts';
+import { GIT_TAG_SEQUENCE } from './tag-sequence.ts';
+
+export type MatchOutcome = { matched: boolean; captures: string[] } | { skipped: string };
+
+// The bounded matcher, supplied by whoever is running the rule. A kind never
+// compiles a taste's pattern itself: the deadline that makes a hostile pattern
+// survivable lives in one place, and every kind borrows it.
+export type Matcher = (pattern: string, capture?: boolean) => Promise<MatchOutcome>;
+
+export interface KindRequest {
+  command: string;
+  cwd: string;
+  env: Record<string, string | undefined>;
+  match: Matcher;
+}
+
+// `fires` refuses and says what was found; `skipped` and `unchecked` both allow
+// and both say so. They are separate because they answer different questions:
+// skipped means this taste could not be applied, unchecked means the state the
+// check needed could not be read.
+export type KindOutcome =
+  | { verdict: 'fires'; finding: string }
+  | { verdict: 'passes' }
+  | { verdict: 'skipped'; detail: string }
+  | { verdict: 'unchecked'; detail: string };
+
+// One entry per enforcement vocabulary agentkit implements. A taste names the
+// kind and parameterises it; the code is always agentkit's, which is what keeps
+// a taste data rather than a program.
+export interface RuleKind {
+  name: string;
+  // Beyond `kind`, `remedy` and `override`, which every kind carries.
+  required: readonly string[];
+  optional: readonly string[];
+  validate(fields: Record<string, string>): string[];
+  evaluate(fields: Record<string, string>, request: KindRequest): Promise<KindOutcome>;
+}
+
+const COMMAND: RuleKind = {
+  name: 'command',
+  required: ['match'],
+  optional: [],
+  validate(fields: Record<string, string>): string[] {
+    return fields.match === undefined ? [] : matchErrors(fields.match);
+  },
+  async evaluate(fields: Record<string, string>, request: KindRequest): Promise<KindOutcome> {
+    const outcome = await request.match(fields.match as string);
+    if ('skipped' in outcome) return { verdict: 'skipped', detail: outcome.skipped };
+    return outcome.matched
+      ? { verdict: 'fires', finding: 'this command matches rule.match' }
+      : { verdict: 'passes' };
+  },
+};
+
+const KINDS: readonly RuleKind[] = [COMMAND, GIT_TAG_SEQUENCE];
+
+export const RULE_KINDS: readonly string[] = KINDS.map((kind) => kind.name);
+
+export function ruleKind(name: string): RuleKind | undefined {
+  return KINDS.find((kind) => kind.name === name);
+}
+
+// What the lint accepts inside a rule of this kind, in reading order: what it
+// is, what it needs, what it may have, what it says, and how to get past it.
+export function ruleKeys(kind: RuleKind): string[] {
+  return ['kind', ...kind.required, ...kind.optional, 'remedy', 'override'];
+}
+
+// A taste written against a newer agentkit names a kind this one has never
+// heard of. It is skipped and said out loud — never a throw, because one taste
+// from the future must not take the whole hook down with it, and never silence,
+// because an enforcement that stopped happening has to be visible.
+export async function evaluateRule(
+  name: string,
+  fields: Record<string, string>,
+  request: KindRequest,
+): Promise<KindOutcome> {
+  const kind = ruleKind(name);
+  if (kind === undefined) {
+    return {
+      verdict: 'skipped',
+      detail: `its rule.kind ${JSON.stringify(name)} is not implemented by this version of `
+        + `agentkit, which has ${RULE_KINDS.join(', ')}. Upgrade agentkit, or keep the taste at `
+        + 'enforce: check',
+    };
+  }
+  return await kind.evaluate(fields, request);
+}

--- a/skills/taste/scripts/rules/pattern.ts
+++ b/skills/taste/scripts/rules/pattern.ts
@@ -1,0 +1,36 @@
+// A rule is tested in-process against every command an agent runs, and a
+// regular expression can be made to backtrack for longer than anyone will wait.
+// The subject is bounded where the matching happens (police.ts); the pattern is
+// bounded here, so an unrunnable rule fails the lint rather than a session.
+export const MAX_MATCH_LENGTH = 200;
+
+const SHELL_SUBSTITUTION = /\$\(|`/;
+
+// Every kind that reads a pattern out of a taste holds it to the same bounds:
+// a second kind's `match` is the same string in the same file, evaluated by the
+// same worker, so a looser one would be a way around the first.
+export function matchErrors(pattern: string): string[] {
+  const errors: string[] = [];
+  if (pattern.length > MAX_MATCH_LENGTH) {
+    errors.push(
+      `rule.match is ${pattern.length} characters — the cap is ${MAX_MATCH_LENGTH}, because `
+        + 'the hook runs it against every command. Narrow the pattern, or keep the taste at check.',
+    );
+  }
+  try {
+    new RegExp(pattern);
+  } catch (error) {
+    errors.push(`rule.match is not a valid regular expression: ${(error as Error).message}`);
+  }
+  if (SHELL_SUBSTITUTION.test(pattern)) {
+    errors.push(
+      'rule.match carries a command substitution — a rule is data; escape it as \\$\\( to '
+        + 'match those characters literally. A backtick cannot appear in a match at all.',
+    );
+  }
+  return errors;
+}
+
+export function carriesSubstitution(value: string): boolean {
+  return SHELL_SUBSTITUTION.test(value);
+}

--- a/skills/taste/scripts/rules/semver.ts
+++ b/skills/taste/scripts/rules/semver.ts
@@ -1,0 +1,67 @@
+export interface Version {
+  major: number;
+  minor: number;
+  patch: number;
+  // Dot-separated identifiers, empty for a release. A release outranks every
+  // prerelease of the same core, which is what makes rc1 -> rc2 -> final an
+  // ascending sequence rather than three unrelated tags.
+  prerelease: string[];
+}
+
+// A leading `v` is the tag convention rather than the grammar, and build
+// metadata is ignored for precedence — both per semver itself.
+const SEMVER =
+  /^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/;
+
+export function parseVersion(tag: string): Version | undefined {
+  const parts = SEMVER.exec(tag.trim());
+  if (parts === null) return undefined;
+  const prerelease = parts[4];
+  return {
+    major: Number(parts[1]),
+    minor: Number(parts[2]),
+    patch: Number(parts[3]),
+    prerelease: prerelease === undefined ? [] : prerelease.split('.'),
+  };
+}
+
+function compareIdentifiers(left: string, right: string): number {
+  const leftNumeric = /^\d+$/.test(left);
+  const rightNumeric = /^\d+$/.test(right);
+  if (leftNumeric && rightNumeric) return Number(left) - Number(right);
+  if (leftNumeric) return -1;
+  if (rightNumeric) return 1;
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function comparePrerelease(left: string[], right: string[]): number {
+  if (left.length === 0 && right.length === 0) return 0;
+  if (left.length === 0) return 1;
+  if (right.length === 0) return -1;
+  for (let index = 0; index < Math.max(left.length, right.length); index += 1) {
+    const one = left[index];
+    const other = right[index];
+    if (one === undefined) return -1;
+    if (other === undefined) return 1;
+    const order = compareIdentifiers(one, other);
+    if (order !== 0) return order;
+  }
+  return 0;
+}
+
+export function compareVersions(left: Version, right: Version): number {
+  if (left.major !== right.major) return left.major - right.major;
+  if (left.minor !== right.minor) return left.minor - right.minor;
+  if (left.patch !== right.patch) return left.patch - right.patch;
+  return comparePrerelease(left.prerelease, right.prerelease);
+}
+
+// The major.minor a tag belongs to. A release line is what makes a lower tag
+// maintenance rather than a mistake.
+export function sameLine(left: Version, right: Version): boolean {
+  return left.major === right.major && left.minor === right.minor;
+}
+
+export function sameCore(left: Version, right: Version): boolean {
+  return sameLine(left, right) && left.patch === right.patch;
+}

--- a/skills/taste/scripts/rules/tag-command.ts
+++ b/skills/taste/scripts/rules/tag-command.ts
@@ -1,0 +1,160 @@
+import { unquote } from '../override.ts';
+import { parseVersion } from './semver.ts';
+
+// Quoted runs are one token, so a separator inside a tag message does not end
+// the command and hide the tag that follows it.
+const TOKEN = /"[^"]*"|'[^']*'|[;&|\n]+|[^\s;&|]+/g;
+const SEPARATOR = /^[;&|\n]+$/;
+const ASSIGNMENT = /^[A-Za-z_][A-Za-z0-9_]*=/;
+
+interface Shape {
+  // An option that means this command lists, verifies or removes a tag rather
+  // than proposing one. Its presence ends the reading.
+  skip: readonly string[];
+  // An option whose value is the next word, which is therefore not a tag.
+  valued: readonly string[];
+  // git push names the remote first; only what follows it is a refspec.
+  dropFirst: boolean;
+}
+
+const GIT_TAG: Shape = {
+  skip: [
+    '-d',
+    '--delete',
+    '-l',
+    '--list',
+    '-v',
+    '--verify',
+    '-n',
+    '--contains',
+    '--no-contains',
+    '--points-at',
+    '--merged',
+    '--no-merged',
+    '--column',
+  ],
+  valued: ['-m', '--message', '-F', '--file', '-u', '--local-user', '--sort', '--format', '--cleanup'],
+  dropFirst: false,
+};
+
+const GIT_PUSH: Shape = {
+  skip: ['-d', '--delete', '--prune', '--mirror'],
+  valued: ['--repo', '-o', '--push-option', '--receive-pack', '--exec'],
+  dropFirst: true,
+};
+
+const GH_RELEASE_CREATE: Shape = {
+  skip: [],
+  valued: [
+    '-t',
+    '--title',
+    '-n',
+    '--notes',
+    '-F',
+    '--notes-file',
+    '--target',
+    '--discussion-category',
+    '-R',
+    '--repo',
+    '--notes-start-tag',
+  ],
+  dropFirst: false,
+};
+
+const GIT_GLOBAL_VALUED = ['-C', '-c', '--git-dir', '--work-tree', '--namespace', '--exec-path'];
+const GH_GLOBAL_VALUED = ['-R', '--repo'];
+
+function segments(command: string): string[][] {
+  const found: string[][] = [[]];
+  for (const token of command.match(TOKEN) ?? []) {
+    if (SEPARATOR.test(token)) {
+      found.push([]);
+      continue;
+    }
+    (found[found.length - 1] as string[]).push(unquote(token));
+  }
+  return found;
+}
+
+function named(word: string, program: string): boolean {
+  return word === program || word.endsWith(`/${program}`);
+}
+
+function dropOptions(words: string[], valued: readonly string[]): void {
+  while (words.length > 0 && (words[0] as string).startsWith('-')) {
+    const option = words.shift() as string;
+    if (valued.includes(option)) words.shift();
+  }
+}
+
+interface Reading {
+  shape: Shape;
+  words: string[];
+}
+
+function readingOf(segment: string[]): Reading | undefined {
+  const words = [...segment];
+  while (words.length > 0 && ASSIGNMENT.test(words[0] as string)) words.shift();
+  const program = words.shift();
+  if (program === undefined) return undefined;
+
+  if (named(program, 'git')) {
+    dropOptions(words, GIT_GLOBAL_VALUED);
+    const subcommand = words.shift();
+    if (subcommand === 'tag') return { shape: GIT_TAG, words };
+    if (subcommand === 'push') return { shape: GIT_PUSH, words };
+    return undefined;
+  }
+
+  if (named(program, 'gh')) {
+    dropOptions(words, GH_GLOBAL_VALUED);
+    if (words.shift() !== 'release') return undefined;
+    if (words.shift() !== 'create') return undefined;
+    return { shape: GH_RELEASE_CREATE, words };
+  }
+
+  return undefined;
+}
+
+function positionals(reading: Reading): string[] | undefined {
+  const found: string[] = [];
+  const words = reading.words;
+  for (let index = 0; index < words.length; index += 1) {
+    const word = words[index] as string;
+    if (word === '--') {
+      found.push(...words.slice(index + 1));
+      break;
+    }
+    if (word.startsWith('-') && word.length > 1) {
+      const option = word.split('=')[0] as string;
+      if (reading.shape.skip.includes(option)) return undefined;
+      if (reading.shape.valued.includes(option) && !word.includes('=')) index += 1;
+      continue;
+    }
+    found.push(word);
+  }
+  return reading.shape.dropFirst ? found.slice(1) : found;
+}
+
+function refName(word: string): string {
+  const target = word.replace(/^\+/, '').split(':').pop() as string;
+  return target.replace(/^refs\/tags\//, '');
+}
+
+// Every version-shaped tag this command would create, in the shapes agentkit
+// recognises. Anything that is not semver is not a tag this can reason about,
+// so it never becomes a proposal.
+export function proposedTags(command: string): string[] {
+  const tags: string[] = [];
+  for (const segment of segments(command)) {
+    const reading = readingOf(segment);
+    if (reading === undefined) continue;
+    const words = positionals(reading);
+    if (words === undefined) continue;
+    for (const word of words) {
+      const tag = refName(word);
+      if (parseVersion(tag) !== undefined && !tags.includes(tag)) tags.push(tag);
+    }
+  }
+  return tags;
+}

--- a/skills/taste/scripts/rules/tag-command.ts
+++ b/skills/taste/scripts/rules/tag-command.ts
@@ -1,11 +1,13 @@
 import { unquote } from '../override.ts';
 import { parseVersion } from './semver.ts';
 
-// Quoted runs are one token, so a separator inside a tag message does not end
-// the command and hide the tag that follows it. A quote may open partway
-// through a word — `-m"a;b"` is one argument to git, and reading it as two
-// would put the tag in a segment that no longer starts with a program name.
-const TOKEN = /(?:"[^"]*"|'[^']*'|[^\s;&|"']+)+|[;&|\n]+/g;
+// Quoted and escaped runs are one token: a separator inside a tag message must
+// not end the command and hide the tag after it, and a quote may open partway
+// through a word — `-m"a;b"` is one argument to git.
+// The double-quoted arm is unrolled rather than `(?:\\.|[^"\\])*`, which matches
+// the same language but backtracks through every position of an unterminated
+// quote — and this runs in the hook's own process, with no deadline around it.
+const TOKEN = /(?:"[^"\\]*(?:\\.[^"\\]*)*"|'[^']*'|\\.|[^\s;&|"'\\]+)+|[;&|\n]+/g;
 const SEPARATOR = /^[;&|\n]+$/;
 const ASSIGNMENT = /^[A-Za-z_][A-Za-z0-9_]*=/;
 

--- a/skills/taste/scripts/rules/tag-command.ts
+++ b/skills/taste/scripts/rules/tag-command.ts
@@ -2,8 +2,10 @@ import { unquote } from '../override.ts';
 import { parseVersion } from './semver.ts';
 
 // Quoted runs are one token, so a separator inside a tag message does not end
-// the command and hide the tag that follows it.
-const TOKEN = /"[^"]*"|'[^']*'|[;&|\n]+|[^\s;&|]+/g;
+// the command and hide the tag that follows it. A quote may open partway
+// through a word — `-m"a;b"` is one argument to git, and reading it as two
+// would put the tag in a segment that no longer starts with a program name.
+const TOKEN = /(?:"[^"]*"|'[^']*'|[^\s;&|"']+)+|[;&|\n]+/g;
 const SEPARATOR = /^[;&|\n]+$/;
 const ASSIGNMENT = /^[A-Za-z_][A-Za-z0-9_]*=/;
 

--- a/skills/taste/scripts/rules/tag-sequence.ts
+++ b/skills/taste/scripts/rules/tag-sequence.ts
@@ -91,9 +91,12 @@ export function judgeTag(
   tag: string,
   existing: readonly string[],
 ): string | undefined {
-  const judge = POLICIES[policy];
+  // Checked against the registered names rather than by looking the key up:
+  // `constructor` and `toString` resolve to functions on any plain object, and
+  // the hook's safety must not rest on the lint two modules away.
   const version = parseVersion(tag);
-  if (judge === undefined || version === undefined) return undefined;
+  if (!TAG_POLICIES.includes(policy) || version === undefined) return undefined;
+  const judge = POLICIES[policy] as Judge;
   return judge({ text: tag, version }, knownTags(existing));
 }
 
@@ -103,18 +106,37 @@ function firstLine(text: string): string {
 
 type Tags = { names: string[] } | { unchecked: string };
 
+// The one failure that means "there is nothing here to check". Exit 128 alone
+// does not: dubious ownership under a CI uid, a permission error and a corrupt
+// repository all use it, and reading those as not-a-repository would delete the
+// guard in exactly the environments that most need it.
+// Both of git's discovery-failed phrasings, and neither of the ones it uses for
+// a repository it found but could not use.
+const NOT_A_REPOSITORY = /not a git repository \(or any /;
+
+// git is asked in C, because the sentence above is what tells a directory with
+// no repository apart from a repository that cannot be read, and a translated
+// git would answer in another language.
+function askedInC(env: Record<string, string | undefined>): Record<string, string | undefined> {
+  return { ...env, LC_ALL: 'C', LANGUAGE: 'C', LANG: 'C' };
+}
+
 // Asymmetric on purpose, and the asymmetry is the design: a directory that is
 // not a repository has no sequence to violate, so it passes silently; git that
 // cannot answer is an unread guard, so it says UNCHECKED and still allows.
 async function repositoryTags(
   cwd: string,
-  env: Record<string, string | undefined>,
+  callerEnv: Record<string, string | undefined>,
 ): Promise<Tags> {
+  const env = askedInC(callerEnv);
   const inside = await runBounded(['git', '-C', cwd, 'rev-parse', '--git-dir'], cwd, env, GIT_TIMEOUT_MS);
   if (inside.code === null || inside.timedOut) {
     return { unchecked: `git could not be run in ${cwd} — ${firstLine(inside.err)}` };
   }
-  if (!inside.ok) return { names: [] };
+  if (!inside.ok) {
+    if (NOT_A_REPOSITORY.test(inside.err)) return { names: [] };
+    return { unchecked: `git could not read the repository at ${cwd} — ${firstLine(inside.err)}` };
+  }
 
   const listed = await runBounded(['git', '-C', cwd, 'tag', '--list'], cwd, env, GIT_TIMEOUT_MS);
   if (!listed.ok) {
@@ -153,6 +175,17 @@ export const GIT_TAG_SEQUENCE: RuleKind = {
   },
 
   async evaluate(fields: Record<string, string>, request: KindRequest): Promise<KindOutcome> {
+    // The lint refuses a policy that is not registered, so reaching this means
+    // the taste was never checked. Said out loud rather than allowed quietly,
+    // for the same reason an unimplemented kind is.
+    if (!TAG_POLICIES.includes(fields.policy as string)) {
+      return {
+        verdict: 'skipped',
+        detail: `its rule.policy ${JSON.stringify(fields.policy ?? null)} is not one of `
+          + TAG_POLICIES.join(', '),
+      };
+    }
+
     const proposals = await proposalsFor(fields, request);
     if (!Array.isArray(proposals)) return { verdict: 'skipped', detail: proposals.skipped };
     if (proposals.length === 0) return { verdict: 'passes' };

--- a/skills/taste/scripts/rules/tag-sequence.ts
+++ b/skills/taste/scripts/rules/tag-sequence.ts
@@ -1,0 +1,172 @@
+import { runBounded } from '../run.ts';
+import type { KindOutcome, KindRequest, RuleKind } from './kinds.ts';
+import { matchErrors } from './pattern.ts';
+import { compareVersions, parseVersion, sameCore, sameLine, type Version } from './semver.ts';
+import { proposedTags } from './tag-command.ts';
+
+// Long enough for a cold repository, short enough that a wedged git costs the
+// session a moment rather than the hook's whole budget.
+export const GIT_TIMEOUT_MS = 3000;
+
+interface Tag {
+  text: string;
+  version: Version;
+}
+
+type Judge = (proposed: Tag, existing: Tag[]) => string | undefined;
+
+function highestOf(tags: Tag[]): Tag | undefined {
+  return tags.reduce<Tag | undefined>(
+    (highest, tag) =>
+      highest === undefined || compareVersions(tag.version, highest.version) > 0 ? tag : highest,
+    undefined,
+  );
+}
+
+function duplicate(proposed: Tag, existing: Tag[]): string | undefined {
+  const clash = existing.find((tag) => compareVersions(tag.version, proposed.version) === 0);
+  if (clash === undefined) return undefined;
+  return clash.text === proposed.text
+    ? `${proposed.text} already exists in this repository`
+    : `${proposed.text} already exists as ${clash.text}`;
+}
+
+// A lower line is maintenance, not a mistake: what a tag may not do is go
+// backwards among the tags it shares a major.minor with.
+function backwardsInLine(proposed: Tag, existing: Tag[]): string | undefined {
+  const line = existing.filter((tag) => sameLine(tag.version, proposed.version));
+  const highest = highestOf(line);
+  if (highest === undefined || compareVersions(highest.version, proposed.version) < 0) {
+    return undefined;
+  }
+  return `${proposed.text} is behind ${highest.text}, the highest tag on the `
+    + `${proposed.version.major}.${proposed.version.minor} line`;
+}
+
+function nextPatchOf(highest: Tag): string {
+  const prefix = highest.text.startsWith('v') ? 'v' : '';
+  const { major, minor, patch } = highest.version;
+  return `${prefix}${major}.${minor}.${patch + 1}`;
+}
+
+// The immediate next patch of the highest tag overall — or the same core, which
+// is how a prerelease reaches its release without the line restarting.
+function notTheSuccessor(proposed: Tag, existing: Tag[]): string | undefined {
+  const highest = highestOf(existing);
+  if (highest === undefined) return undefined;
+  if (compareVersions(proposed.version, highest.version) < 0) {
+    return `${proposed.text} is not above ${highest.text}, the highest tag in this repository`;
+  }
+  const next = { ...highest.version, patch: highest.version.patch + 1, prerelease: [] };
+  if (sameCore(proposed.version, highest.version) || sameCore(proposed.version, next)) {
+    return undefined;
+  }
+  return `${proposed.text} is not the next patch after ${highest.text} — that would be `
+    + nextPatchOf(highest);
+}
+
+const POLICIES: Record<string, Judge> = {
+  'no-duplicate': duplicate,
+  'no-backwards-in-line': (proposed, existing) =>
+    duplicate(proposed, existing) ?? backwardsInLine(proposed, existing),
+  'strict-successor': (proposed, existing) =>
+    duplicate(proposed, existing) ?? notTheSuccessor(proposed, existing),
+};
+
+export const TAG_POLICIES: readonly string[] = Object.keys(POLICIES);
+
+// A tag that is not semver carries no order, so no policy has anything to say
+// about it — as a proposal or as one of the tags already there.
+function knownTags(names: readonly string[]): Tag[] {
+  const tags: Tag[] = [];
+  for (const text of names) {
+    const version = parseVersion(text);
+    if (version !== undefined) tags.push({ text, version });
+  }
+  return tags;
+}
+
+export function judgeTag(
+  policy: string,
+  tag: string,
+  existing: readonly string[],
+): string | undefined {
+  const judge = POLICIES[policy];
+  const version = parseVersion(tag);
+  if (judge === undefined || version === undefined) return undefined;
+  return judge({ text: tag, version }, knownTags(existing));
+}
+
+function firstLine(text: string): string {
+  return text.split('\n').find((line) => line.trim() !== '')?.trim() ?? 'no output';
+}
+
+type Tags = { names: string[] } | { unchecked: string };
+
+// Asymmetric on purpose, and the asymmetry is the design: a directory that is
+// not a repository has no sequence to violate, so it passes silently; git that
+// cannot answer is an unread guard, so it says UNCHECKED and still allows.
+async function repositoryTags(
+  cwd: string,
+  env: Record<string, string | undefined>,
+): Promise<Tags> {
+  const inside = await runBounded(['git', '-C', cwd, 'rev-parse', '--git-dir'], cwd, env, GIT_TIMEOUT_MS);
+  if (inside.code === null || inside.timedOut) {
+    return { unchecked: `git could not be run in ${cwd} — ${firstLine(inside.err)}` };
+  }
+  if (!inside.ok) return { names: [] };
+
+  const listed = await runBounded(['git', '-C', cwd, 'tag', '--list'], cwd, env, GIT_TIMEOUT_MS);
+  if (!listed.ok) {
+    return { unchecked: `git could not list the tags in ${cwd} — ${firstLine(listed.err)}` };
+  }
+  return { names: listed.out.split('\n').map((name) => name.trim()).filter((name) => name !== '') };
+}
+
+async function proposalsFor(
+  fields: Record<string, string>,
+  request: KindRequest,
+): Promise<string[] | { skipped: string }> {
+  const pattern = fields.match;
+  if (pattern === undefined) return proposedTags(request.command);
+
+  const outcome = await request.match(pattern, true);
+  if ('skipped' in outcome) return outcome;
+  return outcome.captures.filter((capture) => parseVersion(capture) !== undefined);
+}
+
+export const GIT_TAG_SEQUENCE: RuleKind = {
+  name: 'git-tag-sequence',
+  required: ['policy'],
+  optional: ['match'],
+
+  validate(fields: Record<string, string>): string[] {
+    const errors: string[] = [];
+    const policy = fields.policy;
+    if (policy !== undefined && !TAG_POLICIES.includes(policy)) {
+      errors.push(
+        `rule.policy: ${JSON.stringify(policy)} is not one of ${TAG_POLICIES.join(', ')}`,
+      );
+    }
+    if (fields.match !== undefined) errors.push(...matchErrors(fields.match));
+    return errors;
+  },
+
+  async evaluate(fields: Record<string, string>, request: KindRequest): Promise<KindOutcome> {
+    const proposals = await proposalsFor(fields, request);
+    if (!Array.isArray(proposals)) return { verdict: 'skipped', detail: proposals.skipped };
+    if (proposals.length === 0) return { verdict: 'passes' };
+
+    const tags = await repositoryTags(request.cwd, request.env);
+    if ('unchecked' in tags) return { verdict: 'unchecked', detail: tags.unchecked };
+    if (tags.names.length === 0) return { verdict: 'passes' };
+
+    for (const proposal of proposals) {
+      const finding = judgeTag(fields.policy as string, proposal, tags.names);
+      if (finding !== undefined) {
+        return { verdict: 'fires', finding: `${finding}, and rule.policy is ${fields.policy}` };
+      }
+    }
+    return { verdict: 'passes' };
+  },
+};

--- a/skills/taste/scripts/run.ts
+++ b/skills/taste/scripts/run.ts
@@ -3,6 +3,10 @@ export interface Run {
   out: string;
   err: string;
   timedOut: boolean;
+  // null when the process never started at all. A caller that treats a failing
+  // exit code as an answer needs to tell that apart from a missing program,
+  // which is no answer.
+  code: number | null;
 }
 
 // Spawned asynchronously so the deadline is a timer on a running event loop: a
@@ -20,7 +24,7 @@ export async function runBounded(
   try {
     child = Bun.spawn({ cmd, cwd, env, stdout: 'pipe', stderr: 'pipe' });
   } catch (error) {
-    return { ok: false, out: '', err: (error as Error).message, timedOut: false };
+    return { ok: false, out: '', err: (error as Error).message, timedOut: false, code: null };
   }
 
   let timedOut = false;
@@ -35,7 +39,13 @@ export async function runBounded(
       new Response(child.stderr).text(),
     ]);
     await child.exited;
-    return { ok: child.exitCode === 0, out: out.trim(), err: err.trim(), timedOut };
+    return {
+      ok: child.exitCode === 0,
+      out: out.trim(),
+      err: err.trim(),
+      timedOut,
+      code: child.exitCode,
+    };
   } finally {
     clearTimeout(deadline);
   }

--- a/tests/taste/kinds.test.ts
+++ b/tests/taste/kinds.test.ts
@@ -60,9 +60,11 @@ describe('the registry is what a kind name resolves to', () => {
 });
 
 describe('a kind this agentkit does not implement', () => {
-  // The version-skew case: a taste vendored from a source whose agentkit is
-  // newer. The hook must survive it, and must say that it did not enforce it.
-  test('is skipped by the hook, loudly, rather than crashing it', async () => {
+  // The dispatch's own answer, asserted at its own level. The resolver drops
+  // such a taste before it reaches here — that path is covered end to end in
+  // police.test.ts — so what this pins is that the dispatch cannot throw if it
+  // ever does arrive.
+  test('is skipped by the dispatch rather than thrown out of it', async () => {
     const outcome = await evaluateRule('git-worktree-shape', { policy: 'whatever' }, request());
     const detail = outcome.verdict === 'skipped' ? outcome.detail : '';
 

--- a/tests/taste/kinds.test.ts
+++ b/tests/taste/kinds.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { lintTasteDirectory } from '../../skills/taste/scripts/lint.ts';
+import {
+  evaluateRule,
+  type KindRequest,
+  type MatchOutcome,
+  RULE_KINDS,
+  ruleKeys,
+  ruleKind,
+} from '../../skills/taste/scripts/rules/kinds.ts';
+import { removeScratch, scratch } from './fixtures.ts';
+
+afterEach(removeScratch);
+
+const BODY = 'Cut the next patch.\n\nWhy: a tag is a promise.\n\nHow to apply: read the tags first.';
+
+// The rule block is the only thing that varies here, so the taste around it is
+// the smallest one the lint accepts at enforce: block.
+function blocking(rule: string): Record<string, string> {
+  const front = [
+    'name: release-tier',
+    'scope: project',
+    'strength: require',
+    'enforce: block',
+    'provenance: 2026-08-05 · session correction',
+    `rule:\n${rule}`,
+  ].join('\n');
+  return { 'release-tier.md': `---\n${front}\n---\n\n${BODY}\n` };
+}
+
+function request(command = 'git tag v1.0.0', match?: () => Promise<MatchOutcome>): KindRequest {
+  return {
+    command,
+    cwd: scratch(),
+    env: {},
+    match: (match ?? (async () => ({ matched: false, captures: [] }))) as KindRequest['match'],
+  };
+}
+
+describe('the registry is what a kind name resolves to', () => {
+  test('both kinds agentkit implements are registered', () => {
+    expect(RULE_KINDS).toEqual(['command', 'git-tag-sequence']);
+  });
+
+  test('a kind declares the fields the lint reads', () => {
+    const command = ruleKind('command');
+    expect(command?.required).toEqual(['match']);
+    expect(ruleKeys(command as NonNullable<typeof command>)).toEqual([
+      'kind',
+      'match',
+      'remedy',
+      'override',
+    ]);
+  });
+
+  test('an unregistered name resolves to nothing rather than a default kind', () => {
+    expect(ruleKind('git-tag-sequenc')).toBeUndefined();
+    expect(ruleKind('')).toBeUndefined();
+  });
+});
+
+describe('a kind this agentkit does not implement', () => {
+  // The version-skew case: a taste vendored from a source whose agentkit is
+  // newer. The hook must survive it, and must say that it did not enforce it.
+  test('is skipped by the hook, loudly, rather than crashing it', async () => {
+    const outcome = await evaluateRule('git-worktree-shape', { policy: 'whatever' }, request());
+    const detail = outcome.verdict === 'skipped' ? outcome.detail : '';
+
+    expect(outcome.verdict).toBe('skipped');
+    expect(detail).toContain('git-worktree-shape');
+    expect(detail).toContain('not implemented');
+    for (const kind of RULE_KINDS) expect(detail).toContain(kind);
+  });
+
+  test('is refused by the lint, naming the kinds that do exist', () => {
+    const dir = scratch(blocking(
+      '  kind: git-worktree-shape\n  policy: whatever\n  remedy: Do it another way.',
+    ));
+    const errors = lintTasteDirectory(dir);
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('rule.kind');
+    for (const kind of RULE_KINDS) expect(errors[0]).toContain(kind);
+  });
+
+  test('a registered kind still reaches its own evaluator', async () => {
+    const matched = async () => ({ matched: true, captures: [] });
+    const outcome = await evaluateRule(
+      'command',
+      { match: 'git tag' },
+      request('git tag v1.0.0', matched),
+    );
+
+    expect(outcome.verdict).toBe('fires');
+  });
+});
+
+describe('the lint reads each kind\'s own vocabulary', () => {
+  test('a field one kind requires is unknown to the other', () => {
+    const dir = scratch(blocking(
+      "  kind: command\n  match: 'git tag'\n  policy: no-duplicate\n  remedy: Cut a patch tag.",
+    ));
+    const errors = lintTasteDirectory(dir);
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('unknown rule key: policy');
+    expect(errors[0]).toContain('kind command carries');
+  });
+
+  test('a tag-sequence rule needs no match, and is accepted without one', () => {
+    const dir = scratch(blocking(
+      '  kind: git-tag-sequence\n  policy: no-backwards-in-line\n  remedy: Cut the next patch.',
+    ));
+
+    expect(lintTasteDirectory(dir)).toEqual([]);
+  });
+
+  test('a tag-sequence rule missing its policy is refused', () => {
+    const dir = scratch(blocking('  kind: git-tag-sequence\n  remedy: Cut the next patch.'));
+    const errors = lintTasteDirectory(dir);
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('rule.policy');
+  });
+
+  test('a command rule missing its match is refused the same way', () => {
+    const dir = scratch(blocking('  kind: command\n  remedy: Cut a patch tag.'));
+    const errors = lintTasteDirectory(dir);
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('rule.match');
+  });
+});

--- a/tests/taste/lint.test.ts
+++ b/tests/taste/lint.test.ts
@@ -6,8 +6,8 @@ import { dirname, join } from 'node:path';
 import {
   lintTasteDirectory,
   lintTastePath,
-  MAX_MATCH_LENGTH,
 } from '../../skills/taste/scripts/lint.ts';
+import { MAX_MATCH_LENGTH } from '../../skills/taste/scripts/rules/pattern.ts';
 
 const repoRoot = join(import.meta.dir, '..', '..');
 const linter = join(repoRoot, 'skills', 'taste', 'scripts', 'lint.ts');
@@ -496,10 +496,11 @@ describe('the command-line surface', () => {
   }
 
   test('a clean folder exits zero and says what it checked', () => {
-    const result = run(sandbox(documentedTastes()));
+    const documented = documentedTastes();
+    const result = run(sandbox(documented));
     expect(result.stderr).toBe('');
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain('1 taste');
+    expect(result.stdout).toContain(`${Object.keys(documented).length} taste`);
   });
 
   test('a violation exits non-zero and prints the message', () => {

--- a/tests/taste/police.test.ts
+++ b/tests/taste/police.test.ts
@@ -8,6 +8,7 @@ import {
   MAX_SUBJECT_LENGTH,
 } from '../../skills/taste/scripts/police.ts';
 import { resolveTastes } from '../../skills/taste/scripts/resolve.ts';
+import { RULE_KINDS } from '../../skills/taste/scripts/rules/kinds.ts';
 
 const repoRoot = join(import.meta.dir, '..', '..');
 const sandboxes: string[] = [];
@@ -149,11 +150,38 @@ describe('taste-police refuses what a block rule matches', () => {
       }),
     });
 
-    // The lint refuses the kind, so the file is malformed rather than silently
-    // inert — and either way nothing is refused on its behalf.
+    // Where the version-skew guarantee is actually delivered: the lint runs
+    // again as the hook loads the folder, so the taste is dropped there. The
+    // notice has to carry enough to act on — which file, and which kinds this
+    // agentkit does implement.
     const verdict = await judge(TAG_MINOR, where);
+    const notices = verdict.notices.join('\n');
+
     expect(verdict.decision).toBe('allow');
-    expect(verdict.notices.join('\n')).toContain('release-tier.md');
+    expect(notices).toContain('release-tier.md');
+    expect(notices).toContain('rule.kind');
+    for (const kind of RULE_KINDS) expect(notices).toContain(kind);
+  });
+
+  // And the taste beside it keeps enforcing: one file from a newer agentkit
+  // must cost its own enforcement and nobody else's.
+  test('a taste of an unknown kind does not disarm the tastes around it', async () => {
+    const where = project({
+      '.agentkit/tastes/from-the-future.md': taste({
+        name: 'from-the-future',
+        scope: 'project',
+        strength: 'require',
+        enforce: 'block',
+        provenance: '2026-08-06 · a newer agentkit',
+      }, { kind: 'git-worktree-shape', policy: 'whatever', remedy: 'Do it another way.' }),
+      '.agentkit/tastes/release-tier.md': releaseTier(),
+    });
+
+    const verdict = await judge(TAG_MINOR, where);
+
+    expect(verdict.decision).toBe('deny');
+    expect(verdict.reason).toContain('release-tier');
+    expect(verdict.reason).toContain('from-the-future');
   });
 });
 

--- a/tests/taste/police.test.ts
+++ b/tests/taste/police.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from 'bun:test';
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import {
@@ -45,6 +45,7 @@ const BODY = [
 interface Rule {
   kind?: string;
   match?: string;
+  policy?: string;
   remedy?: string;
   override?: string;
 }
@@ -397,12 +398,11 @@ describe('a malformed taste is loud, and never contagious', () => {
     // copy so the failure is real rather than mocked.
     test('a matcher that cannot start skips the taste instead of crashing', async () => {
       const scriptDir = sandbox({});
-      for (const name of ['police.ts', 'resolve.ts', 'lint.ts', 'sources.ts', 'layout.ts', 'override.ts']) {
-        writeFileSync(
-          join(scriptDir, name),
-          readFileSync(join(repoRoot, 'skills', 'taste', 'scripts', name), 'utf-8'),
-        );
-      }
+      // Everything the evaluator imports, copied whole except the one thread it
+      // matches on. Enumerating the modules instead would make this test fail
+      // the day another one is added, rather than the day the skip breaks.
+      cpSync(join(repoRoot, 'skills', 'taste', 'scripts'), scriptDir, { recursive: true });
+      rmSync(join(scriptDir, 'match.ts'), { force: true });
       const where = project({ '.agentkit/tastes/release-tier.md': releaseTier() });
 
       const broken = await import(join(scriptDir, 'police.ts')) as {
@@ -477,5 +477,116 @@ describe('taste.enabled switches the whole hook off', () => {
   test('the user config applies when the repository says nothing', async () => {
     const where = project(files, { '.config/agentkit/config.yaml': 'taste:\n  enabled: false\n' });
     expect((await judge(TAG_MINOR, where)).decision).toBe('allow');
+  });
+});
+
+// The second kind, through the whole hook: a taste file on disk, a real
+// repository with real tags, and the same refusal machinery the first kind
+// uses. What differs is only that the finding comes from git state rather than
+// from the command string.
+describe('a git-tag-sequence taste refuses out of the repository\'s own tags', () => {
+  function tagSequence(policy: string, override = 'AGENTKIT_TAG_SEQUENCE'): string {
+    return taste({
+      name: 'tag-sequence',
+      scope: 'project',
+      strength: 'require',
+      enforce: 'block',
+      provenance: '2026-08-06 · session correction',
+    }, {
+      kind: 'git-tag-sequence',
+      policy,
+      remedy: 'Read the existing tags and cut the next patch on that line.',
+      override,
+    });
+  }
+
+  function git(dir: string, ...args: string[]): void {
+    Bun.spawnSync({
+      cmd: ['git', ...args],
+      cwd: dir,
+      env: {
+        ...process.env,
+        GIT_AUTHOR_NAME: 'fixture',
+        GIT_AUTHOR_EMAIL: 'fixture@example.invalid',
+        GIT_COMMITTER_NAME: 'fixture',
+        GIT_COMMITTER_EMAIL: 'fixture@example.invalid',
+      },
+    });
+  }
+
+  function tagged(tags: string[], policy = 'no-backwards-in-line') {
+    const where = project({ '.agentkit/tastes/tag-sequence.md': tagSequence(policy) });
+    writeFileSync(join(where.cwd, 'file.txt'), 'contents');
+    git(where.cwd, 'init', '-q', '-b', 'main');
+    git(where.cwd, 'add', '-A');
+    git(where.cwd, 'commit', '-q', '-m', 'one');
+    for (const tag of tags) git(where.cwd, 'tag', tag);
+    return where;
+  }
+
+  test('a backwards tag is refused with this taste\'s own remedy and override', async () => {
+    const where = tagged(['v0.6.2', 'v0.6.5', 'v0.7.11']);
+    const verdict = await judge('git tag v0.6.3', where);
+
+    expect(verdict.decision).toBe('deny');
+    expect(verdict.reason).toContain('BLOCKED by taste tag-sequence');
+    expect(verdict.reason).toContain('v0.6.5');
+    expect(verdict.reason).toContain('Read the existing tags');
+    expect(verdict.reason).toContain('AGENTKIT_TAG_SEQUENCE');
+  });
+
+  test('a maintenance tag on a lower line passes', async () => {
+    const where = tagged(['v0.6.5', 'v0.7.11']);
+
+    expect((await judge('git tag v0.6.6', where)).decision).toBe('allow');
+  });
+
+  // Mutating the guard's INPUT rather than the guard: same command, same hook,
+  // different tags in the repository. If this still denied, the refusal above
+  // came from something other than the tags.
+  test('removing the tag it was behind removes the refusal', async () => {
+    const where = tagged(['v0.7.11']);
+
+    expect((await judge('git tag v0.6.3', where)).decision).toBe('allow');
+  });
+
+  test('the policy is the taste\'s, not the tool\'s', async () => {
+    const strict = tagged(['v0.6.5', 'v0.7.11'], 'strict-successor');
+
+    expect((await judge('git tag v0.6.6', strict)).decision).toBe('deny');
+  });
+
+  test('the override lets one tag through, deliberately', async () => {
+    const where = tagged(['v0.6.5']);
+    const verdict = await judge('AGENTKIT_TAG_SEQUENCE=1 git tag v0.6.3', where);
+
+    expect(verdict.decision).toBe('allow');
+    expect(verdict.notices.join('\n')).toContain('AGENTKIT_TAG_SEQUENCE');
+  });
+
+  test('a repository whose tags cannot be read allows, and says UNCHECKED', async () => {
+    const where = tagged(['v0.7.11']);
+    writeFileSync(join(where.cwd, '.git', 'packed-refs'), 'this file is not a ref database\n');
+    const verdict = await judge('git tag v0.1.1', where);
+
+    expect(verdict.decision).toBe('allow');
+    expect(verdict.notices.join('\n')).toContain('UNCHECKED');
+    expect(verdict.notices.join('\n')).toContain('tag-sequence');
+  });
+
+  test('a directory that is not a repository allows silently', async () => {
+    const where = project({ '.agentkit/tastes/tag-sequence.md': tagSequence('strict-successor') });
+    const verdict = await judge('git tag v0.1.1', where);
+
+    expect(verdict.decision).toBe('allow');
+    expect(verdict.notices).toEqual([]);
+  });
+
+  test('a command that proposes no tag is untouched', async () => {
+    const where = tagged(['v0.7.11']);
+    const verdict = await judge('git push origin main', where);
+
+    expect(verdict.decision).toBe('allow');
+    expect(verdict.notices).toEqual([]);
   });
 });

--- a/tests/taste/skill.test.ts
+++ b/tests/taste/skill.test.ts
@@ -49,9 +49,12 @@ const FAILURE_DIRECTION: [string, string][] = [
   ['the asymmetry is deliberate, not an oversight', 'Do not "fix" this into symmetry'],
 ];
 
-// The symmetric design, asserted absent. Making the tag check refuse what it
-// cannot read is the plausible "consistency" fix, and it would refuse every tag
-// command on any repository git will not answer for.
+// The symmetric design, asserted absent — making the tag check refuse what it
+// cannot read is the plausible "consistency" fix.
+//
+// An intent marker, not a guard: it keys on two literal phrasings, so the same
+// reversal in other words passes it. The direction is enforced by the UNCHECKED
+// and silent-pass branches in tag-sequence.test.ts, not here.
 const REVERSED_SYMMETRY = [
   'fails closed like the vendoring guard',
   'refuses when the tags cannot be read',

--- a/tests/taste/skill.test.ts
+++ b/tests/taste/skill.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, test } from 'bun:test';
 import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { ENFORCEMENTS, SCOPES, STRENGTHS } from '../../skills/taste/scripts/lint.ts';
+import { RULE_KINDS as REGISTERED_KINDS } from '../../skills/taste/scripts/rules/kinds.ts';
+import { TAG_POLICIES } from '../../skills/taste/scripts/rules/tag-sequence.ts';
 import { VISIBILITIES } from '../../skills/taste/scripts/sources.ts';
 import { TARGET_PRIVATE_OVERRIDE } from '../../skills/taste/scripts/visibility.ts';
 
@@ -20,6 +22,39 @@ const HOOK_BEHAVIOURS: [string, string][] = [
   ['a malformed taste is not contagious', 'takes nothing else down with it'],
   ['an unrunnable hook allows', 'refuses on its own uncertainty'],
   ['the bounds are stated', '200 characters'],
+];
+
+// The rule-kind registry, said in the words an owner is answered with. The
+// vocabulary is the product decision here: what a taste may ask for is agentkit
+// code, and prose that blurred that would invite the next kind to arrive as
+// data in someone's folder.
+const RULE_KINDS: [string, string][] = [
+  ['the vocabulary is extended by agentkit, not by a taste', 'enforcement vocabulary is extensible by agentkit'],
+  ['a kind names a check agentkit implements', 'names a check agentkit implements'],
+  ['the trust property is why it is data', 'a hostile source can at worst over-block you'],
+  ['a new kind is a change to agentkit', 'A preference that no kind can express stays at'],
+  ['an unimplemented kind is skipped rather than fatal', 'is skipped, loudly'],
+  ['version skew must not disable an older hook', 'must not brick an older hook'],
+  ['a check that cannot look says so per taste', 'for that one taste and allows'],
+  ['silence would be read as enforcement', 'read enforcement into a guard that never ran'],
+];
+
+// The asymmetry with the vendoring guard, and the reason for it. Written down
+// because the next reader's instinct is to make the two match.
+const FAILURE_DIRECTION: [string, string][] = [
+  ['vendoring fails closed because a leak is final', '**Vendoring fails closed.**'],
+  ['a rule kind fails open and reports', '**A rule kind fails open, and says so.**'],
+  ['nothing to check is not a failure', 'nothing to check is not a failure at all'],
+  ['the direction follows which error is recoverable', 'fails towards whichever error is'],
+  ['the asymmetry is deliberate, not an oversight', 'Do not "fix" this into symmetry'],
+];
+
+// The symmetric design, asserted absent. Making the tag check refuse what it
+// cannot read is the plausible "consistency" fix, and it would refuse every tag
+// command on any repository git will not answer for.
+const REVERSED_SYMMETRY = [
+  'fails closed like the vendoring guard',
+  'refuses when the tags cannot be read',
 ];
 
 const SETTLED_BEHAVIOURS: [string, string][] = [
@@ -236,6 +271,34 @@ describe('the taste skill and its contract agree', () => {
   // so a behaviour silently dropped from the prose is a behaviour that stops
   // happening. Each entry is a decision the design settled, bound to the words
   // that carry it.
+  test.each(RULE_KINDS)('the skill carries the rule-kind rule: %s', (_rule, phrase) => {
+    expect(skill.includes(phrase), `SKILL.md must say: ${phrase}`).toBe(true);
+  });
+
+  test.each(FAILURE_DIRECTION)('the skill carries the failure direction: %s', (_rule, phrase) => {
+    expect(skill.includes(phrase), `SKILL.md must say: ${phrase}`).toBe(true);
+  });
+
+  test.each(REVERSED_SYMMETRY)('the skill does not make the two guards symmetric: %s', (phrase) => {
+    expect(
+      skill.includes(phrase),
+      `SKILL.md must not say ${JSON.stringify(phrase)} — a rule kind reports UNCHECKED and allows, `
+        + 'and matching it to the vendoring guard would refuse every tag command in a repository '
+        + 'whose tags cannot be read',
+    ).toBe(false);
+  });
+
+  // Every kind the registry implements has to be documented where an owner
+  // writes a rule, or the vocabulary is only discoverable by reading the code.
+  test('the format reference documents every registered kind and tag policy', () => {
+    for (const kind of REGISTERED_KINDS) {
+      expect(reference, `format.md documents kind ${kind}`).toContain(`\`${kind}\``);
+    }
+    for (const policy of TAG_POLICIES) {
+      expect(reference, `format.md documents policy ${policy}`).toContain(`\`${policy}\``);
+    }
+  });
+
   test.each(SETTLED_BEHAVIOURS)('the skill still carries the behaviour: %s', (_behaviour, phrase) => {
     expect(skill.includes(phrase), `SKILL.md must still say: ${phrase}`).toBe(true);
   });
@@ -307,7 +370,7 @@ describe('the taste skill and its contract agree', () => {
   // A phrase split across a line break would bind nothing: the file it is read
   // from is hard-wrapped, and `textWrap: maintain` leaves the author's breaks
   // exactly where they fell.
-  test.each([...LAYOUT, ...LOADING_STRATEGY, ...INSTALL_MODES, ...VENDOR_GUARD])(
+  test.each([...LAYOUT, ...LOADING_STRATEGY, ...INSTALL_MODES, ...VENDOR_GUARD, ...RULE_KINDS, ...FAILURE_DIRECTION])(
     'the phrase bound for %s sits on one line',
     (_rule, phrase) => {
       expect(phrase.includes('\n')).toBe(false);
@@ -320,6 +383,8 @@ describe('the taste skill and its contract agree', () => {
   // the opposite. Uniqueness is what points a binding at one place.
   test.each([
     ...HOOK_BEHAVIOURS,
+    ...RULE_KINDS,
+    ...FAILURE_DIRECTION,
     ...SETTLED_BEHAVIOURS,
     ...CONVERSATIONAL_SURFACES,
     ...EXTERNAL_SOURCES,

--- a/tests/taste/tag-sequence.test.ts
+++ b/tests/taste/tag-sequence.test.ts
@@ -159,6 +159,39 @@ describe('the proposed tag is read out of the command', () => {
   test('a version mentioned inside an attached message is not proposed', () => {
     expect(proposedTags('git tag -m"v0.8.0 fixes A; adds B" v0.7.12')).toEqual(['v0.7.12']);
   });
+
+  // A backslash is how a shell keeps the next character out of the grammar, so
+  // it has to keep it out of this one too — an escaped quote does not close the
+  // message, and an escaped separator does not end the command.
+  test.each([
+    ['an escaped quote inside a quoted message', 'git tag -m "a\\"b; c" v1.2.3'],
+    ['an escaped quote inside an attached message', 'git tag -m"a\\"b; c" v1.2.3'],
+    ['an escaped separator outside any quotes', 'git tag -m a\\;b v1.2.3'],
+    ['an escaped quote then a real one', 'git tag -m "a\\" b" v1.2.3'],
+  ])('reads the tag past %s', (_shape, command) => {
+    expect(proposedTags(command)).toEqual(['v1.2.3']);
+  });
+
+  test('a version inside an escaped-quote message is still not the tag', () => {
+    expect(proposedTags('git tag -m "v0.8.0 \\"quoted\\"; more" v0.7.12')).toEqual(['v0.7.12']);
+  });
+
+  // The option consumed a word that happens to parse as a version. Reading it
+  // as a proposal refuses a legitimate release on the strength of its own
+  // message, so the value has to be stepped over.
+  test.each([
+    ['a bare message value', 'git tag -m v0.8.0 v0.7.12'],
+    ['a bare long-option value', 'git tag --message v0.8.0 v0.7.12'],
+    ['a push option value', 'git push origin --receive-pack v0.8.0 v0.7.12'],
+    ['a forge release note value', 'gh release create v0.7.12 --notes v0.8.0'],
+  ])('steps over %s', (_shape, command) => {
+    expect(proposedTags(command)).toEqual(['v0.7.12']);
+  });
+
+  // An attached value is self-contained, so nothing after it may be skipped.
+  test('an attached option value does not swallow the tag after it', () => {
+    expect(proposedTags('git tag --message=v0.8.0 v0.7.12')).toEqual(['v0.7.12']);
+  });
 });
 
 describe('each policy names what it refuses', () => {

--- a/tests/taste/tag-sequence.test.ts
+++ b/tests/taste/tag-sequence.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from 'bun:test';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { KindRequest, MatchOutcome } from '../../skills/taste/scripts/rules/kinds.ts';
@@ -48,6 +48,37 @@ function repo(tags: string[]): string {
   git(dir, 'add', '-A');
   git(dir, 'commit', '-q', '-m', 'one');
   for (const tag of tags) git(dir, 'tag', tag);
+  return dir;
+}
+
+// A git that fails the way we need it to. Dubious ownership needs a checkout
+// owned by another uid, which a test cannot make; what the code reads is the
+// exit status and the message, and those a stub reproduces exactly.
+function stubGit(message: string, code: number): string {
+  const dir = scratch();
+  const path = join(dir, 'git');
+  writeFileSync(path, `#!/bin/sh\nprintf '%s\\n' ${JSON.stringify(message)} >&2\nexit ${code}\n`);
+  chmodSync(path, 0o755);
+  return dir;
+}
+
+// A git that answers in the session's language unless it is asked in C — which
+// is what a translated git on a developer's machine does, and what would make
+// the sentence above unrecognisable.
+function translatedGit(): string {
+  const dir = scratch();
+  const path = join(dir, 'git');
+  writeFileSync(
+    path,
+    '#!/bin/sh\n'
+      + 'if [ "$LC_ALL" = C ]; then\n'
+      + "  printf '%s\\n' 'fatal: not a git repository (or any parent up to mount point /)' >&2\n"
+      + 'else\n'
+      + "  printf '%s\\n' 'fatal: kein Git-Repository (oder eines der übergeordneten Verzeichnisse)' >&2\n"
+      + 'fi\n'
+      + 'exit 128\n',
+  );
+  chmodSync(path, 0o755);
   return dir;
 }
 
@@ -110,6 +141,24 @@ describe('the proposed tag is read out of the command', () => {
   test('a quoted separator inside a message does not hide the tag', () => {
     expect(proposedTags('git tag -m "fixes a|b; and c" v1.2.3')).toEqual(['v1.2.3']);
   });
+
+  // The shell hands `-ma;b` to git as one argument, so the tag really is
+  // created. A quote opening partway through a word therefore has to keep that
+  // word together, exactly as a quote that opens it does.
+  test.each([
+    ['a double-quoted message attached to -m', 'git tag -m"a;b" v1.2.3'],
+    ['a single-quoted message attached to -m', "git tag -m'a|b' v1.2.3"],
+    ['an attached message carrying &&', 'git tag -m"a&&b" v1.2.3'],
+    ['an attached long-option message', 'git tag --message"a;b" v1.2.3'],
+  ])('reads the tag past %s', (_shape, command) => {
+    expect(proposedTags(command)).toEqual(['v1.2.3']);
+  });
+
+  // And the version named in the message is not the tag being cut. Reading it
+  // as one would refuse the release on the strength of its own release note.
+  test('a version mentioned inside an attached message is not proposed', () => {
+    expect(proposedTags('git tag -m"v0.8.0 fixes A; adds B" v0.7.12')).toEqual(['v0.7.12']);
+  });
 });
 
 describe('each policy names what it refuses', () => {
@@ -171,6 +220,16 @@ describe('each policy names what it refuses', () => {
     expect(judgeTag('strict-successor', 'v0.7.12', ['v0.7.9', 'v0.7.11'])).toBeUndefined();
   });
 
+  // Documented in format.md, so it is asserted here: strict-successor accepts
+  // the next patch and nothing else, which means it cannot open a new minor
+  // line even as a release candidate.
+  test('strict-successor refuses a prerelease that opens a new line', () => {
+    const finding = judgeTag('strict-successor', 'v0.8.0-rc1', ['v0.7.11']);
+
+    expect(finding).toContain('v0.8.0-rc1');
+    expect(finding).toContain('v0.7.12');
+  });
+
   test('a prerelease sorts below its release and may still graduate', () => {
     expect(judgeTag('strict-successor', 'v0.8.0', ['v0.8.0-rc1'])).toBeUndefined();
     expect(judgeTag('strict-successor', 'v0.8.0-rc2', ['v0.8.0-rc1'])).toBeUndefined();
@@ -180,6 +239,17 @@ describe('each policy names what it refuses', () => {
   test('an unknown policy refuses nothing rather than guessing one', () => {
     expect(judgeTag('whatever-comes-next', 'v0.1.1', ['v9.9.9'])).toBeUndefined();
   });
+
+  // A name off Object.prototype resolves to a function on any plain-object
+  // lookup. The lint refuses such a policy long before this, which is exactly
+  // why the guard belongs here too: the hook's safety must not rest on a check
+  // two modules away.
+  test.each([['constructor'], ['toString'], ['__proto__'], ['hasOwnProperty']])(
+    'a policy named %p is not a judge',
+    (policy) => {
+      expect(judgeTag(policy, 'v0.1.1', ['v9.9.9'])).toBeUndefined();
+    },
+  );
 });
 
 describe('the check reads the repository the command runs in', () => {
@@ -225,6 +295,46 @@ describe('the check reads the repository the command runs in', () => {
     expect(outcome.verdict === 'unchecked' && outcome.detail).toContain('git');
   });
 
+  // Only git's own "not a git repository" is evidence of that. Every other
+  // failure — dubious ownership under a CI uid, a corrupt repository, a
+  // permission error — is a guard that could not look, and must say so.
+  test.each([
+    ["fatal: detected dubious ownership in repository at '/src'", 'dubious ownership'],
+    ['fatal: cannot change to \'/src\': Permission denied', 'Permission denied'],
+    ['fatal: not a git repository: \'/src/.git\'', '/src/.git'],
+  ])('a rev-parse failure saying %p is UNCHECKED, not a silent pass', async (message, phrase) => {
+    const outcome = await evaluate({ policy: 'strict-successor' }, 'git tag v0.1.1', scratch(), {
+      env: { PATH: stubGit(message, 128) },
+    });
+
+    expect(outcome.verdict).toBe('unchecked');
+    expect(outcome.verdict === 'unchecked' && outcome.detail).toContain(phrase);
+  });
+
+  // Both phrasings git uses when discovery simply found nothing. The one it
+  // prints depends on whether the walk stopped at a mount point, so pinning
+  // only one of them would silently turn half the real cases into UNCHECKED.
+  test.each([
+    ['fatal: not a git repository (or any of the parent directories): .git'],
+    ['fatal: not a git repository (or any parent up to mount point /)'],
+  ])('git saying %p passes silently', async (message) => {
+    const outcome = await evaluate({ policy: 'strict-successor' }, 'git tag v0.1.1', scratch(), {
+      env: { PATH: stubGit(message, 128) },
+    });
+
+    expect(outcome.verdict).toBe('passes');
+  });
+
+  // Otherwise a translated git turns every directory without a repository into
+  // an UNCHECKED notice, on every tag command, for the whole session.
+  test('git is asked in C, so a translated session still reads as not-a-repository', async () => {
+    const outcome = await evaluate({ policy: 'strict-successor' }, 'git tag v0.1.1', scratch(), {
+      env: { PATH: translatedGit(), LC_ALL: 'de_DE.UTF-8', LANG: 'de_DE.UTF-8' },
+    });
+
+    expect(outcome.verdict).toBe('passes');
+  });
+
   // A missing git is not evidence that this is not a repository, so it must not
   // land on the silent pass that "not a repository" gets.
   test('git that cannot be run at all is UNCHECKED rather than a pass', async () => {
@@ -241,6 +351,21 @@ describe('the check reads the repository the command runs in', () => {
 
     expect(outcome.verdict).toBe('passes');
   });
+});
+
+describe('an unregistered policy stops the taste rather than the hook', () => {
+  test.each([['whatever-comes-next'], ['constructor']])(
+    'policy %p is skipped, by name, and the command is allowed',
+    async (policy) => {
+      const outcome = await evaluate({ policy }, 'git tag v0.1.1', repo(['v0.7.11']));
+
+      expect(outcome.verdict).toBe('skipped');
+      expect(outcome.verdict === 'skipped' && outcome.detail).toContain(policy);
+      for (const known of TAG_POLICIES) {
+        expect(outcome.verdict === 'skipped' && outcome.detail).toContain(known);
+      }
+    },
+  );
 });
 
 describe('rule.match overrides how the tag is read', () => {

--- a/tests/taste/tag-sequence.test.ts
+++ b/tests/taste/tag-sequence.test.ts
@@ -1,0 +1,298 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { KindRequest, MatchOutcome } from '../../skills/taste/scripts/rules/kinds.ts';
+import { proposedTags } from '../../skills/taste/scripts/rules/tag-command.ts';
+import {
+  GIT_TAG_SEQUENCE,
+  judgeTag,
+  TAG_POLICIES,
+} from '../../skills/taste/scripts/rules/tag-sequence.ts';
+
+const sandboxes: string[] = [];
+
+afterEach(() => {
+  while (sandboxes.length > 0) {
+    rmSync(sandboxes.pop() as string, { recursive: true, force: true });
+  }
+});
+
+function scratch(): string {
+  const root = mkdtempSync(join(tmpdir(), 'agentkit-tag-sequence-'));
+  sandboxes.push(root);
+  return root;
+}
+
+function git(dir: string, ...args: string[]): { code: number; err: string } {
+  const result = Bun.spawnSync({
+    cmd: ['git', ...args],
+    cwd: dir,
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'fixture',
+      GIT_AUTHOR_EMAIL: 'fixture@example.invalid',
+      GIT_COMMITTER_NAME: 'fixture',
+      GIT_COMMITTER_EMAIL: 'fixture@example.invalid',
+    },
+  });
+  return { code: result.exitCode ?? -1, err: result.stderr.toString() };
+}
+
+// A repository with a commit to hang tags on. Tags are what the check reads, so
+// every integration case below differs only in which ones exist.
+function repo(tags: string[]): string {
+  const dir = scratch();
+  git(dir, 'init', '-q', '-b', 'main');
+  writeFileSync(join(dir, 'file.txt'), 'contents');
+  git(dir, 'add', '-A');
+  git(dir, 'commit', '-q', '-m', 'one');
+  for (const tag of tags) git(dir, 'tag', tag);
+  return dir;
+}
+
+// The rule never reaches this in the default path: the shapes agentkit
+// recognises are its own code, and only an overriding rule.match is matched.
+function refuseToMatch(): Promise<MatchOutcome> {
+  throw new Error('the default extraction must not use the bounded matcher');
+}
+
+function evaluate(
+  fields: Record<string, string>,
+  command: string,
+  cwd: string,
+  options: { match?: () => Promise<MatchOutcome>; env?: Record<string, string> } = {},
+) {
+  const request: KindRequest = {
+    command,
+    cwd,
+    env: options.env ?? { PATH: process.env.PATH },
+    match: (options.match ?? refuseToMatch) as KindRequest['match'],
+  };
+  return GIT_TAG_SEQUENCE.evaluate(fields, request);
+}
+
+describe('the proposed tag is read out of the command', () => {
+  test.each([
+    ['a plain tag', 'git tag v1.2.3', ['v1.2.3']],
+    ['an annotated tag', 'git tag -a v1.2.3 -m "release"', ['v1.2.3']],
+    ['a signed tag', 'git tag -s v1.2.3 -m "release"', ['v1.2.3']],
+    ['a tag on a named commit', 'git tag v1.2.3 abc1234', ['v1.2.3']],
+    ['a quoted tag', 'git tag "v1.2.3"', ['v1.2.3']],
+    ['git run from another directory', 'git -C /srv/repo tag v1.2.3', ['v1.2.3']],
+    ['a push of one tag', 'git push origin v1.2.3', ['v1.2.3']],
+    ['a push by full ref', 'git push origin refs/tags/v1.2.3', ['v1.2.3']],
+    ['a push with an explicit refspec', 'git push origin v1.2.3:refs/tags/v1.2.3', ['v1.2.3']],
+    ['a release created on the forge', 'gh release create v1.2.3 --notes ok', ['v1.2.3']],
+    ['a tag later in a chain', 'bun test && git tag v1.2.3', ['v1.2.3']],
+    ['an inline override assignment', 'AGENTKIT_TAGS=1 git tag v1.2.3', ['v1.2.3']],
+  ])('reads %s', (_shape, command, expected) => {
+    expect(proposedTags(command)).toEqual(expected);
+  });
+
+  test.each([
+    ['listing tags', 'git tag --list'],
+    ['listing with a pattern', 'git tag -l "v1.*"'],
+    ['deleting a tag', 'git tag -d v1.2.3'],
+    ['deleting a remote tag', 'git push origin --delete v1.2.3'],
+    ['verifying a tag', 'git tag -v v1.2.3'],
+    ['pushing a branch', 'git push origin main'],
+    ['pushing every tag with none named', 'git push --tags'],
+    ['a message that merely mentions a version', 'git commit -m "bump to v1.2.3"'],
+    ['viewing a release', 'gh release view v1.2.3'],
+    ['a wholly unrelated command', 'bun test'],
+  ])('proposes nothing for %s', (_shape, command) => {
+    expect(proposedTags(command)).toEqual([]);
+  });
+
+  // A tag message is prose, and prose splits on nothing: a quoted separator is
+  // one token, so the tag after it is still read.
+  test('a quoted separator inside a message does not hide the tag', () => {
+    expect(proposedTags('git tag -m "fixes a|b; and c" v1.2.3')).toEqual(['v1.2.3']);
+  });
+});
+
+describe('each policy names what it refuses', () => {
+  const EXISTING = ['v0.6.2', 'v0.6.5', 'v0.7.0', 'v0.7.11', 'not-a-version', 'release-2026'];
+
+  // One table, read as: this tag, proposed against those tags, under this
+  // policy. `undefined` is an allow; a string is the finding in the refusal.
+  test.each([
+    ['no-duplicate', 'v0.7.11', false, 'already exists'],
+    ['no-duplicate', 'v0.1.1', true, ''],
+    ['no-duplicate', 'v0.6.3', true, ''],
+    ['no-duplicate', 'v9.9.9', true, ''],
+    ['no-backwards-in-line', 'v0.7.11', false, 'already exists'],
+    ['no-backwards-in-line', 'v0.6.5', false, 'already exists'],
+    // The maintenance line the owner keeps: 0.6.6 is ahead on its own line even
+    // though 0.7.11 is the highest tag in the repository.
+    ['no-backwards-in-line', 'v0.6.6', true, ''],
+    ['no-backwards-in-line', 'v0.6.3', false, 'v0.6.5'],
+    ['no-backwards-in-line', 'v0.7.12', true, ''],
+    ['no-backwards-in-line', 'v0.5.9', true, ''],
+    ['strict-successor', 'v0.7.12', true, ''],
+    ['strict-successor', 'v0.7.11', false, 'already exists'],
+    ['strict-successor', 'v0.6.6', false, 'v0.7.11'],
+    ['strict-successor', 'v0.7.13', false, 'v0.7.12'],
+    ['strict-successor', 'v0.8.0', false, 'v0.7.12'],
+    ['strict-successor', 'v1.0.0', false, 'v0.7.12'],
+  ])('%s %s allowed=%p', (policy, tag, allowed, phrase) => {
+    const finding = judgeTag(policy as string, tag, EXISTING);
+    if (allowed) {
+      expect(finding, `${policy} must allow ${tag}`).toBeUndefined();
+      return;
+    }
+    expect(finding, `${policy} must refuse ${tag}`).toBeDefined();
+    expect(finding).toContain(tag);
+    expect(finding).toContain(phrase);
+  });
+
+  // The case the issue turns on, asserted on its own so a table edit cannot
+  // quietly drop it: a lower line is maintenance, not a mistake.
+  test('v0.6.5 while v0.7.11 exists is allowed in its line and refused as a successor', () => {
+    const existing = ['v0.7.11'];
+    expect(judgeTag('no-backwards-in-line', 'v0.6.5', existing)).toBeUndefined();
+    expect(judgeTag('strict-successor', 'v0.6.5', existing)).toContain('v0.7.11');
+  });
+
+  test.each(TAG_POLICIES)('%s ignores a tag that is not semver', (policy) => {
+    expect(judgeTag(policy, 'nightly', ['v1.0.0', 'nightly'])).toBeUndefined();
+    expect(judgeTag(policy, 'v1.2', ['v1.0.0'])).toBeUndefined();
+  });
+
+  test.each(TAG_POLICIES)('%s has nothing to say when no semver tag exists', (policy) => {
+    expect(judgeTag(policy, 'v1.0.0', ['nightly', 'latest'])).toBeUndefined();
+  });
+
+  // Ordering is semver's, not the string's: 11 is above 9, and a prerelease
+  // sits below the release it leads to.
+  test('the highest tag is read by semver precedence rather than alphabetically', () => {
+    expect(judgeTag('strict-successor', 'v0.7.10', ['v0.7.9', 'v0.7.11'])).toContain('v0.7.11');
+    expect(judgeTag('strict-successor', 'v0.7.12', ['v0.7.9', 'v0.7.11'])).toBeUndefined();
+  });
+
+  test('a prerelease sorts below its release and may still graduate', () => {
+    expect(judgeTag('strict-successor', 'v0.8.0', ['v0.8.0-rc1'])).toBeUndefined();
+    expect(judgeTag('strict-successor', 'v0.8.0-rc2', ['v0.8.0-rc1'])).toBeUndefined();
+    expect(judgeTag('no-backwards-in-line', 'v0.8.0-rc1', ['v0.8.0'])).toContain('v0.8.0');
+  });
+
+  test('an unknown policy refuses nothing rather than guessing one', () => {
+    expect(judgeTag('whatever-comes-next', 'v0.1.1', ['v9.9.9'])).toBeUndefined();
+  });
+});
+
+describe('the check reads the repository the command runs in', () => {
+  test('a tag that goes backwards is refused, naming the tag it is behind', async () => {
+    const dir = repo(['v0.6.2', 'v0.6.5']);
+    const outcome = await evaluate({ policy: 'no-backwards-in-line' }, 'git tag v0.6.3', dir);
+
+    expect(outcome.verdict).toBe('fires');
+    expect(outcome.verdict === 'fires' && outcome.finding).toContain('v0.6.5');
+    expect(outcome.verdict === 'fires' && outcome.finding).toContain('no-backwards-in-line');
+  });
+
+  test('a tag that goes forwards on its own line passes', async () => {
+    const dir = repo(['v0.6.5', 'v0.7.11']);
+    const outcome = await evaluate({ policy: 'no-backwards-in-line' }, 'git tag v0.6.6', dir);
+
+    expect(outcome.verdict).toBe('passes');
+  });
+
+  test('a directory that is not a git repository has nothing to check', async () => {
+    const outcome = await evaluate({ policy: 'strict-successor' }, 'git tag v0.1.1', scratch());
+
+    expect(outcome.verdict).toBe('passes');
+  });
+
+  test('a repository with no tags at all has nothing to check', async () => {
+    const outcome = await evaluate({ policy: 'strict-successor' }, 'git tag v9.9.9', repo([]));
+
+    expect(outcome.verdict).toBe('passes');
+  });
+
+  // Not a silent allow. The command runs, and the session is told the guard did
+  // not see the state it needed — the same contract the hook itself keeps.
+  test('tags that cannot be listed report UNCHECKED and allow', async () => {
+    const dir = repo(['v0.7.11']);
+    // A ref database git refuses to read: the repository is real, so this is
+    // not the not-a-repository case, and the tags genuinely cannot be listed.
+    writeFileSync(join(dir, '.git', 'packed-refs'), 'this file is not a ref database\n');
+
+    const outcome = await evaluate({ policy: 'strict-successor' }, 'git tag v0.1.1', dir);
+
+    expect(outcome.verdict).toBe('unchecked');
+    expect(outcome.verdict === 'unchecked' && outcome.detail).toContain('git');
+  });
+
+  // A missing git is not evidence that this is not a repository, so it must not
+  // land on the silent pass that "not a repository" gets.
+  test('git that cannot be run at all is UNCHECKED rather than a pass', async () => {
+    const dir = repo(['v0.7.11']);
+    const outcome = await evaluate({ policy: 'strict-successor' }, 'git tag v0.1.1', dir, {
+      env: { PATH: '/agentkit-nonexistent' },
+    });
+
+    expect(outcome.verdict).toBe('unchecked');
+  });
+
+  test('a command proposing no tag never asks git anything', async () => {
+    const outcome = await evaluate({ policy: 'strict-successor' }, 'bun test', '/nonexistent');
+
+    expect(outcome.verdict).toBe('passes');
+  });
+});
+
+describe('rule.match overrides how the tag is read', () => {
+  test('the first capture group is the proposed tag', async () => {
+    const dir = repo(['v0.7.11']);
+    const matcher = async () => ({ matched: true, captures: ['v0.1.1'] });
+    const outcome = await evaluate(
+      { policy: 'strict-successor', match: 'release ([^ ]+)' },
+      'ship release v0.1.1',
+      dir,
+      { match: matcher },
+    );
+
+    expect(outcome.verdict).toBe('fires');
+    expect(outcome.verdict === 'fires' && outcome.finding).toContain('v0.1.1');
+  });
+
+  test('a pattern that cannot be run skips the taste rather than refusing', async () => {
+    const dir = repo(['v0.7.11']);
+    const matcher = async () => ({ skipped: 'its rule.match did not finish' });
+    const outcome = await evaluate(
+      { policy: 'strict-successor', match: '(a+)+$' },
+      'git tag v0.1.1',
+      dir,
+      { match: matcher },
+    );
+
+    expect(outcome.verdict).toBe('skipped');
+  });
+});
+
+describe('the lint reads what this kind requires', () => {
+  test('the kind declares its own fields', () => {
+    expect(GIT_TAG_SEQUENCE.name).toBe('git-tag-sequence');
+    expect(GIT_TAG_SEQUENCE.required).toEqual(['policy']);
+    expect(GIT_TAG_SEQUENCE.optional).toEqual(['match']);
+  });
+
+  test('a policy outside the enum is refused, naming the ones that exist', () => {
+    const errors = GIT_TAG_SEQUENCE.validate({ policy: 'no-backwards', remedy: 'Cut a patch.' });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('rule.policy');
+    for (const policy of TAG_POLICIES) expect(errors[0]).toContain(policy);
+  });
+
+  test.each(TAG_POLICIES)('%s passes the lint', (policy) => {
+    expect(GIT_TAG_SEQUENCE.validate({ policy })).toEqual([]);
+  });
+
+  test('an overriding match is held to the same bounds as a command rule', () => {
+    const errors = GIT_TAG_SEQUENCE.validate({ policy: 'no-duplicate', match: 'git tag ([0-9' });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('rule.match');
+  });
+});


### PR DESCRIPTION
Refs #328.

**Why not git-police.** Tag sequencing is one owner's convention; git-police ships universal discipline to everyone who installs agentkit. So it belongs in taste-police as an opt-in taste — which needed the rule vocabulary to grow past a regex over the command string.

**Named predicates.** A rule declares a `kind` agentkit implements and parameterises it with data. Taste data still executes nothing, so a hostile source can at worst over-block you.

### The registry

| | `command` | `git-tag-sequence` |
| --- | --- | --- |
| taste supplies | `match` | `policy`, optional `match` |
| agentkit inspects | the command string | the tags in the repo the hook runs in |

Each entry declares required/optional fields, a validator the lint calls, and an evaluator the hook calls. `kind: command` is entry #1 with byte-identical behaviour — its tests are untouched.

An unknown kind is refused by the lint naming the known kinds, so a taste from a newer agentkit cannot brick an older one. **That guarantee is delivered by the resolver**, which runs the same lint as the hook loads the folder: the taste is dropped there and named in a warning listing the kinds this agentkit has, while every other taste keeps enforcing. The dispatch in `evaluateRule` carries a matching skip as defence in depth — the lookup can return nothing and the answer must never be a throw — but it is not the reachable path, and the comment on it says so.

### The policies

| policy | v0.7.11 exists; proposed → |
| --- | --- |
| `no-duplicate` | refuses a tag that already exists |
| `no-backwards-in-line` | v0.6.5 **allowed** (maintenance line), v0.6.2-with-v0.6.5-present refused |
| `strict-successor` | only v0.7.12; v0.6.5 refused |

Non-semver tags are ignored throughout. Prereleases sort below their release, so `v0.8.0-rc1` → `v0.8.0` ascends.

### Failure semantics, deliberately not the vendor guard's

The vendoring guard fails closed because a leak is final. This is a convention guard, so failing closed would refuse every tag command in any repo whose tags cannot be read, to prevent a mis-ordered tag `git tag -d` undoes in a second.

- no semver tag proposed, not a git repo, or no tags → passes silently, git is never run
- git present but the listing fails → `UNCHECKED` naming the taste, and **allows** — never a silent allow

Documented in SKILL.md with the reasoning, plus an asserted-absent gate on the symmetric wording so the next reader does not "fix" it.

### Evidence

- 674 tests in the taste slice, 2779 in the repo, 0 fail; `scripts/preflight --base origin/main --slice taste` clean.
- 28 mutations across four rounds, all caught. Registry and policies: each policy's comparison inverted; the line scope dropped from `no-backwards-in-line`; both ignore-non-semver branches removed; the extractor's semver filter removed; `git-tag-sequence` dropped from the registry; two SKILL.md sentences reworded. Failure direction: UNCHECKED turned into a silent allow (the listing failure, the missing-git branch, and any `rev-parse` failure); the not-a-repository match loosened to a bare substring; the `UNCHECKED:` marker dropped from the notice; the forced C locale removed. Tokenizer and guards: the quote rule reverted to quote-must-open-the-token; `judgeTag` reverted to a key lookup; the unregistered-policy skip made silent. Version skew: the lint's unknown-kind refusal removed; the resolver made silent; the resolver made to abort at the first broken taste. Tokenizer escapes and option values: the escape handling dropped from the tokenizer; the valued-option skip disabled; an attached `--opt=value` skipped anyway.





### Tokenizer: why the unrolled form rather than the alternation

The escaped-quote fix could be written `"(?:\\.|[^"\\])*"`. It matches the same language as the shipped `"[^"\\]*(?:\\.[^"\\]*)*"` — verified by differential test over 430,940 subjects (exhaustive to length 4 over `a v . 1 " ' \\ ; | & space newline -`, plus 400k random), zero divergences — but it backtracks through every position of an unterminated quote. `proposedTags` runs in the hook's own process: no worker, no 250ms deadline, no subject truncation. Best of three, ms:

| shape | 8k | 32k | 128k | 512k |
| --- | --- | --- | --- | --- |
| unbalanced quote — alternation | 0.065 | 4.003 | 17.590 | — |
| unbalanced quote — **unrolled** | 0.051 | 0.220 | **0.844** | — |
| escaped-quote message — alternation | 0.030 | 0.138 | 11.238 | 43.321 |
| escaped-quote message — **unrolled** | 0.011 | 0.046 | **4.431** | **17.717** |
| plain / alternating / backslashes — unrolled | \<0.14 | \<1.0 | \<2.1 | — |

Neither is exponential: past ~112k both grow linearly, and the jump there is an engine step (the simpler pre-fix regex stays on the fast path and does not hit it). The unrolled form is 20x faster on the unbalanced case and stays under 1ms at 128k, so it is the one shipped.

Deliberately **not** truncating the subject the way `rule.match` is bounded to 4000 characters: with a linear tokenizer it buys nothing, and it would create a real hole — a tag command longer than the bound would go unchecked entirely, which is the silent non-enforcement this guard is built to avoid.
