### PR TITLE
fix(issue-police): a quoted template marker is evidence, not an unfilled section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ release PR — "publish this" authorizes a release, never the tier.
 
 ## [Unreleased]
 
+- fix(issue-police): **an issue that quotes a template marker is no longer refused for having one.**
+  The unfilled-template check matched `<!--` anywhere in the body, so an issue _about_ a bad
+  template — citing the prompt it complains about — was blocked for the thing it was reporting.
+  Caught on a real, well-formed issue filed against a playbook. Fenced blocks and inline code spans
+  are now stripped before the check, and a marker, empty checkbox or bare quick action has to own
+  its line to count as unanswered.
+
 - fix(issue-police): **a host without python3 refused every issue instead of checking none.** The
   completeness checks read the command through a shlex parser, and when it is absent the body and
   the flags are indistinguishable from prose that mentions them — so an issue with a full

--- a/hooks/claude/issue-police.sh
+++ b/hooks/claude/issue-police.sh
@@ -131,12 +131,24 @@ sys.exit(1)
 
 char_count() { printf '%s' "$1" | wc -c | tr -d ' '; }
 
+# An issue about templates quotes template markers as evidence, so the check
+# runs against the prose only: fenced blocks and inline code spans are removed
+# first, and a marker still has to own its line to count as unanswered.
+strip_quoted() {
+	awk '
+		/^[[:space:]]*```/ { fenced = !fenced; next }
+		fenced { next }
+		{ gsub(/`[^`]*`/, ""); print }
+	'
+}
+
 # A skeleton nobody filled in is worse than no template: it reads as answered.
 has_unfilled_skeleton() {
-	local body="$1"
-	echo "$body" | grep -qE '<!--' && return 0
-	echo "$body" | grep -qE '^[[:space:]]*-[[:space:]]*\[[ xX]?\][[:space:]]*$' && return 0
-	echo "$body" | grep -qE '^[[:space:]]*/(milestone|label|assign)[[:space:]]*%?[[:space:]]*$' && return 0
+	local prose
+	prose="$(printf '%s' "$1" | strip_quoted)"
+	echo "$prose" | grep -qE '^[[:space:]]*<!--' && return 0
+	echo "$prose" | grep -qE '^[[:space:]]*-[[:space:]]*\[[ xX]?\][[:space:]]*$' && return 0
+	echo "$prose" | grep -qE '^[[:space:]]*/(milestone|label|assign)[[:space:]]*%?[[:space:]]*$' && return 0
 	return 1
 }
 

--- a/plugins-cc/agentkit/hooks/issue-police.sh
+++ b/plugins-cc/agentkit/hooks/issue-police.sh
@@ -131,12 +131,24 @@ sys.exit(1)
 
 char_count() { printf '%s' "$1" | wc -c | tr -d ' '; }
 
+# An issue about templates quotes template markers as evidence, so the check
+# runs against the prose only: fenced blocks and inline code spans are removed
+# first, and a marker still has to own its line to count as unanswered.
+strip_quoted() {
+	awk '
+		/^[[:space:]]*```/ { fenced = !fenced; next }
+		fenced { next }
+		{ gsub(/`[^`]*`/, ""); print }
+	'
+}
+
 # A skeleton nobody filled in is worse than no template: it reads as answered.
 has_unfilled_skeleton() {
-	local body="$1"
-	echo "$body" | grep -qE '<!--' && return 0
-	echo "$body" | grep -qE '^[[:space:]]*-[[:space:]]*\[[ xX]?\][[:space:]]*$' && return 0
-	echo "$body" | grep -qE '^[[:space:]]*/(milestone|label|assign)[[:space:]]*%?[[:space:]]*$' && return 0
+	local prose
+	prose="$(printf '%s' "$1" | strip_quoted)"
+	echo "$prose" | grep -qE '^[[:space:]]*<!--' && return 0
+	echo "$prose" | grep -qE '^[[:space:]]*-[[:space:]]*\[[ xX]?\][[:space:]]*$' && return 0
+	echo "$prose" | grep -qE '^[[:space:]]*/(milestone|label|assign)[[:space:]]*%?[[:space:]]*$' && return 0
 	return 1
 }
 

--- a/tests/hooks/issue-police.test.ts
+++ b/tests/hooks/issue-police.test.ts
@@ -329,3 +329,43 @@ describe('issue-police: no parser means no opinion', () => {
     );
   });
 });
+
+// An issue about templates quotes template markers as evidence. The first
+// version of the skeleton check refused exactly that — a real, well-formed
+// issue filed against a playbook was blocked for citing the prompt it was
+// complaining about.
+describe('issue-police: a quoted marker is evidence, not an unfilled section', () => {
+  const cited = `${DISPOSITION}
+
+## Description
+
+As an engineer filing an issue, I want the template to ask for the outcome, so
+that what I produce is already the right shape.
+
+Context:
+- \`default.md:13\` prompts \`<!-- One sentence: what needs to be done? -->\`, and
+  the skill says \`Description: One sentence of what needs doing\`.
+
+## Acceptance Criteria
+
+- [ ] the template asks for the outcome line`;
+
+  test('a marker quoted inline in backticks passes', () => {
+    expect(denied(`glab issue create -R o/r -t x --description "${cited}"`)).toBe(false);
+  });
+
+  test('a marker inside a fenced block passes', () => {
+    const fenced = `${DISPOSITION}\n\nThe template reads:\n\n\`\`\`markdown\n<!-- One sentence: what needs to be done? -->\n- [ ]\n\`\`\`\n\nand that is the problem.`;
+    expect(denied(`glab issue create -R o/r -t x --description "${fenced}"`)).toBe(false);
+  });
+
+  test('a marker that owns its line is still refused', () => {
+    const unfilled = `${DISPOSITION}\n\n## Description\n\n<!-- One sentence: what needs to be done? -->\n`;
+    expect(denied(`glab issue create -R o/r -t x --description "${unfilled}"`)).toBe(true);
+  });
+
+  test('an empty checkbox that owns its line is still refused', () => {
+    const unfilled = `${DISPOSITION}\n\n## Criteria\n\n- [ ]\n`;
+    expect(denied(`glab issue create -R o/r -t x --description "${unfilled}"`)).toBe(true);
+  });
+});


### PR DESCRIPTION
Follow-up to #383, caught by a real filing rather than a test.

**The bug.** `has_unfilled_skeleton` matched `<!--` anywhere in the body. So an issue *about* a bad template — one that cites the prompt it is complaining about — was refused **for the thing it was reporting**:

```
- `default.md:13` prompts `<!-- One sentence: what needs to be done? -->`, and
  the skill says `Description: One sentence of what needs doing`.
```

That is a well-formed, 3255-character issue with a user-story opening, five filled acceptance criteria and a disposition. Fed to the hook verbatim it came back:

> BLOCKED: this issue body still carries an unfilled template.

Same for the empty-checkbox rule: a body quoting `- [ ]` inside a fenced block to *show* the unfilled form would be refused for containing one.

**The fix.** Fenced blocks and inline code spans are stripped before the check, and a marker, empty checkbox or bare quick action now has to **own its line** to count as unanswered. A genuinely pasted skeleton is still refused — that case has its own test, and so does the fenced-quotation case.

**Why it matters beyond this one issue.** The check exists to stop a skeleton being filed as if it were answered. Refusing an issue for *quoting* a skeleton inverts that: the more precisely someone documents a template problem, the more certainly they are blocked from reporting it.

**Verification:** `scripts/preflight` all checks passed; `--slice hooks` 431 pass, 0 fail. The real filed body now passes the hook. Mutation probe: removing the strip step fails the quoted-marker test.