### PR TITLE
fix(ci): give the docs deploy the same Hugo binary the build gets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,7 +371,8 @@ jobs:
           install -d -m 700 "$HOME/.config/agentkit"
           umask 077
           printf '%s' "$AGENTKIT_SITE_TOKEN" > "$HOME/.config/agentkit/site-token"
-          (cd docs/hextra && HUGO_BIN=hugo ./build.sh && ./deploy.sh)
+          export HUGO_BIN=hugo
+          (cd docs/hextra && ./build.sh && ./deploy.sh)
 
   site-publish:
     name: Publish the marketing site


### PR DESCRIPTION
`HUGO_BIN=hugo ./build.sh && ./deploy.sh` sets the variable for `build.sh` only. The per-version archive build inside `deploy.sh` fell back to `hugo-extended`, which the runner does not install, so v0.7.16 published the worker and the marketing site but not the docs.

Exported instead, so both see it.