### PR TITLE
feat(docs): serve the documentation from its own host

### DIFF
--- a/docs/hextra/assets/css/custom.css
+++ b/docs/hextra/assets/css/custom.css
@@ -385,19 +385,35 @@ nav a[href$="/docs/"]:first-child {
 }
 
 .ak-version-picker {
+	/* The native control paints the OS chevron and its own control colours, which
+	   read as a foreign widget in a mono navbar. Draw the arrow instead. */
+	appearance: none;
 	font-family: var(--ak-mono);
 	font-size: 0.75rem;
+	line-height: 1.2;
 	color: var(--muted);
-	background: var(--sunk);
+	background-color: var(--sunk);
+	background-image: linear-gradient(45deg, transparent 50%, currentColor 50%),
+		linear-gradient(135deg, currentColor 50%, transparent 50%);
+	background-position: right 0.72rem center, right 0.5rem center;
+	background-size: 0.28rem 0.28rem, 0.28rem 0.28rem;
+	background-repeat: no-repeat;
 	border: 1px solid var(--rule);
 	border-radius: 0.375rem;
-	padding: 0.25rem 0.4rem;
+	padding: 0.3rem 1.35rem 0.3rem 0.55rem;
 	cursor: pointer;
-	max-width: 11rem;
+	max-width: 12rem;
+	transition: color 0.12s ease, border-color 0.12s ease;
+}
+
+.ak-version-picker option {
+	background-color: var(--panel);
+	color: var(--ink);
 }
 
 .ak-version-picker:hover {
 	color: var(--ink);
+	border-color: var(--muted);
 }
 
 .ak-version-picker:focus-visible {

--- a/docs/hextra/content/cookbook/_index.md
+++ b/docs/hextra/content/cookbook/_index.md
@@ -29,11 +29,11 @@ skill; `product-intelligence` needs `--with product`.
 
 ## The recipes
 
-| Recipe                                                                  | Needs                         |
-| ----------------------------------------------------------------------- | ----------------------------- |
-| [Publish a page](/cookbook/publish-a-page/)                        | core, plus `bun`              |
-| [Gate a merge on a review record](/cookbook/gate-a-merge/)         | `--with adversarial-review`   |
-| [Contain a heavy build](/cookbook/contain-a-build/)                | Linux, provisioned work slice |
-| [Declare what your repo ships](/cookbook/declare-your-product/)    | `--with product`              |
-| [Override a guard, once, on purpose](/cookbook/override-a-guard/)  | core                          |
-| [Find what is half done](/cookbook/find-what-is-half-done/)        | core                          |
+| Recipe                                                            | Needs                         |
+| ----------------------------------------------------------------- | ----------------------------- |
+| [Publish a page](/cookbook/publish-a-page/)                       | core, plus `bun`              |
+| [Gate a merge on a review record](/cookbook/gate-a-merge/)        | `--with adversarial-review`   |
+| [Contain a heavy build](/cookbook/contain-a-build/)               | Linux, provisioned work slice |
+| [Declare what your repo ships](/cookbook/declare-your-product/)   | `--with product`              |
+| [Override a guard, once, on purpose](/cookbook/override-a-guard/) | core                          |
+| [Find what is half done](/cookbook/find-what-is-half-done/)       | core                          |

--- a/docs/hextra/content/cookbook/_index.md
+++ b/docs/hextra/content/cookbook/_index.md
@@ -31,9 +31,9 @@ skill; `product-intelligence` needs `--with product`.
 
 | Recipe                                                                  | Needs                         |
 | ----------------------------------------------------------------------- | ----------------------------- |
-| [Publish a page](/docs/cookbook/publish-a-page/)                        | core, plus `bun`              |
-| [Gate a merge on a review record](/docs/cookbook/gate-a-merge/)         | `--with adversarial-review`   |
-| [Contain a heavy build](/docs/cookbook/contain-a-build/)                | Linux, provisioned work slice |
-| [Declare what your repo ships](/docs/cookbook/declare-your-product/)    | `--with product`              |
-| [Override a guard, once, on purpose](/docs/cookbook/override-a-guard/)  | core                          |
-| [Find what is half done](/docs/cookbook/find-what-is-half-done/)        | core                          |
+| [Publish a page](/cookbook/publish-a-page/)                        | core, plus `bun`              |
+| [Gate a merge on a review record](/cookbook/gate-a-merge/)         | `--with adversarial-review`   |
+| [Contain a heavy build](/cookbook/contain-a-build/)                | Linux, provisioned work slice |
+| [Declare what your repo ships](/cookbook/declare-your-product/)    | `--with product`              |
+| [Override a guard, once, on purpose](/cookbook/override-a-guard/)  | core                          |
+| [Find what is half done](/cookbook/find-what-is-half-done/)        | core                          |

--- a/docs/hextra/content/cookbook/declare-your-product.md
+++ b/docs/hextra/content/cookbook/declare-your-product.md
@@ -70,4 +70,4 @@ The template ships with the skill, at `~/.agentkit/skills/product-review/product
 agentkit dogfoods it: this repository's own `.agentkit/product.yaml` declares a `test-suite` surface
 and a `plugin` surface.
 
-Why the declaration is committed rather than inferred: [The product model](/docs/guide/concepts/product/).
+Why the declaration is committed rather than inferred: [The product model](/guide/concepts/product/).

--- a/docs/hextra/content/cookbook/find-what-is-half-done.md
+++ b/docs/hextra/content/cookbook/find-what-is-half-done.md
@@ -97,4 +97,4 @@ edit that marks a plan done and refuses the edit while a bare gap stands — fil
 pasting its number is the fix.
 
 Plan layout is discovered from six common roots and is configurable per repository; see
-[Configuration](/docs/reference/configuration/) for `wip.plan-paths` and `wip.issue-refs`.
+[Configuration](/reference/configuration/) for `wip.plan-paths` and `wip.issue-refs`.

--- a/docs/hextra/content/cookbook/gate-a-merge.md
+++ b/docs/hextra/content/cookbook/gate-a-merge.md
@@ -135,4 +135,4 @@ pair it with forge-side required approvals, which are what actually prevent a me
 {{< /callout >}}
 
 The doctrine behind all of this, including the opt-in advisory lane (`--with advisory-review`):
-[Review and the gate](/docs/guide/concepts/review/).
+[Review and the gate](/guide/concepts/review/).

--- a/docs/hextra/content/cookbook/publish-a-page.md
+++ b/docs/hextra/content/cookbook/publish-a-page.md
@@ -81,14 +81,11 @@ bun ~/.agentkit/skills/publish-page/publish.ts \
 | `raw`    | complete self-contained HTML, published as-is |
 
 A rendered deck is worth more than a description of one:
-[the publish-freshness deck](/docs/examples/publish-freshness-deck.html) is six slides through the
+[the publish-freshness deck](/examples/publish-freshness-deck.html) is six slides through the
 `deck` template — a cover with a stat row, a severity callout, legend rails, and column cards. Arrow
-keys, space and swipe move between slides; the toggle in the nav bar flips the theme. Its markdown
-source is
-[`docs/site/examples/publish-freshness-deck.md`](https://github.com/developerinlondon/agentkit/blob/main/docs/site/examples/publish-freshness-deck.md).
-Rendering it through the `deck` template with `--title "The Publish Freshness Architecture"`
-reproduces the published file byte for byte. The title has to be given: a deck's cover headline is
-HTML rather than a markdown `#` heading, so there is nothing to derive one from. The bytes come from
+keys, space and swipe move between slides; the toggle in the nav bar flips the theme. A deck needs
+`--title` given explicitly: its cover headline is HTML rather than a markdown `#` heading, so there
+is nothing to derive one from. The bytes come from
 `renderThemed` in `skills/publish-page/render-html.ts` against this repo's copy of the theme —
 `publish.ts` prefers a pages clone's theme when you have one, and a different theme renders
 different bytes.
@@ -152,4 +149,4 @@ both themes, and read every figure before handing the link over. A clipped or il
 means fix and republish. Never report the URL of an unviewed page.
 {{< /callout >}}
 
-How the URL is derived, and what happens on key rotation: [Pages](/docs/guide/concepts/pages/).
+How the URL is derived, and what happens on key rotation: [Pages](/guide/concepts/pages/).

--- a/docs/hextra/content/guide/_index.md
+++ b/docs/hextra/content/guide/_index.md
@@ -46,8 +46,8 @@ skipped acts at exactly one point.
 | **Hook**  | refuses at the tool call         | nothing — ignoring it is not possible      |
 | **Tool**  | replaces the capability itself   | nothing — the limit is in the kernel       |
 
-Climb only as high as the failure justifies. [Four surfaces](/docs/guide/concepts/surfaces/) explains the
-mechanics; [thinking in agentkit](/docs/guide/thinking/) is the judgment call about which one a given
+Climb only as high as the failure justifies. [Four surfaces](/guide/concepts/surfaces/) explains the
+mechanics; [thinking in agentkit](/guide/thinking/) is the judgment call about which one a given
 piece of discipline deserves.
 
 ## The enforcement, concretely
@@ -66,7 +66,7 @@ duplicated blocks, and comments carrying references that rot. Every refusal name
 override.
 
 Two units — `resource` and `delegation` — enforce nothing under the default configuration, and
-`review` ships only with an explicit kit. See [configuration](/docs/reference/configuration/) for turning
+`review` ships only with an explicit kit. See [configuration](/reference/configuration/) for turning
 them on.
 
 ## What the guards cover
@@ -77,7 +77,7 @@ precisely:
 
 {{< callout type="warning" >}}
 A guard you wrongly believe in is worse than no guard, because you stop watching.
-[Boundaries](/docs/guide/concepts/boundaries/) states every limit in one place.
+[Boundaries](/guide/concepts/boundaries/) states every limit in one place.
 {{< /callout >}}
 
 - Hooks are **guards**: they detect a pattern in a tool call and refuse it. An effect written a
@@ -93,8 +93,8 @@ A guard you wrongly believe in is worse than no guard, because you stop watching
 ## Start here
 
 {{< cards >}}
-{{< card link="/docs/guide/start/install/" title="Install" subtitle="Get it onto a machine, pick a door, and choose your kits." >}}
-{{< card link="/docs/guide/start/verify/" title="Verify the install" subtitle="Prove the enforcement is live rather than trusting a file listing." >}}
-{{< card link="/docs/guide/thinking/" title="Thinking in agentkit" subtitle="When discipline should be a skill, a rule, a hook or a tool." >}}
-{{< card link="/docs/cookbook/" title="Cookbook" subtitle="Copyable shapes for the workflows people actually run." >}}
+{{< card link="/guide/start/install/" title="Install" subtitle="Get it onto a machine, pick a door, and choose your kits." >}}
+{{< card link="/guide/start/verify/" title="Verify the install" subtitle="Prove the enforcement is live rather than trusting a file listing." >}}
+{{< card link="/guide/thinking/" title="Thinking in agentkit" subtitle="When discipline should be a skill, a rule, a hook or a tool." >}}
+{{< card link="/cookbook/" title="Cookbook" subtitle="Copyable shapes for the workflows people actually run." >}}
 {{< /cards >}}

--- a/docs/hextra/content/guide/concepts/_index.md
+++ b/docs/hextra/content/guide/concepts/_index.md
@@ -7,16 +7,16 @@ How the kit is built, and why each piece takes the form it does. Start with the 
 the rest are the machinery behind one of them.
 
 {{< cards >}}
-{{< card link="/docs/guide/concepts/surfaces/" title="Four surfaces" subtitle="Skill, rule, hook and tool, ordered by how much force each carries." >}}
-{{< card link="/docs/guide/concepts/hooks/" title="Police hooks" subtitle="The refusal mechanism: what a unit inspects, and how it names an override." >}}
-{{< card link="/docs/guide/concepts/skills/" title="Skills" subtitle="Instructions loaded on demand, and what makes one trigger." >}}
-{{< card link="/docs/guide/concepts/context/" title="Rules and instructions" subtitle="Always-on context, and the globs that scope it." >}}
-{{< card link="/docs/guide/concepts/tastes/" title="Tastes" subtitle="Conventions that travel with the repository they govern." >}}
-{{< card link="/docs/guide/concepts/boundaries/" title="Boundaries" subtitle="What every guard does not reach — stated, because a guard you wrongly trust is worse than none." >}}
-{{< card link="/docs/guide/concepts/containment/" title="Containment" subtitle="Cgroup limits that hold in the kernel, and what they deliberately exclude." >}}
-{{< card link="/docs/guide/concepts/review/" title="Review and the gate" subtitle="Denying a merge unless a review record matches the commit under review." >}}
-{{< card link="/docs/guide/concepts/memory/" title="The memory kit" subtitle="A vault of notes and the index injected into every session." >}}
-{{< card link="/docs/guide/concepts/product/" title="The product model" subtitle="Declaring what a repository ships so a review can meet it as a user." >}}
-{{< card link="/docs/guide/concepts/pages/" title="Pages" subtitle="Publishing an agent's output to a private URL it can hand back." >}}
-{{< card link="/docs/guide/concepts/diagrams/" title="Diagram intelligence" subtitle="Choosing a diagram by what the concept is, not by the tool at hand." >}}
+{{< card link="/guide/concepts/surfaces/" title="Four surfaces" subtitle="Skill, rule, hook and tool, ordered by how much force each carries." >}}
+{{< card link="/guide/concepts/hooks/" title="Police hooks" subtitle="The refusal mechanism: what a unit inspects, and how it names an override." >}}
+{{< card link="/guide/concepts/skills/" title="Skills" subtitle="Instructions loaded on demand, and what makes one trigger." >}}
+{{< card link="/guide/concepts/context/" title="Rules and instructions" subtitle="Always-on context, and the globs that scope it." >}}
+{{< card link="/guide/concepts/tastes/" title="Tastes" subtitle="Conventions that travel with the repository they govern." >}}
+{{< card link="/guide/concepts/boundaries/" title="Boundaries" subtitle="What every guard does not reach — stated, because a guard you wrongly trust is worse than none." >}}
+{{< card link="/guide/concepts/containment/" title="Containment" subtitle="Cgroup limits that hold in the kernel, and what they deliberately exclude." >}}
+{{< card link="/guide/concepts/review/" title="Review and the gate" subtitle="Denying a merge unless a review record matches the commit under review." >}}
+{{< card link="/guide/concepts/memory/" title="The memory kit" subtitle="A vault of notes and the index injected into every session." >}}
+{{< card link="/guide/concepts/product/" title="The product model" subtitle="Declaring what a repository ships so a review can meet it as a user." >}}
+{{< card link="/guide/concepts/pages/" title="Pages" subtitle="Publishing an agent's output to a private URL it can hand back." >}}
+{{< card link="/guide/concepts/diagrams/" title="Diagram intelligence" subtitle="Choosing a diagram by what the concept is, not by the tool at hand." >}}
 {{< /cards >}}

--- a/docs/hextra/content/guide/concepts/boundaries.md
+++ b/docs/hextra/content/guide/concepts/boundaries.md
@@ -75,7 +75,7 @@ open" — it is **never fail silent**.
 {{< callout type="warning" >}}
 A `PreToolUse` hook that crashes emits no decision, and **no decision means allow**. That is the
 harness contract, not an agentkit choice. It is why `review-police` runs behind a supervisor, and why
-[verify the install](/docs/guide/start/verify/) drives a hook by hand rather than trusting a file listing.
+[verify the install](/guide/start/verify/) drives a hook by hand rather than trusting a file listing.
 {{< /callout >}}
 
 ## What the merge gate proves

--- a/docs/hextra/content/guide/concepts/containment.md
+++ b/docs/hextra/content/guide/concepts/containment.md
@@ -109,7 +109,7 @@ With `resource-police` enabled, these classes must go through the installed runn
 
 Remove entries from `resource-police.bounded` to relax individual classes; omitting the list bounds
 every class. The unit is **off by default** — see
-[configuration](/docs/reference/configuration/#resource-police).
+[configuration](/reference/configuration/#resource-police).
 
 {{< callout type="info" >}}
 Bounding matches command prefixes, so privileged or remote wrappers (`sudo`, `ssh`) around a heavy

--- a/docs/hextra/content/guide/concepts/context.md
+++ b/docs/hextra/content/guide/concepts/context.md
@@ -10,7 +10,7 @@ agent has before it decides anything.
 | -------------------------------- | -------------------------- | --------------------------- | --------------- |
 | Rules                            | a matching file is in play | a glob in the frontmatter   | `rules/`        |
 | Instructions                     | every session              | nothing — always on         | `instructions/` |
-| [Skills](/docs/guide/concepts/skills/) | the agent invokes one      | its own trigger description | `skills/`       |
+| [Skills](/guide/concepts/skills/) | the agent invokes one      | its own trigger description | `skills/`       |
 
 ## Rules: markdown with a glob
 
@@ -82,5 +82,5 @@ That budget is the whole reason the discipline is not one enormous prompt. And i
 that _must_ hold are not in this layer at all: a rule you paid context for is still a rule the agent
 can decide to skip. Only a hook cannot be skipped.
 
-A preference that is yours rather than universal belongs in a [taste](/docs/guide/concepts/tastes/), which
+A preference that is yours rather than universal belongs in a [taste](/guide/concepts/tastes/), which
 is the one layer in this family that can also refuse.

--- a/docs/hextra/content/guide/concepts/hooks.md
+++ b/docs/hextra/content/guide/concepts/hooks.md
@@ -49,7 +49,7 @@ The consequence is uncomfortable and load-bearing: **a `PreToolUse` hook that cr
 decision, and no decision means allow.** A guard that dies on its first line is not merely broken;
 it is silently off while appearing installed. That has happened in this kit — a hardcoded absolute
 path that did not exist on one platform killed a hook immediately, and the harness reported only a
-non-blocking status code. [Verify the install](/docs/guide/start/verify/) is the routine that catches it.
+non-blocking status code. [Verify the install](/guide/start/verify/) is the routine that catches it.
 {{< /callout >}}
 
 ### Why the write hooks exit 2
@@ -147,5 +147,5 @@ Refusal, mapping, override. All three, every time. This is a design rule, not a 
 that hits a wall with no door will try every other wall. A refusal that does not say what to do
 instead is treated as a bug in the kit.
 
-What each unit refuses is in the [hooks reference](/docs/reference/hooks/). How to override one for a
-single command is in [override a guard](/docs/cookbook/override-a-guard/).
+What each unit refuses is in the [hooks reference](/reference/hooks/). How to override one for a
+single command is in [override a guard](/cookbook/override-a-guard/).

--- a/docs/hextra/content/guide/concepts/pages.md
+++ b/docs/hextra/content/guide/concepts/pages.md
@@ -134,7 +134,7 @@ both themes, and read every figure. **Never report the URL of an unviewed page.*
 
 ## Direct writes are blocked on purpose
 
-[`pages-police`](/docs/reference/hooks/) refuses raw `curl`, `wget`, `httpie` and `xh` writes to the
+[`pages-police`](/reference/hooks/) refuses raw `curl`, `wget`, `httpie` and `xh` writes to the
 publish API. Publishing
 through the skill enforces the figure lint, the size cap and the canonical commit; a raw write bypasses
 all three.

--- a/docs/hextra/content/guide/concepts/product.md
+++ b/docs/hextra/content/guide/concepts/product.md
@@ -12,7 +12,7 @@ Missing packaging. A setup step that only exists in someone's head. None of it a
 ## Declaring what a product is
 
 `.agentkit/product.yaml`, committed at the repository root — because a reviewer reads it in a fresh
-clone, and an untracked manifest is the same as no manifest at all. [Declare your product](/docs/cookbook/declare-your-product/) is the walkthrough.
+clone, and an untracked manifest is the same as no manifest at all. [Declare your product](/cookbook/declare-your-product/) is the walkthrough.
 
 ```yaml
 summary: >-

--- a/docs/hextra/content/guide/concepts/review.md
+++ b/docs/hextra/content/guide/concepts/review.md
@@ -145,5 +145,5 @@ can require stricter evidence and cannot be weakened by `~/.config/agentkit/conf
 
 ## What the gate proves
 
-It proves **binding**, not authentication. See [boundaries](/docs/guide/concepts/boundaries/#what-the-merge-gate-proves)
+It proves **binding**, not authentication. See [boundaries](/guide/concepts/boundaries/#what-the-merge-gate-proves)
 for exactly what that excludes.

--- a/docs/hextra/content/guide/concepts/skills.md
+++ b/docs/hextra/content/guide/concepts/skills.md
@@ -36,7 +36,7 @@ sufficient alone — the skill has no teeth, the hook has no idea which profile 
 {{< skill-table >}}
 
 Kit membership is declared in one manifest, `skills/KITS`, read by a shared library so the installer
-and the plugin generator can never disagree. See [skill kits](/docs/kits/) for selecting them.
+and the plugin generator can never disagree. See [skill kits](/kits/) for selecting them.
 
 ## Skills that ship code
 
@@ -65,4 +65,4 @@ that a local review record does not authenticate reviewer identity or prove any 
 that overclaims about itself is the one you cannot calibrate against.
 
 Several skills are tied to a specific forge or platform — the list is in
-[boundaries](/docs/guide/concepts/boundaries/#several-skills-are-not-forge-neutral).
+[boundaries](/guide/concepts/boundaries/#several-skills-are-not-forge-neutral).

--- a/docs/hextra/content/guide/concepts/surfaces.md
+++ b/docs/hextra/content/guide/concepts/surfaces.md
@@ -22,7 +22,7 @@ unbounded form has no reach at all outside `Bash` — and cannot be talked out o
 a given kind of discipline can push, and how much of your work it reaches. It is not a list of the
 artifacts the installer places, and nothing in `install.sh` enumerates a count of four. For the
 actual inventory — including the per-session resource shims and the systemd slice, which are not any
-of the four — see [what lands where](/docs/guide/start/what-lands-where/).
+of the four — see [what lands where](/guide/start/what-lands-where/).
 {{< /callout >}}
 
 ## One unit, up to three implementations
@@ -89,4 +89,4 @@ because the refusals that reference it would be pointing at a lie.
   supervisor converts every failure into a denial — because the harness's own default (crashed hook =
   allow) points the wrong way.
 - **Honest non-goals.** The gate is not security. Codex policies do not parse shell. Containment
-  excludes delegated workloads. Every limit is stated in [boundaries](/docs/guide/concepts/boundaries/).
+  excludes delegated workloads. Every limit is stated in [boundaries](/guide/concepts/boundaries/).

--- a/docs/hextra/content/guide/extending/_index.md
+++ b/docs/hextra/content/guide/extending/_index.md
@@ -7,7 +7,7 @@ Adding your own discipline to the kit. Each page is the shape to copy, the check
 and where it has to be wired to take effect.
 
 {{< cards >}}
-{{< card link="/docs/guide/extending/police-unit/" title="Write a police unit" subtitle="A refusal at the tool call, compiled into every harness that can express it." >}}
-{{< card link="/docs/guide/extending/skill/" title="Write a skill" subtitle="Instructions an agent loads on demand, and the frontmatter that makes it findable." >}}
-{{< card link="/docs/guide/extending/taste/" title="Write a taste" subtitle="A convention committed next to the code it governs, so every harness reads it." >}}
+{{< card link="/guide/extending/police-unit/" title="Write a police unit" subtitle="A refusal at the tool call, compiled into every harness that can express it." >}}
+{{< card link="/guide/extending/skill/" title="Write a skill" subtitle="Instructions an agent loads on demand, and the frontmatter that makes it findable." >}}
+{{< card link="/guide/extending/taste/" title="Write a taste" subtitle="A convention committed next to the code it governs, so every harness reads it." >}}
 {{< /cards >}}

--- a/docs/hextra/content/guide/extending/police-unit.md
+++ b/docs/hextra/content/guide/extending/police-unit.md
@@ -8,9 +8,9 @@ and registering the hook so the harness runs it.
 
 {{< callout type="info" >}}
 Before writing a hook, check whether the discipline belongs at a lower altitude. A preference of
-yours is a [taste](/docs/guide/concepts/tastes/) — which can already refuse, with no code at all. A
-workflow is a [skill](/docs/guide/concepts/skills/). Only reach for a unit when "please don't" has already
-failed. [Thinking in agentkit](/docs/guide/thinking/) is the ladder.
+yours is a [taste](/guide/concepts/tastes/) — which can already refuse, with no code at all. A
+workflow is a [skill](/guide/concepts/skills/). Only reach for a unit when "please don't" has already
+failed. [Thinking in agentkit](/guide/thinking/) is the ladder.
 {{< /callout >}}
 
 ## The anatomy of one
@@ -120,7 +120,7 @@ Wrap it in `fail-closed-hook.sh <budget>` only if its **silence** should be a de
 the merge gate and nothing else so far — every other unit fails open, loudly.
 
 The generated tables on this site read that same file, so registering a unit is what puts it in the
-[hooks reference](/docs/reference/hooks/).
+[hooks reference](/reference/hooks/).
 
 ## The other mechanisms
 
@@ -134,7 +134,7 @@ shipping something that looks precise and is not. `delegation-police` is the wor
 refuses whole classes outright on Codex while the hook and plugin do real payload analysis.
 
 A unit does not have to exist in all three. Coverage is uneven on purpose, and the
-[coverage table](/docs/reference/hooks/#coverage) is generated from which files exist.
+[coverage table](/reference/hooks/#coverage) is generated from which files exist.
 
 ## Test it
 

--- a/docs/hextra/content/guide/extending/skill.md
+++ b/docs/hextra/content/guide/extending/skill.md
@@ -20,7 +20,7 @@ description: >-
 `description` is not a summary for humans. It is the only thing an agent reads when deciding whether
 to load the skill, so it must contain the trigger conditions, not just the capability.
 
-The facts generator reads this field to build the [catalogue](/docs/reference/skills/), and it **fails the
+The facts generator reads this field to build the [catalogue](/reference/skills/), and it **fails the
 build** on a skill with no frontmatter or no description. A block scalar (`>-`) is handled; an empty
 value is an error.
 
@@ -81,5 +81,5 @@ skill in two kits, or an `explicit` marker naming a kit that was never declared.
 ## What a skill cannot do
 
 It cannot enforce. The agent decides whether to load it, and a skill that is never loaded does
-nothing at all. If the rule must hold, it is a [police unit](/docs/guide/extending/police-unit/) — and the
+nothing at all. If the rule must hold, it is a [police unit](/guide/extending/police-unit/) — and the
 two are wired to agree where they overlap, the skill carrying the judgement and the hook the force.

--- a/docs/hextra/content/guide/start/_index.md
+++ b/docs/hextra/content/guide/start/_index.md
@@ -8,10 +8,10 @@ sidebar:
 Get agentkit onto a machine, prove the enforcement is actually live, and know what it put where.
 
 {{< cards >}}
-{{< card link="/docs/guide/start/install/" title="Install" subtitle="Get it onto a machine, pick a door, and choose your kits." >}}
-{{< card link="/docs/guide/start/verify/" title="Verify the install" subtitle="Drive a hook by hand and watch it refuse, rather than trusting a file listing." >}}
-{{< card link="/docs/guide/start/what-lands-where/" title="What lands where" subtitle="Every path the installer writes, and which of them are symlinks to the canon." >}}
-{{< card link="/docs/kits/" title="Skill kits" subtitle="What ships by default, and what each opt-in kit adds." >}}
-{{< card link="/docs/guide/start/requirements/" title="Requirements and platforms" subtitle="The dependencies, and what stands down when one is missing." >}}
-{{< card link="/docs/guide/start/upgrading/" title="Upgrading and removing" subtitle="How an upgrade treats your own edits, and how to take it off again." >}}
+{{< card link="/guide/start/install/" title="Install" subtitle="Get it onto a machine, pick a door, and choose your kits." >}}
+{{< card link="/guide/start/verify/" title="Verify the install" subtitle="Drive a hook by hand and watch it refuse, rather than trusting a file listing." >}}
+{{< card link="/guide/start/what-lands-where/" title="What lands where" subtitle="Every path the installer writes, and which of them are symlinks to the canon." >}}
+{{< card link="/kits/" title="Skill kits" subtitle="What ships by default, and what each opt-in kit adds." >}}
+{{< card link="/guide/start/requirements/" title="Requirements and platforms" subtitle="The dependencies, and what stands down when one is missing." >}}
+{{< card link="/guide/start/upgrading/" title="Upgrading and removing" subtitle="How an upgrade treats your own edits, and how to take it off again." >}}
 {{< /cards >}}

--- a/docs/hextra/content/guide/start/install.md
+++ b/docs/hextra/content/guide/start/install.md
@@ -62,7 +62,7 @@ git clone git@github.com:developerinlondon/agentkit.git
 ```
 
 The interactive kit picker only appears here, and only on a terminal — see
-[skill kits](/docs/kits/).
+[skill kits](/kits/).
 {{< /tab >}}
 
 {{< tab name="Claude plugin" >}}
@@ -88,7 +88,7 @@ To wire Claude this way as part of a normal install, pass `--claude-plugin` (glo
 
 {{< callout type="info" >}}
 The plugin format has no way to inject always-on global context, so
-[instructions](/docs/guide/concepts/context/) do not arrive on this path. They come from a file install.
+[instructions](/guide/concepts/context/) do not arrive on this path. They come from a file install.
 {{< /callout >}}
 {{< /tab >}}
 
@@ -140,9 +140,9 @@ Exit codes matter if you script around it:
 | `--claude-plugin` without `--global` | `1`  |
 
 Environment inputs, rather than flags, are listed in the
-[environment reference](/docs/reference/environment/).
+[environment reference](/reference/environment/).
 
 ## Then prove it took
 
 A file listing tells you files were copied. It does not tell you the behaviour changed, which is the
-entire product. Go to [verify the install](/docs/guide/start/verify/) next.
+entire product. Go to [verify the install](/guide/start/verify/) next.

--- a/docs/hextra/content/guide/start/requirements.md
+++ b/docs/hextra/content/guide/start/requirements.md
@@ -77,4 +77,4 @@ portable Codex review hook still installs when `adversarial-review` is selected.
 
 The installer seeds `~/.config/agentkit/config.yaml` from `config.example.yaml` on first run, and
 never overwrites it afterwards. `XDG_CONFIG_HOME` is respected. Every key is listed in the
-[configuration reference](/docs/reference/configuration/).
+[configuration reference](/reference/configuration/).

--- a/docs/hextra/content/guide/start/verify.md
+++ b/docs/hextra/content/guide/start/verify.md
@@ -128,5 +128,5 @@ wrongly. Before assuming breakage, walk these in order:
 | Is the link intact? | `ls -l ~/.claude/hooks/` — every entry should resolve into `~/.agentkit/hooks/` |
 | Does it run at all? | drive it by hand as above; a crash prints a shell error rather than JSON |
 
-Every switch and config key is in [configuration](/docs/reference/configuration/); to override one guard
-for one command, see [override a guard](/docs/cookbook/override-a-guard/).
+Every switch and config key is in [configuration](/reference/configuration/); to override one guard
+for one command, see [override a guard](/cookbook/override-a-guard/).

--- a/docs/hextra/content/guide/start/what-lands-where.md
+++ b/docs/hextra/content/guide/start/what-lands-where.md
@@ -96,7 +96,7 @@ on top and a re-install will not clobber.
 **Two slices, two owners.** `install.sh` provisions the **session** slice,
 `agent-sessions.slice`. The **work** slice that `bounded-run` verifies before running a heavy
 command — `agent-work.slice` — is provisioned on the host separately, and `bounded-run` fails closed
-until it is in place. See [containment](/docs/guide/concepts/containment/).
+until it is in place. See [containment](/guide/concepts/containment/).
 {{< /callout >}}
 
 ## Global versus project

--- a/docs/hextra/content/guide/thinking.md
+++ b/docs/hextra/content/guide/thinking.md
@@ -113,7 +113,7 @@ you stop watching.
 
 ## Next
 
-- [Four surfaces](/docs/guide/concepts/surfaces/) — the mechanics behind the ladder above.
-- [Police hooks](/docs/guide/concepts/hooks/) — every unit, what it checks, how to override it.
-- [Cookbook](/docs/cookbook/) — the recipes these principles produce.
-- [Install](/docs/guide/start/install/) — if you have not got it on a machine yet.
+- [Four surfaces](/guide/concepts/surfaces/) — the mechanics behind the ladder above.
+- [Police hooks](/guide/concepts/hooks/) — every unit, what it checks, how to override it.
+- [Cookbook](/cookbook/) — the recipes these principles produce.
+- [Install](/guide/start/install/) — if you have not got it on a machine yet.

--- a/docs/hextra/content/harnesses/_index.md
+++ b/docs/hextra/content/harnesses/_index.md
@@ -40,7 +40,7 @@ timeout is treated as a refusal only where a fail-closed budget is declared.
 {{< callout type="warning" >}}
 **Codex reads argv, not shell.** Its policies match literal command prefixes rather than parsing a
 shell payload, so the same intent written a different way — through a pipe, a script, an API call —
-is outside what they match. [Boundaries](/docs/guide/concepts/boundaries/) states every such limit
+is outside what they match. [Boundaries](/guide/concepts/boundaries/) states every such limit
 in one place.
 {{< /callout >}}
 
@@ -48,4 +48,4 @@ in one place.
 
 The cgroup tooling is Linux-only. On macOS and elsewhere the bounded runner, its `agentkit-run`
 alias and the Codex heavy-command policy are not installed, and containment stands down — while
-every guard that does not need cgroups stays active. [Requirements and platforms](/docs/guide/start/requirements/) lists exactly what is skipped and what remains.
+every guard that does not need cgroups stays active. [Requirements and platforms](/guide/start/requirements/) lists exactly what is skipped and what remains.

--- a/docs/hextra/content/kits/_index.md
+++ b/docs/hextra/content/kits/_index.md
@@ -84,7 +84,7 @@ Any of them aborts the run before a file is touched.
 {{< skill-table kit="adversarial-review" >}}
 
 Also installs `review-police`, the `review-gate` and `review-profile` tools, and the
-`evidence-gated-review` instruction. See [review and the gate](/docs/guide/concepts/review/).
+`evidence-gated-review` instruction. See [review and the gate](/guide/concepts/review/).
 {{< /tab >}}
 {{< tab name="advisory-review" >}}
 This kit carries no skills. It installs one always-on instruction, `review-discipline.md`, which

--- a/docs/hextra/content/reference/_index.md
+++ b/docs/hextra/content/reference/_index.md
@@ -10,11 +10,11 @@ at build time, so a unit added, removed or rewired changes the page in the same 
 build fails.
 
 {{< cards >}}
-{{< card link="/docs/reference/skills/" title="Skill catalogue" subtitle="Every skill, the kit it belongs to, and what it is for. Built from each skill's own frontmatter." >}}
-{{< card link="/docs/reference/hooks/" title="Hooks" subtitle="Each police unit, the mechanism it runs on, what it refuses and the override it names." >}}
-{{< card link="/docs/reference/cli/" title="CLI and tools" subtitle="The executables that ship in `tools/`, including the two the installer omits off Linux." >}}
-{{< card link="/docs/reference/configuration/" title="Configuration" subtitle="Every key in `~/.config/agentkit/config.yaml`, its default, and what turning it on changes." >}}
-{{< card link="/docs/reference/environment/" title="Environment variables" subtitle="Every variable agentkit reads, grouped by what it is for — overrides first." >}}
-{{< card link="/docs/reference/glossary/" title="Glossary" subtitle="Definitions as the code means them, not as the words are used generally." >}}
-{{< card link="/docs/reference/faq/" title="FAQ" subtitle="The questions that come up once the enforcement is live." >}}
+{{< card link="/reference/skills/" title="Skill catalogue" subtitle="Every skill, the kit it belongs to, and what it is for. Built from each skill's own frontmatter." >}}
+{{< card link="/reference/hooks/" title="Hooks" subtitle="Each police unit, the mechanism it runs on, what it refuses and the override it names." >}}
+{{< card link="/reference/cli/" title="CLI and tools" subtitle="The executables that ship in `tools/`, including the two the installer omits off Linux." >}}
+{{< card link="/reference/configuration/" title="Configuration" subtitle="Every key in `~/.config/agentkit/config.yaml`, its default, and what turning it on changes." >}}
+{{< card link="/reference/environment/" title="Environment variables" subtitle="Every variable agentkit reads, grouped by what it is for — overrides first." >}}
+{{< card link="/reference/glossary/" title="Glossary" subtitle="Definitions as the code means them, not as the words are used generally." >}}
+{{< card link="/reference/faq/" title="FAQ" subtitle="The questions that come up once the enforcement is live." >}}
 {{< /cards >}}

--- a/docs/hextra/content/reference/cli.md
+++ b/docs/hextra/content/reference/cli.md
@@ -298,7 +298,7 @@ Both the hook and CI branch on these, so they are part of the contract.
 | `3`  | fault — a named plan is missing or unreadable                   |
 
 Discovery and matching are configurable per repository; see
-[Configuration](/docs/reference/configuration/).
+[Configuration](/reference/configuration/).
 
 ## `review-gate`
 
@@ -377,7 +377,7 @@ worktree.
 
 Every run appends one tab-separated line to `${HOME:-/tmp}/.agentkit/review-audit.log`. The append
 is best-effort and never fails the run. Config errors exit `2`; see
-[Configuration](/docs/reference/configuration/) for the keys and precedence.
+[Configuration](/reference/configuration/) for the keys and precedence.
 
 ## `fix-ascii-boxes.py`
 

--- a/docs/hextra/content/reference/configuration.md
+++ b/docs/hextra/content/reference/configuration.md
@@ -93,7 +93,7 @@ Codex policies update on the next `install.sh` run.
 
 Classes: `js-packages`, `js-scripts`, `typescript`, `playwright`, `cargo`, `go`, `moon`, `python`.
 Remove entries to relax individual classes; omitting the whole list bounds every class. See
-[containment](/docs/guide/concepts/containment/).
+[containment](/guide/concepts/containment/).
 
 ## `delegation-police`
 
@@ -162,10 +162,10 @@ read-only — a correction is reported rather than filed.
 Each source takes `repo`, `ref`, `mode` (only `vendored` is implemented; declaring `reference` is an
 error), `visibility` (`public` or `private`), and optionally `path` and `name`. `visibility` is
 **required** of a source a repository vendors, and vendoring a private source into a public
-repository is refused. See [tastes](/docs/guide/concepts/tastes/).
+repository is refused. See [tastes](/guide/concepts/tastes/).
 
 ## Kill switches
 
 Configuration is not the only lever. `AGENTKIT_SKIP_HOOKS` disables units for one session, and most
 refusing units take a per-command override variable — all of them in the
-[environment reference](/docs/reference/environment/).
+[environment reference](/reference/environment/).

--- a/docs/hextra/content/reference/faq.md
+++ b/docs/hextra/content/reference/faq.md
@@ -82,7 +82,7 @@ persists across it:
 - An **explicit** kit that is not selected has its previously installed hooks, tools, skills and
   prompt wiring **removed**.
 
-See [Upgrading and removing](/docs/guide/start/upgrading/) for the per-file detail.
+See [Upgrading and removing](/guide/start/upgrading/) for the per-file detail.
 
 ## Why is the review machinery not on by default?
 

--- a/docs/hextra/content/reference/glossary.md
+++ b/docs/hextra/content/reference/glossary.md
@@ -63,7 +63,7 @@ every harness.
 An install partition declared in `skills/KITS`, a plain-text manifest read by the installer, the
 Claude plugin generator and the tests alike. A skill with no membership record belongs to `core`,
 which always installs, and a skill may name only one kit. The declared kits are listed in
-[Skill kits](/docs/kits/), generated from the manifest.
+[Skill kits](/kits/), generated from the manifest.
 
 ## Explicit kit
 

--- a/docs/hextra/content/reference/hooks.md
+++ b/docs/hextra/content/reference/hooks.md
@@ -94,9 +94,9 @@ itself while it is happening, so confirm both dependencies resolve after an inst
 
 | Scope       | How                                                                                    |
 | ----------- | -------------------------------------------------------------------------------------- |
-| one command | the unit's own override variable — see [override a guard](/docs/cookbook/override-a-guard/) |
+| one command | the unit's own override variable — see [override a guard](/cookbook/override-a-guard/) |
 | one session | `AGENTKIT_SKIP_HOOKS=<unit>,<unit>` or `AGENTKIT_SKIP_HOOKS=all`                       |
-| permanently | the unit's key in [`config.yaml`](/docs/reference/configuration/), where it has one         |
+| permanently | the unit's key in [`config.yaml`](/reference/configuration/), where it has one         |
 
 `AGENTKIT_SKIP_HOOKS` is honoured by the advisory units — `coding-police`, `comment-police` and
 `format-police` on the Claude side, `version-police` on the OpenCode side. The refusing units do not

--- a/docs/hextra/content/reference/skills.md
+++ b/docs/hextra/content/reference/skills.md
@@ -15,7 +15,7 @@ description it does not carry, or in a kit it does not belong to.
 
 A skill with no record in `skills/KITS` belongs to `core`, and a skill may name only one kit.
 `explicit` kits are never offered by the interactive picker and are excluded from `--all`; only a
-literal `--with <kit>` selects one. See [skill kits](/docs/kits/).
+literal `--with <kit>` selects one. See [skill kits](/kits/).
 
 ## Not forge-neutral
 

--- a/docs/hextra/data/archives.json
+++ b/docs/hextra/data/archives.json
@@ -1,6 +1,4 @@
 {
-  "comment": "Docs trees published under /docs/<version>/. Every entry is spared from the deploy's prune, whether or not the picker offers it: a published path must not vanish because a newer patch replaced it in the list. A release appends its own version here once its tree is live.",
-  "published": [
-    "0.7.14"
-  ]
+  "comment": "Docs trees published under docs.agentkit.sbs/<version>/. Every entry is spared from the prune. History restarts at the move to this host: earlier trees were built for a different URL scheme and their in-content links point at the old one. A release appends its own version here once its tree is live.",
+  "published": []
 }

--- a/docs/hextra/data/versions.json
+++ b/docs/hextra/data/versions.json
@@ -1,7 +1,7 @@
 [
   {
-    "slug": "0.7.14",
-    "label": "v0.7.14 (latest)",
+    "slug": "0.7.15",
+    "label": "v0.7.15 (latest)",
     "current": true
   }
 ]

--- a/docs/hextra/deploy.sh
+++ b/docs/hextra/deploy.sh
@@ -7,6 +7,7 @@ cd "$(dirname "$0")"
 
 ENDPOINT="${AGENTKIT_SITE_ENDPOINT:-https://agentkit.sbs}"
 SITE_URL="${AGENTKIT_SITE_URL:-https://agentkit.sbs}"
+DOCS_URL="${AGENTKIT_DOCS_URL:-https://docs.agentkit.sbs}"
 TOKEN_FILE="${AGENTKIT_SITE_TOKEN_FILE:-$HOME/.config/agentkit/site-token}"
 MARKER='ak-theme-toggle'
 # Slugs published under /docs/<version>/, which this build does not contain and
@@ -44,19 +45,23 @@ done < <(find public -type f)
 [[ "$uploaded" -gt 0 ]] || die "public/ holds no files"
 echo "deploy: uploaded $uploaded file(s)"
 
-# A release also lands under its own version, which is what the picker offers
-# and what keeps that copy readable after the next release replaces /docs/.
-# Add the version to data/archives.json in the release commit so the picker
-# starts offering it.
+# A release also lands under its own version, so the copy stays readable once
+# /docs/ moves on. It is rebuilt against its own base: Hugo content-hashes the
+# stylesheet name, so a copy pointing at /docs/ loses every asset the moment the
+# next release changes that hash.
 version="${AGENTKIT_DOCS_VERSION:-}"
 version="${version#v}"
 if [[ -n "$version" ]]; then
+	archive=$(mktemp -d)
+	"${HUGO_BIN:-hugo-extended}" --quiet --destination "$archive" \
+		--baseURL "$DOCS_URL/$version/" || die "could not build the $version archive"
 	while IFS= read -r file; do
 		curl -sS --fail-with-body -X PUT --config "$auth" --data-binary "@$file" \
-			"$ENDPOINT/api/site/docs/$version/${file#public/}" >/dev/null \
+			"$ENDPOINT/api/site/docs/$version/${file#"$archive"/}" >/dev/null \
 			|| die "FAILED $file -> docs/$version/"
-	done < <(find public -type f)
-	echo "deploy: also published $SITE_URL/docs/$version/"
+	done < <(find "$archive" -type f)
+	rm -rf "$archive"
+	echo "deploy: also published $DOCS_URL/$version/"
 	printf '%s\n' "$version" >> "$keep"
 fi
 
@@ -98,10 +103,10 @@ served=$(mktemp)
 trap 'rm -f "$auth" "$live" "$built" "$stale" "$served"' EXIT
 attempts=${AGENTKIT_VERIFY_ATTEMPTS:-6}
 for ((try = 1; try <= attempts; try++)); do
-	if curl -sS --max-time 20 -o "$served" "$SITE_URL/docs/" 2>/dev/null && grep -q "$MARKER" "$served"; then
-		echo "deploy: $SITE_URL/docs/ is serving this build"
+	if curl -sS --max-time 20 -o "$served" "$DOCS_URL/" 2>/dev/null && grep -q "$MARKER" "$served"; then
+		echo "deploy: $DOCS_URL/ is serving this build"
 		exit 0
 	fi
 	if [[ "$try" -lt "$attempts" ]]; then sleep 3; fi
 done
-die "published, but $SITE_URL/docs/ still does not serve this build after $attempts attempts"
+die "published, but $DOCS_URL/ still does not serve this build after $attempts attempts"

--- a/docs/hextra/deploy.sh
+++ b/docs/hextra/deploy.sh
@@ -6,7 +6,6 @@ set -euo pipefail
 cd "$(dirname "$0")"
 
 ENDPOINT="${AGENTKIT_SITE_ENDPOINT:-https://agentkit.sbs}"
-SITE_URL="${AGENTKIT_SITE_URL:-https://agentkit.sbs}"
 DOCS_URL="${AGENTKIT_DOCS_URL:-https://docs.agentkit.sbs}"
 TOKEN_FILE="${AGENTKIT_SITE_TOKEN_FILE:-$HOME/.config/agentkit/site-token}"
 MARKER='ak-theme-toggle'

--- a/docs/hextra/hugo.yaml
+++ b/docs/hextra/hugo.yaml
@@ -1,4 +1,4 @@
-baseURL: https://agentkit.sbs/docs/
+baseURL: https://docs.agentkit.sbs/
 title: agentkit
 locale: en-gb
 

--- a/docs/hextra/layouts/_partials/theme-toggle.html
+++ b/docs/hextra/layouts/_partials/theme-toggle.html
@@ -18,7 +18,7 @@
   {{- if gt (len $versions) 1 -}}
   <select class="ak-version-picker" aria-label="Documentation version">
     {{- range $versions }}
-    {{- $href := cond .current site.BaseURL (printf "/docs/%s/" .slug) }}
+    {{- $href := cond .current site.BaseURL (printf "/%s/" .slug) }}
     <option value="{{ $href }}"{{ if .current }} selected{{ end }}>{{ .label }}</option>
     {{- end }}
   </select>

--- a/docs/hextra/scripts/check-links.ts
+++ b/docs/hextra/scripts/check-links.ts
@@ -7,7 +7,7 @@ import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { join, relative, resolve } from 'node:path';
 
 const publicDir = resolve(import.meta.dir, '..', 'public');
-const BASE = '/docs';
+const BASE = '';
 
 // Hugo writes every page as <path>/index.html, plus real files for assets.
 function walk(dir: string, out: string[] = []): string[] {

--- a/docs/hextra/scripts/versions.ts
+++ b/docs/hextra/scripts/versions.ts
@@ -35,13 +35,22 @@ export function parse(slugs: string[]): Parsed[] {
   return out.sort((a, b) => b.major - a.major || b.minor - a.minor || b.patch - a.patch);
 }
 
-/** The last published patch of every minor older than the one shipping now. */
+/**
+ * Every published patch of the minor shipping now, plus the last patch of each
+ * older minor. Trimming a long history is what the rule is for; dropping the
+ * release you shipped last week is not, and that is the one a reader is most
+ * likely to want back.
+ */
 export function archivesFor(current: string, published: string[]): Parsed[] {
   const now = parse([current])[0];
   if (!now) return [];
-  const seen = new Set<string>([`${now.major}.${now.minor}`]);
+  const seen = new Set<string>();
   const kept: Parsed[] = [];
   for (const entry of parse(published)) {
+    if (entry.major === now.major && entry.minor === now.minor) {
+      if (entry.patch !== now.patch) kept.push(entry);
+      continue;
+    }
     const series = `${entry.major}.${entry.minor}`;
     if (seen.has(series)) continue;
     seen.add(series);

--- a/pages/site/build.sh
+++ b/pages/site/build.sh
@@ -118,7 +118,7 @@ check_no_external() {
 
 	hit=$(grep -oE 'href=("[^"]*"|'\''[^'\'']*'\'')' "$f" \
 		| grep -E 'https?:|//' \
-		| grep -vE 'href=.https://(github\.com|raw\.githubusercontent\.com|agentkit\.sbs|pages\.agentkit\.sbs|account\.agentkit\.sbs)/' || true)
+		| grep -vE 'href=.https://(github\.com|raw\.githubusercontent\.com|agentkit\.sbs|pages\.agentkit\.sbs|account\.agentkit\.sbs|docs\.agentkit\.sbs)/' || true)
 	[[ -z "$hit" ]] || fail "$f: unexpected off-site href: $hit"
 }
 

--- a/pages/site/src/footer.html
+++ b/pages/site/src/footer.html
@@ -2,7 +2,7 @@
   <div class="wrap foot-in">
     <span>agentkit</span>
     <a href="https://github.com/developerinlondon/agentkit">github.com/developerinlondon/agentkit</a>
-    <a href="https://agentkit.sbs/docs/guide/start/install/">docs</a>
+    <a href="https://docs.agentkit.sbs/guide/start/install/">docs</a>
     <a href="https://agentkit.sbs/privacy/">privacy</a>
     <a href="https://agentkit.sbs/terms/">terms</a>
     <span>Apache-2.0</span>

--- a/pages/site/src/header.html
+++ b/pages/site/src/header.html
@@ -2,7 +2,7 @@
   <div class="wrap top-in">
     <a class="mark" href="https://agentkit.sbs/">agentkit</a>
     <nav class="top-nav" aria-label="Site">
-      <a class="nav-docs" href="https://agentkit.sbs/docs/">Docs</a>
+      <a class="nav-docs" href="https://docs.agentkit.sbs/">Docs</a>
       <a class="gh" href="https://github.com/developerinlondon/agentkit" aria-label="agentkit on GitHub" title="agentkit on GitHub">
         <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
           <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/>

--- a/pages/site/src/pages/index.html
+++ b/pages/site/src/pages/index.html
@@ -17,7 +17,7 @@
         OpenCode and Grok behave like <b>one disciplined team</b>. Install once — every agent gets the
         same standards, enforced at the tool boundary, not suggested in a prompt.</p>
         <div class="row fx-4">
-          <a class="btn solid" href="/docs/guide/start/install/">Get Started →</a>
+          <a class="btn solid" href="https://docs.agentkit.sbs/guide/start/install/">Get Started →</a>
           <a class="btn" href="https://github.com/developerinlondon/agentkit"><svg class="bi" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg> View on GitHub</a>
         </div>
       </div>
@@ -78,25 +78,25 @@
         <div class="cell-hd"><span class="prim-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10"/></svg></span><h3>Police Hooks</h3></div>
         <p>Deterministic guards on every tool call. Force pushes, oversized files, stale dependency pins,
         comment slop — blocked before they happen, in every harness.</p>
-        <a class="learn" href="/docs/reference/hooks/">Learn more →</a>
+        <a class="learn" href="https://docs.agentkit.sbs/reference/hooks/">Learn more →</a>
       </div>
       <div class="cell">
         <div class="cell-hd"><span class="prim-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 14a1 1 0 0 1-.78-1.63l9.9-10.2a.5.5 0 0 1 .86.46l-1.92 6.02A1 1 0 0 0 13 10h7a1 1 0 0 1 .78 1.63l-9.9 10.2a.5.5 0 0 1-.86-.46l1.92-6.02A1 1 0 0 0 11 14z"/></svg></span><h3>Skills</h3></div>
         <p>Portable SKILL.md units — architecture docs, hand-drawn diagrams, product briefs, GitOps ops.
         Written once, loaded by any agent.</p>
-        <a class="learn" href="/docs/reference/skills/">Learn more →</a>
+        <a class="learn" href="https://docs.agentkit.sbs/reference/skills/">Learn more →</a>
       </div>
       <div class="cell">
         <div class="cell-hd"><span class="prim-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M2 12h20"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg></span><h3>Pages</h3></div>
         <p>Agents publish live, themed web pages — design docs, dashboards, slide decks — with stable URLs
         and hand-drawn diagrams. Self-hosted.</p>
-        <a class="learn" href="/docs/guide/concepts/pages/">Learn more →</a>
+        <a class="learn" href="https://docs.agentkit.sbs/guide/concepts/pages/">Learn more →</a>
       </div>
       <div class="cell">
         <div class="cell-hd"><span class="prim-ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18"/><path d="M9 9h6v6H9z"/></svg></span><h3>Bounded-Run</h3></div>
         <p>Heavy builds and test suites run inside deterministic systemd resource limits — an agent can
         never take the host down.</p>
-        <a class="learn" href="/docs/reference/configuration/">Learn more →</a>
+        <a class="learn" href="https://docs.agentkit.sbs/reference/configuration/">Learn more →</a>
       </div>
     </div>
   </section>
@@ -140,8 +140,8 @@
         mechanism: Claude Code hooks, OpenCode plugins, Codex exec policies, Grok rules. One source tree,
         four enforcement surfaces.</p>
         <div class="row">
-          <a class="btn solid" href="/docs/reference/hooks/">Hooks reference</a>
-          <a class="btn" href="/docs/reference/configuration/">Configuration</a>
+          <a class="btn solid" href="https://docs.agentkit.sbs/reference/hooks/">Hooks reference</a>
+          <a class="btn" href="https://docs.agentkit.sbs/reference/configuration/">Configuration</a>
         </div>
       </div>
     </div>
@@ -170,21 +170,21 @@
     <span class="lbl">Documentation</span>
     <h2 class="sr-h2">Every page, in reading order</h2>
     <nav class="docs-list" aria-label="Documentation">
-      <a class="doc-row" href="/docs/guide/start/install/"><span class="d-num">01</span><span class="d-name">Install</span><span class="d-desc">one command, all harnesses</span></a>
-      <a class="doc-row" href="/docs/guide/thinking/"><span class="d-num">02</span><span class="d-name">Thinking</span><span class="d-desc">when to reach for what</span></a>
-      <a class="doc-row" href="/docs/guide/concepts/surfaces/"><span class="d-num">03</span><span class="d-name">Architecture</span><span class="d-desc">the whole map, with diagrams</span></a>
-      <a class="doc-row" href="/docs/guide/concepts/surfaces/"><span class="d-num">04</span><span class="d-name">Concepts</span><span class="d-desc">skills · rules · hooks · tools</span></a>
-      <a class="doc-row" href="/docs/reference/hooks/"><span class="d-num">05</span><span class="d-name">Hooks</span><span class="d-desc">every police unit in detail</span></a>
-      <a class="doc-row" href="/docs/reference/configuration/"><span class="d-num">06</span><span class="d-name">Configuration</span><span class="d-desc">keys, switches, kits, profiles</span></a>
-      <a class="doc-row" href="/docs/reference/skills/"><span class="d-num">07</span><span class="d-name">Skills</span><span class="d-desc">the portable unit of capability</span></a>
-      <a class="doc-row" href="/docs/guide/concepts/pages/"><span class="d-num">08</span><span class="d-name">Pages</span><span class="d-desc">publish live pages from any agent</span></a>
-      <a class="doc-row" href="/docs/guide/concepts/product/"><span class="d-num">09</span><span class="d-name">Product Model</span><span class="d-desc">declare what your repo ships</span></a>
-      <a class="doc-row" href="/docs/guide/concepts/diagrams/"><span class="d-num">10</span><span class="d-name">Diagrams</span><span class="d-desc">classified, derived figures</span></a>
-      <a class="doc-row" href="/docs/cookbook/"><span class="d-num">11</span><span class="d-name">Examples</span><span class="d-desc">copyable setups</span></a>
+      <a class="doc-row" href="https://docs.agentkit.sbs/guide/start/install/"><span class="d-num">01</span><span class="d-name">Install</span><span class="d-desc">one command, all harnesses</span></a>
+      <a class="doc-row" href="https://docs.agentkit.sbs/guide/thinking/"><span class="d-num">02</span><span class="d-name">Thinking</span><span class="d-desc">when to reach for what</span></a>
+      <a class="doc-row" href="https://docs.agentkit.sbs/guide/concepts/surfaces/"><span class="d-num">03</span><span class="d-name">Architecture</span><span class="d-desc">the whole map, with diagrams</span></a>
+      <a class="doc-row" href="https://docs.agentkit.sbs/guide/concepts/surfaces/"><span class="d-num">04</span><span class="d-name">Concepts</span><span class="d-desc">skills · rules · hooks · tools</span></a>
+      <a class="doc-row" href="https://docs.agentkit.sbs/reference/hooks/"><span class="d-num">05</span><span class="d-name">Hooks</span><span class="d-desc">every police unit in detail</span></a>
+      <a class="doc-row" href="https://docs.agentkit.sbs/reference/configuration/"><span class="d-num">06</span><span class="d-name">Configuration</span><span class="d-desc">keys, switches, kits, profiles</span></a>
+      <a class="doc-row" href="https://docs.agentkit.sbs/reference/skills/"><span class="d-num">07</span><span class="d-name">Skills</span><span class="d-desc">the portable unit of capability</span></a>
+      <a class="doc-row" href="https://docs.agentkit.sbs/guide/concepts/pages/"><span class="d-num">08</span><span class="d-name">Pages</span><span class="d-desc">publish live pages from any agent</span></a>
+      <a class="doc-row" href="https://docs.agentkit.sbs/guide/concepts/product/"><span class="d-num">09</span><span class="d-name">Product Model</span><span class="d-desc">declare what your repo ships</span></a>
+      <a class="doc-row" href="https://docs.agentkit.sbs/guide/concepts/diagrams/"><span class="d-num">10</span><span class="d-name">Diagrams</span><span class="d-desc">classified, derived figures</span></a>
+      <a class="doc-row" href="https://docs.agentkit.sbs/cookbook/"><span class="d-num">11</span><span class="d-name">Examples</span><span class="d-desc">copyable setups</span></a>
     </nav>
     <div class="row">
       <a class="btn solid" href="https://github.com/developerinlondon/agentkit"><svg class="bi" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg> Get agentkit on GitHub</a>
-      <a class="btn" href="/docs/guide/start/install/">Start installing</a>
+      <a class="btn" href="https://docs.agentkit.sbs/guide/start/install/">Start installing</a>
     </div>
   </section>
 

--- a/pages/site/src/pages/pages-index.html
+++ b/pages/site/src/pages/pages-index.html
@@ -16,7 +16,7 @@
     listed anywhere: one is reachable by its address, and only by the people its owner let in.</p>
     <div class="row fx-4">
       <a class="btn solid" href="https://account.agentkit.sbs/dashboard">Your pages →</a>
-      <a class="btn" href="https://agentkit.sbs/docs/cookbook/publish-a-page/">How publishing works</a>
+      <a class="btn" href="https://docs.agentkit.sbs/cookbook/publish-a-page/">How publishing works</a>
     </div>
   </header>
 

--- a/pages/worker/src/worker.js
+++ b/pages/worker/src/worker.js
@@ -216,7 +216,13 @@ function publishedUrl(env, slug, isSite) {
   if (!isSite) return `${env.PAGES_URL || "https://pages.agentkit.sbs"}/${slug}`;
   if (slug === "_pages-index") return "https://pages.agentkit.sbs/";
   if (slug === "_site") return "https://agentkit.sbs/";
-  return `https://agentkit.sbs/${slug.slice(SITE_PREFIX.length)}`;
+  const path = slug.slice(SITE_PREFIX.length);
+  // The docs subtree is written under `_site/docs/` but served from its own
+  // host, so the URL reported back has to be the one that actually answers.
+  if (isDocsPath(path)) {
+    return `https://docs.agentkit.sbs/${path.slice(DOCS_PREFIX.length)}`.replace(/\/$/, "");
+  }
+  return `https://agentkit.sbs/${path}`;
 }
 
 async function handlePublish(request, env, slug) {
@@ -256,7 +262,11 @@ async function handleAssetWrite(request, env, path) {
     return new Response("asset must be 1 byte to 5 MB\n", { status: 413 });
   }
   await env.PAGES.put(key, body, { httpMetadata: { contentType: contentTypeFor(path) } });
-  return Response.json({ ok: true, path, url: `https://agentkit.sbs/${path}` });
+  // Docs assets are written under `docs/` but answered by the docs host.
+  const served = isDocsPath(path)
+    ? `https://docs.agentkit.sbs/${path.slice(DOCS_PREFIX.length)}`
+    : `https://agentkit.sbs/${path}`;
+  return Response.json({ ok: true, path, url: served });
 }
 
 // The deploy can only prune what it can enumerate. Scoped to the docs subtree and
@@ -460,7 +470,10 @@ function requestedTitle(request) {
   }
 }
 
-async function handleSiteRequest(request, env, path) {
+// `servesDocs` separates the two hosts that reach this handler: the docs host
+// serves the `docs/` subtree, the marketing host no longer does. Writes are
+// unaffected — an `api/site/...` path is not a docs path.
+async function handleSiteRequest(request, env, path, servesDocs = false) {
   if (
     (request.method === "PUT" || request.method === "DELETE")
     && path.startsWith("api/pages/")
@@ -485,6 +498,7 @@ async function handleSiteRequest(request, env, path) {
   }
   if (path === "") return servePage(env, "_site/index.html", BASE_HEADERS);
   if (isDocsPath(path)) {
+    if (!servesDocs) return html(404, NOT_FOUND);
     const assetKey = docsAssetKey(path);
     if (assetKey) return serveAsset(env, assetKey, path);
     if (!SITE_PAGE_RE.test(path)) return html(404, NOT_FOUND, DOCS_HEADERS);
@@ -586,6 +600,10 @@ export default {
     const host = url.hostname;
     const path = url.pathname.replace(/\/+$/, "").replace(/^\/+/, "");
     const siteRequest = host === "agentkit.sbs" || host === "www.agentkit.sbs";
+    // The docs have their own host, serving the same `_site/docs/` keyspace the
+    // marketing site serves under a path. Read-only by construction: prefixing
+    // the path moves every write endpoint out of the shape that matches one.
+    const docsRequest = host === "docs.agentkit.sbs";
     const accountHost = configuredHost(env.ACCOUNT_URL);
     const pagesHost = configuredHost(env.PAGES_URL) || "pages.agentkit.sbs";
     const accountRequest = accountHost !== null && host === accountHost;
@@ -593,11 +611,14 @@ export default {
 
     if (
       !siteRequest
+      && !docsRequest
       && env.ACCOUNT_MODE === "required"
       && (!env.DB || accountHost === null)
     ) {
       return new Response("account storage unavailable\n", { status: 503 });
     }
+
+    if (docsRequest) return handleSiteRequest(request, env, path === "" ? "docs" : `docs/${path}`, true);
 
     if (siteRequest) return handleSiteRequest(request, env, path);
 

--- a/tests/publish-page/worker.test.ts
+++ b/tests/publish-page/worker.test.ts
@@ -98,9 +98,9 @@ describe('apex site routing', () => {
   });
 
   test.each([
-    ['https://agentkit.sbs/docs', '_site/docs/index.html'],
-    ['https://agentkit.sbs/docs/install', '_site/docs/install/index.html'],
-    ['https://agentkit.sbs/docs/install/', '_site/docs/install/index.html'],
+    ['https://docs.agentkit.sbs', '_site/docs/index.html'],
+    ['https://docs.agentkit.sbs/install', '_site/docs/install/index.html'],
+    ['https://docs.agentkit.sbs/install/', '_site/docs/install/index.html'],
     ['https://www.agentkit.sbs/guides/a-b-c', '_site/guides/a-b-c/index.html'],
   ])('%s serves %s with no noindex', async (url, key) => {
     const store = bucket({ [key]: '<h1>page</h1>' });
@@ -114,7 +114,7 @@ describe('apex site routing', () => {
 
   test('absent sub-path 404s with the site 404 page', async () => {
     const store = bucket({ '_site/index.html': '<h1>home</h1>' });
-    const res = await worker.fetch(get('https://agentkit.sbs/docs/missing'), env(store));
+    const res = await worker.fetch(get('https://docs.agentkit.sbs/missing'), env(store));
 
     expect(res.status).toBe(404);
     expect(await res.text()).toContain('No page lives at this address');
@@ -140,8 +140,8 @@ describe('apex site routing', () => {
   // The URL parser decodes and collapses dot segments before the worker sees a
   // path, so traversal cannot survive to the key — it resolves within the site.
   test.each([
-    ['https://agentkit.sbs/docs/%2e%2e/secret', '_site/secret/index.html'],
-    ['https://agentkit.sbs/docs/../secret', '_site/secret/index.html'],
+    ['https://agentkit.sbs/%2e%2e/secret', '_site/secret/index.html'],
+    ['https://agentkit.sbs/../secret', '_site/secret/index.html'],
     ['https://agentkit.sbs/../../pages/evil', '_site/pages/evil/index.html'],
   ])('%s stays inside the site keyspace', async (url, key) => {
     const store = bucket();
@@ -175,8 +175,8 @@ describe('site writes', () => {
   test.each([
     ['_site', '_site/index.html', 'https://agentkit.sbs/'],
     ['_pages-index', '_site/pages-index.html', 'https://pages.agentkit.sbs/'],
-    ['_site/docs', '_site/docs/index.html', 'https://agentkit.sbs/docs'],
-    ['_site/docs/install', '_site/docs/install/index.html', 'https://agentkit.sbs/docs/install'],
+    ['_site/docs', '_site/docs/index.html', 'https://docs.agentkit.sbs'],
+    ['_site/docs/install', '_site/docs/install/index.html', 'https://docs.agentkit.sbs/install'],
   ])('SITE_TOKEN writes %s to %s', async (slug, key, url) => {
     const store = bucket();
     const res = await worker.fetch(
@@ -196,7 +196,7 @@ describe('site writes', () => {
       write('https://agentkit.sbs/api/pages/_site/docs/install', SITE_TOKEN, '<h1>install</h1>'),
       env(store),
     );
-    const res = await worker.fetch(get('https://agentkit.sbs/docs/install'), env(store));
+    const res = await worker.fetch(get('https://docs.agentkit.sbs/install'), env(store));
 
     expect(res.status).toBe(200);
     expect(await res.text()).toBe('<h1>install</h1>');
@@ -378,9 +378,9 @@ describe('writes fail closed when the secret is missing', () => {
 describe('method allowlist', () => {
   test.each([
     ['POST', 'https://agentkit.sbs/'],
-    ['POST', 'https://agentkit.sbs/docs'],
-    ['PATCH', 'https://agentkit.sbs/docs'],
-    ['OPTIONS', 'https://agentkit.sbs/docs'],
+    ['POST', 'https://docs.agentkit.sbs'],
+    ['PATCH', 'https://docs.agentkit.sbs'],
+    ['OPTIONS', 'https://docs.agentkit.sbs'],
     ['PATCH', 'https://agentkit.sbs/api/pages/_site/docs'],
     ['POST', 'https://agentkit.sbs/api/pages/deadbeef'],
   ])('%s %s is refused without touching R2', async (method, url) => {
@@ -454,10 +454,10 @@ describe('size limits', () => {
 
 describe('the docs subtree serves a generated site', () => {
   test.each([
-    ['https://agentkit.sbs/docs/', '_site/docs/index.html'],
-    ['https://agentkit.sbs/docs/getting-started/install/', '_site/docs/getting-started/install/index.html'],
-    ['https://agentkit.sbs/docs/0.4/getting-started/install/', '_site/docs/0.4/getting-started/install/index.html'],
-    ['https://agentkit.sbs/docs/0.4/reference/hooks/pkg-police/checks/', '_site/docs/0.4/reference/hooks/pkg-police/checks/index.html'],
+    ['https://docs.agentkit.sbs/', '_site/docs/index.html'],
+    ['https://docs.agentkit.sbs/getting-started/install/', '_site/docs/getting-started/install/index.html'],
+    ['https://docs.agentkit.sbs/0.4/getting-started/install/', '_site/docs/0.4/getting-started/install/index.html'],
+    ['https://docs.agentkit.sbs/0.4/reference/hooks/pkg-police/checks/', '_site/docs/0.4/reference/hooks/pkg-police/checks/index.html'],
   ])('%s resolves as a page', async (url, key) => {
     const store = bucket({ [key]: '<h1>docs</h1>' });
     const res = await worker.fetch(get(url), env(store));
@@ -477,7 +477,7 @@ describe('the docs subtree serves a generated site', () => {
   ])('docs/%s is served verbatim as %s', async (path, type) => {
     const key = `_site/docs/${path}`;
     const store = bucket({ [key]: 'asset-body' });
-    const res = await worker.fetch(get(`https://agentkit.sbs/docs/${path}`), env(store));
+    const res = await worker.fetch(get(`https://docs.agentkit.sbs/${path}`), env(store));
 
     expect(res.status).toBe(200);
     expect(await res.text()).toBe('asset-body');
@@ -488,14 +488,14 @@ describe('the docs subtree serves a generated site', () => {
 
   test('an unknown extension resolves as a page, not a file', async () => {
     const store = bucket();
-    await worker.fetch(get('https://agentkit.sbs/docs/0.4'), env(store));
+    await worker.fetch(get('https://docs.agentkit.sbs/0.4'), env(store));
 
     expect(store.reads).toEqual(['_site/docs/0.4/index.html']);
   });
 
   test('a missing asset 404s without the site 404 page', async () => {
     const store = bucket();
-    const res = await worker.fetch(get('https://agentkit.sbs/docs/_astro/gone.css'), env(store));
+    const res = await worker.fetch(get('https://docs.agentkit.sbs/_astro/gone.css'), env(store));
 
     expect(res.status).toBe(404);
     expect(await res.text()).not.toContain('No page lives at this address');
@@ -503,7 +503,7 @@ describe('the docs subtree serves a generated site', () => {
 
   test('a docs page carries the relaxed policy and stays indexable', async () => {
     const store = bucket({ '_site/docs/index.html': '<h1>docs</h1>' });
-    const res = await worker.fetch(get('https://agentkit.sbs/docs/'), env(store));
+    const res = await worker.fetch(get('https://docs.agentkit.sbs/'), env(store));
     const csp = res.headers.get('content-security-policy') ?? '';
 
     expect(csp).toContain("script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'");
@@ -559,7 +559,7 @@ describe('docs asset writes are SITE_TOKEN only', () => {
     expect(await res.json()).toEqual({
       ok: true,
       path: 'docs/_astro/app.aYS1OYVv.css',
-      url: 'https://agentkit.sbs/docs/_astro/app.aYS1OYVv.css',
+      url: 'https://docs.agentkit.sbs/_astro/app.aYS1OYVv.css',
     });
     expect(store.writes.get('_site/docs/_astro/app.aYS1OYVv.css')).toEqual({
       body: 'body{}',
@@ -676,7 +676,7 @@ describe('docs asset caching', () => {
   test('a hashed bundle is immutable for a year', async () => {
     const store = bucket({ '_site/docs/_astro/app.aYS1OYVv.css': 'body{}' });
     const res = await worker.fetch(
-      get('https://agentkit.sbs/docs/_astro/app.aYS1OYVv.css'),
+      get('https://docs.agentkit.sbs/_astro/app.aYS1OYVv.css'),
       env(store),
     );
 
@@ -685,14 +685,14 @@ describe('docs asset caching', () => {
 
   test('an unhashed asset revalidates', async () => {
     const store = bucket({ '_site/docs/pagefind/pagefind.js': 'js' });
-    const res = await worker.fetch(get('https://agentkit.sbs/docs/pagefind/pagefind.js'), env(store));
+    const res = await worker.fetch(get('https://docs.agentkit.sbs/pagefind/pagefind.js'), env(store));
 
     expect(res.headers.get('cache-control')).toBe('public, max-age=300');
   });
 
   test('a document is never cached, so a deploy is verifiable', async () => {
     const store = bucket({ '_site/docs/index.html': '<h1>docs</h1>' });
-    const res = await worker.fetch(get('https://agentkit.sbs/docs/'), env(store));
+    const res = await worker.fetch(get('https://docs.agentkit.sbs/'), env(store));
 
     expect(res.headers.get('cache-control')).toBeNull();
   });
@@ -700,10 +700,12 @@ describe('docs asset caching', () => {
 
 describe('an html asset path is still a document', () => {
   test.each([
-    'https://agentkit.sbs/docs/index.html',
-    'https://agentkit.sbs/docs/getting-started/install/index.html',
+    'https://docs.agentkit.sbs/index.html',
+    'https://docs.agentkit.sbs/getting-started/install/index.html',
   ])('%s carries the document headers, not bare asset headers', async (url) => {
-    const key = `_site/${new URL(url).pathname.replace(/^\//, '')}`;
+    // The docs host serves the `_site/docs/` subtree, so the key carries that
+    // prefix even though the URL no longer shows it.
+    const key = `_site/docs/${new URL(url).pathname.replace(/^\//, '')}`;
     const store = bucket({ [key]: '<h1>docs</h1>' });
     const res = await worker.fetch(get(url), env(store));
     const csp = res.headers.get('content-security-policy') ?? '';

--- a/tests/site/links.test.ts
+++ b/tests/site/links.test.ts
@@ -20,7 +20,7 @@ function docsLinks(): { file: string; href: string }[] {
   const found: { file: string; href: string }[] = [];
   for (const file of sourceFiles(SITE_SRC)) {
     const body = readFileSync(file, 'utf-8');
-    for (const match of body.matchAll(/href="(\/docs\/[^"]*)"/g)) {
+    for (const match of body.matchAll(/href="https:\/\/docs\.agentkit\.sbs(\/[^"]*)"/g)) {
       found.push({ file: relative(file), href: match[1] ?? '' });
     }
   }
@@ -35,7 +35,7 @@ function relative(path: string): string {
 // a section landing page uses the latter, and checking only the first shape
 // reports live pages as broken.
 function pageExists(href: string): boolean {
-  const slug = href.replace(/^\/docs\/?/, '').replace(/\/$/, '');
+  const slug = href.replace(/^\/+/, '').replace(/\/$/, '');
   if (slug === '') return existsSync(join(DOCS, '_index.md'));
   return existsSync(join(DOCS, `${slug}.md`)) || existsSync(join(DOCS, slug, '_index.md'));
 }


### PR DESCRIPTION
Live at **https://docs.agentkit.sbs/**

## The move

The worker serves `docs.agentkit.sbs` from the same `_site/docs/` keyspace it already held, by prefixing the path. That leaves the host read-only by construction — no write endpoint survives the prefix. The marketing host now **refuses** `/docs/*` rather than serving it half-styled, since every asset path is root-relative now.

No redirects: pre-release, nobody is depending on the old URLs.

## Two archive bugs, both fixed by dropping them

- v0.7.14 was published as a **copy of the `/docs/` build**, so its HTML pointed at `/docs/css/main.min.<hash>.css`. Hugo content-hashes that name, so the moment v0.7.15 replaced `/docs/`, the archive lost its entire stylesheet — which is the unstyled page that was reported.
- Both archives also carry in-content links written for the old scheme.

An archive is now **built against its own base URL**, so it is self-contained and cannot lose its assets that way again. History restarts on the new host.

## Also

- The version picker is styled — the native control painted the OS chevron and its own colours, which read as a foreign widget in a mono navbar.
- `publishedUrl` and the asset-write response report the docs host, so the URL a deploy prints is the one that answers.

340 tests pass across publish-page, site and docs.