### PR TITLE
fix(brain): name the sync override for the guard, not for taste

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ release PR — "publish this" authorizes a release, never the tier.
 
 ## [Unreleased]
 
+- fix(brain): **the sync override is `AGENTKIT_TARGET_PRIVATE`, not `AGENTKIT_TASTE_TARGET_PRIVATE`.**
+  The guard serves memory sources too now, so a refusal about a knowledgebase named a variable with
+  taste in it. Pre-1.0 rename with no dual reading: the old name is not consulted.
 - feat(brain): **a knowledgebase is read as `brain.memory.sources`, not as a third unit.** A git
   repository of human-authored notes — ADRs, designs, runbooks — is declared the way a taste source
   is, pinned to a ref, snapshotted markdown-only into `<vault>/external/<name>/` and recorded in that

--- a/docs/hextra/content/reference/environment.md
+++ b/docs/hextra/content/reference/environment.md
@@ -25,7 +25,7 @@ gave.
 | `AGENTKIT_BRANCH_WIP_MAX=<n>`      | raises `git-police`'s cap on open unfinished branches                                                        |
 | `AGENTKIT_MR_POLICE_MAX=<n>`       | raises `mr-police`'s cap on open authored merge requests                                                     |
 | `AGENTKIT_SKIP_HOOKS=<unit>,…`     | short-circuits the named advisory units, or `all`                                                            |
-| `AGENTKIT_TARGET_PRIVATE=1`  | permits vendoring a private source into a target that would otherwise refuse                           |
+| `AGENTKIT_TARGET_PRIVATE=1`        | permits vendoring a private source into a target that would otherwise refuse                                 |
 
 A unit's own override is named **inside its refusal message**. If a message does not name one, the
 unit deliberately has none.

--- a/docs/hextra/content/reference/environment.md
+++ b/docs/hextra/content/reference/environment.md
@@ -25,7 +25,7 @@ gave.
 | `AGENTKIT_BRANCH_WIP_MAX=<n>`      | raises `git-police`'s cap on open unfinished branches                                                        |
 | `AGENTKIT_MR_POLICE_MAX=<n>`       | raises `mr-police`'s cap on open authored merge requests                                                     |
 | `AGENTKIT_SKIP_HOOKS=<unit>,…`     | short-circuits the named advisory units, or `all`                                                            |
-| `AGENTKIT_TASTE_TARGET_PRIVATE=1`  | permits vendoring a private taste source into a target that would otherwise refuse                           |
+| `AGENTKIT_TARGET_PRIVATE=1`  | permits vendoring a private source into a target that would otherwise refuse                           |
 
 A unit's own override is named **inside its refusal message**. If a message does not name one, the
 unit deliberately has none.

--- a/plugins-cc/agentkit-brain/skills/taste/SKILL.md
+++ b/plugins-cc/agentkit-brain/skills/taste/SKILL.md
@@ -160,7 +160,7 @@ prose does not stop a sync.
   a dotfiles repository is the shape this exists for — it is a target like any other and is judged
   the same way. Machine sources default to `private`, so this refuses by default and says how to
   proceed: move the store out of the work tree, or declare the source `visibility: public`.
-- **The override is `AGENTKIT_TASTE_TARGET_PRIVATE=1`** on the sync command. It supplies the one
+- **The override is `AGENTKIT_TARGET_PRIVATE=1`** on the sync command. It supplies the one
   fact the tool could not establish — that this repository is private — and nothing else: a
   target the forge answered _public_ for stays refused with it set, because that case is the
   leak rather than the inconvenience. Empty, `0`, `false`, `no` and `off` are refusals here too.

--- a/plugins-cc/agentkit-brain/skills/taste/references/format.md
+++ b/plugins-cc/agentkit-brain/skills/taste/references/format.md
@@ -243,7 +243,7 @@ words** into the repository it runs in:
   than the one whose URL was read.
 - **The machine's own store is judged too when it sits inside a git work tree** — a dotfiles
   repository. Outside one it publishes nothing and no check runs.
-- **`AGENTKIT_TASTE_TARGET_PRIVATE=1`** on the sync command asserts the one fact the tool could
+- **`AGENTKIT_TARGET_PRIVATE=1`** on the sync command asserts the one fact the tool could
   not establish. It does not overrule a forge that answered, and empty, `0`, `false`, `no` and
   `off` do not switch it on.
 

