### PR TITLE
fix(pages): unbreak the account dashboard, and rebuild it

### DIFF
--- a/pages/worker/src/dashboard.js
+++ b/pages/worker/src/dashboard.js
@@ -1,5 +1,83 @@
 import { deviceTokensForUser, invitesForUserPages, pagesForUser } from "./accounts.js";
-import { escapeHtml } from "./ui.js";
+import { escapeHtml, MARK, shell } from "./ui.js";
+
+function day(seconds) {
+  return new Date(seconds * 1000).toISOString().slice(0, 10);
+}
+
+function shareRow(page) {
+  const on = Boolean(page.share_token_hash);
+  const slug = escapeHtml(page.slug);
+  return `<div class="row">
+    <span class="grant">${on ? "Anyone with the link" : "Link sharing is off"}
+      <span class="how">${on ? "no sign-in needed" : "only invited people can open it"}</span></span>
+    <form method="post" action="/api/pages/${slug}/share">
+      <input type="hidden" name="enabled" value="${on ? "false" : "true"}">
+      <button class="${on ? "quiet" : ""}">${on ? "Turn off" : "Create a link"}</button>
+    </form>
+  </div>`;
+}
+
+function inviteRow(slug, email) {
+  return `<div class="row">
+    <span class="grant">Access: ${escapeHtml(email)}
+      <span class="how">signs in to open it</span></span>
+    <form method="post" action="/api/pages/${escapeHtml(slug)}/invites/remove">
+      <input type="hidden" name="email" value="${escapeHtml(email)}">
+      <button class="quiet">Remove</button>
+    </form>
+  </div>`;
+}
+
+function pageCard(env, page, invites) {
+  const slug = escapeHtml(page.slug);
+  const open = `/access?return_to=${encodeURIComponent(`${env.PAGES_URL}/${page.slug}`)}`;
+  const shared = Boolean(page.share_token_hash);
+  return `<article class="card">
+    <div class="card-head">
+      <h2><a href="${open}">${escapeHtml(page.title || page.slug)}</a></h2>
+      <span class="pill${shared ? " on" : ""}">${shared ? "Shared by link" : "Private"}</span>
+    </div>
+    <p class="meta"><code>${slug}</code> &middot; updated ${day(page.updated_at)}</p>
+    <div class="ledger">
+      <div class="row">
+        <span class="grant">You <span class="how">owner</span></span>
+      </div>
+      ${invites.map((invite) => inviteRow(page.slug, invite.email)).join("")}
+      ${shareRow(page)}
+    </div>
+    <form class="invite" method="post" action="/api/pages/${slug}/invites">
+      <input type="email" name="email" required placeholder="name@example.com"
+        aria-label="Give someone access to ${slug} by email">
+      <button class="primary">Give access</button>
+    </form>
+  </article>`;
+}
+
+function deviceCard(device) {
+  const used = device.last_used_at ? `last used ${day(device.last_used_at)}` : "never used";
+  return `<article class="card">
+    <div class="card-head">
+      <h2>${escapeHtml(device.name)}</h2>
+      <span class="pill">${used}</span>
+    </div>
+    <p class="meta"><code>${escapeHtml(device.scopes)}</code> &middot; expires ${day(device.expires_at)}</p>
+    <div class="ledger">
+      <div class="row">
+        <span class="grant">Can publish to your account
+          <span class="how">until you revoke it</span></span>
+        <form method="post" action="/api/devices/${escapeHtml(device.token_hash)}/revoke">
+          <button class="quiet">Revoke</button>
+        </form>
+      </div>
+    </div>
+  </article>`;
+}
+
+function section(title, count, cards, blank) {
+  return `<h2 class="label">${title}<span class="count">${count}</span></h2>
+    ${cards || `<div class="blank">${blank}</div>`}`;
+}
 
 export async function dashboard(env, user) {
   const [pages, invites, devices] = await Promise.all([
@@ -7,39 +85,30 @@ export async function dashboard(env, user) {
     invitesForUserPages(env, user.id),
     deviceTokensForUser(env, user.id),
   ]);
-  const invitesByPage = Map.groupBy(invites, (invite) => invite.page_slug);
-  const cards = pages.map((page) => `
-    <article>
-      <h2><a href="/access?return_to=${encodeURIComponent(`${env.PAGES_URL}/${page.slug}`)}">${escapeHtml(page.title || page.slug)}</a></h2>
-      <p><code>${escapeHtml(page.slug)}</code> · private${page.share_token_hash ? " · sharing on" : ""}</p>
-      ${(invitesByPage.get(page.slug) || []).map((invite) =>
-        `<p>Access: ${escapeHtml(invite.email)}</p>`).join("")}
-      <form method="post" action="/api/pages/${escapeHtml(page.slug)}/share">
-        <input type="hidden" name="enabled" value="${page.share_token_hash ? "false" : "true"}">
-        <button>${page.share_token_hash ? "Turn sharing off" : "Create sharing link"}</button>
-      </form>
-      <form method="post" action="/api/pages/${escapeHtml(page.slug)}/invites">
-        <label>Invite by Assay email <input type="email" name="email" required></label>
-        <button>Invite</button>
-      </form>
-      <form method="post" action="/api/pages/${escapeHtml(page.slug)}/invites/remove">
-        <label>Remove email access <input type="email" name="email" required></label>
-        <button>Remove</button>
-      </form>
-    </article>`).join("");
-  const deviceCards = devices.map((device) => `
-    <li><strong>${escapeHtml(device.name)}</strong>${device.last_used_at ? " · active" : " · unused"}
-      · ${escapeHtml(device.scopes)} · expires ${escapeHtml(new Date(device.expires_at * 1000).toISOString().slice(0, 10))}
-      <form method="post" action="/api/devices/${escapeHtml(device.token_hash)}/revoke">
-        <button>Revoke</button>
-      </form>
-    </li>`).join("");
-  return `<!doctype html><meta charset="utf-8"><meta name="viewport" content="width=device-width">
-<title>AgentKit Pages</title><style>
-body{font:16px system-ui;max-width:58rem;margin:3rem auto;padding:0 1rem;background:#fafafa;color:#18181b}
-header{display:flex;justify-content:space-between;align-items:center}article{background:white;padding:1.25rem;margin:1rem 0;border:1px solid #ddd;border-radius:12px}
-form{display:inline-flex;gap:.5rem;margin:.5rem .5rem 0 0}button,input{font:inherit;padding:.5rem}a{color:#4338ca}
-</style><header><div><h1>Your pages</h1><p>Signed in as ${escapeHtml(user.email)}</p></div><form method="post" action="/logout"><button>Sign out</button></form></header>
-${cards || "<p>You have not published a page yet.</p>"}
-<section><h2>Publishing devices</h2><ul>${deviceCards || "<li>No publishing devices.</li>"}</ul></section>`;
+  const byPage = Map.groupBy(invites, (invite) => invite.page_slug);
+  const body = `<header class="top">
+      <span class="brand" style="color:var(--accent)">${MARK}<b style="color:var(--text)">agentkit pages</b></span>
+      <span class="who">Signed in as <span class="mono">${escapeHtml(user.email)}</span>
+        <form method="post" action="/logout" style="display:inline-flex;margin-left:.6rem">
+          <button>Sign out</button></form></span>
+    </header>
+    ${
+    section(
+      "Pages",
+      pages.length,
+      pages.map((page) => pageCard(env, page, byPage.get(page.slug) || [])).join(""),
+      `<p>Nothing published yet.</p><p class="note">Your agent publishes one for you.</p>
+       <code>PUT /api/pages/&lt;slug&gt;</code>`,
+    )
+  }
+    ${
+    section(
+      "Publishing devices",
+      devices.length,
+      devices.map(deviceCard).join(""),
+      `<p>No device can publish to this account.</p>
+       <p class="note">Connect one at <code>/device</code>.</p>`,
+    )
+  }`;
+  return shell("AgentKit Pages", body);
 }

--- a/pages/worker/src/ui.js
+++ b/pages/worker/src/ui.js
@@ -1,7 +1,12 @@
+// `no-referrer` is not available here, however much the account UI would like
+// it: a browser serialises the Origin of a form POST to the string `null`
+// under that policy, so the same-origin check rejects every control on the
+// page. `same-origin` still sends no referrer off-site, and an attacker's
+// cross-origin POST still arrives with an origin that is not ours.
 export const UI_HEADERS = {
   "content-type": "text/html; charset=utf-8",
   "x-content-type-options": "nosniff",
-  "referrer-policy": "no-referrer",
+  "referrer-policy": "same-origin",
   "content-security-policy":
     "default-src 'none'; style-src 'unsafe-inline'; frame-ancestors 'none'; form-action 'self'; base-uri 'none'",
 };

--- a/pages/worker/src/ui.js
+++ b/pages/worker/src/ui.js
@@ -15,3 +15,134 @@ export function escapeHtml(value) {
     "'": "&#39;",
   })[character]);
 }
