### PR TITLE
feat(docs): make kits and harnesses first-class, and trail back to the front page

### DIFF
--- a/docs/hextra/content/_index.md
+++ b/docs/hextra/content/_index.md
@@ -29,11 +29,12 @@ layout: hextra-home
 <div class="hx:mt-12"></div>
 
 {{< hextra/feature-grid >}}
-{{< hextra/feature-card title="Police units" link="guide/concepts/hooks/" subtitle="Discipline as a refusal at the tool call. A force push, a `--no-verify`, an unbounded build — denied, with the legitimate override named in the message." >}}
-{{< hextra/feature-card title="Skills" link="guide/concepts/skills/" subtitle="Instructions an agent loads when the work calls for them, so the guidance arrives at the moment it applies rather than filling the context." >}}
+{{< hextra/feature-card title="Skills" link="guide/concepts/skills/" subtitle="Instructions an agent loads when the work calls for them, so guidance arrives at the moment it applies rather than filling the context." >}}
+{{< hextra/feature-card title="Police units" link="guide/concepts/hooks/" subtitle="Discipline as a refusal at the tool call. A force push, a `--no-verify`, an unbounded build — denied, with the legitimate override named." >}}
+{{< hextra/feature-card title="Tools" link="guide/concepts/containment/" subtitle="Where a refusal is not enough the capability itself is replaced: `bounded-run` caps memory and CPU in the kernel, not in a prompt." >}}
+{{< hextra/feature-card title="Kits" link="kits/" subtitle="Skills are partitioned into kits. `core` always installs; memory, the product model, the review lanes and ClickUp are opted into and remembered." >}}
+{{< hextra/feature-card title="Harnesses" link="harnesses/" subtitle="One canonical copy, installed into Claude Code, Codex CLI, OpenCode and Grok CLI — with each guard expressed wherever that harness can carry it." >}}
+{{< hextra/feature-card title="Pages" link="guide/concepts/pages/" subtitle="An agent finishes something worth looking at and chat is the wrong container. Publishing puts it on a private URL, behind an account, that it can hand back." >}}
 {{< hextra/feature-card title="Rules and instructions" link="guide/concepts/context/" subtitle="Always-on context, scoped by glob. What every agent reads before it touches the files that rule governs." >}}
-{{< hextra/feature-card title="Tools" link="guide/concepts/containment/" subtitle="Where advice will not hold, the capability itself is replaced: `bounded-run` caps memory and CPU in the kernel, not in a prompt." >}}
-{{< hextra/feature-card title="Kits" link="guide/start/kits/" subtitle="Skills are partitioned into kits. `core` always installs; memory, the product model, the review lanes and ClickUp are opted into and remembered." >}}
 {{< hextra/feature-card title="Boundaries" link="guide/concepts/boundaries/" subtitle="What each guard does not reach, written where the feature is. A guard you wrongly believe in is worse than no guard at all." >}}
-{{< hextra/feature-card title="Pages" link="guide/concepts/pages/" subtitle="An agent finishes something worth looking at and chat is the wrong container. Publishing puts it on a private URL it can hand back." >}}
 {{< /hextra/feature-grid >}}

--- a/docs/hextra/content/guide/concepts/pages.md
+++ b/docs/hextra/content/guide/concepts/pages.md
@@ -66,6 +66,21 @@ Every one of those relaxations is confined to that prefix. Outside it the apex s
 `<slug>/index.html` under `default-src 'none'`.
 {{< /callout >}}
 
+## Accounts and sign-in
+
+Publishing needs an account, and a published page is private to it. There are two ways in, for two
+different actors.
+
+| Who                          | How it signs in                                                                               | What it can do                                 |
+| ---------------------------- | --------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| **You, in a browser**        | `account.agentkit.sbs` redirects to the identity service, which authenticates you with Google | manage sharing, invite readers, revoke devices |
+| **Your agent, on a machine** | a device flow: it prints a short code, you approve it once in the browser                     | write and delete pages for 90 days             |
+
+The identity service issues its own token to the site, so the page service never sees your Google
+credentials. Sharing is managed from the dashboard: a revocable link anyone can follow, or an email
+address that has to sign in to read. Removing someone destroys the pass they are holding rather than
+waiting for it to expire.
+
 ## Credentials have separate jobs
 
 | Credential      | Grants                                                             | Storage                                               |

--- a/docs/hextra/content/guide/concepts/skills.md
+++ b/docs/hextra/content/guide/concepts/skills.md
@@ -36,7 +36,7 @@ sufficient alone — the skill has no teeth, the hook has no idea which profile 
 {{< skill-table >}}
 
 Kit membership is declared in one manifest, `skills/KITS`, read by a shared library so the installer
