### PR TITLE
Remove deselected optional-kit artifacts

### DIFF
--- a/docs/site/src/content/docs/concepts/memory.md
+++ b/docs/site/src/content/docs/concepts/memory.md
@@ -34,10 +34,9 @@ Two rules protect the vault's future: no secrets in notes, ever — a vault may 
 synced beyond one machine — and all skill or vault changes land as diffs a human reviews, never as
 silent self-modification.
 
-Like every non-explicit kit, deselecting it later (`--without memory`) stops future installs but
-leaves already-installed skills _and_ hooks in place — the hooks stay silent no-ops wherever no
-vault exists. To get them off the machine, uninstall and reinstall without the kit
-(`install.sh --global --uninstall`, then a plain `install.sh --global`).
+Like every optional kit, deselecting it later (`--without memory`) removes the AgentKit-managed
+skills, hooks, settings entries, prompts, and plugin on that install. A later bare install keeps it
+absent until `--with memory` selects it again.
 
 The kit is opt-in:
 

--- a/docs/site/src/content/docs/getting-started/skill-kits.mdx
+++ b/docs/site/src/content/docs/getting-started/skill-kits.mdx
@@ -52,7 +52,7 @@ The shims go through `bootstrap.sh` and `install.sh` unchanged, so the recorded 
 consent semantics are identical to typing `--with <id>` yourself. Explicit kits deliberately have
 no shim — their consent story is a literal, typed `--with`.
 
-## Explicit kits are consent-gated
+## Explicit kits require literal selection
 
 A kit marked `explicit` in the manifest behaves differently from a merely optional one, and the
 difference is the whole point:
@@ -60,11 +60,11 @@ difference is the whole point:
 - The interactive wizard never offers it. A `y` at a prompt is too easy to give without reading
   what it wires in.
 - `--all` does not include it.
-- When a run does **not** select it, the installer **removes** its previously installed skills,
-  hooks, tools and prompt wiring.
+- Only a literal `--with <kit>` or a remembered prior literal selection keeps it selected.
 
-That last rule is deliberate: presence without recorded selection is not consent. Finding the
-merge gate on disk is not evidence that anybody chose to be gated.
+Removal is deliberately consistent across every optional kit: when a run does **not** select one,
+the installer removes its AgentKit-managed artifacts. Presence without recorded selection is not
+selection, and a discoverable skill can still be auto-triggered by a harness.
 
 A remembered selection still counts as selected, so a bare `install.sh --global` after
 `--with adversarial-review` **keeps** it. To take it away, drop it explicitly:
@@ -77,7 +77,7 @@ Observed removal on that run — the skill, both hooks, both tools, the Codex pr
 wiring, the `CLAUDE.md` prompt block and the OpenCode `instructions[]` entry all go:
 
 ```text
-[skills] Removing (explicit kit 'adversarial-review' not selected): adversarial-review
+[skills] Removing (kit 'adversarial-review' not selected): adversarial-review
 [claude] Removed prompt block (evidence-gated-review.md): …/.claude/CLAUDE.md
 [opencode] Removed global prompt: …/.config/opencode/opencode.json
 [claude] Removing hook (adversarial-review kit not selected): review-police.sh
@@ -96,10 +96,9 @@ A global install records the chosen kits in `~/.agentkit/kits`, so a later bare
 `install.sh --global` upgrades the same set with no flags to re-pass. `--with` adds to that set
 rather than replacing it; `--without <kit>` drops one.
 
-Deleting a line stops the kit being **selected**. For a normal optional kit it never deletes
-files already on disk — an already-installed skill from an unselected kit is still refreshed,
-and the installer says so. (An explicit kit is the exception above: deselecting it removes its
-artifacts.)
+Deleting a line deselects the kit. The next install removes that kit's AgentKit-managed artifacts
+from the canonical skill tree and client integrations. It does not remove unrelated user-managed
+skills, prompts, hooks, or plugins.
 
 An unknown kit name left in that file is reported on stderr and ignored, not taken as a
 selection.

--- a/docs/site/src/content/docs/getting-started/upgrading.md
+++ b/docs/site/src/content/docs/getting-started/upgrading.md
@@ -11,13 +11,13 @@ and the marker blocks it writes into files you also own.
 
 ## What a second run does
 
-| Class                                   | On re-run                                |
-| --------------------------------------- | ---------------------------------------- |
-| skills, rules, tools, hooks, plugins    | overwritten unconditionally              |
-| shell profile, client configs           | marker-guarded, never duplicated         |
-| `~/.config/agentkit/config.yaml`        | preserved — seeded once, then left alone |
-| artifacts unsupported on this platform  | actively removed                         |
-| artifacts of an unselected explicit kit | actively removed                         |
+| Class                                    | On re-run                                |
+| ---------------------------------------- | ---------------------------------------- |
+| skills, rules, tools, hooks, plugins     | overwritten unconditionally              |
+| shell profile, client configs            | marker-guarded, never duplicated         |
+| `~/.config/agentkit/config.yaml`         | preserved — seeded once, then left alone |
+| artifacts unsupported on this platform   | actively removed                         |
+| artifacts of any unselected optional kit | actively removed                         |
 
 :::caution[Local edits inside an installed skill are destroyed on upgrade]
 An existing skill directory is removed and re-copied. Edit the clone, not the install.
@@ -25,14 +25,13 @@ An existing skill directory is removed and re-copied. Edit the clone, not the in
 
 Two more details:
 
-- **Deselecting an ordinary kit never deletes anything.** An already-installed skill from an
-  unselected kit is still refreshed, and the installer says so. Deselection changes what is
-  chosen, never what is on disk, so an upgrade never removes a skill you are using.
-- **An unselected explicit kit is the exception.** `advisory-review` and `adversarial-review` are
-  consent-gated: when one is not selected, its hooks, tools, skills and prompt wiring are removed.
-  Presence without recorded selection is not consent. In particular, upgrading from a version where
-  `review-discipline.md` was core removes that instruction on the next plain install — pass
-  `--with advisory-review` to keep it.
+- **Selection is the installed set.** Deselecting `memory`, `product`, or either review kit removes
+  its AgentKit-managed skills, hooks, tools, prompts, settings entries, and plugins. Otherwise a
+  harness could continue to discover and auto-trigger a workflow the user removed.
+- **Explicit controls how a kit is selected, not how it is removed.** `advisory-review` and
+  `adversarial-review` are never offered by the picker or included by `--all`; only a literal
+  `--with` selects them. Like every optional kit, a remembered selection keeps them installed and
+  `--without` removes them.
 
 Config files carrying your own content are guarded by markers or predicates, so re-runs do not
 duplicate blocks. In `CLAUDE.md` those markers look like
@@ -46,18 +45,17 @@ in `CLAUDE.md` and 5 entries in the OpenCode `instructions[]` array rather than 
 
 ## Removing one kit
 
-`--without <kit>` drops a kit from the selection and from the remembered set, but what that
-does on disk depends on the kind of kit:
+`--without <kit>` drops a kit from the selection and remembered set, then removes that kit's
+AgentKit-managed artifacts:
 
-| Kit                                     | `install.sh --global --without <kit>`                                  |
-| --------------------------------------- | ---------------------------------------------------------------------- |
-| `adversarial-review`, `advisory-review` | Fully removed — skills, hooks, `settings.json` entries, tools, prompts |
-| `memory`, `product`                     | De-selected only; installed skills and hooks stay and keep updating    |
+| Kit                                     | `install.sh --global --without <kit>`                                    |
+| --------------------------------------- | ------------------------------------------------------------------------ |
+| `adversarial-review`, `advisory-review` | Removes managed instructions, skills, hooks, tools, prompts, and plugins |
+| `memory`, `product`                     | Removes managed skills, hooks, settings entries, prompts, and plugins    |
 
-That asymmetry is the same rule as above: a consent-gated kit goes when consent is withdrawn,
-an ordinary one is never taken out from under someone using it. To get an ordinary kit off a
-machine, uninstall and reinstall the set you want — the uninstall clears the remembered
-selection along with everything else.
+Real directories and plugins that AgentKit does not own remain untouched. A real directory using
+the same name as an AgentKit skill is reported instead of deleted from a client skill directory;
+the canonical `~/.agentkit/skills` tree remains installer-owned and is reconciled exactly.
 
 ## Removing all of it
 

--- a/docs/site/src/generated/kit-facts.json
+++ b/docs/site/src/generated/kit-facts.json
@@ -403,7 +403,7 @@
       "name": "uninstall",
       "kit": "core",
       "explicit": false,
-      "description": "Remove AgentKit, or one of its skill kits, without hand-deleting files. Covers `install.sh --uninstall` for a global or project install, what it reverts inside configs the user owns, what it deliberately leaves alone, and how kit removal differs between opt-in and consent-gated kits. Use when asked to uninstall AgentKit, remove a kit, undo the installer, or clean a machine of it."
+      "description": "Remove AgentKit, or one of its skill kits, without hand-deleting files. Covers `install.sh --uninstall` for a global or project install, what it reverts inside configs the user owns, what it deliberately leaves alone, and how deselecting one optional kit removes its managed artifacts. Use when asked to uninstall AgentKit, remove a kit, undo the installer, or clean a machine of it."
     },
     {
       "name": "wip",

--- a/install.sh
+++ b/install.sh
@@ -29,14 +29,14 @@ Options:
                        Kits marked `explicit` in skills/KITS
                        (advisory-review, adversarial-review) are never offered by
                        that prompt and are excluded from --all: only a literal
-                       --with installs them, and when one is not selected the
-                       installer REMOVES its previously installed hooks, tools,
-                       skills, and prompt wiring.
+                       --with installs them. Every optional kit, explicit or
+                       prompted, is removed from managed install locations when
+                       it is not selected.
   --no-prompt          Never ask about optional kits, even on a terminal.
                        AGENTKIT_SKIP_PROMPT=1 and a non-empty CI do the same.
   --without <kit>      Drop a kit from the selection and from the remembered
-                       set (repeatable). Skills already installed are left in
-                       place; `core` cannot be dropped.
+                       set (repeatable), removing its managed artifacts on this
+                       install. `core` cannot be dropped.
   --all                Install every declared skill kit. A global install
                        remembers the chosen kits in ~/.agentkit/kits, so a
                        later bare `install.sh --global` upgrades the same set
@@ -231,7 +231,7 @@ write_version_stamp() {
 
 kits_state_header() {
 	echo "# Skill kits chosen at install time; a bare install.sh --global keeps them."
-	echo "# Delete a line to stop installing that kit (installed skills are left alone)."
+	echo "# Deleting a line deselects and removes that kit on the next install."
 }
 
 inherit_retired_kit_state() {
@@ -502,27 +502,18 @@ install_skills() {
 		local target="$dest/$skill_name"
 		kit="$(skill_kit "$skill_name")"
 
-		# An unselected kit that is already installed is still refreshed:
-		# dropping it on upgrade would silently take a skill away from someone
-		# who is using it, and leaving it unupdated rots it instead. Explicit
-		# kits invert that: they are consent-gated, and presence without a
-		# recorded selection is not consent — remove them.
+		# The persisted selection is the active set. Retaining a deselected skill
+		# keeps it discoverable and lets harnesses auto-trigger a workflow the
+		# user removed. Only this canonical AgentKit-owned tree is reconciled;
+		# unrelated skills in client directories are left alone below.
 		if ! kit_selected "$kit"; then
-			if kit_explicit "$kit"; then
-				if [[ -e "$target" ]]; then
-					echo "[skills] Removing (explicit kit '$kit' not selected): $skill_name"
-					rm -rf "$target"
-				else
-					echo "[skills] Skipping (explicit kit '$kit' — add --with $kit): $skill_name"
-				fi
-				continue
-			fi
-			if [[ -e "$target" ]]; then
-				echo "[skills] Keeping installed (kit '$kit' not selected): $skill_name"
+			if [[ -e "$target" || -L "$target" ]]; then
+				echo "[skills] Removing (kit '$kit' not selected): $skill_name"
+				rm -rf "$target"
 			else
 				echo "[skills] Skipping (kit '$kit' — add --with $kit): $skill_name"
-				continue
 			fi
+			continue
 		fi
 
 		if [[ -d "$target" && ! -L "$target" ]]; then
@@ -1037,27 +1028,20 @@ install_claude_hooks() {
 		local owning_kit
 		owning_kit="$(hook_kit "$name")"
 		if [[ "$owning_kit" != core ]] && ! kit_selected "$owning_kit"; then
-			if kit_explicit "$owning_kit"; then
-				if command -v jq &>/dev/null; then
-					if [[ -e "$install_dir/$name" || -L "$install_dir/$name" ]]; then
-						echo "[claude] Removing hook ($owning_kit kit not selected): $name"
-						rm -f "$install_dir/$name"
-					fi
-					if [[ "$hooks_dir" != "$install_dir" && (-e "$hooks_dir/$name" || -L "$hooks_dir/$name") ]]; then
-						rm -f "$hooks_dir/$name"
-					fi
-					continue
-				fi
-				if [[ ! -e "$install_dir/$name" && ! -L "$install_dir/$name" ]]; then
-					continue
-				fi
-				echo "[claude] WARNING: jq missing — keeping $name so its settings.json entries stay functional." >&2
-			elif [[ ! -e "$install_dir/$name" && ! -L "$install_dir/$name" ]]; then
-				# Mirror install_skills: an installed non-explicit kit stays
-				# refreshed, a never-installed one is skipped.
+			if [[ ! -e "$install_dir/$name" && ! -L "$install_dir/$name" ]]; then
 				echo "[claude] Skipping hook (kit '$owning_kit' — add --with $owning_kit): $name"
 				continue
 			fi
+			if ! command -v jq &>/dev/null; then
+				echo "[claude] ERROR: jq is required to remove deselected $owning_kit hook wiring safely: $name" >&2
+				return 1
+			fi
+			echo "[claude] Removing hook ($owning_kit kit not selected): $name"
+			rm -f "$install_dir/$name"
+			if [[ "$hooks_dir" != "$install_dir" && (-e "$hooks_dir/$name" || -L "$hooks_dir/$name") ]]; then
+				rm -f "$hooks_dir/$name"
+			fi
+			continue
 		fi
 
 		if [[ -f "$install_dir/$name" && ! -L "$install_dir/$name" ]]; then
@@ -1136,9 +1120,8 @@ merge_claude_settings() {
 	kit_selected adversarial-review || review_selected=false
 
 	# The memory strip list derives from hook_kit so it cannot drift from
-	# ownership. Wiring follows the scripts: selected, or already installed —
-	# non-explicit kits keep their installed hooks like install_skills keeps
-	# their skills, so the settings must keep matching them.
+	# ownership. Wiring follows the selected set exactly; deselected scripts
+	# were removed above before this canonical settings merge.
 	local memory_hooks_json hook_name
 	memory_hooks_json="$(for hook_file in "$REPO_DIR"/hooks/claude/*.sh; do
 		hook_name="$(basename "$hook_file")"
@@ -1147,16 +1130,7 @@ merge_claude_settings() {
 		fi
 	done | jq -R . | jq -s .)"
 	local memory_wired=false
-	if kit_selected memory; then
-		memory_wired=true
-	else
-		for hook_name in $(printf '%s' "$memory_hooks_json" | jq -r '.[]'); do
-			if [[ -e "$hooks_dir/$hook_name" || -L "$hooks_dir/$hook_name" ]]; then
-				memory_wired=true
-				break
-			fi
-		done
-	fi
+	kit_selected memory && memory_wired=true
 
 	local hooks_json
 	hooks_json=$(jq --arg dir "$hooks_dir" \
@@ -1495,17 +1469,13 @@ install_codex_skills() {
 		kit="$(skill_kit "$name")"
 
 		if ! kit_selected "$kit"; then
-			if kit_explicit "$kit"; then
-				if [[ -f "$target" ]]; then
-					echo "[codex] Removing prompt (explicit kit '$kit' not selected): $name.md"
-					rm -f "$target"
-				fi
-				continue
-			fi
-			if [[ ! -f "$target" ]]; then
+			if [[ -f "$target" || -L "$target" ]]; then
+				echo "[codex] Removing prompt (kit '$kit' not selected): $name.md"
+				rm -f "$target"
+			else
 				echo "[codex] Skipping prompt (kit '$kit' — add --with $kit): $name.md"
-				continue
 			fi
+			continue
 		fi
 
 		if [[ -f "$target" ]]; then
@@ -1528,18 +1498,14 @@ plugin_is_installed() {
 		jq -e --arg id "$1" '.[] | select(.id == $id and .scope == "user")' >/dev/null
 }
 
-# An unselected kit whose plugin is already installed is still updated — the
-# plugin-mode counterpart of keeping an already-installed skill.
 claude_plugin_targets() {
-	local installed="$1" kit id
+	local kit
 	for kit in $(declared_kits); do
 		# Skills are the whole payload of a kit plugin, so a kit with none
 		# publishes none — asking to install it fails the whole run.
 		kit_has_skills "$kit" || continue
-		id="$(kit_plugin_id "$kit")@agentkit"
-		if kit_selected "$kit" || plugin_is_installed "$id" "$installed"; then
-			printf '%s\n' "$id"
-		fi
+		kit_selected "$kit" || continue
+		printf '%s@agentkit\n' "$(kit_plugin_id "$kit")"
 	done
 }
 
@@ -1575,6 +1541,21 @@ remove_retired_claude_plugins() {
 	done
 }
 
+remove_deselected_claude_plugins() {
+	local installed="$1" kit id
+	for kit in $(declared_kits); do
+		kit_selected "$kit" && continue
+		kit_has_skills "$kit" || continue
+		id="$(kit_plugin_id "$kit")@agentkit"
+		plugin_is_installed "$id" "$installed" || continue
+		echo "[claude] Uninstalling deselected plugin: $id"
+		if ! claude plugin uninstall "$id"; then
+			echo "[claude] ERROR: failed to uninstall deselected $id." >&2
+			return 1
+		fi
+	done
+}
+
 install_claude_plugin() {
 	if ! command -v claude &>/dev/null; then
 		echo "[claude] WARNING: claude CLI not found — cannot install the plugin."
@@ -1605,13 +1586,13 @@ install_claude_plugin() {
 	fi
 
 	remove_retired_claude_plugins "$installed_plugins"
+	remove_deselected_claude_plugins "$installed_plugins" || return 1
 
 	local targets plugin_id
-	targets="$(claude_plugin_targets "$installed_plugins")"
+	targets="$(claude_plugin_targets)"
 	for plugin_id in $targets; do
 		ensure_claude_plugin "$plugin_id" "$installed_plugins" || return 1
 	done
-
 	local ready_plugins
 	if ! ready_plugins="$(claude plugin list --json)"; then
 		echo "[claude] ERROR: could not verify the installed Claude plugin." >&2
@@ -1625,6 +1606,16 @@ install_claude_plugin() {
 		if ! printf '%s' "$ready_plugins" | jq -e --arg id "$plugin_id" \
 			'.[] | select(.id == $id and .scope == "user" and .enabled == true)' >/dev/null; then
 			echo "[claude] ERROR: $plugin_id is not enabled after installation or update." >&2
+			return 1
+		fi
+	done
+	local kit
+	for kit in $(declared_kits); do
+		kit_selected "$kit" && continue
+		kit_has_skills "$kit" || continue
+		plugin_id="$(kit_plugin_id "$kit")@agentkit"
+		if plugin_is_installed "$plugin_id" "$ready_plugins"; then
+			echo "[claude] ERROR: deselected $plugin_id remains installed." >&2
 			return 1
 		fi
 	done
@@ -2200,7 +2191,7 @@ if [[ "$GLOBAL" == true ]]; then
 	for skill_dir in "$REPO_DIR"/skills/*/; do
 		skill_name="$(basename "$skill_dir")"
 		skill_kit_name="$(skill_kit "$skill_name")"
-		if kit_explicit "$skill_kit_name" && ! kit_selected "$skill_kit_name"; then
+		if ! kit_selected "$skill_kit_name"; then
 			for client_skills in "$HOME/.agents/skills" "$HOME/.claude/skills" "$HOME/.grok/skills"; do
 				if [[ -e "$client_skills/$skill_name" && ! -L "$client_skills/$skill_name" ]]; then
 					echo "[skills] WARNING: leaving $client_skills/$skill_name in place (not installed by this installer); remove it manually if unwanted." >&2

--- a/plugins-cc/agentkit/skills/uninstall/SKILL.md
+++ b/plugins-cc/agentkit/skills/uninstall/SKILL.md
@@ -3,8 +3,8 @@ name: uninstall
 description: >-
   Remove AgentKit, or one of its skill kits, without hand-deleting files. Covers
   `install.sh --uninstall` for a global or project install, what it reverts inside
-  configs the user owns, what it deliberately leaves alone, and how kit removal
-  differs between opt-in and consent-gated kits. Use when asked to uninstall
+  configs the user owns, what it deliberately leaves alone, and how deselecting
+  one optional kit removes its managed artifacts. Use when asked to uninstall
   AgentKit, remove a kit, undo the installer, or clean a machine of it.
 ---
 
@@ -25,26 +25,25 @@ a machine that never had AgentKit on it.
 
 ## Removing one kit
 
-Kit removal is not uniform, and the difference matters before you promise a user
-anything.
+`--without <kit>` removes that kit's AgentKit-managed artifacts on the same run.
 
-| Kit                                     | `install.sh --global --without <kit>`                                  |
-| --------------------------------------- | ---------------------------------------------------------------------- |
-| `adversarial-review`, `advisory-review` | Fully removed — skills, hooks, `settings.json` entries, tools, prompts |
-| `memory`, `product`                     | De-selected only; installed skills and hooks stay and keep updating    |
+| Kit                                     | `install.sh --global --without <kit>`                                    |
+| --------------------------------------- | ------------------------------------------------------------------------ |
+| `adversarial-review`, `advisory-review` | Removes managed instructions, skills, hooks, tools, prompts, and plugins |
+| `memory`, `product`                     | Removes managed skills, hooks, settings entries, prompts, and plugins    |
 
-The consent-gated kits are removed because presence without a recorded selection is
-not consent. An ordinary kit is deliberately left on disk: dropping it would take a
-skill away from somebody mid-use. So `--without memory` changes what a future
-install writes, not what is on the machine right now.
-
-To actually get an ordinary kit off a machine, uninstall and reinstall the set you
-want — the uninstall clears the remembered selection with everything else:
+The selected kit set is the active installed set. Keeping a deselected skill on disk
+would leave it discoverable and auto-triggerable, so presence without a recorded
+selection is not enough to keep any optional kit. `core` cannot be deselected.
 
 ```sh
