### PR TITLE
fix(ci): let a self-hosted Mac be taken out of rotation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,10 +55,17 @@ jobs:
           # compare unequal and land on hosted, and non-PR events stay false so
           # main and tag pushes can still use the Mac.
           IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+          SELF_HOSTED_MAC: ${{ vars.SELF_HOSTED_MAC || 'on' }}
         run: |
           mac='["macos-15"]'
           if [ "$IS_FORK" = 'true' ]; then
             echo 'fork pull request: hosted macOS only'
+          elif [ "$SELF_HOSTED_MAC" = 'off' ]; then
+            # Online and idle is not the same as healthy: a runner whose network
+            # cannot reach the release CDN accepts the job and then fails at
+            # toolchain install. This takes it out of rotation without a code
+            # change, and without deregistering it.
+            echo 'self-hosted macOS disabled by repository variable'
           elif online=$(gh api "repos/$GITHUB_REPOSITORY/actions/runners?per_page=100" \
               --jq '[.runners[] | select(.status=="online" and .busy==false)
                      | select((["self-hosted","macOS","ARM64"] - [.labels[].name]) | length == 0)] | length') \


### PR DESCRIPTION
## What was happening

The macOS job failed five times today, always at toolchain install, never reaching a test. Each failure cost the long pole's full duration, and a retry usually passed — so it read as flakiness.

## Measured on the runner

| Target | Throughput |
| --- | --- |
| Cloudflare, 10 MB | 4.1 MB/s |
| GitHub release CDN (185.199.x, Fastly) | **38 KB/s, then `curl: (28)`** |

Same on IPv4 and IPv6. That reproduces the CI error exactly. eda pulls the same Cloudflare file at 55 MB/s, and GitHub-hosted runners are unaffected — so this is that ISP's path to Fastly, not the machine, the workflow, or GitHub.

## The gap this exposes

`pick-runners` already falls back to hosted when no self-hosted runner is **online and idle**. Neither is health: this runner is both, and cannot fetch a toolchain. A repository variable now takes it out of rotation without deregistering it or editing the selection logic, so it returns when the path recovers.