### PR TITLE
chore: cut v0.7.13 — optional kit cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ release PR — "publish this" authorizes a release, never the tier.
 
 ## [Unreleased]
 
+## v0.7.13 — 2026-08-09
+
+- fix(installer): **the remembered kit selection is now the active installed set.** Deselecting
+  `product`, `memory`, or either review kit removes its AgentKit-managed skills, hooks, settings
+  wiring, prompts, tools, and Claude plugin instead of leaving the optional workflow discoverable
+  indefinitely. Canonical AgentKit artifacts are reconciled exactly; unrelated user-owned client
+  skill directories and third-party plugins remain untouched.
+
 ## v0.7.12 — 2026-08-06
 
 - feat(taste): **a rule declares a kind agentkit implements, and parameterises it** (#328). The


### PR DESCRIPTION
Refs #332

Patch release for #333: deselected optional kits now remove their AgentKit-managed artifacts while preserving unrelated user-owned skills and third-party plugins.

The release tier is patch, following the repository and owner rule for fixes. The preceding release is `v0.7.12`, so `v0.7.13` is the strict successor.