-./install.sh --global --uninstall
-./install.sh --global --with product      # memory is gone, product is back
+./install.sh --global --without memory
+./install.sh --global --with memory       # select and install it again later
 ```
+
+The installer reconciles only artifacts it owns. It preserves unrelated skills,
+hooks, prompts and plugins, and reports a real user-owned skill directory rather
+than deleting it from a client integration.
 
 ## What `--uninstall` removes
 

--- a/skills/uninstall/SKILL.md
+++ b/skills/uninstall/SKILL.md
@@ -3,8 +3,8 @@ name: uninstall
 description: >-
   Remove AgentKit, or one of its skill kits, without hand-deleting files. Covers
   `install.sh --uninstall` for a global or project install, what it reverts inside
-  configs the user owns, what it deliberately leaves alone, and how kit removal
-  differs between opt-in and consent-gated kits. Use when asked to uninstall
+  configs the user owns, what it deliberately leaves alone, and how deselecting
+  one optional kit removes its managed artifacts. Use when asked to uninstall
   AgentKit, remove a kit, undo the installer, or clean a machine of it.
 ---
 
@@ -25,26 +25,25 @@ a machine that never had AgentKit on it.
 
 ## Removing one kit
 
-Kit removal is not uniform, and the difference matters before you promise a user
-anything.
+`--without <kit>` removes that kit's AgentKit-managed artifacts on the same run.
 
-| Kit                                     | `install.sh --global --without <kit>`                                  |
-| --------------------------------------- | ---------------------------------------------------------------------- |
-| `adversarial-review`, `advisory-review` | Fully removed — skills, hooks, `settings.json` entries, tools, prompts |
-| `memory`, `product`                     | De-selected only; installed skills and hooks stay and keep updating    |
+| Kit                                     | `install.sh --global --without <kit>`                                    |
+| --------------------------------------- | ------------------------------------------------------------------------ |
+| `adversarial-review`, `advisory-review` | Removes managed instructions, skills, hooks, tools, prompts, and plugins |
+| `memory`, `product`                     | Removes managed skills, hooks, settings entries, prompts, and plugins    |
 
-The consent-gated kits are removed because presence without a recorded selection is
-not consent. An ordinary kit is deliberately left on disk: dropping it would take a
-skill away from somebody mid-use. So `--without memory` changes what a future
-install writes, not what is on the machine right now.
-
-To actually get an ordinary kit off a machine, uninstall and reinstall the set you
-want — the uninstall clears the remembered selection with everything else:
+The selected kit set is the active installed set. Keeping a deselected skill on disk
+would leave it discoverable and auto-triggerable, so presence without a recorded
+selection is not enough to keep any optional kit. `core` cannot be deselected.
 
 ```sh
