### PR TITLE
fix(docs): stop the table-of-contents footer painting white over the grid

### DIFF
--- a/docs/hextra/assets/css/custom.css
+++ b/docs/hextra/assets/css/custom.css
@@ -137,6 +137,17 @@ aside.sidebar-container,
 	color: var(--muted);
 }
 
+/* Hextra paints the ToC's sticky footer white, with a white glow above it to
+   mask entries scrolling underneath. Over the dot grid that reads as a bright
+   panel pasted into the sidebar rather than part of it. The hairline alone
+   ends the list, which is the same edge the rest of the chrome uses. */
+.hextra-toc .hx\:bg-white,
+.dark .hextra-toc .hx\:dark\:bg-dark {
+	background: var(--ground);
+	box-shadow: none;
+	border-color: var(--rule);
+}
+
 .sidebar-container a {
 	border-inline-start: 1px solid var(--rule-lo);
 }


### PR DESCRIPTION
Closes #360

The sticky footer of the right-hand table of contents — "Edit this page on GitHub →" and "Scroll to top" — rendered as an opaque white rectangle on the cream dot grid. Hextra hardcodes `bg-white` there plus a white glow to mask entries scrolling underneath; `custom.css` ports every other piece of chrome onto the design tokens but never claimed this block.

It takes `--ground` now, in both themes, and the existing hairline `--rule` ends the list on its own instead of a fade — the same hard edge the rest of the chrome uses.

Verified by building the site and rendering `/cookbook/declare-your-product/` headless at 1600px in both themes: the block is gone, the grid runs continuously, the rule remains. `bun test tests/docs/` — 40 pass, 0 fail; `check-links` clean across 47 pages.