### PR TITLE
feat(issue-police,mr-police): check completeness, over a cached forge lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ release PR — "publish this" authorizes a release, never the tier.
 
 ## [Unreleased]
 
+- feat(issue-police, mr-police): **the forge units check completeness, not just presence, over a
+  shared cached lookup.** An audit of one agent account's output — 22 issues, 22 merge requests —
+  found 2 issues filed with an empty body, one that was the template pasted with every placeholder
+  still in it, and 12 MRs assigned to the bot itself: the `--assignee` requirement had been
+  satisfied in the cheapest way that cleared it. `issue-police` now refuses an empty body and an
+  unfilled template everywhere, and a project can add a floor, a ceiling, required fields (with a
+  required label checked against the project's own taxonomy) and a self-assignment refusal.
+  `mr-police` gains the REST creation path it never matched — `glab api --method POST …
+  /merge_requests` walked straight past a unit that only knew `glab mr create` — plus opt-in
+  issue-reference and closing-keyword refusals. Forge answers are cached under
+  `$XDG_CACHE_HOME/agentkit/forge`, and a cached answer that would deny is refetched before
+  anything is refused, so staleness can cost a wasted call but never a wrong block. Both units
+  still fail open with no CLI or an unreachable forge.
+
 - feat(taste): **taste installs with `core`; the `brain` kit is the memory vault.** A convention the
   owner states once bound only the machines that had remembered `--with brain`: 14 taste files sat on
   the author's own machine for eleven days, read by nothing, with no signal that the reader was

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -37,6 +37,33 @@ git-police:
     #     - brain
     #     - my-notes
 
+issue-police:
+  # An empty body and an unfilled template are refused with no configuration.
+  # These add the parts only a project can decide.
+
+  # Refuse a body shorter than this many characters. 0 disables the floor.
+  min-body-chars: 0
+
+  # Refuse a body longer than this many characters. 0 disables the ceiling.
+  max-body-chars: 0
+
+  # Comma-separated fields every issue must carry: labels, assignee, milestone.
+  # A required label is also checked against the project's own taxonomy.
+  require: ""
+
+  # Refuse an issue assigned to the account whose token filed it. For a bot
+  # account only: an agent driving a person's credentials assigns to that
+  # person legitimately.
+  refuse-self-assignment: false
+
+mr-police:
+  # Refuse a merge request whose body names no issue.
+  require-issue-reference: false
+
+  # Refuse close/fix/resolve/implement next to an issue number, which would let
+  # the merge decide the work is done before the requester has verified it.
+  forbid-closing-keywords: false
+
 coding-police:
   # Maximum lines per file before warning to split.
   max-file-lines: 1000

--- a/docs/hextra/content/reference/configuration.md
+++ b/docs/hextra/content/reference/configuration.md
@@ -47,6 +47,48 @@ Delete a granular key to inherit the selected profile.
 Entries match by repo name (`brain`) or `owner/name` (`myorg/brain`); partial matches are supported,
 so `brain` matches `myorg/brain`.
 
+## `issue-police`
+
+Two refusals need no configuration, because they are wrong everywhere: an issue filed with **no
+body at all**, and one whose body still carries an **unfilled template** — a guidance comment, an
+empty checkbox, or a bare quick action like `/milestone %`. The rest is what only a project can
+decide.
+
+| Key                      | Type   | Default | Effect                                                           |
+| ------------------------ | ------ | ------- | ---------------------------------------------------------------- |
+| `min-body-chars`         | int    | `0`     | refuse a body shorter than this; `0` disables the floor          |
+| `max-body-chars`         | int    | `0`     | refuse a body longer than this; `0` disables the ceiling         |
+| `require`                | string | `""`    | comma-separated: `labels`, `assignee`, `milestone`               |
+| `refuse-self-assignment` | bool   | `false` | refuse an issue assigned to the account whose token is filing it |
+
+A required **label** is additionally checked against the project's own taxonomy, because a label the
+project does not define is dropped on creation — the item lands unlabelled while the command that
+filed it looks correct.
+
+`refuse-self-assignment` is off by default because only the operator knows which case they are in:
+an agent driving a person's own credentials assigns to that person legitimately, while a bot
+assigning to itself produces an item that looks owned and is not.
+
+## `mr-police`
+
+| Key                       | Type | Default | Effect                                                             |
+| ------------------------- | ---- | ------- | ------------------------------------------------------------------ |
+| `require-issue-reference` | bool | `false` | refuse a merge request whose body names no issue                   |
+| `forbid-closing-keywords` | bool | `false` | refuse `close`/`fix`/`resolve`/`implement` next to an issue number |
+
+The open-MR cap is separate and set by `AGENTKIT_MR_POLICE_MAX` in the environment, not here.
+
+`forbid-closing-keywords` stays off by default because auto-close is the behaviour most projects
+want. Turn it on where completion is the requester's call to make after verifying, not the merge's.
+
+### The forge lookups are cached
+
+Checking a label against a taxonomy, or an assignee against the token's own identity, needs the
+forge. Those answers are cached under `$XDG_CACHE_HOME/agentkit/forge` — identity for a day,
+taxonomies for an hour — and the cache can only ever cost a wasted refresh, never a wrong refusal:
+a cached answer that would **pass** is trusted, and one that would **deny** is refetched before
+anything is refused. With no CLI installed, or a forge that cannot be reached, both units fail open.
+
 ## `coding-police`
 
 | Key                    | Type | Default | Effect                                                                                             |

--- a/hooks/claude/issue-police.sh
+++ b/hooks/claude/issue-police.sh
@@ -7,6 +7,10 @@ set -euo pipefail
 
 # shellcheck source=lib/hook-input.sh
 source "${BASH_SOURCE[0]%/*}/lib/hook-input.sh"
+# shellcheck source=lib/forge-config.sh
+source "${BASH_SOURCE[0]%/*}/lib/forge-config.sh"
+# shellcheck source=lib/forge-cache.sh
+source "${BASH_SOURCE[0]%/*}/lib/forge-cache.sh"
 agentkit_slurp_input
 COMMAND=$(agentkit_command)
 
@@ -65,7 +69,238 @@ done
 # on the quote character itself.
 DISPOSITION_RE="[Dd]isposition:[[:space:]]*[^[:space:]\"'\`]"
 
+BODY_TEXT=""
+for body_file in $BODY_FILES; do
+	[[ "$body_file" == "-" ]] && continue
+	if [[ "$body_file" != /* && -n "$TARGET_DIR" ]]; then
+		body_file="$TARGET_DIR/$body_file"
+	fi
+	[[ -r "$body_file" ]] || continue
+	BODY_TEXT="$BODY_TEXT"$'\n'"$(cat "$body_file" 2>/dev/null || true)"
+done
+
+# shlex, because a body is a quoted argument containing everything a regex would
+# have to survive: newlines, nested quotes, flags quoted inside prose.
+forge_flag_value() {
+	command -v python3 >/dev/null 2>&1 || return 1
+	COMMAND="$COMMAND" python3 -c '
+import os, shlex, sys
+names = sys.argv[1:]
+try:
+    parts = shlex.split(os.environ["COMMAND"], comments=False)
+except ValueError:
+    sys.exit(1)
+for i, part in enumerate(parts):
+    for name in names:
+        if part == name and i + 1 < len(parts):
+            print(parts[i + 1])
+            sys.exit(0)
+        if part.startswith(name + "="):
+            print(part[len(name) + 1:])
+            sys.exit(0)
+sys.exit(1)
+' "$@" 2>/dev/null
+}
+
+# The REST spelling carries the body as `--field description=…`, not as a flag.
+forge_field_value() {
+	command -v python3 >/dev/null 2>&1 || return 1
+	COMMAND="$COMMAND" python3 -c '
+import os, shlex, sys
+names = sys.argv[1:]
+flags = ("--field", "-f", "--raw-field", "-F")
+try:
+    parts = shlex.split(os.environ["COMMAND"], comments=False)
+except ValueError:
+    sys.exit(1)
+for i, part in enumerate(parts):
+    pair = None
+    if part in flags and i + 1 < len(parts):
+        pair = parts[i + 1]
+    elif part.startswith("--field=") or part.startswith("--raw-field="):
+        pair = part.split("=", 1)[1]
+    if not pair or "=" not in pair:
+        continue
+    key, value = pair.split("=", 1)
+    if key in names:
+        print(value)
+        sys.exit(0)
+sys.exit(1)
+' "$@" 2>/dev/null
+}
+
+char_count() { printf '%s' "$1" | wc -c | tr -d ' '; }
+
+# A skeleton nobody filled in is worse than no template: it reads as answered.
+has_unfilled_skeleton() {
+	local body="$1"
+	echo "$body" | grep -qE '<!--' && return 0
+	echo "$body" | grep -qE '^[[:space:]]*-[[:space:]]*\[[ xX]?\][[:space:]]*$' && return 0
+	echo "$body" | grep -qE '^[[:space:]]*/(milestone|label|assign)[[:space:]]*%?[[:space:]]*$' && return 0
+	return 1
+}
+
+completeness_checks() {
+	local body min max require assignee
+	body="$(forge_flag_value --description -d --body -b || true)"
+	[[ -z "$body" ]] && body="$(forge_field_value description body || true)"
+	[[ -z "$body" ]] && body="$BODY_TEXT"
+	body="${body#"${body%%[![:space:]]*}"}"
+
+	# An empty body is wrong everywhere; how short is too short is a house call,
+	# so the floor and the ceiling are both opt-in.
+	min="$(agentkit_forge_config_or issue-police min-body-chars 0)"
+	max="$(agentkit_forge_config_or issue-police max-body-chars 0)"
+
+	if [[ -z "$body" ]]; then
+		deny "BLOCKED: this issue has no description.
+
+An issue with a title and nothing else asks the next reader to reconstruct what you already knew. Pass the body with --description (glab) or --body (gh), or write it to a file and pass --description-file / --body-file.
+
+State the problem, what done looks like, and the evidence you have — a few lines beat a heading with nothing under it."
+	fi
+
+	if [[ "$min" -gt 0 && "$(char_count "$body")" -lt "$min" ]]; then
+		deny "BLOCKED: this issue body is shorter than this project's floor of ${min} characters.
+
+A stub costs the next reader the whole investigation again. Say what is wrong, what done looks like, and cite the evidence — file:line, or the command and what it showed.
+
+Raise or lower the floor with issue-police.min-body-chars in .agentkit/config.yaml."
+	fi
+
+	if [[ "$max" -gt 0 && "$(char_count "$body")" -gt "$max" ]]; then
+		deny "BLOCKED: this issue body is longer than this project's ceiling of ${max} characters.
+
+Concise is not the same as empty, and neither is complete the same as long. Keep the template's sections, cut the narration: bullets and tables, evidence as citations rather than retellings.
+
+Change the ceiling with issue-police.max-body-chars in .agentkit/config.yaml."
+	fi
+
+	if has_unfilled_skeleton "$body"; then
+		deny "BLOCKED: this issue body still carries an unfilled template.
+
+A template comment, an empty checkbox, or a bare quick action means the skeleton was pasted and not answered — which reads as a completed issue while carrying no more than the blank form did.
+
+Answer each section, delete the ones that genuinely do not apply (and say why), and remove the guidance comments before filing."
+	fi
+
+	require="$(agentkit_forge_config_or issue-police require '')"
+	require_fields "$require"
+
+	assignee="$(forge_flag_value --assignee -a || true)"
+	[[ -n "$assignee" ]] && refuse_self_assignment "$assignee"
+	return 0
+}
+
+forge_cli() {
+	echo "$STRIPPED" | grep -qiE '\bglab\b' && {
+		printf 'glab'
+		return 0
+	}
+	echo "$STRIPPED" | grep -qiE '\bgh\b' && {
+		printf 'gh'
+		return 0
+	}
+	return 1
+}
+
+forge_project() {
+	forge_flag_value --repo -R
+}
+
+require_fields() {
+	local wanted="$1" field flag value
+	[[ -n "$wanted" ]] || return 0
+	for field in $(echo "$wanted" | tr ',' ' '); do
+		case "$field" in
+		labels) flag="--label" ;;
+		assignee) flag="--assignee" ;;
+		milestone) flag="--milestone" ;;
+		*) continue ;;
+		esac
+		value="$(forge_flag_value "$flag" "${flag:1:2}" || true)"
+		[[ -n "$value" ]] || deny "BLOCKED: this issue has no ${field}, and this project requires one.
+
+An item without ${field} is invisible to the board, the milestone report, or the epic rollup it belongs to — accurate text does not make it findable.
+
+Read what the project actually offers before you choose, then pass ${flag}. Requirements live in issue-police.require in .agentkit/config.yaml."
+		if [[ "$field" == labels ]]; then
+			refuse_unknown_labels "$value"
+		fi
+	done
+	return 0
+}
+
+LABELS_WANTED=""
+
+labels_all_known() {
+	local known="$1" label
+	for label in $(echo "$LABELS_WANTED" | tr ',' ' '); do
+		echo "$known" | grep -qxF "$label" || return 1
+	done
+	return 0
+}
+
+# An invented label is silently dropped by the forge, so the issue lands
+# unlabelled while the command that filed it looks correct.
+refuse_unknown_labels() {
+	local cli project
+	LABELS_WANTED="$1"
+	cli="$(forge_cli || true)"
+	[[ "$cli" == glab ]] || return 0
+	command -v glab >/dev/null 2>&1 || return 0
+	project="$(forge_project || true)"
+	[[ -n "$project" ]] || return 0
+	LABEL_PROJECT="$project"
+	agentkit_forge_verify "labels/$project" 3600 labels_all_known forge_labels_glab && return 0
+	deny "BLOCKED: at least one of these labels does not exist in ${project}: ${LABELS_WANTED}.
+
+A label the project does not define is dropped on creation, so the item lands unlabelled while the command looks right.
+
+List what exists and pick from it: glab label list -R ${project}"
+}
+
+# Stated in the passing direction on purpose: an unreachable forge then reads as
+# "not self" and the hook fails open, the way every other lookup here does.
+identity_is_other() {
+	[[ -n "$1" && "$1" != "$ASSIGNEE_WANTED" ]]
+}
+
+ASSIGNEE_WANTED=""
+
+# Opt-in, because only a dedicated bot account can tell the two cases apart: an
+# agent driving a person's own credentials assigns to that person legitimately,
+# while a bot assigning to itself leaves the item unowned.
+refuse_self_assignment() {
+	local cli me_key
+	agentkit_forge_flag issue-police refuse-self-assignment || return 0
+	ASSIGNEE_WANTED="$1"
+	cli="$(forge_cli || true)"
+	[[ -n "$cli" ]] || return 0
+	command -v "$cli" >/dev/null 2>&1 || return 0
+	me_key="identity/$cli/${GITLAB_HOST:-${GH_HOST:-default}}"
+	if [[ "$cli" == glab ]]; then
+		agentkit_forge_verify "$me_key" 86400 identity_is_other forge_identity_glab && return 0
+	else
+		agentkit_forge_verify "$me_key" 86400 identity_is_other forge_identity_gh && return 0
+	fi
+	deny "BLOCKED: you assigned this item to yourself (${ASSIGNEE_WANTED}), the account this token belongs to.
+
+An item assigned to the authoring agent looks owned and is not: no human is going to see it on their board. Assign the person who asked for the work.
+
+If this account genuinely owns the item, say so and let the operator assign it."
+}
+
+forge_identity_glab() { glab api /user 2>/dev/null | jq -r '.username // empty'; }
+forge_identity_gh() { gh api user 2>/dev/null | jq -r '.login // empty'; }
+
+LABEL_PROJECT=""
+forge_labels_glab() {
+	glab label list -R "$LABEL_PROJECT" -F json --per-page 100 2>/dev/null | jq -r '.[].name // empty'
+}
+
 if echo "$TEXT" | grep -qE "$DISPOSITION_RE"; then