-./install.sh --global --uninstall
-./install.sh --global --with product      # memory is gone, product is back
+./install.sh --global --without memory
+./install.sh --global --with memory       # select and install it again later
 ```
+
+The installer reconciles only artifacts it owns. It preserves unrelated skills,
+hooks, prompts and plugins, and reports a real user-owned skill directory rather
+than deleting it from a client integration.
 
 ## What `--uninstall` removes
 

--- a/tests/install-claude-plugin.test.ts
+++ b/tests/install-claude-plugin.test.ts
@@ -103,7 +103,9 @@ const kitPluginState = (ids: string[]) =>
   JSON.stringify(ids.map((id) => ({ id, scope: 'user', enabled: true })));
 
 function runKitPluginInstall(selectedKits: string, productAlreadyInstalled = false) {
-  const ids = ['agentkit@agentkit', 'agentkit-product@agentkit'];
+  const ids = selectedKits.includes('product')
+    ? ['agentkit@agentkit', 'agentkit-product@agentkit']
+    : ['agentkit@agentkit'];
   return runPluginInstall(
     false,
     false,
@@ -205,13 +207,23 @@ describe('Claude plugin install lifecycle', () => {
     expect(calls).toContain('plugin install agentkit-product@agentkit');
   });
 
-  test('updates an installed kit plugin the current flags did not select', () => {
-    const { calls, result } = runKitPluginInstall('core', true);
+  test('uninstalls an installed kit plugin the current flags did not select', () => {
+    const { calls, result } = runPluginInstall(
+      false,
+      false,
+      0,
+      kitPluginState(['agentkit@agentkit', 'third-party@elsewhere']),
+      0,
+      'core',
+      kitPluginState(['agentkit-product@agentkit', 'third-party@elsewhere']),
+    );
     expect(result.status, result.stderr).toBe(0);
-    // Same promise as a retained skill: an upgrade must not abandon what the
-    // user already has installed.
-    expect(calls).toContain('plugin update agentkit-product@agentkit');
+    expect(calls).toContain('plugin uninstall agentkit-product@agentkit');
+    expect(calls).not.toContain('plugin update agentkit-product@agentkit');
     expect(calls).not.toContain('plugin install agentkit-product@agentkit');
+    expect(calls.filter((call) => call.startsWith('plugin uninstall'))).toEqual([
+      'plugin uninstall agentkit-product@agentkit',
+    ]);
   });
 
   // The plugin id is the one artifact named after a kit, so renaming a kit strands

--- a/tests/install-hooks.test.ts
+++ b/tests/install-hooks.test.ts
@@ -225,7 +225,7 @@ describe('Claude Code and Codex hook wiring', () => {
     }
   }, globalInstallTimeoutMs);
 
-  test('deselecting the memory kit keeps installed brain hooks and their wiring', () => {
+  test('deselecting the memory kit removes installed brain hooks and their wiring', () => {
     const home = mkdtempSync(join(tmpdir(), 'agentkit-hooks-'));
     const claudeDir = join(home, '.claude');
 
@@ -235,17 +235,13 @@ describe('Claude Code and Codex hook wiring', () => {
       result = runGlobalInstall(home, {}, ['--without', 'memory']);
       expect(result.status, result.stderr.toString()).toBe(0);
 
-      // Mirrors install_skills: dropping a non-explicit kit stops future
-      // installs, but never takes an installed hook — or its settings entry,
-      // which would otherwise go stale against the still-present script —
-      // away from someone using it.
       const settings = installedSettings(claudeDir);
-      expect(commandNames(settings.hooks.PostToolUse[0].hooks)).toContain('brain-index.sh');
+      expect(commandNames(settings.hooks.PostToolUse[0].hooks)).not.toContain('brain-index.sh');
       expect(
         settings.hooks.SessionStart.flatMap((kit: any) => commandNames(kit.hooks)),
-      ).toContain('brain-inject.sh');
+      ).not.toContain('brain-inject.sh');
       for (const name of ['brain-inject.sh', 'brain-index.sh']) {
-        expect(existsSync(join(claudeDir, 'hooks', name)), name).toBe(true);
+        expect(existsSync(join(claudeDir, 'hooks', name)), name).toBe(false);
       }
     } finally {
       rmSync(home, { force: true, recursive: true });

--- a/tests/install/skill-kits.test.ts
+++ b/tests/install/skill-kits.test.ts
@@ -96,12 +96,13 @@ describe('skill kit selection', () => {
     }
   }, globalInstallTimeoutMs);
 
-  test('an upgrade keeps and refreshes an already-installed product skill', () => {
+  test('an upgrade removes a product skill that is no longer selected', () => {
     const home = mkdtempSync(join(tmpdir(), 'agentkit-kits-'));
 
     try {
-      // Someone who installed before the split has these; taking them away on
-      // upgrade — or leaving them frozen at the old content — is a regression.
+      // Someone who installed before kit selection has this without a recorded
+      // opt-in. Presence is not a selection: leaving it discoverable keeps the
+      // optional workflow active.
       const installed = canonSkill(home, 'product-review');
       mkdirSync(installed, { recursive: true });
       writeFileSync(join(installed, 'SKILL.md'), '# stale\n');
@@ -109,13 +110,10 @@ describe('skill kit selection', () => {
       const result = install(home);
       expect(result.status, result.stderr).toBe(0);
 
-      expect(readFileSync(join(installed, 'SKILL.md'), 'utf-8')).toBe(
-        readFileSync(join(repoRoot, 'skills', 'product-review', 'SKILL.md'), 'utf-8'),
-      );
+      expect(existsSync(installed)).toBe(false);
       expect(result.stdout).toContain(
-        "[skills] Keeping installed (kit 'product' not selected): product-review",
+        "[skills] Removing (kit 'product' not selected): product-review",
       );
-      // Retention is per-skill: the one that was never installed stays out.
       expect(existsSync(canonSkill(home, 'product-intelligence'))).toBe(false);
     } finally {
       rmSync(home, { force: true, recursive: true });
@@ -304,18 +302,22 @@ describe('skill kit selection', () => {
     }
   }, globalInstallTimeoutMs * 2);
 
-  test('dropping a kit from the persisted file stops selecting it', () => {
+  test('dropping kits from the persisted file removes their managed artifacts', () => {
     const home = mkdtempSync(join(tmpdir(), 'agentkit-kits-'));
 
     try {
-      expect(install(home, ['--with', 'product']).status).toBe(0);
+      expect(install(home, ['--with', 'product', '--with', 'memory']).status).toBe(0);
       writeFileSync(join(home, '.agentkit', 'kits'), '');
 
       const upgrade = install(home);
       expect(upgrade.status, upgrade.stderr).toBe(0);
       expect(upgrade.stdout).toContain('Skill kits:    core\n');
-      expect(upgrade.stdout).toContain(
-        "[skills] Keeping installed (kit 'product' not selected): product-review",
+      expect(existsSync(canonSkill(home, 'product-review'))).toBe(false);
+      expect(existsSync(canonSkill(home, 'reflect'))).toBe(false);
+      expect(existsSync(join(home, '.codex', 'prompts', 'product-review.md'))).toBe(false);
+      expect(existsSync(join(home, '.claude', 'hooks', 'brain-inject.sh'))).toBe(false);
+      expect(readFileSync(join(home, '.claude', 'settings.json'), 'utf-8')).not.toContain(
+        'brain-inject.sh',
       );
     } finally {
       rmSync(home, { force: true, recursive: true });
@@ -383,20 +385,30 @@ describe('skill kit selection', () => {
 
     try {
       expect(install(home, ['--with', 'product']).status).toBe(0);
+      const userSkill = join(home, '.claude', 'skills', 'user-owned');
+      mkdirSync(userSkill, { recursive: true });
+      writeFileSync(join(userSkill, 'SKILL.md'), '# user owned\n');
 
       const dropped = install(home, ['--without', 'product']);
       expect(dropped.status, dropped.stderr).toBe(0);
       expect(dropped.stdout).toContain('Skill kits:    core\n');
       expect(readFileSync(join(home, '.agentkit', 'kits'), 'utf-8')).not.toContain('product');
 
-      // Deselection changes what is chosen, never what is on disk: the
-      // installer removes nothing it previously installed.
       expect(dropped.stdout).toContain(
-        "[skills] Keeping installed (kit 'product' not selected): product-review",
+        "[skills] Removing (kit 'product' not selected): product-review",
       );
+      expect(existsSync(canonSkill(home, 'product-review'))).toBe(false);
+      expect(existsSync(join(home, '.claude', 'skills', 'product-review'))).toBe(false);
+      expect(existsSync(join(home, '.codex', 'prompts', 'product-review.md'))).toBe(false);
+      expect(existsSync(join(canonSkill(home, 'code-quality'), 'SKILL.md'))).toBe(true);
+      expect(readFileSync(join(userSkill, 'SKILL.md'), 'utf-8')).toBe('# user owned\n');
       // It sticks: the next bare upgrade does not resurrect it.
       const after = install(home);
       expect(after.stdout).toContain('Skill kits:    core\n');
+      expect(existsSync(canonSkill(home, 'product-review'))).toBe(false);
+      expect(readFileSync(join(home, '.agentkit', 'kits'), 'utf-8')).toContain(
+        'removes that kit on the next install',
+      );
     } finally {
       rmSync(home, { force: true, recursive: true });
     }


### PR DESCRIPTION
Refs #332

## Why

The persisted kit selection must be the active installed set. Retaining deselected product, memory, or review artifacts leaves their workflows discoverable and auto-triggerable.

## What changed

- remove deselected AgentKit-managed skills and Codex prompts
- remove deselected Claude hooks plus their settings wiring
- uninstall deselected AgentKit Claude plugins while preserving unrelated plugins
- document uniform optional-kit lifecycle semantics
- keep real user-owned client skill directories untouched and warn instead

## Verification

- installer slice: 161 passed, 0 failed
- docs slice: 133 passed, 0 failed
- test routing: 96 test files and 676 production surfaces covered
- `bash -n install.sh`
- generated plugin mirrors and documentation facts validated
- dprint and `git diff --check` clean

The PR workflow owns the authoritative pinned Moon selection. Because `install.sh` is a configured critical input, CI may deliberately escalate this change to `agentkit:test-full`.