### PR TITLE
fix(docs): fill every section landing, and fix the navigation gaps

### DIFF
--- a/docs/hextra/assets/css/custom.css
+++ b/docs/hextra/assets/css/custom.css
@@ -73,8 +73,10 @@
 	border-radius: 0;
 }
 
+/* The marketing site sets its whole body in mono; the docs follow it rather
+   than reading as a different product one click away. */
 html {
-	font-family: var(--ak-sans);
+	font-family: var(--ak-mono);
 }
 
 body {
@@ -401,4 +403,14 @@ nav a[href$="/docs/"]:first-child {
 .ak-version-picker:focus-visible {
 	outline: 2px solid var(--signal);
 	outline-offset: 2px;
+}
+
+/* A lone version is stated, not offered: same place and weight as the picker,
+   without the affordance of a control that cannot do anything. */
+.ak-version-label {
+	font-family: var(--ak-mono);
+	font-size: 0.75rem;
+	color: var(--muted);
+	padding: 0.25rem 0.1rem;
+	white-space: nowrap;
 }

--- a/docs/hextra/content/_index.md
+++ b/docs/hextra/content/_index.md
@@ -29,10 +29,11 @@ layout: hextra-home
 <div class="hx:mt-12"></div>
 
 {{< hextra/feature-grid >}}
-{{< hextra/feature-card title="Refusal, not advice" link="guide/concepts/hooks/" subtitle="A force push, a `--no-verify`, an unbounded build — refused at the tool call, not warned about afterwards." >}}
-{{< hextra/feature-card title="Install once, every agent" link="guide/start/what-lands-where/" subtitle="One copy under `~/.agentkit`, linked into each harness. Skills you installed yourself survive every upgrade." >}}
-{{< hextra/feature-card title="Honest boundaries" link="guide/concepts/boundaries/" subtitle="Every limit states what it reaches, what it cannot see, and what it does when it cannot run." >}}
-{{< hextra/feature-card title="Limits the kernel holds" link="guide/concepts/containment/" subtitle="`bounded-run` caps memory and CPU in a systemd scope, and fails closed if its slice is missing." >}}
-{{< hextra/feature-card title="A gate with teeth" link="guide/concepts/review/" subtitle="The merge is denied unless a review record matches the exact commit under review." >}}
-{{< hextra/feature-card title="Reference built from the tree" link="reference/" subtitle="Every table here is generated from the repository it documents, or the build fails." >}}
+{{< hextra/feature-card title="Police units" link="guide/concepts/hooks/" subtitle="Discipline as a refusal at the tool call. A force push, a `--no-verify`, an unbounded build — denied, with the legitimate override named in the message." >}}
+{{< hextra/feature-card title="Skills" link="guide/concepts/skills/" subtitle="Instructions an agent loads when the work calls for them, so the guidance arrives at the moment it applies rather than filling the context." >}}
+{{< hextra/feature-card title="Rules and instructions" link="guide/concepts/context/" subtitle="Always-on context, scoped by glob. What every agent reads before it touches the files that rule governs." >}}
+{{< hextra/feature-card title="Tools" link="guide/concepts/containment/" subtitle="Where advice will not hold, the capability itself is replaced: `bounded-run` caps memory and CPU in the kernel, not in a prompt." >}}
+{{< hextra/feature-card title="Kits" link="guide/start/kits/" subtitle="Skills are partitioned into kits. `core` always installs; memory, the product model, the review lanes and ClickUp are opted into and remembered." >}}
+{{< hextra/feature-card title="Boundaries" link="guide/concepts/boundaries/" subtitle="What each guard does not reach, written where the feature is. A guard you wrongly believe in is worse than no guard at all." >}}
+{{< hextra/feature-card title="Pages" link="guide/concepts/pages/" subtitle="An agent finishes something worth looking at and chat is the wrong container. Publishing puts it on a private URL it can hand back." >}}
 {{< /hextra/feature-grid >}}

--- a/docs/hextra/content/guide/_index.md
+++ b/docs/hextra/content/guide/_index.md
@@ -94,7 +94,7 @@ A guard you wrongly believe in is worse than no guard, because you stop watching
 
 {{< cards >}}
   {{< card link="/docs/guide/start/install/" title="Install" subtitle="Get it onto a machine, pick a door, and choose your kits." >}}
-  {{< card link="/docs/guide/start/verify/" title="Verify it took" subtitle="Prove the enforcement is live rather than trusting a file listing." >}}
+  {{< card link="/docs/guide/start/verify/" title="Verify the install" subtitle="Prove the enforcement is live rather than trusting a file listing." >}}
   {{< card link="/docs/guide/thinking/" title="Thinking in agentkit" subtitle="When discipline should be a skill, a rule, a hook or a tool." >}}
   {{< card link="/docs/cookbook/" title="Cookbook" subtitle="Copyable shapes for the workflows people actually run." >}}
 {{< /cards >}}

--- a/docs/hextra/content/guide/_index.md
+++ b/docs/hextra/content/guide/_index.md
@@ -39,8 +39,8 @@ flowchart LR
 Each surface trades reach for force. What arrives everywhere can only advise; what cannot be
 skipped acts at exactly one point.
 
-| Surface  | Reach                            | Ignored on a Friday evening, the result is  |
-| -------- | -------------------------------- | ------------------------------------------- |
+| Surface   | Reach                            | Ignored on a Friday evening, the result is |
+| --------- | -------------------------------- | ------------------------------------------ |
 | **Skill** | loaded on demand, agent's choice | the work is worse                          |
 | **Rule**  | always-on context, glob-tagged   | bad habits land, and show up in review     |
 | **Hook**  | refuses at the tool call         | nothing — ignoring it is not possible      |
@@ -85,7 +85,7 @@ A guard you wrongly believe in is worse than no guard, because you stop watching
 - Codex policies match literal argv prefixes rather than parsing shell payloads, so work delegated
   through an API or a socket is outside their reach.
 - The review record lives in the repository and the agent can write it. The gate makes the honest
-  path correct and a *stale* review mechanically impossible to merge past; forge-side required
+  path correct and a _stale_ review mechanically impossible to merge past; forge-side required
   approvals are what actually prevent a merge.
 - Containment deliberately excludes delegated workloads — `docker`, `podman`, `systemd-run`, `ssh` —
   because the child work can escape the cgroup.
@@ -93,8 +93,8 @@ A guard you wrongly believe in is worse than no guard, because you stop watching
 ## Start here
 
 {{< cards >}}
-  {{< card link="/docs/guide/start/install/" title="Install" subtitle="Get it onto a machine, pick a door, and choose your kits." >}}
-  {{< card link="/docs/guide/start/verify/" title="Verify the install" subtitle="Prove the enforcement is live rather than trusting a file listing." >}}
-  {{< card link="/docs/guide/thinking/" title="Thinking in agentkit" subtitle="When discipline should be a skill, a rule, a hook or a tool." >}}
-  {{< card link="/docs/cookbook/" title="Cookbook" subtitle="Copyable shapes for the workflows people actually run." >}}
+{{< card link="/docs/guide/start/install/" title="Install" subtitle="Get it onto a machine, pick a door, and choose your kits." >}}
+{{< card link="/docs/guide/start/verify/" title="Verify the install" subtitle="Prove the enforcement is live rather than trusting a file listing." >}}
+{{< card link="/docs/guide/thinking/" title="Thinking in agentkit" subtitle="When discipline should be a skill, a rule, a hook or a tool." >}}
+{{< card link="/docs/cookbook/" title="Cookbook" subtitle="Copyable shapes for the workflows people actually run." >}}
 {{< /cards >}}

--- a/docs/hextra/content/guide/concepts/_index.md
+++ b/docs/hextra/content/guide/concepts/_index.md
@@ -2,3 +2,21 @@
 title: Concepts
 weight: 2
 ---
+
+How the kit is built, and why each piece takes the form it does. Start with the four surfaces —
+the rest are the machinery behind one of them.
+
+{{< cards >}}
+  {{< card link="/docs/guide/concepts/surfaces/" title="Four surfaces" subtitle="Skill, rule, hook and tool, ordered by how much force each carries." >}}
+  {{< card link="/docs/guide/concepts/hooks/" title="Police hooks" subtitle="The refusal mechanism: what a unit inspects, and how it names an override." >}}
+  {{< card link="/docs/guide/concepts/skills/" title="Skills" subtitle="Instructions loaded on demand, and what makes one trigger." >}}
+  {{< card link="/docs/guide/concepts/context/" title="Rules and instructions" subtitle="Always-on context, and the globs that scope it." >}}
+  {{< card link="/docs/guide/concepts/tastes/" title="Tastes" subtitle="Conventions that travel with the repository they govern." >}}
+  {{< card link="/docs/guide/concepts/boundaries/" title="Boundaries" subtitle="What every guard does not reach — stated, because a guard you wrongly trust is worse than none." >}}
+  {{< card link="/docs/guide/concepts/containment/" title="Containment" subtitle="Cgroup limits that hold in the kernel, and what they deliberately exclude." >}}
+  {{< card link="/docs/guide/concepts/review/" title="Review and the gate" subtitle="Denying a merge unless a review record matches the commit under review." >}}
+  {{< card link="/docs/guide/concepts/memory/" title="The memory kit" subtitle="A vault of notes and the index injected into every session." >}}
+  {{< card link="/docs/guide/concepts/product/" title="The product model" subtitle="Declaring what a repository ships so a review can meet it as a user." >}}
+  {{< card link="/docs/guide/concepts/pages/" title="Pages" subtitle="Publishing an agent's output to a private URL it can hand back." >}}
+  {{< card link="/docs/guide/concepts/diagrams/" title="Diagram intelligence" subtitle="Choosing a diagram by what the concept is, not by the tool at hand." >}}
+{{< /cards >}}

--- a/docs/hextra/content/guide/concepts/_index.md
+++ b/docs/hextra/content/guide/concepts/_index.md
@@ -7,16 +7,16 @@ How the kit is built, and why each piece takes the form it does. Start with the 
 the rest are the machinery behind one of them.
 
 {{< cards >}}
-  {{< card link="/docs/guide/concepts/surfaces/" title="Four surfaces" subtitle="Skill, rule, hook and tool, ordered by how much force each carries." >}}
-  {{< card link="/docs/guide/concepts/hooks/" title="Police hooks" subtitle="The refusal mechanism: what a unit inspects, and how it names an override." >}}
-  {{< card link="/docs/guide/concepts/skills/" title="Skills" subtitle="Instructions loaded on demand, and what makes one trigger." >}}
-  {{< card link="/docs/guide/concepts/context/" title="Rules and instructions" subtitle="Always-on context, and the globs that scope it." >}}
-  {{< card link="/docs/guide/concepts/tastes/" title="Tastes" subtitle="Conventions that travel with the repository they govern." >}}
-  {{< card link="/docs/guide/concepts/boundaries/" title="Boundaries" subtitle="What every guard does not reach — stated, because a guard you wrongly trust is worse than none." >}}
-  {{< card link="/docs/guide/concepts/containment/" title="Containment" subtitle="Cgroup limits that hold in the kernel, and what they deliberately exclude." >}}
-  {{< card link="/docs/guide/concepts/review/" title="Review and the gate" subtitle="Denying a merge unless a review record matches the commit under review." >}}
-  {{< card link="/docs/guide/concepts/memory/" title="The memory kit" subtitle="A vault of notes and the index injected into every session." >}}
-  {{< card link="/docs/guide/concepts/product/" title="The product model" subtitle="Declaring what a repository ships so a review can meet it as a user." >}}
-  {{< card link="/docs/guide/concepts/pages/" title="Pages" subtitle="Publishing an agent's output to a private URL it can hand back." >}}
-  {{< card link="/docs/guide/concepts/diagrams/" title="Diagram intelligence" subtitle="Choosing a diagram by what the concept is, not by the tool at hand." >}}
+{{< card link="/docs/guide/concepts/surfaces/" title="Four surfaces" subtitle="Skill, rule, hook and tool, ordered by how much force each carries." >}}
+{{< card link="/docs/guide/concepts/hooks/" title="Police hooks" subtitle="The refusal mechanism: what a unit inspects, and how it names an override." >}}
+{{< card link="/docs/guide/concepts/skills/" title="Skills" subtitle="Instructions loaded on demand, and what makes one trigger." >}}
+{{< card link="/docs/guide/concepts/context/" title="Rules and instructions" subtitle="Always-on context, and the globs that scope it." >}}
+{{< card link="/docs/guide/concepts/tastes/" title="Tastes" subtitle="Conventions that travel with the repository they govern." >}}
+{{< card link="/docs/guide/concepts/boundaries/" title="Boundaries" subtitle="What every guard does not reach — stated, because a guard you wrongly trust is worse than none." >}}
+{{< card link="/docs/guide/concepts/containment/" title="Containment" subtitle="Cgroup limits that hold in the kernel, and what they deliberately exclude." >}}
+{{< card link="/docs/guide/concepts/review/" title="Review and the gate" subtitle="Denying a merge unless a review record matches the commit under review." >}}
+{{< card link="/docs/guide/concepts/memory/" title="The memory kit" subtitle="A vault of notes and the index injected into every session." >}}
+{{< card link="/docs/guide/concepts/product/" title="The product model" subtitle="Declaring what a repository ships so a review can meet it as a user." >}}
+{{< card link="/docs/guide/concepts/pages/" title="Pages" subtitle="Publishing an agent's output to a private URL it can hand back." >}}
+{{< card link="/docs/guide/concepts/diagrams/" title="Diagram intelligence" subtitle="Choosing a diagram by what the concept is, not by the tool at hand." >}}
 {{< /cards >}}

--- a/docs/hextra/content/guide/concepts/boundaries.md
+++ b/docs/hextra/content/guide/concepts/boundaries.md
@@ -75,7 +75,7 @@ open" — it is **never fail silent**.
 {{< callout type="warning" >}}
 A `PreToolUse` hook that crashes emits no decision, and **no decision means allow**. That is the
 harness contract, not an agentkit choice. It is why `review-police` runs behind a supervisor, and why
-[verify it took](/docs/guide/start/verify/) drives a hook by hand rather than trusting a file listing.
+[verify the install](/docs/guide/start/verify/) drives a hook by hand rather than trusting a file listing.
 {{< /callout >}}
 
 ## What the merge gate proves

--- a/docs/hextra/content/guide/concepts/hooks.md
+++ b/docs/hextra/content/guide/concepts/hooks.md
@@ -49,7 +49,7 @@ The consequence is uncomfortable and load-bearing: **a `PreToolUse` hook that cr
 decision, and no decision means allow.** A guard that dies on its first line is not merely broken;
 it is silently off while appearing installed. That has happened in this kit — a hardcoded absolute
 path that did not exist on one platform killed a hook immediately, and the harness reported only a
-non-blocking status code. [Verify it took](/docs/guide/start/verify/) is the routine that catches it.
+non-blocking status code. [Verify the install](/docs/guide/start/verify/) is the routine that catches it.
 {{< /callout >}}
 
 ### Why the write hooks exit 2

--- a/docs/hextra/content/guide/extending/_index.md
+++ b/docs/hextra/content/guide/extending/_index.md
@@ -2,3 +2,12 @@
 title: Extending it
 weight: 4
 ---
+
+Adding your own discipline to the kit. Each page is the shape to copy, the checks it has to pass,
+and where it has to be wired to take effect.
+
+{{< cards >}}
+  {{< card link="/docs/guide/extending/police-unit/" title="Write a police unit" subtitle="A refusal at the tool call, compiled into every harness that can express it." >}}
+  {{< card link="/docs/guide/extending/skill/" title="Write a skill" subtitle="Instructions an agent loads on demand, and the frontmatter that makes it findable." >}}
+  {{< card link="/docs/guide/extending/taste/" title="Write a taste" subtitle="A convention committed next to the code it governs, so every harness reads it." >}}
+{{< /cards >}}

--- a/docs/hextra/content/guide/extending/_index.md
+++ b/docs/hextra/content/guide/extending/_index.md
@@ -7,7 +7,7 @@ Adding your own discipline to the kit. Each page is the shape to copy, the check
 and where it has to be wired to take effect.
 
 {{< cards >}}
-  {{< card link="/docs/guide/extending/police-unit/" title="Write a police unit" subtitle="A refusal at the tool call, compiled into every harness that can express it." >}}
-  {{< card link="/docs/guide/extending/skill/" title="Write a skill" subtitle="Instructions an agent loads on demand, and the frontmatter that makes it findable." >}}
-  {{< card link="/docs/guide/extending/taste/" title="Write a taste" subtitle="A convention committed next to the code it governs, so every harness reads it." >}}
+{{< card link="/docs/guide/extending/police-unit/" title="Write a police unit" subtitle="A refusal at the tool call, compiled into every harness that can express it." >}}
+{{< card link="/docs/guide/extending/skill/" title="Write a skill" subtitle="Instructions an agent loads on demand, and the frontmatter that makes it findable." >}}
+{{< card link="/docs/guide/extending/taste/" title="Write a taste" subtitle="A convention committed next to the code it governs, so every harness reads it." >}}
 {{< /cards >}}

--- a/docs/hextra/content/guide/start/_index.md
+++ b/docs/hextra/content/guide/start/_index.md
@@ -4,3 +4,14 @@ weight: 1
 sidebar:
   open: true
 ---
+
+Get agentkit onto a machine, prove the enforcement is actually live, and know what it put where.
+
+{{< cards >}}
+{{< card link="/docs/guide/start/install/" title="Install" subtitle="Get it onto a machine, pick a door, and choose your kits." >}}
+{{< card link="/docs/guide/start/verify/" title="Verify the install" subtitle="Drive a hook by hand and watch it refuse, rather than trusting a file listing." >}}
+{{< card link="/docs/guide/start/what-lands-where/" title="What lands where" subtitle="Every path the installer writes, and which of them are symlinks to the canon." >}}
+{{< card link="/docs/guide/start/kits/" title="Skill kits" subtitle="What ships by default, and what each opt-in kit adds." >}}
+{{< card link="/docs/guide/start/requirements/" title="Requirements and platforms" subtitle="The dependencies, and what stands down when one is missing." >}}
+{{< card link="/docs/guide/start/upgrading/" title="Upgrading and removing" subtitle="How an upgrade treats your own edits, and how to take it off again." >}}
+{{< /cards >}}

--- a/docs/hextra/content/guide/start/install.md
+++ b/docs/hextra/content/guide/start/install.md
@@ -145,4 +145,4 @@ Environment inputs, rather than flags, are listed in the
 ## Then prove it took
 
 A file listing tells you files were copied. It does not tell you the behaviour changed, which is the
-entire product. Go to [verify it took](/docs/guide/start/verify/) next.
+entire product. Go to [verify the install](/docs/guide/start/verify/) next.

--- a/docs/hextra/content/guide/start/verify.md
+++ b/docs/hextra/content/guide/start/verify.md
@@ -1,5 +1,5 @@
 ---
-title: Verify it took
+title: Verify the install
 weight: 2
 ---
 

--- a/docs/hextra/data/archives.json
+++ b/docs/hextra/data/archives.json
@@ -1,4 +1,6 @@
 {
-  "comment": "Docs trees published under /docs/<version>/. Version history starts at the Hugo cutover: earlier trees were built by a different generator and documented a product that had not launched. A release appends its own version here after its tree is live.",
-  "published": []
+  "comment": "Docs trees published under /docs/<version>/. Every entry is spared from the deploy's prune, whether or not the picker offers it: a published path must not vanish because a newer patch replaced it in the list. A release appends its own version here once its tree is live.",
+  "published": [
+    "0.7.14"
+  ]
 }

--- a/docs/hextra/data/versions.json
+++ b/docs/hextra/data/versions.json
@@ -1,7 +1,7 @@
 [
   {
-    "slug": "0.7.13",
-    "label": "v0.7.13 (latest)",
+    "slug": "0.7.14",
+    "label": "v0.7.14 (latest)",
     "current": true
   }
 ]

--- a/docs/hextra/deploy.sh
+++ b/docs/hextra/deploy.sh
@@ -48,7 +48,8 @@ echo "deploy: uploaded $uploaded file(s)"
 # and what keeps that copy readable after the next release replaces /docs/.
 # Add the version to data/archives.json in the release commit so the picker
 # starts offering it.
-version="${AGENTKIT_DOCS_VERSION#v}"
+version="${AGENTKIT_DOCS_VERSION:-}"
+version="${version#v}"
 if [[ -n "$version" ]]; then
 	while IFS= read -r file; do
 		curl -sS --fail-with-body -X PUT --config "$auth" --data-binary "@$file" \

--- a/docs/hextra/hugo.yaml
+++ b/docs/hextra/hugo.yaml
@@ -71,6 +71,10 @@ params:
   navbar:
     displayTitle: true
     displayLogo: false
+    # Without this the wordmark links to the docs home, which is where the
+    # reader already is; they expect it to leave for the site.
+    logo:
+      link: https://agentkit.sbs/
 
   theme:
     default: system

--- a/docs/hextra/layouts/_partials/theme-toggle.html
+++ b/docs/hextra/layouts/_partials/theme-toggle.html
@@ -10,15 +10,20 @@
 {{- $versions := site.Data.versions -}}
 
 <div class="ak-navbar-controls">
+  {{- /* Which version you are reading is worth saying even when there is
+         nothing to switch to, so a lone version renders as a label rather than
+         a dropdown with one dead option. The current docs are wherever this
+         build is served from, so it follows the baseURL; an archive is always
+         at its own published path. */ -}}
   {{- if gt (len $versions) 1 -}}
-  {{- /* The current docs are wherever this build is served from, so its option
-         follows the baseURL; an archive is always at its own published path. */ -}}
   <select class="ak-version-picker" aria-label="Documentation version">
     {{- range $versions }}
     {{- $href := cond .current site.BaseURL (printf "/docs/%s/" .slug) }}
     <option value="{{ $href }}"{{ if .current }} selected{{ end }}>{{ .label }}</option>
     {{- end }}
   </select>
+  {{- else if $versions -}}
+  <span class="ak-version-label">{{ (index $versions 0).label }}</span>
   {{- end -}}
 
   <button

--- a/docs/hextra/scripts/versions.ts
+++ b/docs/hextra/scripts/versions.ts
@@ -82,10 +82,9 @@ if (import.meta.main) {
     process.exit(1);
   }
   writeFileSync(join(dataDir, 'versions.json'), `${JSON.stringify(versions, null, 2)}\n`);
-  writeFileSync(
-    join(here, '..', 'archives.txt'),
-    `${versions.slice(1).map((v) => v.slug).join('\n')}\n`,
-  );
+  // Every published tree, not just the ones the picker offers: a version the
+  // list stops showing is still a URL someone may hold.
+  writeFileSync(join(here, '..', 'archives.txt'), `${published.join('\n')}\n`);
   console.log(
     `versions: current ${current}, archives ${versions.slice(1).map((v) => v.slug).join(', ') || '(none)'}`,
   );


### PR DESCRIPTION
Live and verified at https://agentkit.sbs/docs/

## The homepage breakdown

The grid mixed concept, mechanism and kit at one level — two cards described install and docs machinery, and the review lane sat beside them as though it were a surface rather than something a kit brings. It now leads with the **four surfaces in order of force** (police units, skills, rules, tools), then **how the kit is shaped and bounded** (kits, boundaries, pages). Diagram and product intelligence are kit contents and live on the kits page rather than competing on the homepage.

## Empty landings — the class, not the instances

| Landing | Was | Now |
| --- | --- | --- |
| Concepts | title only | 250 words + cards to all 12 |
| Getting started | title only | 137 words + cards to all 6 |
| Extending it | title only | 99 words + cards to all 3 |

Cookbook and Reference were fixed when they were reported; the class was not, so three more stayed empty until they were found by clicking.

## Other gaps found by using it

- The wordmark linked to the docs home — where the reader already is. It leaves for the site now.
- Body prose was sans while the marketing site is mono, so one click read as a different product.
- "Verify it took" said nothing to anyone who had not already read the page.
- The version is stated even when there is nothing to switch to.

## Two real bugs

- `archives.txt` spared only versions the picker offers. A version in the current minor is never listed as an archive, so **`/docs/0.7.14/` was one deploy from being pruned.** It now spares every published tree.
- The per-version publish read an unset variable under `set -u` and aborted. It failed after upload and before prune, so nothing was lost — but it never published the version path.