+	completeness_checks
 	exit 0
 fi
 

--- a/hooks/claude/lib/forge-cache.sh
+++ b/hooks/claude/lib/forge-cache.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# A short-lived cache for forge lookups shared by issue-police and mr-police.
+# Staleness costs a wasted refresh, never a wrong refusal — see
+# agentkit_forge_verify.
+
+AGENTKIT_FORGE_CACHE_ROOT="${AGENTKIT_FORGE_CACHE_ROOT:-${XDG_CACHE_HOME:-$HOME/.cache}/agentkit/forge}"
+
+agentkit_forge_cache_file() {
+	local key="$1"
+	printf '%s/%s' "$AGENTKIT_FORGE_CACHE_ROOT" "$(printf '%s' "$key" | tr -c 'A-Za-z0-9._-' '_')"
+}
+
+agentkit_file_mtime() {
+	stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null || printf '0'
+}
+
+# Prints the cached value when it is younger than <ttl> seconds.
+agentkit_forge_cached() {
+	local file age now
+	file="$(agentkit_forge_cache_file "$1")"
+	[[ -f "$file" ]] || return 1
+	now="$(date +%s)"
+	age=$((now - $(agentkit_file_mtime "$file")))
+	[[ "$age" -lt "$2" ]] || return 1
+	cat "$file"
+}
+
+agentkit_forge_store() {
+	local file tmp
+	file="$(agentkit_forge_cache_file "$1")"
+	mkdir -p "$(dirname "$file")" 2>/dev/null || return 0
+	tmp="$(mktemp "${file}.XXXXXX")" || return 0
+	printf '%s' "$2" >"$tmp" && mv -f "$tmp" "$file" || rm -f "$tmp"
+}
+
+# Cached value for <key>, or the output of <command…> stored under it. An empty
+# result is not cached — that is usually a failed call, and caching it would
+# turn one network blip into an hour of wrong answers.
+agentkit_forge_lookup() {
+	local key="$1" ttl="$2" value
+	shift 2
+	if value="$(agentkit_forge_cached "$key" "$ttl")"; then
+		printf '%s' "$value"
+		return 0
+	fi
+	value="$("$@" 2>/dev/null)" || return 1
+	[[ -n "$value" ]] || return 1
+	agentkit_forge_store "$key" "$value"
+	printf '%s' "$value"
+}
+
+# Re-runs <command…> and replaces the cache entry.
+agentkit_forge_refresh() {
+	local key="$1" value
+	shift
+	value="$("$@" 2>/dev/null)" || return 1
+	[[ -n "$value" ]] || return 1
+	agentkit_forge_store "$key" "$value"
+	printf '%s' "$value"
+}
+
+# The gate every cache-backed refusal goes through: <predicate> is run against
+# the cached value, and only a second failure against freshly fetched data is
+# reported as a real one. Returns 0 when the check passes.
+agentkit_forge_verify() {
+	local key="$1" ttl="$2" predicate="$3" value
+	shift 3
+	value="$(agentkit_forge_lookup "$key" "$ttl" "$@")" || return 0
+	"$predicate" "$value" && return 0
+	value="$(agentkit_forge_refresh "$key" "$@")" || return 0
+	"$predicate" "$value"
+}

