### PR TITLE
fix(pages): give pages.agentkit.sbs a source and bring it up to date

### DIFF
--- a/pages/site/build.sh
+++ b/pages/site/build.sh
@@ -62,9 +62,7 @@ meta() { # meta <key> <file>
 # Only the leading metadata block is build input. A `<!--@…-->` line further
 # down belongs to the author, most likely a page documenting this format.
 strip_meta() {
-	awk 'head && /^[[:space:]]*<!--@/ { next }
-	     head && /^[[:space:]]*$/ { next }
-	     { head = 0; print }' head=1 "$1"
+	awk 'head && /^[[:space:]]*(<!--@|$)/ { next } { head = 0; print }' head=1 "$1"
 }
 
 fail() { echo "build: $*" >&2; exit 1; }

--- a/pages/site/build.sh
+++ b/pages/site/build.sh
@@ -120,7 +120,7 @@ check_no_external() {
 
 	hit=$(grep -oE 'href=("[^"]*"|'\''[^'\'']*'\'')' "$f" \
 		| grep -E 'https?:|//' \
-		| grep -vE 'href=.https://(github\.com|raw\.githubusercontent\.com|pages\.agentkit\.sbs)/' || true)
+		| grep -vE 'href=.https://(github\.com|raw\.githubusercontent\.com|agentkit\.sbs|pages\.agentkit\.sbs|account\.agentkit\.sbs)/' || true)
 	[[ -z "$hit" ]] || fail "$f: unexpected off-site href: $hit"
 }
 

--- a/pages/site/deploy.sh
+++ b/pages/site/deploy.sh
@@ -4,6 +4,7 @@ cd "$(dirname "$0")"
 TOKEN_FILE="${AGENTKIT_SITE_TOKEN_FILE:-$HOME/.config/agentkit/site-token}"
 ENDPOINT="${AGENTKIT_SITE_ENDPOINT:-https://agentkit.sbs}"
 SITE_URL="${AGENTKIT_SITE_URL:-https://agentkit.sbs}"
+PAGES_URL="${AGENTKIT_PAGES_SITE_URL:-https://pages.agentkit.sbs}"
 [[ -f "$TOKEN_FILE" ]] || { echo "deploy: site token missing at $TOKEN_FILE" >&2; exit 1; }
 
 ./build.sh