+
+// The serving CSP is `default-src 'none'` with only inline style allowed, so
+// this interface has no script, no webfont and no image. Machine values carry
+// the identity instead: every slug, scope, token and date is set in the
+// monospace face, which is also the vernacular of the tool that publishes them.
+const STYLES = `
+:root { color-scheme: dark light; --radius: 10px; --ink: rgb(11, 12, 14); --surface: rgb(20, 22, 25); --raised: rgb(27, 30, 35); --line: rgb(36, 39, 44); --line-soft: rgb(28, 31, 36); --text: rgb(232, 234, 237); --muted: rgb(150, 156, 165); --accent: rgb(245, 167, 66); --accent-ink: rgb(8, 9, 10); --accent-quiet: rgba(245, 167, 66, 0.13); --danger: rgb(239, 139, 122); }
+@media (prefers-color-scheme: light) {
+  :root { --ink: rgb(251, 250, 248); --surface: rgb(255, 255, 255); --raised: rgb(246, 246, 244); --line: rgb(226, 226, 223); --line-soft: rgb(238, 238, 236); --text: rgb(25, 26, 28); --muted: rgb(99, 103, 110); --accent: rgb(154, 92, 7); --accent-ink: rgb(255, 255, 255); --accent-quiet: rgba(154, 92, 7, 0.08); --danger: rgb(163, 52, 28); }
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0; padding: 2.5rem 1.25rem 5rem;
+  background: var(--ink); color: var(--text);
+  font: 15px/1.55 system-ui, -apple-system, "Segoe UI", sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+.wrap { max-width: 54rem; margin: 0 auto; }
+code, .mono, input {
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+}
+
+.top {
+  display: flex; flex-wrap: wrap; gap: 1rem;
+  align-items: center; justify-content: space-between;
+  padding-bottom: 1.25rem; border-bottom: 1px solid var(--line);
+}
+.brand { display: flex; align-items: center; gap: .6rem; }
+.brand svg { display: block; }
+.brand b { font-weight: 600; letter-spacing: -0.01em; font-size: 1rem; }
+.who { color: var(--muted); font-size: .8125rem; }
+.who .mono { color: var(--text); }
+
+/* The chevron marks a section the way a prompt marks a line: it is the one
+   motif carried from the agentkit mark, so nothing else needs decoration. */
+.label {
+  display: flex; align-items: baseline; gap: .5rem;
+  margin: 2.25rem 0 .75rem;
+  font-size: .6875rem; font-weight: 600;
+  text-transform: uppercase; letter-spacing: .14em; color: var(--muted);
+}
+.label::before { content: "\\203A"; color: var(--accent); font-size: .9rem; line-height: 1; }
+.label .count {
+  margin-left: auto; letter-spacing: 0; text-transform: none;
+  font-weight: 400; color: var(--muted);
+}
+
+.card {
+  background: var(--surface); border: 1px solid var(--line);
+  border-radius: var(--radius); padding: 1.1rem 1.15rem; margin-bottom: .85rem;
+}
+.card-head {
+  display: flex; flex-wrap: wrap; gap: .35rem .75rem;
+  align-items: baseline; justify-content: space-between;
+}
+.card-head h2 { margin: 0; font-size: 1.0625rem; font-weight: 600; letter-spacing: -0.01em; }
+.card-head h2 a { color: inherit; text-decoration: none; }
+.card-head h2 a:hover { text-decoration: underline; text-underline-offset: 3px; }
+.meta { margin: .3rem 0 0; font-size: .8125rem; color: var(--muted); }
+.meta .mono { color: var(--muted); }
+
+.pill {
+  font-size: .6875rem; font-weight: 600; letter-spacing: .04em;
+  padding: .2rem .45rem; border-radius: 5px;
+  border: 1px solid var(--line); color: var(--muted); white-space: nowrap;
+}
+.pill.on { color: var(--accent); border-color: var(--accent); background: var(--accent-quiet); }
+
+/* The access ledger: one row per way in. It answers the only question that
+   matters on this screen — who can open this page right now. */
+.ledger { margin-top: .9rem; border-top: 1px solid var(--line-soft); }
+.row {
+  display: flex; flex-wrap: wrap; gap: .5rem .75rem; align-items: center;
+  padding: .6rem 0; border-bottom: 1px solid var(--line-soft);
+}
+.row .grant { flex: 1 1 14rem; min-width: 0; font-size: .875rem; overflow-wrap: anywhere; }
+.row .how { color: var(--muted); font-size: .75rem; }
+.empty { padding: .75rem 0; color: var(--muted); font-size: .8125rem; }
+
+.row form { display: inline-flex; gap: .5rem; }
+.invite { display: flex; gap: .5rem; flex-wrap: wrap; padding: .7rem 0 0; }
+.invite input {
+  flex: 1 1 13rem; min-width: 0;
+  background: var(--raised); color: var(--text);
+  border: 1px solid var(--line); border-radius: 7px;
+  padding: .45rem .6rem; font-size: .8125rem;
+}
+.invite input::placeholder { color: var(--muted); }
+.invite input:focus-visible, a:focus-visible, button:focus-visible {
+  outline: 2px solid var(--accent); outline-offset: 2px;
+}
+
+button {
+  font: inherit; font-size: .8125rem; font-weight: 500;
+  padding: .45rem .7rem; border-radius: 7px; cursor: pointer;
+  background: var(--raised); color: var(--text); border: 1px solid var(--line);
+}
+button:hover { border-color: var(--muted); }
+button.primary { background: var(--accent); color: var(--accent-ink); border-color: var(--accent); }
+button.primary:hover { filter: brightness(1.08); }
+button.quiet { background: none; color: var(--muted); border-color: transparent; padding: .45rem .5rem; }
+button.quiet:hover { color: var(--danger); border-color: var(--line); }
+
+.blank {
+  border: 1px dashed var(--line); border-radius: var(--radius);
+  padding: 1.75rem 1.25rem; text-align: center; color: var(--muted);
+}
+.blank p { margin: 0 0 .5rem; }
+.blank code {
+  display: inline-block; margin-top: .25rem; font-size: .8125rem;
+  background: var(--surface); border: 1px solid var(--line);
+  border-radius: 6px; padding: .3rem .5rem; color: var(--text);
+}
+a { color: var(--accent); }
+.link-out { display: block; margin-top: .9rem; font-size: .875rem; overflow-wrap: anywhere; }
+.note { color: var(--muted); font-size: .8125rem; }
+@media (prefers-reduced-motion: reduce) { * { transition: none !important; } }
+`;
+
+// The chevron and cursor bar from the agentkit mark, inline because the CSP
+// forbids loading an image at all.
+export const MARK = `<svg width="20" height="20" viewBox="0 0 32 32" role="img" aria-label="agentkit">
+<path d="M6 9 L12 16 L6 23" fill="none" stroke="currentColor" stroke-width="3.4" stroke-linecap="round" stroke-linejoin="round"/>
+<rect x="16" y="19.5" width="10" height="3.5" rx="1.75" fill="currentColor"/></svg>`;
+
+export function shell(title, body) {
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${escapeHtml(title)}</title><style>${STYLES}</style></head>
+<body><div class="wrap">${body}</div></body></html>`;
+}

--- a/pages/worker/src/worker.js
+++ b/pages/worker/src/worker.js
@@ -17,7 +17,7 @@ import {
 import { dashboard } from "./dashboard.js";
 import { approveDevice, devicePage, pollDevice, startDevice } from "./devices.js";
 import { completeLogin, startLogin } from "./oidc.js";
-import { escapeHtml, UI_HEADERS } from "./ui.js";
+import { escapeHtml, shell, UI_HEADERS } from "./ui.js";
 
 const SLUG_RE = /^[a-z0-9][a-z0-9-]{0,63}(\/[a-z0-9][a-z0-9-]{0,63}){0,3}$/;
 const MAX_PAGE_BYTES = 5 * 1024 * 1024;
@@ -326,10 +326,13 @@ async function handleShare(request, env, slug) {
   if (!request.headers.get("content-type")?.startsWith("application/json")) {
     if (token) {
       const url = `${env.PAGES_URL}/${slug}?share=${token}`;
-      return html(200, `<!doctype html><meta charset="utf-8"><title>Sharing link</title>
-<body style="font:16px system-ui;max-width:42rem;margin:4rem auto;padding:1rem"><h1>Sharing is on</h1>
-<p>This link is shown once. Anyone who has it can read this page until you turn sharing off.</p>
-<p><a href="${escapeHtml(url)}">${escapeHtml(url)}</a></p><p><a href="/dashboard">Back to dashboard</a></p></body>`, UI_HEADERS);
+      return html(200, shell("Sharing link", `<h2 class="label">Sharing link</h2>
+<article class="card"><div class="card-head"><h2>Copy this now</h2>
+<span class="pill on">Shown once</span></div>
+<p class="meta">Anyone with this link can read <code>${escapeHtml(slug)}</code> without signing in,
+until you turn sharing off.</p>
+<a class="link-out mono" href="${escapeHtml(url)}">${escapeHtml(url)}</a></article>
+<p class="note"><a href="/dashboard">Back to your pages</a></p>`), UI_HEADERS);
     }
     return new Response(null, { status: 303, headers: { location: "/dashboard" } });
   }

--- a/tests/publish-page/accounts.test.ts
+++ b/tests/publish-page/accounts.test.ts
@@ -617,9 +617,31 @@ describe('private access and sharing', () => {
     const response = await worker.fetch(signedIn(`${ACCOUNT_URL}/dashboard`), setup.env);
 
     expect(response.headers.get('content-security-policy')).toContain("form-action 'self'");
+    // Under `no-referrer` a browser sends `Origin: null` on a same-origin form
+    // POST, which the check below then rejects — every control 403s in a real
+    // browser while every test that sets the header by hand still passes.
+    expect(response.headers.get('referrer-policy')).toBe('same-origin');
     const body = await response.text();
     expect(body).toContain('/api/pages/private-page/invites/remove');
     expect(body).toContain('value="other@example.com"');
+  });
+
+  test('an opaque origin cannot drive a dashboard control', async () => {
+    const setup = await accountEnv();
+    expect((await worker.fetch(publish('device-a'), setup.env)).status).toBe(200);
+    const response = await worker.fetch(
+      new Request(`${ACCOUNT_URL}/api/pages/private-page/share`, {
+        method: 'POST',
+        headers: {
+          cookie: 'agentkit_session=session-a',
+          origin: 'null',
+          'content-type': 'application/x-www-form-urlencoded',
+        },
+        body: new URLSearchParams({ enabled: 'true' }),
+      }),
+      setup.env,
+    );
+    expect(response.status).toBe(403);
   });
 
   test('the dashboard share form displays the new one-time link', async () => {

--- a/tests/publish-page/accounts.test.ts
+++ b/tests/publish-page/accounts.test.ts
@@ -611,10 +611,15 @@ describe('private access and sharing', () => {
   test('dashboard controls can submit only to the same origin', async () => {
     const setup = await accountEnv();
     expect((await worker.fetch(publish('device-a'), setup.env)).status).toBe(200);
+    // Revoke renders per granted email: with no grants there is nothing to revoke.
+    const grant = accountPost(`${ACCOUNT_URL}/api/pages/private-page/invites`, { email: 'other@example.com' });
+    expect((await worker.fetch(grant, setup.env)).status).toBe(200);
     const response = await worker.fetch(signedIn(`${ACCOUNT_URL}/dashboard`), setup.env);
 
     expect(response.headers.get('content-security-policy')).toContain("form-action 'self'");
-    expect(await response.text()).toContain('/api/pages/private-page/invites/remove');
+    const body = await response.text();
+    expect(body).toContain('/api/pages/private-page/invites/remove');
+    expect(body).toContain('value="other@example.com"');
   });
 
   test('the dashboard share form displays the new one-time link', async () => {


### PR DESCRIPTION
## The bug

Every POST control in the account UI returned **403 forbidden** in a real browser — approving a publishing device, creating a sharing link, inviting someone, revoking a device, signing out.

`Referrer-Policy: no-referrer` makes a browser serialise the Origin of a same-origin form POST to the string `null`, which the same-origin CSRF check then rejects. Measured in headless Chromium:

| Referrer-Policy | Origin sent on same-origin form POST |
| --- | --- |
| `no-referrer` | `null` |
| `same-origin` | `http://127.0.0.1:8781` |

Every test set the Origin header by hand, so none of them could see it. `same-origin` still sends no referrer off-site, and a cross-origin attacker still arrives with an origin that is not ours.

## The redesign

The dashboard is rebuilt around an access ledger: each page states who can open it, one row per grant, with the revoke control attached to the grant it revokes instead of a free-text email box. Adds a shared shell (the share-link page was unstyled), dark/light themes, and a mobile layout. No script and no images — the serving CSP allows neither.

## Verified

- 298/298 publish-page tests pass
- Rendered and screenshotted in dark, light and at 390 px
- Regression guards: the referrer policy is asserted, and an opaque `null` origin is asserted to stay rejected