### PR TITLE
fix(hooks): issue-police catches issues filed through the REST API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ release PR — "publish this" authorizes a release, never the tier.
 
 ## [Unreleased]
 
+- fix(hooks): **`issue-police` catches an issue filed through the REST API, not just the
+  subcommand.** It matched `gh|glab issue create` only, so `glab api --method POST
+  <project>/issues` filed an issue with no `Disposition:` line and no refusal — the guard was
+  present and silent. The URL is normally quoted, and quoted strings are emptied before the
+  trigger match, so the path is now read from the original command truncated at the first body
+  flag: an issues URL quoted inside a description is still not a creation. Reads, updates, and
+  notes on an existing issue remain untouched. `issue-police.sh` also joins the hooks whose
+  packaged plugin copy is asserted byte-for-byte, so the pair cannot drift again.
+
 ## v0.7.17 — 2026-08-13
 
 - fix(ci): **the docs publish gets the same Hugo binary the build gets.** `HUGO_BIN` was set as a

--- a/hooks/claude/issue-police.sh
+++ b/hooks/claude/issue-police.sh
@@ -19,9 +19,22 @@ STRIPPED=$(echo "$COMMAND" |
 	sed -E "s/\"([^\"\\\\]|\\\\.)*\"/\"\"/g" |
 	sed -E "s/'[^']*'/''/g")
 