-and the plugin generator can never disagree. See [skill kits](/docs/guide/start/kits/) for selecting them.
+and the plugin generator can never disagree. See [skill kits](/docs/kits/) for selecting them.
 
 ## Skills that ship code
 

--- a/docs/hextra/content/guide/start/_index.md
+++ b/docs/hextra/content/guide/start/_index.md
@@ -11,7 +11,7 @@ Get agentkit onto a machine, prove the enforcement is actually live, and know wh
 {{< card link="/docs/guide/start/install/" title="Install" subtitle="Get it onto a machine, pick a door, and choose your kits." >}}
 {{< card link="/docs/guide/start/verify/" title="Verify the install" subtitle="Drive a hook by hand and watch it refuse, rather than trusting a file listing." >}}
 {{< card link="/docs/guide/start/what-lands-where/" title="What lands where" subtitle="Every path the installer writes, and which of them are symlinks to the canon." >}}
-{{< card link="/docs/guide/start/kits/" title="Skill kits" subtitle="What ships by default, and what each opt-in kit adds." >}}
+{{< card link="/docs/kits/" title="Skill kits" subtitle="What ships by default, and what each opt-in kit adds." >}}
 {{< card link="/docs/guide/start/requirements/" title="Requirements and platforms" subtitle="The dependencies, and what stands down when one is missing." >}}
 {{< card link="/docs/guide/start/upgrading/" title="Upgrading and removing" subtitle="How an upgrade treats your own edits, and how to take it off again." >}}
 {{< /cards >}}

