### PR TITLE
fix(pages): show each page's address, reveal the sharing link in place

### DIFF
--- a/pages/worker/src/dashboard.js
+++ b/pages/worker/src/dashboard.js
@@ -29,17 +29,29 @@ function inviteRow(slug, email) {
   </div>`;
 }
 
-function pageCard(env, page, invites) {
+function revealRow(url) {
+  return `<div class="row reveal">
+    <span class="grant"><strong>Your sharing link</strong>
+      <span class="how">shown once — copy it now</span>
+      <a class="link-out mono" href="${escapeHtml(url)}">${escapeHtml(url)}</a></span>
+  </div>`;
+}
+
+function pageCard(env, page, invites, flash) {
   const slug = escapeHtml(page.slug);
-  const open = `/access?return_to=${encodeURIComponent(`${env.PAGES_URL}/${page.slug}`)}`;
+  const address = `${env.PAGES_URL}/${page.slug}`;
+  const open = `/access?return_to=${encodeURIComponent(address)}`;
   const shared = Boolean(page.share_token_hash);
   return `<article class="card">
     <div class="card-head">
       <h2><a href="${open}">${escapeHtml(page.title || page.slug)}</a></h2>
       <span class="pill${shared ? " on" : ""}">${shared ? "Shared by link" : "Private"}</span>
     </div>
-    <p class="meta"><code>${slug}</code> &middot; updated ${day(page.updated_at)}</p>
+    <p class="meta"><a class="mono addr" href="${escapeHtml(open)}">${
+    escapeHtml(address.replace(/^https:\/\//, ""))
+  }</a> &middot; updated ${day(page.updated_at)}</p>
     <div class="ledger">
+      ${flash ? revealRow(flash.url) : ""}
       <div class="row">
         <span class="grant">You <span class="how">owner</span></span>
       </div>
@@ -79,7 +91,7 @@ function section(title, count, cards, blank) {
     ${cards || `<div class="blank">${blank}</div>`}`;
 }
 
-export async function dashboard(env, user) {
+export async function dashboard(env, user, flash = null) {
   const [pages, invites, devices] = await Promise.all([
     pagesForUser(env, user.id),
     invitesForUserPages(env, user.id),
@@ -96,7 +108,9 @@ export async function dashboard(env, user) {
     section(
       "Pages",
       pages.length,
-      pages.map((page) => pageCard(env, page, byPage.get(page.slug) || [])).join(""),
+      pages.map((page) =>
+        pageCard(env, page, byPage.get(page.slug) || [], flash?.slug === page.slug ? flash : null)
+      ).join(""),
       `<p>Nothing published yet.</p><p class="note">Your agent publishes one for you.</p>
        <code>PUT /api/pages/&lt;slug&gt;</code>`,
     )

--- a/pages/worker/src/ui.js
+++ b/pages/worker/src/ui.js
@@ -77,9 +77,15 @@ code, .mono, input {
 }
 .card-head h2 { margin: 0; font-size: 1.0625rem; font-weight: 600; letter-spacing: -0.01em; }
 .card-head h2 a { color: inherit; text-decoration: none; }
-.card-head h2 a:hover { text-decoration: underline; text-underline-offset: 3px; }
+.card-head h2 a:hover { color: var(--accent); }
 .meta { margin: .3rem 0 0; font-size: .8125rem; color: var(--muted); }
-.meta .mono { color: var(--muted); }
+.meta .addr { color: var(--accent); text-decoration: none; overflow-wrap: anywhere; }
+.meta .addr:hover { text-decoration: underline; text-underline-offset: 3px; }
+
+/* The sharing link is minted once and never stored in the clear, so it is
+   handed back in place rather than on a page the reader has to come back from. */
+.row.reveal { background: var(--accent-quiet); border-radius: 8px; padding: .7rem .75rem; margin: .5rem 0; }
+.row.reveal .link-out { margin-top: .35rem; }
 
 .pill {
   font-size: .6875rem; font-weight: 600; letter-spacing: .04em;

--- a/pages/worker/src/worker.js
+++ b/pages/worker/src/worker.js
@@ -17,7 +17,7 @@ import {
 import { dashboard } from "./dashboard.js";
 import { approveDevice, devicePage, pollDevice, startDevice } from "./devices.js";
 import { completeLogin, startLogin } from "./oidc.js";
-import { escapeHtml, shell, UI_HEADERS } from "./ui.js";
+import { UI_HEADERS } from "./ui.js";
 
 const SLUG_RE = /^[a-z0-9][a-z0-9-]{0,63}(\/[a-z0-9][a-z0-9-]{0,63}){0,3}$/;
 const MAX_PAGE_BYTES = 5 * 1024 * 1024;
@@ -312,6 +312,28 @@ function sameOrigin(request) {
   return request.headers.get("origin") === new URL(request.url).origin;
 }
 
+const FLASH_COOKIE = "agentkit_share";
+
+function flashCookie(value, maxAge) {
+  return `${FLASH_COOKIE}=${encodeURIComponent(value)}; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=${maxAge}`;
+}
+
+// Reads the one-shot sharing link back out, so the dashboard can render it
+// once and the next request has nothing left to leak.
+function takeShareFlash(request, env) {
+  const raw = (request.headers.get("cookie") || "")
+    .split(";").map((part) => part.trim())
+    .find((part) => part.startsWith(`${FLASH_COOKIE}=`));
+  if (!raw) return null;
+  const value = decodeURIComponent(raw.slice(FLASH_COOKIE.length + 1));
+  const separator = value.indexOf("|");
+  if (separator < 1) return null;
+  const slug = value.slice(0, separator);
+  const token = value.slice(separator + 1);
+  if (!SLUG_RE.test(slug) || !token) return null;
+  return { slug, url: `${env.PAGES_URL}/${slug}?share=${token}` };
+}
+
 async function requestBody(request) {
   if (request.headers.get("content-type")?.startsWith("application/json")) return request.json();
   return Object.fromEntries(await request.formData());
@@ -324,17 +346,12 @@ async function handleShare(request, env, slug) {
   const enabled = body.enabled === true || body.enabled === "true";
   const token = await setShareLink(env, slug, enabled);
   if (!request.headers.get("content-type")?.startsWith("application/json")) {
-    if (token) {
-      const url = `${env.PAGES_URL}/${slug}?share=${token}`;
-      return html(200, shell("Sharing link", `<h2 class="label">Sharing link</h2>
-<article class="card"><div class="card-head"><h2>Copy this now</h2>
-<span class="pill on">Shown once</span></div>
-<p class="meta">Anyone with this link can read <code>${escapeHtml(slug)}</code> without signing in,
-until you turn sharing off.</p>
-<a class="link-out mono" href="${escapeHtml(url)}">${escapeHtml(url)}</a></article>
-<p class="note"><a href="/dashboard">Back to your pages</a></p>`), UI_HEADERS);
-    }
-    return new Response(null, { status: 303, headers: { location: "/dashboard" } });
+    // The link is handed back through a one-shot cookie rather than the URL:
+    // the dashboard can then show it in place, and the token stays out of the
+    // address bar, browser history and any referrer.
+    const headers = { location: "/dashboard" };
+    if (token) headers["set-cookie"] = flashCookie(`${slug}|${token}`, 120);
+    return new Response(null, { status: 303, headers });
   }
   const url = token ? `${env.PAGES_URL}/${slug}?share=${token}` : null;
   return Response.json({ ok: true, enabled, url });
@@ -531,7 +548,11 @@ async function handleAccountRequest(request, env, path) {
         headers: { location: "/login?return_to=%2Fdashboard" },
       });
     }
-    return html(200, await dashboard(env, user), UI_HEADERS);
+    const flash = takeShareFlash(request, env);
+    const headers = flash
+      ? { ...UI_HEADERS, "set-cookie": flashCookie("", 0) }
+      : UI_HEADERS;
+    return html(200, await dashboard(env, user, flash), headers);
   }
   if (request.method !== "GET" && request.method !== "HEAD") {
     return new Response("method not allowed\n", { status: 405 });

--- a/tests/publish-page/accounts.test.ts
+++ b/tests/publish-page/accounts.test.ts
@@ -660,8 +660,22 @@ describe('private access and sharing', () => {
       setup.env,
     );
 
-    expect(response.status).toBe(200);
-    expect(await response.text()).toContain('https://pages.agentkit.sbs/private-page?share=');
+    // The link comes back through a one-shot cookie and is rendered on the
+    // dashboard itself, so the token never reaches the address bar or history.
+    expect(response.status).toBe(303);
+    const flash = response.headers.get('set-cookie') ?? '';
+    expect(flash).toContain('agentkit_share=');
+    expect(flash).toContain('HttpOnly');
+
+    const dashboardResponse = await worker.fetch(
+      new Request(`${ACCOUNT_URL}/dashboard`, {
+        headers: { cookie: `agentkit_session=session-a; ${flash.split(';')[0]}` },
+      }),
+      setup.env,
+    );
+    expect(await dashboardResponse.text()).toContain('https://pages.agentkit.sbs/private-page?share=');
+    // Cleared on the way out, so a reload cannot show it a second time.
+    expect(dashboardResponse.headers.get('set-cookie')).toContain('Max-Age=0');
   });
 
   test('a cross-origin request cannot change sharing', async () => {


### PR DESCRIPTION
Two gaps found by using the dashboard rather than reading it.

**You could not see your pages.** The card title was the only way to open one, styled `color: inherit; text-decoration: none` — indistinguishable from plain text. And the address you would actually send someone was never displayed at all. Each card now shows its public address as a visible link.

**The sharing link took you off the page.** Creating one navigated to a separate confirmation page. It now renders inside the card, like every other tool. The CSP forbids JavaScript, so the token is handed back through a one-shot cookie rather than the URL — it never reaches the address bar, history or a referrer, and is cleared on the way out so a reload cannot replay it.

298/298 publish-page tests pass; the share test now follows the cookie through to the rendered dashboard and asserts it is cleared. Rendered and screenshotted in both themes.