### PR TITLE
feat(docs): publish each release under its own version path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,6 +361,8 @@ jobs:
       - name: Build and publish the docs site
         env:
           AGENTKIT_SITE_TOKEN: ${{ secrets.AGENTKIT_SITE_TOKEN }}
+          # Set only on a tag, so only a release also lands under /docs/<version>/.
+          AGENTKIT_DOCS_VERSION: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
         run: |
           if [ -z "$AGENTKIT_SITE_TOKEN" ]; then
             echo 'docs: AGENTKIT_SITE_TOKEN is not configured' >&2

--- a/docs/hextra/deploy.sh
+++ b/docs/hextra/deploy.sh
@@ -9,6 +9,9 @@ ENDPOINT="${AGENTKIT_SITE_ENDPOINT:-https://agentkit.sbs}"
 SITE_URL="${AGENTKIT_SITE_URL:-https://agentkit.sbs}"
 TOKEN_FILE="${AGENTKIT_SITE_TOKEN_FILE:-$HOME/.config/agentkit/site-token}"
 MARKER='ak-theme-toggle'
+# Slugs published under /docs/<version>/, which this build does not contain and
+# which the prune must therefore spare.
+keep=archives.txt
 
 die() {
 	echo "deploy: $*" >&2
@@ -41,9 +44,23 @@ done < <(find public -type f)
 [[ "$uploaded" -gt 0 ]] || die "public/ holds no files"
 echo "deploy: uploaded $uploaded file(s)"
 
+# A release also lands under its own version, which is what the picker offers
+# and what keeps that copy readable after the next release replaces /docs/.
+# Add the version to data/archives.json in the release commit so the picker
+# starts offering it.
+version="${AGENTKIT_DOCS_VERSION#v}"
+if [[ -n "$version" ]]; then
+	while IFS= read -r file; do
+		curl -sS --fail-with-body -X PUT --config "$auth" --data-binary "@$file" \
+			"$ENDPOINT/api/site/docs/$version/${file#public/}" >/dev/null \
+			|| die "FAILED $file -> docs/$version/"
+	done < <(find public -type f)
+	echo "deploy: also published $SITE_URL/docs/$version/"
+	printf '%s\n' "$version" >> "$keep"
+fi
+
 # Archives are published once and never rebuilt, so they are absent from this
 # build and would otherwise read as stale on every deploy.
-keep=archives.txt
 if ! curl -sS --fail-with-body --config "$auth" "$ENDPOINT/api/site-list/docs/" > "$live.json" 2>/dev/null; then
 	die "could not list what is live — not pruning"
 fi


### PR DESCRIPTION
The version picker can only offer a version that exists. A tagged publish now lands the same build at `/docs/<version>/` as well as `/docs/`, so the previous release stays readable once `/docs/` moves on, and `data/archives.json` gains that version in the release commit.

Completes the versioning half of the Hugo cutover: history starts at the next release rather than carrying forward twenty-one Astro-built trees.