@@ -40,10 +41,18 @@ while IFS= read -r page; do
 	rel=${page#site/}
 	if [[ "$rel" == index.html ]]; then
 		slug=_site
-		path=
+		url="$SITE_URL/"
+	elif [[ "$rel" == pages-index/index.html ]]; then
+		# The pages origin has its own front door, served from its own slug
+		# rather than a path under the marketing site. Without this case the
+		# transform below would file it at agentkit.sbs/pages-index, and
+		# pages.agentkit.sbs would keep serving whatever was uploaded by hand.
+		slug=_pages-index
+		url="$PAGES_URL/"
 	else
 		path=${rel%/index.html}
 		slug="_site/$path"
+		url="$SITE_URL/$path"
 	fi
 
 	if ! body=$(curl -sS --fail-with-body -X PUT \
@@ -53,8 +62,8 @@ while IFS= read -r page; do
 		exit 1
 	fi
 
-	echo "deployed: $SITE_URL/$path"
-	urls+=("$SITE_URL/$path")
+	echo "deployed: $url"
+	urls+=("$url")
 	deployed=$((deployed + 1))
 	# Root last, deliberately rather than by sort accident: if the walk dies
 	# part-way the front page still points at the previous, coherent set.

--- a/pages/site/src/footer.html
+++ b/pages/site/src/footer.html
@@ -2,9 +2,9 @@
   <div class="wrap foot-in">
     <span>agentkit</span>
     <a href="https://github.com/developerinlondon/agentkit">github.com/developerinlondon/agentkit</a>
-    <a href="/docs/getting-started/install/">docs</a>
-    <a href="/privacy/">privacy</a>
-    <a href="/terms/">terms</a>
+    <a href="https://agentkit.sbs/docs/getting-started/install/">docs</a>
+    <a href="https://agentkit.sbs/privacy/">privacy</a>
+    <a href="https://agentkit.sbs/terms/">terms</a>
     <span>Apache-2.0</span>
     <span class="build">build {{BUILD_SHA}} · {{BUILD_DATE}}</span>
   </div>

--- a/pages/site/src/header.html
+++ b/pages/site/src/header.html
@@ -1,8 +1,8 @@
 <header class="top">
   <div class="wrap top-in">
-    <a class="mark" href="/">agentkit</a>
+    <a class="mark" href="https://agentkit.sbs/">agentkit</a>
     <nav class="top-nav" aria-label="Site">
-      <a class="nav-docs" href="/docs/">Docs</a>
+      <a class="nav-docs" href="https://agentkit.sbs/docs/">Docs</a>
       <a class="gh" href="https://github.com/developerinlondon/agentkit" aria-label="agentkit on GitHub" title="agentkit on GitHub">
         <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
           <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/>

--- a/pages/site/src/pages/pages-index.html
+++ b/pages/site/src/pages/pages-index.html
@@ -1,0 +1,64 @@
+<!--@id: pages-index-->
+<!--@title: agentkit pages-->
+<!--@description: Pages published by agents live here. Every page is private to whoever published it until they share it, by link or by naming the people who may read it.-->
+
+<main id="main" class="wrap">
+<div class="rail">
+
+  <header class="hero">
+    <span class="tick" aria-hidden="true"></span>
+    <div class="brow fx-1">
+      <span>pages.agentkit.sbs</span><span class="badge-lbl">— published by agents</span>
+    </div>
+    <h1 class="hero-title fx-2">Pages published by agents live here</h1>
+    <p class="hero-sub fx-3">Every page has a stable address at
+    <code>pages.agentkit.sbs/&lt;slug&gt;</code>. There is no public directory, and no page is
+    listed anywhere: one is reachable by its address, and only by the people its owner let in.</p>
+    <div class="row fx-4">
+      <a class="btn solid" href="https://account.agentkit.sbs/dashboard">Your pages →</a>
+      <a class="btn" href="https://agentkit.sbs/docs/cookbook/publish-a-page/">How publishing works</a>
+    </div>
+  </header>
+
+  <section class="sect">
+    <h2>Who can open a page</h2>
+    <p class="p">A published page is private the moment it exists. Its owner opens one of two doors,
+    and closes it again whenever they like.</p>
+    <ul class="p">
+      <li><b>You</b> — the account that published it, always.</li>
+      <li><b>People you name.</b> Add someone's email address; they sign in and the service checks
+      the address against your list. Forwarding the page address to anyone else achieves nothing.</li>
+      <li><b>Anyone holding a sharing link.</b> One link per page, shown once, no sign-in. Turn it
+      off and the link dies immediately.</li>
+    </ul>
+    <p class="note">Removing someone also destroys the pass they are holding, so the page closes on
+    their next request rather than at the end of it.</p>
+  </section>
+
+  <section class="sect">
+    <h2>Publish one</h2>
+    <p class="p">Say it to whichever agent you already work with. It picks the address, renders the
+    page through a theme, checks how it came out, and hands back the link.</p>
+    <div class="ask-block">
+      <pre class="ask-pre"><code>Publish this as a page.</code></pre>
+    </div>
+    <p class="note">Republishing the same thing updates the same address instead of leaving a second
+    copy behind, so &ldquo;update that page&rdquo; works too.</p>
+  </section>
+
+  <section class="sect">
+    <h2>Look at one</h2>
+    <p class="p">These three predate accounts, so they have no owner recorded and stay readable by
+    anyone with the address &mdash; the one exception to everything above.</p>
+    <ul class="p">
+      <li><a class="ln out" href="https://pages.agentkit.sbs/skill-test">A page</a> &mdash; the
+      <code>doc</code> theme: sections, tables, figures.</li>
+      <li><a class="ln out" href="https://pages.agentkit.sbs/skill-test/deck">A deck</a> &mdash; the
+      same markdown split into slides.</li>
+      <li><a class="ln out" href="https://pages.agentkit.sbs/design/agentkit-pages">The design doc
+      for Pages</a> &mdash; how this service is built.</li>
+    </ul>
+  </section>
+
+</div>
+</main>


### PR DESCRIPTION
You said nothing changed on `pages.agentkit.sbs`. It hadn't — and it couldn't have.

That front page was uploaded by hand once, to the `_pages-index` slug, and has **no source in any repository**. Nothing in CI writes it, so it froze. It was still saying:

> Publishing requires a token; accounts with private pages and sharing are **coming next**.

Both shipped. It was also where the `bun skills/publish-page/publish.ts --slug reports/q3 --file q3.md` instruction came from — a repo-relative path, and not how anyone publishes.

## The fix

It is now `pages/site/src/pages/pages-index.html`, built and deployed by the same walk as the rest of the marketing site, with one explicit case: `pages-index/index.html` uploads to `_pages-index` and verifies against `pages.agentkit.sbs` rather than filing itself at `agentkit.sbs/pages-index`.

Content now matches the service: private by default, the two ways in, removal killing a live pass, and "Publish this as a page." as the way to publish. It also links to the dashboard, which it never did.

The shared header and footer now address `agentkit.sbs` absolutely — relative `/docs/` links 404 when the same partials are served from the pages origin. `build.sh`'s off-site href check allows the three agentkit hosts accordingly.

523 tests pass across publish-page, build and docs; built and screenshotted in both themes.