### PR TITLE
fix(issue-police): allow, and say UNCHECKED, when python3 is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ release PR — "publish this" authorizes a release, never the tier.
 
 ## [Unreleased]
 
+- fix(issue-police): **a host without python3 refused every issue instead of checking none.** The
+  completeness checks read the command through a shlex parser, and when it is absent the body and
+  the flags are indistinguishable from prose that mentions them — so an issue with a full
+  description was denied for having none, on every creation, with no way around it. Found on a
+  deployed agent image that ships jq but not python3. The unit now says UNCHECKED and allows,
+  matching taste-police: a gate that cannot read its subject does not get an opinion about it. The
+  disposition gate is unaffected — it reads the raw text and still applies.
+
 - feat(issue-police, mr-police): **the forge units check completeness, not just presence, over a
   shared cached lookup.** An audit of one agent account's output — 22 issues, 22 merge requests —
   found 2 issues filed with an empty body, one that was the template pasted with every placeholder

--- a/hooks/claude/issue-police.sh
+++ b/hooks/claude/issue-police.sh
@@ -140,8 +140,15 @@ has_unfilled_skeleton() {
 	return 1
 }
 
+# Every check below reads the command through the shlex parser. Without it the
+# body and the flags cannot be told apart from prose that mentions them, and a
+# gate that cannot read its subject must not refuse it.
 completeness_checks() {
 	local body min max require assignee
+	command -v python3 >/dev/null 2>&1 || {
+		agentkit_advise_json "UNCHECKED: issue-police read no further than the disposition — python3 is missing, so the body and metadata of this issue were not examined. Install python3 to enforce issue completeness."
+		return 0
+	}
 	body="$(forge_flag_value --description -d --body -b || true)"
 	[[ -z "$body" ]] && body="$(forge_field_value description body || true)"
 	[[ -z "$body" ]] && body="$BODY_TEXT"

--- a/plugins-cc/agentkit/hooks/issue-police.sh
+++ b/plugins-cc/agentkit/hooks/issue-police.sh
@@ -140,8 +140,15 @@ has_unfilled_skeleton() {
 	return 1
 }
 
+# Every check below reads the command through the shlex parser. Without it the
+# body and the flags cannot be told apart from prose that mentions them, and a
+# gate that cannot read its subject must not refuse it.
 completeness_checks() {
 	local body min max require assignee
+	command -v python3 >/dev/null 2>&1 || {
+		agentkit_advise_json "UNCHECKED: issue-police read no further than the disposition — python3 is missing, so the body and metadata of this issue were not examined. Install python3 to enforce issue completeness."
+		return 0
+	}
 	body="$(forge_flag_value --description -d --body -b || true)"
 	[[ -z "$body" ]] && body="$(forge_field_value description body || true)"
 	[[ -z "$body" ]] && body="$BODY_TEXT"

--- a/tests/hooks/issue-police.test.ts
+++ b/tests/hooks/issue-police.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import { spawnSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -286,5 +286,46 @@ describe('issue-police: required metadata', () => {
     expect(
       withConfig('issue-police:\n  require: milestone,assignee\n', `${bare} --milestone "Aug" --assignee sam`),
     ).toBe(false);
+  });
+});
+
+// A gate that cannot read its subject must not refuse it. Without python3 the
+// shlex parser is gone, so the body and flags are indistinguishable from prose
+// that mentions them — and denying there blocks every issue on the host.
+describe('issue-police: no parser means no opinion', () => {
+  function withoutPython(command: string): string {
+    const bin = mkdtempSync(join(tmpdir(), 'agentkit-nopython-'));
+    try {
+      for (const tool of ['bash', 'grep', 'sed', 'jq', 'cat', 'wc', 'tr', 'awk', 'head', 'date']) {
+        const found = spawnSync('sh', ['-c', `command -v ${tool}`], { encoding: 'utf-8' }).stdout?.trim();
+        if (found) symlinkSync(found, join(bin, tool));
+      }
+      const res = spawnSync('bash', [HOOK], {
+        cwd: root,
+        input: JSON.stringify({ tool_input: { command } }),
+        encoding: 'utf-8',
+        env: { PATH: bin, HOME: root },
+      });
+      return res.stdout ?? '';
+    } finally {
+      rmSync(bin, { force: true, recursive: true });
+    }
+  }
+
+  const filed = `glab issue create -R o/r -t x --description "${DISPOSITION} and the detail"`;
+
+  test('an issue is allowed through when python3 is absent', () => {
+    const out = withoutPython(filed);
+    expect(out).not.toContain('"deny"');
+  });
+
+  test('and it says so, rather than passing silently as if it had checked', () => {
+    expect(withoutPython(filed)).toContain('UNCHECKED');
+  });
+
+  test('the disposition gate still refuses without python3', () => {
+    expect(withoutPython('glab issue create -R o/r -t x --description "no disposition here"')).toContain(
+      '"deny"',
+    );
   });
 });


### PR DESCRIPTION
Follow-up to #380 / #383, found by verifying the deploy rather than the merge.

**The bug.** The completeness checks added in #383 read the command through a shlex parser (python3). When it is absent, `forge_flag_value` returns nothing, the body reads as empty, and the unit denies **every** issue creation with "this issue has no description" — including issues carrying a full one. There is no way around it short of uninstalling the hook.

Caught on the deployed Proxima image, which ships `jq` but not `python3`. A well-formed `glab issue create` with description, labels, assignee and milestone was refused:

```
BLOCKED: this issue has no description.
```

That is fail-**closed**, which inverts the doctrine every other lookup in these units follows ("Need glab to check; if it's unavailable, don't block").

**The fix.** `completeness_checks` gates on parser availability and emits `UNCHECKED` instead — the same shape `taste-police` uses when it cannot run, so silence is never mistaken for a pass. A gate that cannot read its subject does not get an opinion about it.

The **disposition gate is unaffected**: it matches against the raw command text and needs no parser, so the #256 rule still applies everywhere.

**Verification**
- `scripts/preflight`: all checks passed. `--slice hooks`: 427 pass, 0 fail.
- Three new tests run the hook against a PATH containing bash/grep/sed/jq/awk but **no python3**: a filed issue is allowed, the output says `UNCHECKED`, and an issue with no disposition is still refused.
- Mutation probe: removing the guard fails 2 of the 3. Reverted.

Note `plugins-cc/agentkit/.claude-plugin/plugin.json` already declares python3 a hook dependency — the image was non-compliant. That is being fixed on the image side too, but a stated dependency going missing must degrade, not block.