### PR TITLE
ci: select self-hosted macOS by capability, not by machine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,9 @@ jobs:
             echo 'fork pull request: hosted macOS only'
           elif online=$(gh api "repos/$GITHUB_REPOSITORY/actions/runners?per_page=100" \
               --jq '[.runners[] | select(.status=="online" and .busy==false)
-                     | select((["self-hosted","macOS","ARM64","rentamac"] - [.labels[].name]) | length == 0)] | length') \
+                     | select((["self-hosted","macOS","ARM64"] - [.labels[].name]) | length == 0)] | length') \
             && [ "${online:-0}" -gt 0 ]; then
-            mac='["self-hosted","macOS","ARM64","rentamac"]'
+            mac='["self-hosted","macOS","ARM64"]'
             echo "self-hosted macOS available ($online idle)"
           else
             echo 'no idle self-hosted macOS runner: falling back to hosted'


### PR DESCRIPTION
Closes #336.

The rented Mac mini is gone and its two runner registrations are deleted. `pick-runners` selected on a `rentamac` label, tying CI to one machine; the remaining MacBook runners carry that label only as a leftover.

Now matches `self-hosted` + `macOS` + `ARM64` — any self-hosted Mac qualifies. Hosted `macos-15` fallback and the fork guard are unchanged.

Verified against the live runner list before committing:

| Selector | Matches |
| --- | --- |
| with `rentamac` (old) | 2 |
| without `rentamac` (new) | 2 |
| with a label no runner carries (control) | 0 |

The control matters — it shows the selector still discriminates rather than admitting everything.