-if ! echo "$STRIPPED" | grep -qiE '\b(gh|glab)[[:space:]]+issue[[:space:]]+create\b'; then
-	exit 0
-fi
+is_creation() {
+	echo "$STRIPPED" | grep -qiE '\b(gh|glab)[[:space:]]+issue[[:space:]]+create\b' && return 0
+
+	echo "$STRIPPED" | grep -qiE '\b(gh|glab)[[:space:]]+api\b' || return 1
+	echo "$STRIPPED" | grep -qiE '(--method|-X)[[:space:]=]+POST\b' || return 1
+
+	# STRIPPED has emptied the quoted URL, so the path is read from the original,
+	# truncated at the first body flag: an issues URL quoted inside a description
+	# is not itself a creation.
+	url_part=$(echo "$COMMAND" |
+		sed -E 's/[[:space:]](--field|--raw-field|-f|--input|--body|--body-file|--description-file)[[:space:]=].*//')
+	# Trailing segment only — /issues/7/notes and /issues_statistics create nothing.
+	echo "$url_part" | grep -qE '/issues([^/[:alnum:]_]|$)'
+}
+
+is_creation || exit 0
 
 deny() {
 	agentkit_deny_json "$1"

--- a/plugins-cc/agentkit/hooks/issue-police.sh
+++ b/plugins-cc/agentkit/hooks/issue-police.sh
@@ -19,9 +19,22 @@ STRIPPED=$(echo "$COMMAND" |
 	sed -E "s/\"([^\"\\\\]|\\\\.)*\"/\"\"/g" |
 	sed -E "s/'[^']*'/''/g")
 
-if ! echo "$STRIPPED" | grep -qiE '\b(gh|glab)[[:space:]]+issue[[:space:]]+create\b'; then
-	exit 0
-fi
+is_creation() {
+	echo "$STRIPPED" | grep -qiE '\b(gh|glab)[[:space:]]+issue[[:space:]]+create\b' && return 0
+
+	echo "$STRIPPED" | grep -qiE '\b(gh|glab)[[:space:]]+api\b' || return 1
+	echo "$STRIPPED" | grep -qiE '(--method|-X)[[:space:]=]+POST\b' || return 1
+
+	# STRIPPED has emptied the quoted URL, so the path is read from the original,
+	# truncated at the first body flag: an issues URL quoted inside a description
+	# is not itself a creation.
+	url_part=$(echo "$COMMAND" |
+		sed -E 's/[[:space:]](--field|--raw-field|-f|--input|--body|--body-file|--description-file)[[:space:]=].*//')
+	# Trailing segment only — /issues/7/notes and /issues_statistics create nothing.
+	echo "$url_part" | grep -qE '/issues([^/[:alnum:]_]|$)'
+}
+
+is_creation || exit 0
 
 deny() {
 	agentkit_deny_json "$1"

--- a/tests/comment-police-hook.test.ts
+++ b/tests/comment-police-hook.test.ts
@@ -124,7 +124,7 @@ describe('police hooks reach the model', () => {
   test('the packaged plugin copy matches the canonical hook byte for byte', () => {
     // Two copies ship; a fix applied to one and not the other is a hook that
     // behaves differently depending on how agentkit was installed.
-    for (const name of ['comment-police.sh', 'coding-police.sh', 'format-police.sh']) {
+    for (const name of ['comment-police.sh', 'coding-police.sh', 'format-police.sh', 'issue-police.sh']) {
       const a = readFileSync(join(repoRoot, 'hooks', 'claude', name), 'utf-8');
       const b = readFileSync(join(repoRoot, 'plugins-cc', 'agentkit', 'hooks', name), 'utf-8');
       expect(b).toBe(a);

--- a/tests/hooks/issue-police.test.ts
+++ b/tests/hooks/issue-police.test.ts
@@ -153,3 +153,47 @@ describe('issue-police: harness compatibility', () => {
     expect(res.stdout ?? '').toContain('"deny"');
   });
 });
+
+describe('issue-police: the REST spelling of a creation', () => {
+  const url = '"projects/GTI%2Fgroup%2Frepo/issues"';
+
+  test('glab api POST to an issues collection with no disposition is refused', () => {
+    expect(denied(`glab api --method POST ${url} --field title="broken thing"`)).toBe(true);
+  });
+
+  test('the -X spelling is refused too', () => {
+    expect(denied(`glab api -X POST ${url} --field title="broken thing"`)).toBe(true);
+  });
+
+  test('gh api POST to an issues collection is refused', () => {
+    expect(denied('gh api --method POST /repos/o/r/issues -f title="broken thing"')).toBe(true);
+  });
+
+  test('a disposition in the field body passes', () => {
+    expect(
+      denied(
+        `glab api --method POST ${url} --field description="Disposition: new work, unrelated to anything in flight"`,
+      ),
+    ).toBe(false);
+  });
+
+  test('posting a NOTE to an existing issue is not a creation', () => {
+    expect(denied('glab api --method POST "projects/g%2Fr/issues/140/notes" --field body="an update"')).toBe(
+      false,
+    );
+  });
+
+  test('an issues URL quoted inside a description is not a creation', () => {
+    expect(
+      denied('glab api --method POST "projects/g%2Fr/merge_requests" --field description="see /issues"'),
+    ).toBe(false);
+  });
+
+  test('reading issues is not a creation', () => {
+    expect(denied('glab api "projects/g%2Fr/issues?state=opened"')).toBe(false);
+  });
+
+  test('updating an issue is not a creation', () => {
+    expect(denied('glab api --method PUT "projects/g%2Fr/issues/140" --field labels="bug"')).toBe(false);
+  });
+});


### PR DESCRIPTION
`issue-police` matched `gh|glab issue create` and nothing else, so an issue filed through
the REST API — `glab api --method POST "<project>/issues"` — reached the forge with no
`Disposition:` line and no refusal. The guard was installed, wired, and silent.

Found the way these things usually are: by filing exactly that issue, noticing later it was
missing its disposition, and going looking for why nothing stopped it.

## The awkward part of the fix

The trigger is matched against `STRIPPED`, which empties quoted strings so that an issue
body *quoting* a create command is not itself a creation. But the API URL is essentially
always quoted — percent-encoded project paths force it — so by the time the trigger runs,
the path is gone.

So the path is read from the original command instead, truncated at the first body flag
(`--field`, `-f`, `--body`, `--input`, …). An issues URL quoted inside a description sits
after such a flag and is therefore not seen, which keeps the property `STRIPPED` was
protecting.

The segment match is `/issues([^/[:alnum:]_]|$)` — trailing segment only, so
`/issues/7/notes` and `/issues_statistics` are not creations.

## Verification

`bun test tests/hooks/issue-police.test.ts` → 34 pass.

Mutation-probed rather than assumed: reverting the hook and rerunning fails **3** of the 8
new tests — the three that assert a refusal. The other 5 assert what must *not* be blocked
(notes, reads, updates, an issues URL quoted in an MR description) and pass either way,
which is what makes them regression guards rather than restatements of the fix.

Also confirmed against the literal command that slipped through: now `"decision": "deny"`.

`shellcheck` clean apart from the pre-existing SC1091 on the sourced lib, and it parses
under stock macOS `bash 3.2.57`.

## Drift

`issue-police.sh` ships twice, and only `comment-police.sh`, `coding-police.sh` and
`format-police.sh` were asserted byte-for-byte. `issue-police.sh` now joins that list, so a
fix applied to one copy and not the other fails the suite instead of shipping.

## Unrelated failures on this branch

`tests/install-hooks.test.ts` fails 8 tests — **identical set on clean `main`**, verified by
stashing. Not touched here.