--- a/docs/hextra/content/guide/start/install.md
+++ b/docs/hextra/content/guide/start/install.md
@@ -62,7 +62,7 @@ git clone git@github.com:developerinlondon/agentkit.git
 ```
 
 The interactive kit picker only appears here, and only on a terminal — see
-[skill kits](/docs/guide/start/kits/).
+[skill kits](/docs/kits/).
 {{< /tab >}}
 
 {{< tab name="Claude plugin" >}}

--- a/docs/hextra/content/harnesses/_index.md
+++ b/docs/hextra/content/harnesses/_index.md
@@ -1,0 +1,51 @@
+---
+title: Harnesses
+weight: 3
+cascade:
+  type: docs
+---
+
+agentkit installs into four coding harnesses from one canonical copy, so the same discipline
+applies whichever one you happen to be driving. Coverage is deliberately uneven: a harness gets a
+guard only where its extension mechanism can express the check.
+
+## The four
+
+| Harness         | Skills and rules                              | Enforcement mechanism                                        |
+| --------------- | --------------------------------------------- | ------------------------------------------------------------ |
+| **Claude Code** | symlinked from `~/.agentkit` into `~/.claude` | hook scripts, registered in `settings.json`                  |
+| **Grok CLI**    | symlinked into `~/.grok`                      | the same hook scripts, through its Claude-compatibility path |
+| **OpenCode**    | symlinked into `~/.agents`                    | TypeScript plugins, copied and refreshed on install          |
+| **Codex CLI**   | prompts copied into `~/.codex`                | exec policies matching literal argv prefixes                 |
+
+Skills and rules are **symlinks** to the canon, so editing one file reaches every harness that
+links it. Codex prompts, the OpenCode plugins and the executables on your `PATH` are real copies,
+refreshed on the next install run. Nothing sweeps a client directory — skills you installed from
+anywhere else sit untouched alongside.
+
+## What each unit reaches
+
+Every police unit declares which mechanisms it can be expressed in. A blank cell is not an
+oversight; it means that harness cannot see the thing the unit checks.
+
+{{< unit-table >}}
+
+## Where the guards land
+
+Hook units bind to a harness event and a tool matcher, with a timeout. A unit that overruns its
+timeout is treated as a refusal only where a fail-closed budget is declared.
+
+{{< wiring-table >}}
+
+{{< callout type="warning" >}}
+**Codex reads argv, not shell.** Its policies match literal command prefixes rather than parsing a
+shell payload, so the same intent written a different way — through a pipe, a script, an API call —
+is outside what they match. [Boundaries](/docs/guide/concepts/boundaries/) states every such limit
+in one place.
+{{< /callout >}}
+
+## Platform differences
+
+The cgroup tooling is Linux-only. On macOS and elsewhere the bounded runner, its `agentkit-run`
+alias and the Codex heavy-command policy are not installed, and containment stands down — while
+every guard that does not need cgroups stays active. [Requirements and platforms](/docs/guide/start/requirements/) lists exactly what is skipped and what remains.

--- a/docs/hextra/content/kits/_index.md
+++ b/docs/hextra/content/kits/_index.md
@@ -1,6 +1,8 @@
 ---
-title: Skill kits
-weight: 4
+title: Kits
+weight: 2
+cascade:
+  type: docs
 ---
 
 Skills are partitioned into **kits**. `core` always installs; everything else is opted into, and the
@@ -46,14 +48,14 @@ discovering and auto-triggering a workflow the user removed.
 
 The interactive picker is narrow on purpose. It runs only when **all** of these hold:
 
-| Condition | Why |
-| --- | --- |
-| the install is `--global` | project installs never write the remembered set |
-| stdin is a terminal | a piped `curl … \| bash` has no terminal, so it cannot ask |
-| `--no-prompt` was not passed | the explicit opt-out |
-| `AGENTKIT_SKIP_PROMPT` is unset | the environment opt-out, for CI |
-| `CI` is unset | CI is never interactive |
-| no `--with`/`--without`/`--all` was passed | you already stated the selection |
+| Condition                                  | Why                                                        |
+| ------------------------------------------ | ---------------------------------------------------------- |
+| the install is `--global`                  | project installs never write the remembered set            |
+| stdin is a terminal                        | a piped `curl … \| bash` has no terminal, so it cannot ask |
+| `--no-prompt` was not passed               | the explicit opt-out                                       |
+| `AGENTKIT_SKIP_PROMPT` is unset            | the environment opt-out, for CI                            |
+| `CI` is unset                              | CI is never interactive                                    |
+| no `--with`/`--without`/`--all` was passed | you already stated the selection                           |
 
 That is why the bootstrap one-liner installs `core` only unless you pass `--with <kit>`: piped
 stdin is not a terminal, so the question never fires.
@@ -74,18 +76,18 @@ Any of them aborts the run before a file is touched.
 ## What is in each kit
 
 {{< tabs >}}
-  {{< tab name="core" >}}{{< skill-table kit="core" >}}{{< /tab >}}
-  {{< tab name="memory" >}}{{< skill-table kit="memory" >}}{{< /tab >}}
-  {{< tab name="product" >}}{{< skill-table kit="product" >}}{{< /tab >}}
-  {{< tab name="clickup" >}}{{< skill-table kit="clickup" >}}{{< /tab >}}
-  {{< tab name="adversarial-review" >}}
+{{< tab name="core" >}}{{< skill-table kit="core" >}}{{< /tab >}}
+{{< tab name="memory" >}}{{< skill-table kit="memory" >}}{{< /tab >}}
+{{< tab name="product" >}}{{< skill-table kit="product" >}}{{< /tab >}}
+{{< tab name="clickup" >}}{{< skill-table kit="clickup" >}}{{< /tab >}}
+{{< tab name="adversarial-review" >}}
 {{< skill-table kit="adversarial-review" >}}
 
 Also installs `review-police`, the `review-gate` and `review-profile` tools, and the
 `evidence-gated-review` instruction. See [review and the gate](/docs/guide/concepts/review/).
-  {{< /tab >}}
-  {{< tab name="advisory-review" >}}
+{{< /tab >}}
+{{< tab name="advisory-review" >}}
 This kit carries no skills. It installs one always-on instruction, `review-discipline.md`, which
 asks for one non-authoring reviewer pass per substantive change. Nothing enforces it.
-  {{< /tab >}}
+{{< /tab >}}
 {{< /tabs >}}

--- a/docs/hextra/content/reference/glossary.md
+++ b/docs/hextra/content/reference/glossary.md
@@ -63,7 +63,7 @@ every harness.
 An install partition declared in `skills/KITS`, a plain-text manifest read by the installer, the
 Claude plugin generator and the tests alike. A skill with no membership record belongs to `core`,
 which always installs, and a skill may name only one kit. The declared kits are listed in
-[Skill kits](/docs/guide/start/kits/), generated from the manifest.
+[Skill kits](/docs/kits/), generated from the manifest.
 
 ## Explicit kit
 

--- a/docs/hextra/content/reference/skills.md
+++ b/docs/hextra/content/reference/skills.md
@@ -15,7 +15,7 @@ description it does not carry, or in a kit it does not belong to.
 
 A skill with no record in `skills/KITS` belongs to `core`, and a skill may name only one kit.
 `explicit` kits are never offered by the interactive picker and are excluded from `--all`; only a
-literal `--with <kit>` selects one. See [skill kits](/docs/guide/start/kits/).
+literal `--with <kit>` selects one. See [skill kits](/docs/kits/).
 
 ## Not forge-neutral
 

--- a/docs/hextra/hugo.yaml
+++ b/docs/hextra/hugo.yaml
@@ -32,12 +32,18 @@ menu:
     - name: Guide
       pageRef: /guide
       weight: 1
+    - name: Kits
+      pageRef: /kits
+      weight: 2
+    - name: Harnesses
+      pageRef: /harnesses
+      weight: 3
     - name: Reference
       pageRef: /reference
-      weight: 2
+      weight: 4
     - name: Cookbook
       pageRef: /cookbook
-      weight: 3
+      weight: 5
     - name: Search
       weight: 8
       params:

--- a/docs/hextra/layouts/_partials/breadcrumb.html
+++ b/docs/hextra/layouts/_partials/breadcrumb.html
@@ -1,0 +1,26 @@
+{{- /*
+  The theme's breadcrumb drops the home page, which on a docs-only site is the
+  documentation front page — leaving a nested reader with no trail back to it.
+  This keeps it, as the first crumb.
+*/ -}}
+{{- $page := .page -}}
+{{- $enable := .enable -}}
+{{- if (default $enable $page.Params.breadcrumbs) -}}
+  <div class="hx:mt-1.5 hx:flex hx:items-center hx:gap-1 hx:overflow-hidden hx:text-sm hx:text-gray-500 hx:dark:text-gray-400 hx:contrast-more:text-current">
+    <div class="hx:whitespace-nowrap hx:transition-colors hx:hover:text-gray-900 hx:dark:hover:text-gray-100">
+      <a href="{{ site.Home.RelPermalink }}" class="hx:inline-block hx:rounded-sm hx:hextra-focus-visible-inset">Docs</a>
+    </div>
+    {{- partial "utils/icon.html" (dict "name" "chevron-right" "attributes" "class=\"hx:w-3.5 hx:shrink-0 hx:rtl:-rotate-180\"") -}}
+    {{- range $page.Ancestors.Reverse }}
+      {{- if not .IsHome }}
+        <div class="hx:whitespace-nowrap hx:transition-colors hx:min-w-[24px] hx:overflow-hidden hx:text-ellipsis hx:hover:text-gray-900 hx:dark:hover:text-gray-100">
+          <a href="{{ .RelPermalink }}" class="hx:inline-block hx:rounded-sm hx:hextra-focus-visible-inset">{{- partial "utils/title" . -}}</a>
+        </div>
+        {{- partial "utils/icon.html" (dict "name" "chevron-right" "attributes" "class=\"hx:w-3.5 hx:shrink-0 hx:rtl:-rotate-180\"") -}}
+      {{ end -}}
+    {{ end -}}
+    <div class="hx:whitespace-nowrap hx:font-medium hx:text-gray-700 hx:contrast-more:font-bold hx:contrast-more:text-current hx:dark:text-gray-100 hx:contrast-more:dark:text-current">
+      {{- partial "utils/title" $page -}}
+    </div>
+  </div>
+{{- end -}}


### PR DESCRIPTION
Live at https://agentkit.sbs/docs/

## Why kits was buried

That page was written as an *install* topic — "how do I select a kit?" — so it lived under Getting started. It is a first-class entity, and it now has a first-class URL: `/docs/kits/`. The six inbound links move with it.

## Harnesses had no page at all

Multi-agent support is arguably the whole point, and it was mentioned across five pages and owned by none. `/docs/harnesses/` now states what each of the four gets and which guards it can carry, rendered from the same declarations the installer reads — so a mechanism a harness cannot express shows as a gap rather than going unsaid.

| Harness | Skills and rules | Enforcement |
| --- | --- | --- |
| Claude Code | symlinked into `~/.claude` | hook scripts |
| Grok CLI | symlinked into `~/.grok` | same hooks, via its Claude-compat path |
| OpenCode | symlinked into `~/.agents` | TypeScript plugins |
| Codex CLI | prompts copied into `~/.codex` | argv-prefix exec policies |

## Breadcrumb

The theme drops the home crumb. On a docs-only site that page **is** the documentation front page, so a nested reader had no trail back. It now reads `Docs › Introduction › Concepts › Pages`.

## Pages: accounts

Sign-in was described in passing inside a credentials table. Who signs in, how, and what each actor may do now has a section: you in a browser via the identity service, your agent via a device flow.

## Homepage

Row one is now what agentkit *is* — Skills, Police units, Tools, Kits, Harnesses, Pages — with rules and boundaries beneath.