### PR TITLE
chore: cut v0.7.17 — complete the documentation publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ release PR — "publish this" authorizes a release, never the tier.
 
 ## [Unreleased]
 
+## v0.7.17 — 2026-08-13
+
+- fix(ci): **the docs publish gets the same Hugo binary the build gets.** `HUGO_BIN` was set as a
+  prefix on `build.sh`, so it reached that command and not the deploy chained after it; the archive
+  build fell back to a binary the runner does not install, and v0.7.16 published everything except
+  the documentation.
+- fix(ci): **a self-hosted Mac can be taken out of rotation.** Online and idle is not health: a
+  runner whose network cannot reach the release CDN still won the job and failed at toolchain
+  install. Measured on it — 4.1 MB/s from Cloudflare against 38 KB/s from GitHub's release CDN on
+  both IPv4 and IPv6 — so the repository variable removes it without deregistering it.
+
 ## v0.7.16 — 2026-08-13
 
 - feat(docs): **the documentation has its own host, `docs.agentkit.sbs`.** The worker serves it


### PR DESCRIPTION
v0.7.16 published the worker and the marketing site but not the docs: `HUGO_BIN` reached `build.sh` and not the deploy chained after it. Fixed in #355, and the self-hosted Mac that was failing every macOS job is out of rotation in #356.

Re-tagging rather than moving v0.7.16, so a tag keeps pointing at the code it was cut from.