--- a/plugins-cc/agentkit-brain/skills/taste/scripts/visibility.ts
+++ b/plugins-cc/agentkit-brain/skills/taste/scripts/visibility.ts
@@ -11,7 +11,7 @@ export interface Target {
 // toolchain is. It asserts a fact the tool could not establish — that this
 // repository is private — and asserts nothing about a repository the forge
 // already answered for.
-export const TARGET_PRIVATE_OVERRIDE = 'AGENTKIT_TASTE_TARGET_PRIVATE';
+export const TARGET_PRIVATE_OVERRIDE = 'AGENTKIT_TARGET_PRIVATE';
 
 export const FORGE_TIMEOUT_MS = 20_000;
 

--- a/skills/taste/SKILL.md
+++ b/skills/taste/SKILL.md
@@ -160,7 +160,7 @@ prose does not stop a sync.
   a dotfiles repository is the shape this exists for — it is a target like any other and is judged
   the same way. Machine sources default to `private`, so this refuses by default and says how to
   proceed: move the store out of the work tree, or declare the source `visibility: public`.
-- **The override is `AGENTKIT_TASTE_TARGET_PRIVATE=1`** on the sync command. It supplies the one
+- **The override is `AGENTKIT_TARGET_PRIVATE=1`** on the sync command. It supplies the one
   fact the tool could not establish — that this repository is private — and nothing else: a
   target the forge answered _public_ for stays refused with it set, because that case is the
   leak rather than the inconvenience. Empty, `0`, `false`, `no` and `off` are refusals here too.

--- a/skills/taste/references/format.md
+++ b/skills/taste/references/format.md
@@ -243,7 +243,7 @@ words** into the repository it runs in:
   than the one whose URL was read.
 - **The machine's own store is judged too when it sits inside a git work tree** — a dotfiles
   repository. Outside one it publishes nothing and no check runs.
-- **`AGENTKIT_TASTE_TARGET_PRIVATE=1`** on the sync command asserts the one fact the tool could
+- **`AGENTKIT_TARGET_PRIVATE=1`** on the sync command asserts the one fact the tool could
   not establish. It does not overrule a forge that answered, and empty, `0`, `false`, `no` and
   `off` do not switch it on.
 

--- a/skills/taste/scripts/visibility.ts
+++ b/skills/taste/scripts/visibility.ts
@@ -11,7 +11,7 @@ export interface Target {
 // toolchain is. It asserts a fact the tool could not establish — that this
 // repository is private — and asserts nothing about a repository the forge
 // already answered for.
-export const TARGET_PRIVATE_OVERRIDE = 'AGENTKIT_TASTE_TARGET_PRIVATE';
+export const TARGET_PRIVATE_OVERRIDE = 'AGENTKIT_TARGET_PRIVATE';
 
 export const FORGE_TIMEOUT_MS = 20_000;
 

--- a/tests/taste/skill.test.ts
+++ b/tests/taste/skill.test.ts
@@ -169,7 +169,7 @@ const VENDOR_GUARD: [string, string][] = [
   ['internal is on the public side', '**Internal is not private.**'],
   ['the machine level is gated once it publishes', 'gated only when it publishes'],
   ['a dotfiles repository is the shape it exists for', 'a dotfiles repository is the shape'],
-  ['the override is named', 'AGENTKIT_TASTE_TARGET_PRIVATE=1'],
+  ['the override is named', 'AGENTKIT_TARGET_PRIVATE=1'],
   ['the override supplies only what was unknown', 'stays refused with it set'],
   ['off-reading values do not grant it', 'are refusals here too'],
 ];


### PR DESCRIPTION
Follow-up to #367, found by running the merged code on this machine rather than in a fixture.

The visibility guard now serves both brain units. Its override did not follow:

```
memory: knowledge: refusing to vendor a private source into a repository whose
visibility could not be determined — no git remote named origin in . Set
AGENTKIT_TASTE_TARGET_PRIVATE=1 on the command if you know it is private, …
```

A refusal about a vendored **knowledgebase** telling the owner to set a variable with `taste` in its name is the kind of thing that makes someone doubt they are reading the right error.

`AGENTKIT_TASTE_TARGET_PRIVATE` → **`AGENTKIT_TARGET_PRIVATE`**. Pre-1.0 rename with no dual reading — the old name is not consulted, and the changelog carries it. The variable is asserted in `tests/taste/skill.test.ts`, which pins the documented name against the constant, so the two cannot drift.

Verification: 747 pass / 0 fail across the taste, memory and docs slices; `dprint check` clean.
