### PR TITLE
feat(memory): stop the brain index growing with the vault

### DIFF
--- a/docs/site/src/content/docs/concepts/memory.md
+++ b/docs/site/src/content/docs/concepts/memory.md
@@ -14,6 +14,13 @@ markdown notes with a `brain/index.md` of bare `[[wikilinks]]`. Two small hooks 
 `brain-index.sh` deterministically rebuilds the index after any write inside `brain/`. Both are
 silent no-ops in projects without a vault, so the kit is safe to install globally.
 
+The index is injected into every session, so it must not grow with the vault. Once a section
+holds more than 20 notes it is summarised as a count and an `ls` hint instead of listed note by
+note, which keeps the index proportional to the number of sections rather than the size of the
+vault. Set `AGENTKIT_BRAIN_INDEX_MAX_PER_SECTION` to change the threshold, or `0` to always list
+everything. Summarised sections stay reachable — the agent is told to `ls` the directory and read
+what matches, which is how a self-describing note name earns its keep.
+
 Three skills form the loop:
 
 - **reflect** runs at session end or after a correction. It scans the conversation for mistakes,

--- a/hooks/claude/brain-index.sh
+++ b/hooks/claude/brain-index.sh
@@ -31,6 +31,13 @@ disk="$(cd "$brain_dir" && find . -name '*.md' ! -name 'index.md' -type f \
 
 dirs="$(awk -F/ 'NF>1{print $1}' <<<"$disk" | sort -u)"
 
