### PR TITLE
docs: retire the Starlight vocabulary from the editorial standard

### DIFF
--- a/docs/hextra/EDITORIAL.md
+++ b/docs/hextra/EDITORIAL.md
@@ -7,27 +7,30 @@ instruction. Accuracy is never sacrificed — framing is.
 
 ## Callout policy (mechanically enforced)
 
+Callouts are the Hextra shortcode, `{{< callout type="…" >}}`, and the theme's
+vocabulary is `info` / `warning` / `error`.
+
 `tests/docs/docs-tone.test.ts` fails the suite when a page violates this:
 
-- **`:::danger` is not used.** Nothing in these docs warrants a red box.
-- **`:::caution` is reserved for user-protective warnings** — data loss,
-  irreversible operations, prerequisites whose absence breaks an install. Each
-  caution is allowlisted in the test by file and title; adding one is a
-  deliberate, reviewed act.
-- Everything else is prose, `:::note`, or `:::tip`.
+- **`error` is not used.** It is the escalation Starlight spelled `danger`, and
+  nothing in these docs warrants a red box.
+- `warning` is this theme's ordinary emphasis callout rather than the rare,
+  reviewed escalation `caution` was, so it carries no allowlist.
+- Everything else is prose or `info`.
 
 ## Version picker retention
 
-The picker offers the current release plus the last 20 releases, derived from
-the git tags — there is no list to curate, and `ARCHIVE_LIMIT` in
-`src/lib/release.ts` is the one knob. Releases are excluded automatically when
-they are at or above the release being built, or when their tag predates the
-docs site and so cannot build an archive at all.
+Candidates come from `data/archives.json`, not from the git tags: archives are
+never rebuilt, so a tag whose tree was never published here would put a 404 in
+the picker. History restarts at the move to `docs.agentkit.sbs` — earlier trees
+were built for a different URL scheme and their in-content links point at it.
 
-Each entry is a full site build from its own tag at deploy time, so raising the
-cap costs a build per release added. A release whose tag stops building fails
-the deploy naming that tag, which is the intended failure: an archive that
-cannot be rebuilt is not a version the picker should still be offering.
+`scripts/versions.ts` keeps every published patch of the minor shipping now,
+plus the last patch of each older minor, and labels the rest `(archived)`. A
+release publishes its own tree under `/<version>/` at deploy time and appends
+that version to `archives.json`, which is also the spare-list the deploy's prune
+reads. Trimming a long history is what the rule is for; dropping the release
+that shipped last week is not, and that is the one a reader most wants back.
 
 ## Voice
 


### PR DESCRIPTION
`docs/hextra/EDITORIAL.md` did not survive the Hugo cutover intact. It still told contributors to write `:::danger`, `:::caution`, `:::note` and `:::tip`, and pointed the version-retention rule at an `ARCHIVE_LIMIT` in `src/lib/release.ts`. None of that exists now:

| The standard said | What the repo does |
|---|---|
| `:::danger` / `:::caution` / `:::note` / `:::tip` | Hextra's `{{< callout type="…" >}}` over `info` / `warning` / `error` — 29 info and 25 warning in the tree today |
| each caution allowlisted by file and title | `docs-tone.test.ts` allowlists nothing; it forbids `error` outright |
| picker derives from git tags, capped by `ARCHIVE_LIMIT` in `src/lib/release.ts` | candidates come from `data/archives.json`; `scripts/versions.ts` keeps every patch of the current minor plus the last patch of each older minor |
| each entry rebuilt from its own tag at deploy | archives are never rebuilt — a release publishes its own tree under `/<version>/` and appends itself to `archives.json` |

A contributor following it would have written callouts the build rejects, then gone looking for a file that isn't there. Found while surveying the docs for the handover on the ClickUp documentation task, so it gets fixed before that work starts rather than filed against it.

`bun test tests/docs/` — 40 pass, 0 fail. Prose only; no content or build change.