--- a/hooks/claude/lib/forge-config.sh
+++ b/hooks/claude/lib/forge-config.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Scalar config lookup for issue-police and mr-police. What a project requires of
+# an issue or an MR is data the hook reads, so the agent never has to rediscover
+# a taxonomy it could have been handed.
+
+# Project config wins over the machine's, matching brain-config.
+agentkit_forge_config() {
+	local section="$1" want="$2" value file
+	for file in \
+		"${CLAUDE_PROJECT_DIR:-$PWD}/.agentkit/config.yaml" \
+		"${XDG_CONFIG_HOME:-$HOME/.config}/agentkit/config.yaml"; do
+		[[ -f "$file" ]] || continue
+		value="$(awk -v section="$section" -v want="$want" '
+			/^[^[:space:]#]/ { in_section = ($0 == section ":"); next }
+			!in_section { next }
+			{
+				line = $0
+				sub(/[[:space:]]*#.*$/, "", line)
+				if (line ~ /^[[:space:]]*$/) next
+				sub(/^[[:space:]]+/, "", line)
+				split(line, kv, ":")
+				if (kv[1] != want) next
+				value = substr(line, length(kv[1]) + 2)
+				sub(/^[[:space:]]+/, "", value)
+				sub(/[[:space:]]+$/, "", value)
+				gsub(/^["'"'"']|["'"'"']$/, "", value)
+				print value
+				exit
+			}
+		' "$file" 2>/dev/null)"
+		[[ -n "$value" ]] && {
+			printf '%s' "$value"
+			return 0
+		}
+	done
+	return 1
+}
+
+agentkit_forge_config_or() {
+	local section="$1" key="$2" fallback="$3" value
+	value="$(agentkit_forge_config "$section" "$key" || true)"
+	printf '%s' "${value:-$fallback}"
+}
+
+# Absent reads as off: a house policy not every repository shares is asked for.
+agentkit_forge_flag() {
+	local value
+	value="$(agentkit_forge_config "$1" "$2" || true)"
+	case "$value" in
+	true | yes | on | 1) return 0 ;;
+	esac
+	return 1
+}

--- a/hooks/claude/mr-police.sh
+++ b/hooks/claude/mr-police.sh
@@ -19,14 +19,34 @@ set -euo pipefail
 # missing-jq fail-open probe), and a source failure under set -e would silence
 # the gate. BASH_SOURCE is absolute when the harness invokes the script by path.
 source "${BASH_SOURCE[0]%/*}/lib/hook-input.sh"
+# shellcheck source=lib/forge-config.sh
+source "${BASH_SOURCE[0]%/*}/lib/forge-config.sh"
 agentkit_slurp_input
 COMMAND=$(agentkit_command)
 [[ -z "$COMMAND" ]] && exit 0
 
+# Quoted strings are emptied before the trigger is matched, so an MR body that
+# quotes a creation command is not itself a creation.
+STRIPPED=$(echo "$COMMAND" |
+	sed -E "s/\"([^\"\\\\]|\\\\.)*\"/\"\"/g" |
+	sed -E "s/'[^']*'/''/g")
+
+# The REST path creates exactly the same MR as the CLI does, so a unit that only
+# knows the CLI is a gate with a documented way around it.
+is_rest_creation() {
+	echo "$STRIPPED" | grep -qiE '\b(gh|glab)[[:space:]]+api\b' || return 1
+	echo "$STRIPPED" | grep -qiE '(--method|-X)[[:space:]=]+POST\b' || return 1
+	echo "$COMMAND" |
+		sed -E 's/[[:space:]](--field|--raw-field|-f|--input|--body|--body-file|--description-file)[[:space:]=].*//' |
+		grep -qE '/(merge_requests|pulls)([^/[:alnum:]_]|$)'
+}
+
+is_cli_creation() {
+	echo "$STRIPPED" | grep -qiE 'glab[[:space:]]+mr[[:space:]]+create|gh[[:space:]]+pr[[:space:]]+create|merge_request\.create'
+}
+
 # Only act on MR-creation commands; everything else passes through instantly.
-if ! echo "$COMMAND" | grep -qiE 'glab[[:space:]]+mr[[:space:]]+create|merge_request\.create'; then
-	exit 0
-fi
+is_cli_creation || is_rest_creation || exit 0
 
 deny() {
 	agentkit_deny_json "$1"
@@ -38,6 +58,47 @@ deny() {
 if echo "$COMMAND" | grep -qiE 'glab[[:space:]]+mr[[:space:]]+create' \
 	&& ! echo "$COMMAND" | grep -qE -- '--assignee|[[:space:]]-a[[:space:]]'; then
 	deny "BLOCKED: glab mr create must include an assignee. Add --assignee <username> (or --assignee @me) and retry — unassigned MRs are not allowed."
+fi
+
+if is_rest_creation && ! echo "$COMMAND" | grep -qE 'assignee'; then
+	deny "BLOCKED: this creates a merge request through the REST API with no assignee.
+
+The API path lands exactly the MR the CLI would, so it carries the same rule — an unassigned MR has no owner from the moment it exists.
+
+Prefer the CLI, which names the flag for you: glab mr create --assignee <username>"
+fi
+
+mr_body_text() {
+	local text="$COMMAND" file
+	for file in $(echo "$COMMAND" |
+		grep -oE -- '(--body-file|--description-file|-F)[[:space:]=]+[^[:space:]"'"'"']+' |
+		sed -E 's/^[^[:space:]=]+[[:space:]=]+//' || true); do
+		[[ "$file" == "-" || ! -r "$file" ]] && continue
+		text="$text"$'\n'"$(cat "$file" 2>/dev/null || true)"
+	done
+	printf '%s' "$text"
+}
+
+if agentkit_forge_flag mr-police require-issue-reference; then
+	if ! mr_body_text | grep -qE '(#[0-9]+|/issues/[0-9]+|![0-9]+)'; then
+		deny "BLOCKED: this merge request names no issue, and this project runs issue-first.
+
+A merged diff with no issue is an orphan: the reason it was made lives in a session nobody else can read.
+
+Reference the issue in the description — Addresses #<n> — or file one first if none covers this work. Turn the requirement off with mr-police.require-issue-reference in .agentkit/config.yaml."
+	fi
+fi
+
+# GitLab closes an issue when a keyword lands next to its number, which takes the
+# completion call away from whoever asked for the work.
+if agentkit_forge_flag mr-police forbid-closing-keywords; then
+	if mr_body_text | grep -qiE '\b(clos(e|es|ed|ing)|fix(es|ed)?|resolv(e|es|ed)|implement(s|ed)?)\b[[:space:]]*[#!][0-9]+'; then
+		deny "BLOCKED: this merge request carries a closing keyword next to an issue reference.
+
+On merge the forge would close that issue, deciding the work is done before the person who asked for it has verified anything.
+
+Write Addresses #<n> or Refs #<n> instead. Turn this off with mr-police.forbid-closing-keywords in .agentkit/config.yaml."
+	fi
 fi
 
 # Need glab to check; if it's unavailable, don't block (fail open).

--- a/plugins-cc/agentkit-adversarial-review/hooks/lib/forge-cache.sh
+++ b/plugins-cc/agentkit-adversarial-review/hooks/lib/forge-cache.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# A short-lived cache for forge lookups shared by issue-police and mr-police.
+# Staleness costs a wasted refresh, never a wrong refusal — see
+# agentkit_forge_verify.
+
+AGENTKIT_FORGE_CACHE_ROOT="${AGENTKIT_FORGE_CACHE_ROOT:-${XDG_CACHE_HOME:-$HOME/.cache}/agentkit/forge}"
+
+agentkit_forge_cache_file() {
+	local key="$1"
+	printf '%s/%s' "$AGENTKIT_FORGE_CACHE_ROOT" "$(printf '%s' "$key" | tr -c 'A-Za-z0-9._-' '_')"
+}
+
+agentkit_file_mtime() {
+	stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null || printf '0'
+}
+
+# Prints the cached value when it is younger than <ttl> seconds.
+agentkit_forge_cached() {
+	local file age now
+	file="$(agentkit_forge_cache_file "$1")"
+	[[ -f "$file" ]] || return 1
+	now="$(date +%s)"
+	age=$((now - $(agentkit_file_mtime "$file")))
+	[[ "$age" -lt "$2" ]] || return 1
+	cat "$file"
+}
+
+agentkit_forge_store() {
+	local file tmp
+	file="$(agentkit_forge_cache_file "$1")"
+	mkdir -p "$(dirname "$file")" 2>/dev/null || return 0
+	tmp="$(mktemp "${file}.XXXXXX")" || return 0
+	printf '%s' "$2" >"$tmp" && mv -f "$tmp" "$file" || rm -f "$tmp"
+}
+
+# Cached value for <key>, or the output of <command…> stored under it. An empty
+# result is not cached — that is usually a failed call, and caching it would
+# turn one network blip into an hour of wrong answers.
+agentkit_forge_lookup() {
+	local key="$1" ttl="$2" value
+	shift 2
+	if value="$(agentkit_forge_cached "$key" "$ttl")"; then
+		printf '%s' "$value"
+		return 0
+	fi
+	value="$("$@" 2>/dev/null)" || return 1
+	[[ -n "$value" ]] || return 1
+	agentkit_forge_store "$key" "$value"
+	printf '%s' "$value"
+}
+
+# Re-runs <command…> and replaces the cache entry.
+agentkit_forge_refresh() {
+	local key="$1" value
+	shift
+	value="$("$@" 2>/dev/null)" || return 1
+	[[ -n "$value" ]] || return 1
+	agentkit_forge_store "$key" "$value"
+	printf '%s' "$value"
+}
+
+# The gate every cache-backed refusal goes through: <predicate> is run against
+# the cached value, and only a second failure against freshly fetched data is
+# reported as a real one. Returns 0 when the check passes.
+agentkit_forge_verify() {
+	local key="$1" ttl="$2" predicate="$3" value
+	shift 3
+	value="$(agentkit_forge_lookup "$key" "$ttl" "$@")" || return 0
+	"$predicate" "$value" && return 0
+	value="$(agentkit_forge_refresh "$key" "$@")" || return 0
+	"$predicate" "$value"
+}

--- a/plugins-cc/agentkit-adversarial-review/hooks/lib/forge-config.sh
+++ b/plugins-cc/agentkit-adversarial-review/hooks/lib/forge-config.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Scalar config lookup for issue-police and mr-police. What a project requires of
+# an issue or an MR is data the hook reads, so the agent never has to rediscover
+# a taxonomy it could have been handed.
+
+# Project config wins over the machine's, matching brain-config.
+agentkit_forge_config() {
+	local section="$1" want="$2" value file
+	for file in \
+		"${CLAUDE_PROJECT_DIR:-$PWD}/.agentkit/config.yaml" \
+		"${XDG_CONFIG_HOME:-$HOME/.config}/agentkit/config.yaml"; do
+		[[ -f "$file" ]] || continue
+		value="$(awk -v section="$section" -v want="$want" '
+			/^[^[:space:]#]/ { in_section = ($0 == section ":"); next }
+			!in_section { next }
+			{
+				line = $0
+				sub(/[[:space:]]*#.*$/, "", line)
+				if (line ~ /^[[:space:]]*$/) next
+				sub(/^[[:space:]]+/, "", line)
+				split(line, kv, ":")
+				if (kv[1] != want) next
+				value = substr(line, length(kv[1]) + 2)
+				sub(/^[[:space:]]+/, "", value)
+				sub(/[[:space:]]+$/, "", value)
+				gsub(/^["'"'"']|["'"'"']$/, "", value)
+				print value
+				exit
+			}
+		' "$file" 2>/dev/null)"
+		[[ -n "$value" ]] && {
+			printf '%s' "$value"
+			return 0
+		}
+	done
+	return 1
+}
+
+agentkit_forge_config_or() {
+	local section="$1" key="$2" fallback="$3" value
+	value="$(agentkit_forge_config "$section" "$key" || true)"
+	printf '%s' "${value:-$fallback}"
+}
+
+# Absent reads as off: a house policy not every repository shares is asked for.
+agentkit_forge_flag() {
+	local value
+	value="$(agentkit_forge_config "$1" "$2" || true)"
+	case "$value" in
+	true | yes | on | 1) return 0 ;;
+	esac
+	return 1
+}

--- a/plugins-cc/agentkit-brain/hooks/lib/forge-cache.sh
+++ b/plugins-cc/agentkit-brain/hooks/lib/forge-cache.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# A short-lived cache for forge lookups shared by issue-police and mr-police.
+# Staleness costs a wasted refresh, never a wrong refusal — see
+# agentkit_forge_verify.
+
+AGENTKIT_FORGE_CACHE_ROOT="${AGENTKIT_FORGE_CACHE_ROOT:-${XDG_CACHE_HOME:-$HOME/.cache}/agentkit/forge}"
+
+agentkit_forge_cache_file() {
+	local key="$1"
+	printf '%s/%s' "$AGENTKIT_FORGE_CACHE_ROOT" "$(printf '%s' "$key" | tr -c 'A-Za-z0-9._-' '_')"
+}
+
+agentkit_file_mtime() {
+	stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null || printf '0'
+}
+
+# Prints the cached value when it is younger than <ttl> seconds.
+agentkit_forge_cached() {
+	local file age now
+	file="$(agentkit_forge_cache_file "$1")"
+	[[ -f "$file" ]] || return 1
+	now="$(date +%s)"
+	age=$((now - $(agentkit_file_mtime "$file")))
+	[[ "$age" -lt "$2" ]] || return 1
+	cat "$file"
+}
+
+agentkit_forge_store() {
+	local file tmp
+	file="$(agentkit_forge_cache_file "$1")"
+	mkdir -p "$(dirname "$file")" 2>/dev/null || return 0
+	tmp="$(mktemp "${file}.XXXXXX")" || return 0
+	printf '%s' "$2" >"$tmp" && mv -f "$tmp" "$file" || rm -f "$tmp"
+}
+
+# Cached value for <key>, or the output of <command…> stored under it. An empty
+# result is not cached — that is usually a failed call, and caching it would
+# turn one network blip into an hour of wrong answers.
+agentkit_forge_lookup() {
+	local key="$1" ttl="$2" value
+	shift 2
+	if value="$(agentkit_forge_cached "$key" "$ttl")"; then
+		printf '%s' "$value"
+		return 0
+	fi
+	value="$("$@" 2>/dev/null)" || return 1
+	[[ -n "$value" ]] || return 1
+	agentkit_forge_store "$key" "$value"
+	printf '%s' "$value"
+}
+
+# Re-runs <command…> and replaces the cache entry.
+agentkit_forge_refresh() {
+	local key="$1" value
+	shift
+	value="$("$@" 2>/dev/null)" || return 1
+	[[ -n "$value" ]] || return 1
+	agentkit_forge_store "$key" "$value"
+	printf '%s' "$value"
+}
+
+# The gate every cache-backed refusal goes through: <predicate> is run against
+# the cached value, and only a second failure against freshly fetched data is
+# reported as a real one. Returns 0 when the check passes.
+agentkit_forge_verify() {
+	local key="$1" ttl="$2" predicate="$3" value
+	shift 3
+	value="$(agentkit_forge_lookup "$key" "$ttl" "$@")" || return 0
+	"$predicate" "$value" && return 0
+	value="$(agentkit_forge_refresh "$key" "$@")" || return 0
+	"$predicate" "$value"
+}

--- a/plugins-cc/agentkit-brain/hooks/lib/forge-config.sh
+++ b/plugins-cc/agentkit-brain/hooks/lib/forge-config.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Scalar config lookup for issue-police and mr-police. What a project requires of
+# an issue or an MR is data the hook reads, so the agent never has to rediscover
+# a taxonomy it could have been handed.
+
+# Project config wins over the machine's, matching brain-config.
+agentkit_forge_config() {
+	local section="$1" want="$2" value file
+	for file in \
+		"${CLAUDE_PROJECT_DIR:-$PWD}/.agentkit/config.yaml" \
+		"${XDG_CONFIG_HOME:-$HOME/.config}/agentkit/config.yaml"; do
+		[[ -f "$file" ]] || continue
+		value="$(awk -v section="$section" -v want="$want" '
+			/^[^[:space:]#]/ { in_section = ($0 == section ":"); next }
+			!in_section { next }
+			{
+				line = $0
+				sub(/[[:space:]]*#.*$/, "", line)
+				if (line ~ /^[[:space:]]*$/) next
+				sub(/^[[:space:]]+/, "", line)
+				split(line, kv, ":")
+				if (kv[1] != want) next
+				value = substr(line, length(kv[1]) + 2)
+				sub(/^[[:space:]]+/, "", value)
+				sub(/[[:space:]]+$/, "", value)
+				gsub(/^["'"'"']|["'"'"']$/, "", value)
+				print value
+				exit
+			}
+		' "$file" 2>/dev/null)"
+		[[ -n "$value" ]] && {
+			printf '%s' "$value"
+			return 0
+		}
+	done
+	return 1
+}
+
+agentkit_forge_config_or() {
+	local section="$1" key="$2" fallback="$3" value
+	value="$(agentkit_forge_config "$section" "$key" || true)"
+	printf '%s' "${value:-$fallback}"
+}
+
+# Absent reads as off: a house policy not every repository shares is asked for.
+agentkit_forge_flag() {
+	local value
+	value="$(agentkit_forge_config "$1" "$2" || true)"
+	case "$value" in
+	true | yes | on | 1) return 0 ;;
+	esac
+	return 1
+}

--- a/plugins-cc/agentkit/hooks/issue-police.sh
+++ b/plugins-cc/agentkit/hooks/issue-police.sh
@@ -7,6 +7,10 @@ set -euo pipefail
 
 # shellcheck source=lib/hook-input.sh
 source "${BASH_SOURCE[0]%/*}/lib/hook-input.sh"
+# shellcheck source=lib/forge-config.sh
+source "${BASH_SOURCE[0]%/*}/lib/forge-config.sh"
+# shellcheck source=lib/forge-cache.sh
+source "${BASH_SOURCE[0]%/*}/lib/forge-cache.sh"
 agentkit_slurp_input
 COMMAND=$(agentkit_command)
 
@@ -65,7 +69,238 @@ done
 # on the quote character itself.
 DISPOSITION_RE="[Dd]isposition:[[:space:]]*[^[:space:]\"'\`]"
 
+BODY_TEXT=""
+for body_file in $BODY_FILES; do
+	[[ "$body_file" == "-" ]] && continue
+	if [[ "$body_file" != /* && -n "$TARGET_DIR" ]]; then
+		body_file="$TARGET_DIR/$body_file"
+	fi
+	[[ -r "$body_file" ]] || continue
+	BODY_TEXT="$BODY_TEXT"$'\n'"$(cat "$body_file" 2>/dev/null || true)"
+done
+
+# shlex, because a body is a quoted argument containing everything a regex would
+# have to survive: newlines, nested quotes, flags quoted inside prose.
+forge_flag_value() {
+	command -v python3 >/dev/null 2>&1 || return 1
+	COMMAND="$COMMAND" python3 -c '
+import os, shlex, sys
+names = sys.argv[1:]
+try:
+    parts = shlex.split(os.environ["COMMAND"], comments=False)
+except ValueError:
+    sys.exit(1)
+for i, part in enumerate(parts):
+    for name in names:
+        if part == name and i + 1 < len(parts):
+            print(parts[i + 1])
+            sys.exit(0)
+        if part.startswith(name + "="):
+            print(part[len(name) + 1:])
+            sys.exit(0)
+sys.exit(1)
+' "$@" 2>/dev/null
+}
+
+# The REST spelling carries the body as `--field description=…`, not as a flag.
+forge_field_value() {
+	command -v python3 >/dev/null 2>&1 || return 1
+	COMMAND="$COMMAND" python3 -c '
+import os, shlex, sys
+names = sys.argv[1:]
+flags = ("--field", "-f", "--raw-field", "-F")
+try:
+    parts = shlex.split(os.environ["COMMAND"], comments=False)
+except ValueError:
+    sys.exit(1)
+for i, part in enumerate(parts):
+    pair = None
+    if part in flags and i + 1 < len(parts):
+        pair = parts[i + 1]
+    elif part.startswith("--field=") or part.startswith("--raw-field="):
+        pair = part.split("=", 1)[1]
+    if not pair or "=" not in pair:
+        continue
+    key, value = pair.split("=", 1)
+    if key in names:
+        print(value)
+        sys.exit(0)
+sys.exit(1)
+' "$@" 2>/dev/null
+}
+
+char_count() { printf '%s' "$1" | wc -c | tr -d ' '; }
+
+# A skeleton nobody filled in is worse than no template: it reads as answered.
+has_unfilled_skeleton() {
+	local body="$1"
+	echo "$body" | grep -qE '<!--' && return 0
+	echo "$body" | grep -qE '^[[:space:]]*-[[:space:]]*\[[ xX]?\][[:space:]]*$' && return 0
+	echo "$body" | grep -qE '^[[:space:]]*/(milestone|label|assign)[[:space:]]*%?[[:space:]]*$' && return 0
+	return 1
+}
+
+completeness_checks() {
+	local body min max require assignee
+	body="$(forge_flag_value --description -d --body -b || true)"
+	[[ -z "$body" ]] && body="$(forge_field_value description body || true)"
+	[[ -z "$body" ]] && body="$BODY_TEXT"
+	body="${body#"${body%%[![:space:]]*}"}"
+
+	# An empty body is wrong everywhere; how short is too short is a house call,
+	# so the floor and the ceiling are both opt-in.
+	min="$(agentkit_forge_config_or issue-police min-body-chars 0)"
+	max="$(agentkit_forge_config_or issue-police max-body-chars 0)"
+
+	if [[ -z "$body" ]]; then
+		deny "BLOCKED: this issue has no description.
+
+An issue with a title and nothing else asks the next reader to reconstruct what you already knew. Pass the body with --description (glab) or --body (gh), or write it to a file and pass --description-file / --body-file.
+
+State the problem, what done looks like, and the evidence you have — a few lines beat a heading with nothing under it."
+	fi
+
+	if [[ "$min" -gt 0 && "$(char_count "$body")" -lt "$min" ]]; then
+		deny "BLOCKED: this issue body is shorter than this project's floor of ${min} characters.
+
+A stub costs the next reader the whole investigation again. Say what is wrong, what done looks like, and cite the evidence — file:line, or the command and what it showed.
+
+Raise or lower the floor with issue-police.min-body-chars in .agentkit/config.yaml."
+	fi
+
+	if [[ "$max" -gt 0 && "$(char_count "$body")" -gt "$max" ]]; then
+		deny "BLOCKED: this issue body is longer than this project's ceiling of ${max} characters.
+
+Concise is not the same as empty, and neither is complete the same as long. Keep the template's sections, cut the narration: bullets and tables, evidence as citations rather than retellings.
+
+Change the ceiling with issue-police.max-body-chars in .agentkit/config.yaml."
+	fi
+
+	if has_unfilled_skeleton "$body"; then
+		deny "BLOCKED: this issue body still carries an unfilled template.
+
+A template comment, an empty checkbox, or a bare quick action means the skeleton was pasted and not answered — which reads as a completed issue while carrying no more than the blank form did.
+
+Answer each section, delete the ones that genuinely do not apply (and say why), and remove the guidance comments before filing."
+	fi
+
+	require="$(agentkit_forge_config_or issue-police require '')"
+	require_fields "$require"
+
+	assignee="$(forge_flag_value --assignee -a || true)"
+	[[ -n "$assignee" ]] && refuse_self_assignment "$assignee"
+	return 0
+}
+
+forge_cli() {
+	echo "$STRIPPED" | grep -qiE '\bglab\b' && {
+		printf 'glab'
+		return 0
+	}
+	echo "$STRIPPED" | grep -qiE '\bgh\b' && {
+		printf 'gh'
+		return 0
+	}
+	return 1
+}
+
+forge_project() {
+	forge_flag_value --repo -R
+}
+
+require_fields() {
+	local wanted="$1" field flag value
+	[[ -n "$wanted" ]] || return 0
+	for field in $(echo "$wanted" | tr ',' ' '); do
+		case "$field" in
+		labels) flag="--label" ;;
+		assignee) flag="--assignee" ;;
+		milestone) flag="--milestone" ;;
+		*) continue ;;
+		esac
+		value="$(forge_flag_value "$flag" "${flag:1:2}" || true)"
+		[[ -n "$value" ]] || deny "BLOCKED: this issue has no ${field}, and this project requires one.
+
+An item without ${field} is invisible to the board, the milestone report, or the epic rollup it belongs to — accurate text does not make it findable.
+
+Read what the project actually offers before you choose, then pass ${flag}. Requirements live in issue-police.require in .agentkit/config.yaml."
+		if [[ "$field" == labels ]]; then
+			refuse_unknown_labels "$value"
+		fi
+	done
+	return 0
+}
+
+LABELS_WANTED=""
+
+labels_all_known() {
+	local known="$1" label
+	for label in $(echo "$LABELS_WANTED" | tr ',' ' '); do
+		echo "$known" | grep -qxF "$label" || return 1
+	done
+	return 0
+}
+
+# An invented label is silently dropped by the forge, so the issue lands
+# unlabelled while the command that filed it looks correct.
+refuse_unknown_labels() {
+	local cli project
+	LABELS_WANTED="$1"
+	cli="$(forge_cli || true)"
+	[[ "$cli" == glab ]] || return 0
+	command -v glab >/dev/null 2>&1 || return 0
+	project="$(forge_project || true)"
+	[[ -n "$project" ]] || return 0
+	LABEL_PROJECT="$project"
+	agentkit_forge_verify "labels/$project" 3600 labels_all_known forge_labels_glab && return 0
+	deny "BLOCKED: at least one of these labels does not exist in ${project}: ${LABELS_WANTED}.
+
+A label the project does not define is dropped on creation, so the item lands unlabelled while the command looks right.
+
+List what exists and pick from it: glab label list -R ${project}"
+}
+
+# Stated in the passing direction on purpose: an unreachable forge then reads as
+# "not self" and the hook fails open, the way every other lookup here does.
+identity_is_other() {
+	[[ -n "$1" && "$1" != "$ASSIGNEE_WANTED" ]]
+}
+
+ASSIGNEE_WANTED=""
+
+# Opt-in, because only a dedicated bot account can tell the two cases apart: an
+# agent driving a person's own credentials assigns to that person legitimately,
+# while a bot assigning to itself leaves the item unowned.
+refuse_self_assignment() {
+	local cli me_key
+	agentkit_forge_flag issue-police refuse-self-assignment || return 0
+	ASSIGNEE_WANTED="$1"
+	cli="$(forge_cli || true)"
+	[[ -n "$cli" ]] || return 0
+	command -v "$cli" >/dev/null 2>&1 || return 0
+	me_key="identity/$cli/${GITLAB_HOST:-${GH_HOST:-default}}"
+	if [[ "$cli" == glab ]]; then
+		agentkit_forge_verify "$me_key" 86400 identity_is_other forge_identity_glab && return 0
+	else
+		agentkit_forge_verify "$me_key" 86400 identity_is_other forge_identity_gh && return 0
+	fi
+	deny "BLOCKED: you assigned this item to yourself (${ASSIGNEE_WANTED}), the account this token belongs to.
+
+An item assigned to the authoring agent looks owned and is not: no human is going to see it on their board. Assign the person who asked for the work.
+
+If this account genuinely owns the item, say so and let the operator assign it."
+}
+
+forge_identity_glab() { glab api /user 2>/dev/null | jq -r '.username // empty'; }
+forge_identity_gh() { gh api user 2>/dev/null | jq -r '.login // empty'; }
+
+LABEL_PROJECT=""
+forge_labels_glab() {
+	glab label list -R "$LABEL_PROJECT" -F json --per-page 100 2>/dev/null | jq -r '.[].name // empty'
+}
+
 if echo "$TEXT" | grep -qE "$DISPOSITION_RE"; then
+	completeness_checks
 	exit 0
 fi
 

--- a/plugins-cc/agentkit/hooks/lib/forge-cache.sh
+++ b/plugins-cc/agentkit/hooks/lib/forge-cache.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# A short-lived cache for forge lookups shared by issue-police and mr-police.
+# Staleness costs a wasted refresh, never a wrong refusal — see
+# agentkit_forge_verify.
+
+AGENTKIT_FORGE_CACHE_ROOT="${AGENTKIT_FORGE_CACHE_ROOT:-${XDG_CACHE_HOME:-$HOME/.cache}/agentkit/forge}"
+
+agentkit_forge_cache_file() {
+	local key="$1"
+	printf '%s/%s' "$AGENTKIT_FORGE_CACHE_ROOT" "$(printf '%s' "$key" | tr -c 'A-Za-z0-9._-' '_')"
+}
+
+agentkit_file_mtime() {
+	stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null || printf '0'
+}
+
+# Prints the cached value when it is younger than <ttl> seconds.
+agentkit_forge_cached() {
+	local file age now
+	file="$(agentkit_forge_cache_file "$1")"
+	[[ -f "$file" ]] || return 1
+	now="$(date +%s)"
+	age=$((now - $(agentkit_file_mtime "$file")))
+	[[ "$age" -lt "$2" ]] || return 1
+	cat "$file"
+}
+
+agentkit_forge_store() {
+	local file tmp
+	file="$(agentkit_forge_cache_file "$1")"
+	mkdir -p "$(dirname "$file")" 2>/dev/null || return 0
+	tmp="$(mktemp "${file}.XXXXXX")" || return 0
+	printf '%s' "$2" >"$tmp" && mv -f "$tmp" "$file" || rm -f "$tmp"
+}
+
+# Cached value for <key>, or the output of <command…> stored under it. An empty
+# result is not cached — that is usually a failed call, and caching it would
+# turn one network blip into an hour of wrong answers.
+agentkit_forge_lookup() {
+	local key="$1" ttl="$2" value
+	shift 2
+	if value="$(agentkit_forge_cached "$key" "$ttl")"; then
+		printf '%s' "$value"
+		return 0
+	fi
+	value="$("$@" 2>/dev/null)" || return 1
+	[[ -n "$value" ]] || return 1
+	agentkit_forge_store "$key" "$value"
+	printf '%s' "$value"
+}
+
+# Re-runs <command…> and replaces the cache entry.
+agentkit_forge_refresh() {
+	local key="$1" value
+	shift
+	value="$("$@" 2>/dev/null)" || return 1
+	[[ -n "$value" ]] || return 1
+	agentkit_forge_store "$key" "$value"
+	printf '%s' "$value"
+}
+
+# The gate every cache-backed refusal goes through: <predicate> is run against
+# the cached value, and only a second failure against freshly fetched data is
+# reported as a real one. Returns 0 when the check passes.
+agentkit_forge_verify() {
+	local key="$1" ttl="$2" predicate="$3" value
+	shift 3
+	value="$(agentkit_forge_lookup "$key" "$ttl" "$@")" || return 0
+	"$predicate" "$value" && return 0
+	value="$(agentkit_forge_refresh "$key" "$@")" || return 0
+	"$predicate" "$value"
+}

--- a/plugins-cc/agentkit/hooks/lib/forge-config.sh
+++ b/plugins-cc/agentkit/hooks/lib/forge-config.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Scalar config lookup for issue-police and mr-police. What a project requires of
+# an issue or an MR is data the hook reads, so the agent never has to rediscover
+# a taxonomy it could have been handed.
+
+# Project config wins over the machine's, matching brain-config.
+agentkit_forge_config() {
+	local section="$1" want="$2" value file
+	for file in \
+		"${CLAUDE_PROJECT_DIR:-$PWD}/.agentkit/config.yaml" \
+		"${XDG_CONFIG_HOME:-$HOME/.config}/agentkit/config.yaml"; do
+		[[ -f "$file" ]] || continue
+		value="$(awk -v section="$section" -v want="$want" '
+			/^[^[:space:]#]/ { in_section = ($0 == section ":"); next }
+			!in_section { next }
+			{
+				line = $0
+				sub(/[[:space:]]*#.*$/, "", line)
+				if (line ~ /^[[:space:]]*$/) next
+				sub(/^[[:space:]]+/, "", line)
+				split(line, kv, ":")
+				if (kv[1] != want) next
+				value = substr(line, length(kv[1]) + 2)
+				sub(/^[[:space:]]+/, "", value)
+				sub(/[[:space:]]+$/, "", value)
+				gsub(/^["'"'"']|["'"'"']$/, "", value)
+				print value
+				exit
+			}
+		' "$file" 2>/dev/null)"
+		[[ -n "$value" ]] && {
+			printf '%s' "$value"
+			return 0
+		}
+	done
+	return 1
+}
+
+agentkit_forge_config_or() {
+	local section="$1" key="$2" fallback="$3" value
+	value="$(agentkit_forge_config "$section" "$key" || true)"
+	printf '%s' "${value:-$fallback}"
+}
+
+# Absent reads as off: a house policy not every repository shares is asked for.
+agentkit_forge_flag() {
+	local value
+	value="$(agentkit_forge_config "$1" "$2" || true)"
+	case "$value" in
+	true | yes | on | 1) return 0 ;;
+	esac
+	return 1
+}

--- a/plugins-cc/agentkit/hooks/mr-police.sh
+++ b/plugins-cc/agentkit/hooks/mr-police.sh
@@ -19,14 +19,34 @@ set -euo pipefail
 # missing-jq fail-open probe), and a source failure under set -e would silence
 # the gate. BASH_SOURCE is absolute when the harness invokes the script by path.
 source "${BASH_SOURCE[0]%/*}/lib/hook-input.sh"
+# shellcheck source=lib/forge-config.sh
+source "${BASH_SOURCE[0]%/*}/lib/forge-config.sh"
 agentkit_slurp_input
 COMMAND=$(agentkit_command)
 [[ -z "$COMMAND" ]] && exit 0
 
+# Quoted strings are emptied before the trigger is matched, so an MR body that
+# quotes a creation command is not itself a creation.
+STRIPPED=$(echo "$COMMAND" |
+	sed -E "s/\"([^\"\\\\]|\\\\.)*\"/\"\"/g" |
+	sed -E "s/'[^']*'/''/g")
+
+# The REST path creates exactly the same MR as the CLI does, so a unit that only
+# knows the CLI is a gate with a documented way around it.
+is_rest_creation() {
+	echo "$STRIPPED" | grep -qiE '\b(gh|glab)[[:space:]]+api\b' || return 1
+	echo "$STRIPPED" | grep -qiE '(--method|-X)[[:space:]=]+POST\b' || return 1
+	echo "$COMMAND" |
+		sed -E 's/[[:space:]](--field|--raw-field|-f|--input|--body|--body-file|--description-file)[[:space:]=].*//' |
+		grep -qE '/(merge_requests|pulls)([^/[:alnum:]_]|$)'
+}
+
+is_cli_creation() {
+	echo "$STRIPPED" | grep -qiE 'glab[[:space:]]+mr[[:space:]]+create|gh[[:space:]]+pr[[:space:]]+create|merge_request\.create'
+}
+
 # Only act on MR-creation commands; everything else passes through instantly.
-if ! echo "$COMMAND" | grep -qiE 'glab[[:space:]]+mr[[:space:]]+create|merge_request\.create'; then
-	exit 0
-fi
+is_cli_creation || is_rest_creation || exit 0
 
 deny() {
 	agentkit_deny_json "$1"
@@ -38,6 +58,47 @@ deny() {
 if echo "$COMMAND" | grep -qiE 'glab[[:space:]]+mr[[:space:]]+create' \
 	&& ! echo "$COMMAND" | grep -qE -- '--assignee|[[:space:]]-a[[:space:]]'; then
 	deny "BLOCKED: glab mr create must include an assignee. Add --assignee <username> (or --assignee @me) and retry — unassigned MRs are not allowed."
+fi
+
+if is_rest_creation && ! echo "$COMMAND" | grep -qE 'assignee'; then
+	deny "BLOCKED: this creates a merge request through the REST API with no assignee.
+
+The API path lands exactly the MR the CLI would, so it carries the same rule — an unassigned MR has no owner from the moment it exists.
+
+Prefer the CLI, which names the flag for you: glab mr create --assignee <username>"
+fi
+
+mr_body_text() {
+	local text="$COMMAND" file
+	for file in $(echo "$COMMAND" |
+		grep -oE -- '(--body-file|--description-file|-F)[[:space:]=]+[^[:space:]"'"'"']+' |
+		sed -E 's/^[^[:space:]=]+[[:space:]=]+//' || true); do
+		[[ "$file" == "-" || ! -r "$file" ]] && continue
+		text="$text"$'\n'"$(cat "$file" 2>/dev/null || true)"
+	done
+	printf '%s' "$text"
+}
+
+if agentkit_forge_flag mr-police require-issue-reference; then
+	if ! mr_body_text | grep -qE '(#[0-9]+|/issues/[0-9]+|![0-9]+)'; then
+		deny "BLOCKED: this merge request names no issue, and this project runs issue-first.
+
+A merged diff with no issue is an orphan: the reason it was made lives in a session nobody else can read.
+
+Reference the issue in the description — Addresses #<n> — or file one first if none covers this work. Turn the requirement off with mr-police.require-issue-reference in .agentkit/config.yaml."
+	fi
+fi
+
+# GitLab closes an issue when a keyword lands next to its number, which takes the
+# completion call away from whoever asked for the work.
+if agentkit_forge_flag mr-police forbid-closing-keywords; then
+	if mr_body_text | grep -qiE '\b(clos(e|es|ed|ing)|fix(es|ed)?|resolv(e|es|ed)|implement(s|ed)?)\b[[:space:]]*[#!][0-9]+'; then
+		deny "BLOCKED: this merge request carries a closing keyword next to an issue reference.
+
+On merge the forge would close that issue, deciding the work is done before the person who asked for it has verified anything.
+
+Write Addresses #<n> or Refs #<n> instead. Turn this off with mr-police.forbid-closing-keywords in .agentkit/config.yaml."
+	fi
 fi
 
 # Need glab to check; if it's unavailable, don't block (fail open).

--- a/rules/issue-tracking.md
+++ b/rules/issue-tracking.md
@@ -17,6 +17,11 @@ an orphan.
   else could pick it up.
 - Trivial one-line fixes may ride an existing issue's scope instead of getting their own; if no
   related issue exists, file one anyway when the change is user-visible.
+- **Tracking work you are about to do is not the same as filing what you noticed.** A review
+  finding defaults to being fixed in the change that caused it, and scope carved out of the issue
+  in flight is a deferral needing the operator's sign-off. Both are exceptions that have to be
+  argued, which is what the `Disposition:` line on a new issue is for — filing is not free, and a
+  backlog nobody asked for costs more than the finding did.
 - If work started without an issue (it happens), file one **before** opening the PR/MR — never
   merge untracked work.
 

--- a/tests/hooks/issue-police.test.ts
+++ b/tests/hooks/issue-police.test.ts
@@ -197,3 +197,94 @@ describe('issue-police: the REST spelling of a creation', () => {
     expect(denied('glab api --method PUT "projects/g%2Fr/issues/140" --field labels="bug"')).toBe(false);
   });
 });
+
+const DISPOSITION = 'Disposition: new work, unrelated to anything in flight';
+
+function withConfig(body: string, command: string): boolean {
+  const home = mkdtempSync(join(tmpdir(), 'agentkit-issuecfg-'));
+  try {
+    mkdirSync(join(home, 'agentkit'), { recursive: true });
+    writeFileSync(join(home, 'agentkit', 'config.yaml'), body);
+    const res = spawnSync('bash', [HOOK], {
+      cwd: root,
+      input: JSON.stringify({ tool_input: { command } }),
+      encoding: 'utf-8',
+      env: { ...process.env, XDG_CONFIG_HOME: home, CLAUDE_PROJECT_DIR: root },
+    });
+    return (res.stdout ?? '').includes('"deny"');
+  } finally {
+    rmSync(home, { force: true, recursive: true });
+  }
+}
+
+describe('issue-police: an issue that says nothing is not an issue', () => {
+  test('a title with no description is refused even when the disposition is in the title', () => {
+    const out = runHook(`gh issue create --title "${DISPOSITION}"`);
+    expect(out).toContain('"deny"');
+    expect(out).toContain('no description');
+  });
+
+  test('a template pasted with its guidance comments still in it is refused', () => {
+    const out = runHook(
+      `glab issue create -R o/r -t x --description "${DISPOSITION}\n\n## Description\n<!-- one sentence -->\n"`,
+    );
+    expect(out).toContain('unfilled template');
+  });
+
+  test('an empty checkbox is an unanswered section', () => {
+    expect(
+      denied(`glab issue create -R o/r -t x --description "${DISPOSITION}\n\n## Criteria\n- [ ]\n"`),
+    ).toBe(true);
+  });
+
+  test('a placeholder quick action is refused', () => {
+    expect(denied(`glab issue create -R o/r -t x --description "${DISPOSITION}\n\n/milestone %\n"`)).toBe(
+      true,
+    );
+  });
+
+  test('a filled body with real checkboxes passes', () => {
+    expect(
+      denied(
+        `glab issue create -R o/r -t x --description "${DISPOSITION}\n\n## Criteria\n- [ ] the poller sees threaded events\n"`,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('issue-police: the body bounds are the project’s to set', () => {
+  const short = `glab issue create -R o/r -t x --description "${DISPOSITION}"`;
+
+  test('no floor is configured, so a short body passes', () => {
+    expect(denied(short)).toBe(false);
+  });
+
+  test('a configured floor refuses the same body', () => {
+    expect(withConfig('issue-police:\n  min-body-chars: 400\n', short)).toBe(true);
+  });
+
+  test('a configured ceiling refuses a wall of prose', () => {
+    const long = `glab issue create -R o/r -t x --description "${DISPOSITION}. ${'word '.repeat(400)}"`;
+    expect(withConfig('issue-police:\n  max-body-chars: 500\n', long)).toBe(true);
+    expect(denied(long)).toBe(false);
+  });
+});
+
+describe('issue-police: required metadata', () => {
+  const bare = `glab issue create -R o/r -t x --description "${DISPOSITION} and here is the detail"`;
+
+  test('nothing is required by default', () => {
+    expect(denied(bare)).toBe(false);
+  });
+
+  test('a required field the command omits is refused, naming it', () => {
+    expect(withConfig('issue-police:\n  require: milestone\n', bare)).toBe(true);
+    expect(withConfig('issue-police:\n  require: assignee\n', `${bare} --milestone "Aug"`)).toBe(true);
+  });
+
+  test('the requirement is satisfied by passing the flag', () => {
+    expect(
+      withConfig('issue-police:\n  require: milestone,assignee\n', `${bare} --milestone "Aug" --assignee sam`),
+    ).toBe(false);
+  });
+});

--- a/tests/mr-police.test.ts
+++ b/tests/mr-police.test.ts
@@ -132,3 +132,102 @@ describe('mr-police assignee rule', () => {
     expect(shimCalls()).toBe('');
   });
 });
+
+// The command-text gates below run BEFORE the glab lookups, so they need no
+// shim — a PATH without a forge CLI proves they fire on their own.
+function runTextGate(command: string, configYaml?: string): string {
+  const home = mkdtempSync(join(tmpdir(), 'agentkit-mrcfg-'));
+  try {
+    if (configYaml) {
+      mkdirSync(join(home, 'agentkit'), { recursive: true });
+      writeFileSync(join(home, 'agentkit', 'config.yaml'), configYaml);
+    }
+    const res = spawnSync('bash', [HOOK], {
+      cwd: root,
+      input: JSON.stringify({ tool_input: { command } }),
+      encoding: 'utf-8',
+      env: { PATH: '/usr/bin:/bin', HOME: root, CLAUDE_PROJECT_DIR: root, XDG_CONFIG_HOME: home },
+    });
+    return res.stdout ?? '';
+  } finally {
+    rmSync(home, { force: true, recursive: true });
+  }
+}
+
+function textGateDenied(command: string, configYaml?: string): boolean {
+  return runTextGate(command, configYaml).includes('"deny"');
+}
+
+describe('mr-police: the REST path is the same creation as the CLI', () => {
+  test('a REST merge request with no assignee is refused', () => {
+    const out = runTextGate(
+      'glab api --method POST "projects/g%2Fr/merge_requests" -f source_branch=fix -f title=x',
+    );
+    expect(out).toContain('"deny"');
+    expect(out).toContain('REST API with no assignee');
+  });
+
+  test('a REST merge request naming an assignee passes', () => {
+    expect(
+      textGateDenied('glab api --method POST "projects/g%2Fr/merge_requests" -f title=x -f assignee_id=42'),
+    ).toBe(false);
+  });
+
+  test('a GitHub pull request created over the API carries the same rule', () => {
+    expect(textGateDenied('gh api --method POST /repos/o/r/pulls -f title=x -f base=main')).toBe(true);
+  });
+
+  test('reading merge requests is not a creation', () => {
+    expect(textGateDenied('glab api "projects/g%2Fr/merge_requests?state=opened"')).toBe(false);
+  });
+
+  test('a merge_requests URL quoted in a body is not a creation', () => {
+    expect(
+      textGateDenied('glab api --method POST "projects/g%2Fr/issues" -f description="see /merge_requests"'),
+    ).toBe(false);
+  });
+});
+
+describe('mr-police: issue-first is the project’s call', () => {
+  const noRef = 'glab mr create --assignee sam --title "fix the poller" --description "widens the filter"';
+
+  test('nothing is required by default', () => {
+    expect(textGateDenied(noRef)).toBe(false);
+  });
+
+  test('with the requirement on, an MR naming no issue is refused', () => {
+    expect(textGateDenied(noRef, 'mr-police:\n  require-issue-reference: true\n')).toBe(true);
+  });
+
+  test('a reference satisfies it', () => {
+    expect(
+      textGateDenied(
+        'glab mr create --assignee sam --title x --description "Addresses #42"',
+        'mr-police:\n  require-issue-reference: true\n',
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('mr-police: closing keywords decide completion for someone else', () => {
+  const closing = 'glab mr create --assignee sam --title x --description "Closes #42"';
+
+  test('allowed by default, because many projects want the auto-close', () => {
+    expect(textGateDenied(closing)).toBe(false);
+  });
+
+  test('refused where the project has turned it off', () => {
+    const out = runTextGate(closing, 'mr-police:\n  forbid-closing-keywords: true\n');
+    expect(out).toContain('"deny"');
+    expect(out).toContain('closing keyword');
+  });
+
+  test('the word alone, with no issue number beside it, is prose and passes', () => {
+    expect(
+      textGateDenied(
+        'glab mr create --assignee sam --title x --description "this fixes the poller"',
+        'mr-police:\n  forbid-closing-keywords: true\n',
+      ),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #380. Enforcement counterpart to #379 (which owns drafting) and the extension of #256 past presence-only.

**Evidence.** Every issue (22) and merge request (22) authored by one agent account: 2 empty issue bodies, 1 template pasted with every placeholder still in it, 19 without acceptance criteria, 17 without a milestone — and **12 MRs assigned to the bot itself**. The `--assignee` requirement had been satisfied in the cheapest way that cleared it, which is the third instance of the pattern #256 named and #255 chased.

**A hole, not a gap.** `mr-police`'s trigger was `glab mr create|merge_request.create`, so `glab api --method POST …/merge_requests` walked straight past it; one MR reached `gitops` unassigned that way. `issue-police` already covered its REST path, which is why the issue side never had this.

### What is on by default

Only what is wrong everywhere: an issue with **no body**, and one whose body still carries an **unfilled template** — a guidance comment, an empty checkbox, or a bare `/milestone %`.

### What a project opts into

| Unit | Key | Refuses |
| --- | --- | --- |
| `issue-police` | `min-body-chars` / `max-body-chars` | a stub, or a wall of prose |
| | `require: labels,assignee,milestone` | a missing field — and a label the project does not define |
| | `refuse-self-assignment` | an item assigned to the token's own account |
| `mr-police` | `require-issue-reference` | an MR naming no issue |
| | `forbid-closing-keywords` | `close/fix/resolve` next to an issue number |

Two defaults are deliberate. **Self-assignment is opt-in** because only the operator knows which case they are in — an agent driving a person's own credentials assigns to that person legitimately, and defaulting it on would have blocked the issues filed while writing this. **A body floor is opt-in** because how short is too short is a house call; an *empty* body needs no configuration to be wrong.

### The cache

`lib/forge-cache.sh`: identity for a day, taxonomies for an hour, under `$XDG_CACHE_HOME/agentkit/forge`. The load-bearing rule is `agentkit_forge_verify` — a cached answer that would **pass** is trusted, one that would **deny** is refetched before anything is refused. Staleness costs a wasted call, never a wrong block, and an unreachable forge or missing CLI fails open (asserted in the helper's own smoke path and by the PATH-stripped tests).

Every refusal names the values it read (`glab label list -R <project>`, the active milestones), because a denial that says "conform to this project's standards" sends the agent shopping through the API on every issue — worse than no enforcement.

**Also:** `rules/issue-tracking.md` no longer reads as file-by-default, which contradicted the `Disposition:` line the hook has always required (#264).

### Verification

- `scripts/preflight`: all checks passed — and it caught three real findings first (a status leak in `require_fields`, an unformatted docs file, an unrouted test file, now folded into the existing `tests/mr-police.test.ts` rather than shipping a second file with the same name).
- `scripts/preflight --slice hooks`: 424 pass, 0 fail.
- Mutation probes, both reverted after: dropping `is_rest_creation` from the trigger fails 2 tests; neutering the skeleton detector fails 3.