+# The index is injected into every session, so one line per note grows it without
+# bound. Past this, a section is summarised rather than listed. 0 disables.
+max_per_section="${AGENTKIT_BRAIN_INDEX_MAX_PER_SECTION:-20}"
+case "$max_per_section" in
+'' | *[!0-9]*) max_per_section=20 ;;
+esac
+
 tmp="$(mktemp "$brain_dir/.index-rebuild.XXXXXX")"
 trap 'rm -f "$tmp"' EXIT
 {
@@ -39,6 +46,14 @@ trap 'rm -f "$tmp"' EXIT
 		[[ -n "$section" ]] || continue
 		first="$(printf '%s' "${section:0:1}" | LC_ALL=C tr '[:lower:]' '[:upper:]')"
 		printf '\n## %s%s\n' "$first" "${section:1}"
+		count=0
+		while IFS= read -r f; do
+			case "$f" in "$section"/*) count=$((count + 1)) ;; esac
+		done <<<"$disk"
+		if [[ "$max_per_section" -gt 0 && "$count" -gt "$max_per_section" ]]; then
+			printf -- '- %s notes — `ls brain/%s/` then read what matches\n' "$count" "$section"
+			continue
+		fi
 		while IFS= read -r f; do
 			case "$f" in "$section"/*) echo "- [[$f]]" ;; esac
 		done <<<"$disk"

--- a/plugins-cc/agentkit-memory/hooks/brain-index.sh
+++ b/plugins-cc/agentkit-memory/hooks/brain-index.sh
@@ -31,6 +31,13 @@ disk="$(cd "$brain_dir" && find . -name '*.md' ! -name 'index.md' -type f \
 
 dirs="$(awk -F/ 'NF>1{print $1}' <<<"$disk" | sort -u)"
 
+# The index is injected into every session, so one line per note grows it without
+# bound. Past this, a section is summarised rather than listed. 0 disables.
+max_per_section="${AGENTKIT_BRAIN_INDEX_MAX_PER_SECTION:-20}"
+case "$max_per_section" in
+'' | *[!0-9]*) max_per_section=20 ;;
+esac
+
 tmp="$(mktemp "$brain_dir/.index-rebuild.XXXXXX")"
 trap 'rm -f "$tmp"' EXIT
 {
@@ -39,6 +46,14 @@ trap 'rm -f "$tmp"' EXIT
 		[[ -n "$section" ]] || continue
 		first="$(printf '%s' "${section:0:1}" | LC_ALL=C tr '[:lower:]' '[:upper:]')"
 		printf '\n## %s%s\n' "$first" "${section:1}"
+		count=0
+		while IFS= read -r f; do
+			case "$f" in "$section"/*) count=$((count + 1)) ;; esac
+		done <<<"$disk"
+		if [[ "$max_per_section" -gt 0 && "$count" -gt "$max_per_section" ]]; then
+			printf -- '- %s notes — `ls brain/%s/` then read what matches\n' "$count" "$section"
+			continue
+		fi
 		while IFS= read -r f; do
 			case "$f" in "$section"/*) echo "- [[$f]]" ;; esac
 		done <<<"$disk"

--- a/tests/memory/brain-hooks.test.ts
+++ b/tests/memory/brain-hooks.test.ts
@@ -39,6 +39,63 @@ function vaultProject(): string {
 }
 
 describe('brain-index.sh', () => {
+  function bigVault(noteCount: number): string {
+    const dir = mkdtempSync(join(tmpdir(), 'brain-cap-'));
+    mkdirSync(join(dir, 'brain', 'big'), { recursive: true });
+    mkdirSync(join(dir, 'brain', 'small'), { recursive: true });
+    writeFileSync(join(dir, 'brain', 'index.md'), '# Brain\n');
+    for (let i = 0; i < noteCount; i++) {
+      writeFileSync(join(dir, 'brain', 'big', `n${i}.md`), 'note\n');
+    }
+    writeFileSync(join(dir, 'brain', 'small', 'one.md'), 'note\n');
+    return dir;
+  }
+
+  function rebuild(dir: string, cap?: string) {
+    const env: Record<string, string> = { ...process.env, CLAUDE_PROJECT_DIR: dir };
+    if (cap !== undefined) env.AGENTKIT_BRAIN_INDEX_MAX_PER_SECTION = cap;
+    spawnSync('bash', [indexHook], {
+      encoding: 'utf8',
+      input: writePayload(join(dir, 'brain', 'small', 'one.md')),
+      env,
+    });
+    return readFileSync(join(dir, 'brain', 'index.md'), 'utf8');
+  }
+
+  // The index is injected into every session. One line per note makes it grow
+  // without bound, which is the defect this cap exists to prevent.
+  test('summarises a section past the cap and leaves small sections listed', () => {
+    const dir = bigVault(25);
+    try {
+      const index = rebuild(dir);
+      expect(index).toContain('- 25 notes — `ls brain/big/`');
+      expect(index).not.toContain('[[big/n0]]');
+      expect(index).toContain('[[small/one]]');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('cap is configurable and 0 disables it', () => {
+    const dir = bigVault(25);
+    try {
+      expect(rebuild(dir, '30')).toContain('[[big/n0]]');
+      expect(rebuild(dir, '5')).toContain('- 25 notes —');
+      expect(rebuild(dir, '0')).toContain('[[big/n0]]');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('a non-numeric cap falls back to the default rather than disabling it', () => {
+    const dir = bigVault(25);
+    try {
+      expect(rebuild(dir, 'abc')).toContain('- 25 notes —');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test('rebuilds the index grouped by directory with standalone files under Other', () => {
     const dir = vaultProject();
     try {


### PR DESCRIPTION
Closes #344.

`brain/index.md` listed one wikilink per note and `brain-inject.sh` prints it every session, so the index grew with the vault and its signal fell as it grew.

This is not theoretical. Claude Code's own memory index has the identical design plus a **25,000-byte cap hard-coded in its binary**. On my machine it hit the wall:

| | |
| --- | --- |
| index | 18,093 B against the 25,000 cap |
| cost per note | ~66 B |
| implied ceiling | **378 notes, ever** |
| actual pace | 10.9/day → **9 days to blockade** |

`brain/` has no cap, so it fails softer — it just stops being readable.

## Change

A section holding more than `AGENTKIT_BRAIN_INDEX_MAX_PER_SECTION` notes (default 20) is summarised rather than listed:

```
## Big
- 25 notes — `ls brain/big/` then read what matches

## Small
- [[small/s1]]
- [[small/s2]]
```

29 notes across three sections render in **13 lines**. The index now scales with sections, not vault size.

`0` disables the cap. A non-numeric value falls back to the default rather than silently disabling it — a typo should not quietly restore the unbounded behaviour.

## Why not merge notes into rollups

That was the approach in #344 and I changed it after reading the hook. `brain/` already groups by directory, and merging files would destroy the one-note-per-topic structure the Obsidian-compatible tree exists to provide, plus require rewriting every inbound wikilink. Capping the *listing* gets the same O(1) index with no migration and no data movement.

For the flat Claude-native store I did merge, because it has no directory structure to lean on — 116 behavioural notes became 10 thematic rollups and the index went 18,093 → 3,509 B. Different store, different right answer.

## Verified

Three tests added to `tests/memory/brain-hooks.test.ts` — cap applies, cap is configurable, `0` disables, non-numeric falls back. **Mutation-checked**: all three fail with the cap removed and pass with it restored. 9/9 pass.

Also confirmed the hook keeps its existing guarantees: atomic replace, exact no-op when the index already agrees, no temp files left behind.

`plugins-cc/agentkit-memory/hooks/brain-index.sh` was a verbatim duplicate of the hook and is synced.