### PR TITLE
docs(pages): lead the publish recipe with the way it is actually used

### DIFF
--- a/docs/site/src/content/docs/cookbook/publish-a-page.md
+++ b/docs/site/src/content/docs/cookbook/publish-a-page.md
@@ -5,8 +5,28 @@ sidebar:
   order: 2
 ---
 
-Write markdown, publish it through a theme, get a stable URL. Republishing the same `--name`
-updates the same page.
+Write markdown, publish it through a theme, get a stable URL.
+
+## Ask your agent
+
+This is the path you will actually use. The skill is written to be driven by an agent rather than
+typed: it chooses the name, the template and the title itself, publishes, loads the result in both
+themes to check the render, and hands back the URL.
+
+```text
+Publish this as a page.
+Publish the Q3 roadmap as a deck.
+Take the auth flow page down.
+```
+
+Nothing to decide up front, and nothing to remember afterwards: the address is derived from the
+name the agent chose, so "update that page" republishes over the same URL instead of leaving a
+second copy behind.
+
+## What runs underneath
+
+Reach for the command yourself when you are scripting it, or when you want a particular name or a
+readable address.
 
 The skill ships a `package.json`, so the installer already ran `bun install` in it — and its build
 script, if it has one. That only happens when a usable `bun` was on `PATH` at install time; if it

--- a/plugins-cc/agentkit-product/skills/product-intelligence/SKILL.md
+++ b/plugins-cc/agentkit-product/skills/product-intelligence/SKILL.md
@@ -34,10 +34,11 @@ ledger's verbatim quotes and the findings into one page-ready
 `brief-page.html` (derived, never committed), which publish-page puts on a URL:
 
 ```sh
-bun skills/product-intelligence/scripts/render.ts <dir>
-bun skills/publish-page/publish.ts --name <slug> --file <dir>/brief-page.html \
-  --title "<subject>: what the evidence says"
+bun <skill-dir>/scripts/render.ts <dir>
 ```
+
+Then publish `<dir>/brief-page.html` through the **publish-page** skill, passing
+`--title "<subject>: what the evidence says"`.
 
 The render is HTML rather than markdown because a crawled quote must reach the
 reader as the source wrote it: escaping into markdown cannot say "literal"
@@ -49,10 +50,11 @@ page that is not markdown has no heading for publish-page to lift.
 For a walked-through presentation rather than a page to read, add `--deck`:
 
 ```sh
-bun skills/product-intelligence/scripts/render.ts <dir> --deck
-bun skills/publish-page/publish.ts --name <slug> --file <dir>/brief-deck.md \
-  --template deck --title "<subject>"
+bun <skill-dir>/scripts/render.ts <dir> --deck
 ```
+
+Then publish `<dir>/brief-deck.md` through the **publish-page** skill with
+`--template deck --title "<subject>"`.
 
 It writes `brief-deck.md` in the publish-page deck grammar — a title slide
 with the claim counts, then one idea per slide across the brief's sections and

--- a/skills/product-intelligence/SKILL.md
+++ b/skills/product-intelligence/SKILL.md
@@ -34,10 +34,11 @@ ledger's verbatim quotes and the findings into one page-ready
 `brief-page.html` (derived, never committed), which publish-page puts on a URL:
 
 ```sh
-bun skills/product-intelligence/scripts/render.ts <dir>
-bun skills/publish-page/publish.ts --name <slug> --file <dir>/brief-page.html \
-  --title "<subject>: what the evidence says"
+bun <skill-dir>/scripts/render.ts <dir>
 ```
+
+Then publish `<dir>/brief-page.html` through the **publish-page** skill, passing
+`--title "<subject>: what the evidence says"`.
 
 The render is HTML rather than markdown because a crawled quote must reach the
 reader as the source wrote it: escaping into markdown cannot say "literal"
@@ -49,10 +50,11 @@ page that is not markdown has no heading for publish-page to lift.
 For a walked-through presentation rather than a page to read, add `--deck`:
 
 ```sh
-bun skills/product-intelligence/scripts/render.ts <dir> --deck
-bun skills/publish-page/publish.ts --name <slug> --file <dir>/brief-deck.md \
-  --template deck --title "<subject>"
+bun <skill-dir>/scripts/render.ts <dir> --deck
 ```
+
+Then publish `<dir>/brief-deck.md` through the **publish-page** skill with
+`--template deck --title "<subject>"`.
 
 It writes `brief-deck.md` in the publish-page deck grammar — a title slide
 with the claim counts, then one idea per slide across the brief's sections and


### PR DESCRIPTION
You spotted that the cookbook opened on this:

```sh
bun ~/.agentkit/skills/publish-page/publish.ts --name … --file … --template doc
```

Nobody publishes a page that way. The skill is explicitly written to be driven by an agent — its own instructions say to pick the name and template itself and publish "without asking the user for details". The cookbook index already leads with **Ask your agent**; this one recipe skipped straight to the CLI.

The recipe now opens with the sentence you say (`Publish this as a page.`), and keeps the command under **What runs underneath** for scripting or when you want a specific name.

## A concrete bug found alongside it

`product-intelligence` told the agent to run:

```sh
bun skills/publish-page/publish.ts …
```

That path only resolves inside a checkout of this repository. An installed user following it would not find the file. Its own script now uses the `<skill-dir>` convention every other skill uses, and the cross-skill call defers to the publish-page skill rather than hardcoding a sibling's install layout. The `plugins-cc` copy was regenerated with `scripts/sync-cc-plugin.sh` rather than hand-edited.

298/298 publish-page tests pass; the docs site builds with all internal links valid.