### PR TITLE
issue-police board hygiene + SSH-first transport rule

### DIFF
--- a/hooks/claude/issue-police.sh
+++ b/hooks/claude/issue-police.sh
@@ -23,8 +23,16 @@ STRIPPED=$(echo "$COMMAND" |
 	sed -E "s/\"([^\"\\\\]|\\\\.)*\"/\"\"/g" |
 	sed -E "s/'[^']*'/''/g")
 
+# What matched decides what can be demanded of it: an epic filed over the API
+# carries its fields as -f pairs, so flag requires would false-block it, and
+# the advisory below is its enforcement instead.
+CREATION_KIND=""
+
 is_creation() {
-	echo "$STRIPPED" | grep -qiE '\b(gh|glab)[[:space:]]+issue[[:space:]]+create\b' && return 0
+	echo "$STRIPPED" | grep -qiE '\b(gh|glab)[[:space:]]+issue[[:space:]]+create\b' && {
+		CREATION_KIND="issue"
+		return 0
+	}
 
 	echo "$STRIPPED" | grep -qiE '\b(gh|glab)[[:space:]]+api\b' || return 1
 	echo "$STRIPPED" | grep -qiE '(--method|-X)[[:space:]=]+POST\b' || return 1
@@ -35,7 +43,17 @@ is_creation() {
 	url_part=$(echo "$COMMAND" |
 		sed -E 's/[[:space:]](--field|--raw-field|-f|--input|--body|--body-file|--description-file)[[:space:]=].*//')
 	# Trailing segment only — /issues/7/notes and /issues_statistics create nothing.
-	echo "$url_part" | grep -qE '/issues([^/[:alnum:]_]|$)'
+	echo "$url_part" | grep -qE '/issues([^/[:alnum:]_]|$)' && {
+		CREATION_KIND="issue"
+		return 0
+	}
+	# Epics are work items with the same board obligations, and were the gap
+	# through which a bare epic reached the board unremarked.
+	echo "$url_part" | grep -qE '/epics([^/[:alnum:]_]|$)' && {
+		CREATION_KIND="epic"
+		return 0
+	}
+	return 1
 }
 
 is_creation || exit 0
@@ -204,7 +222,9 @@ Answer each section, delete the ones that genuinely do not apply (and say why), 
 	fi
 
 	require="$(agentkit_forge_config_or issue-police require '')"
-	require_fields "$require"
+	# An epic's fields travel as -f pairs, not flags; requiring flags of it
+	# blocks every epic the API can create. The advisory is its enforcement.
+	[[ "$CREATION_KIND" == epic ]] || require_fields "$require"
 
 	assignee="$(forge_flag_value --assignee -a || true)"
 	[[ -n "$assignee" ]] && refuse_self_assignment "$assignee"
@@ -235,6 +255,13 @@ require_fields() {
 		labels) flag="--label" ;;
 		assignee) flag="--assignee" ;;
 		milestone) flag="--milestone" ;;
+		weight)
+			# A GitLab planning field; gh has no such flag, and a machine-wide
+			# require must not block GitHub repositories for a field their forge
+			# cannot carry.
+			[[ "$(forge_cli || true)" == glab ]] || continue
+			flag="--weight"
+			;;
 		*) continue ;;
 		esac
 		value="$(forge_flag_value "$flag" "${flag:1:2}" || true)"
@@ -318,8 +345,25 @@ forge_labels_glab() {
 	glab label list -R "$LABEL_PROJECT" -F json --per-page 100 2>/dev/null | jq -r '.[].name // empty'
 }
 
+# Filed is not finished: the fields no create flag can carry are exactly the
+# ones that decide whether the item appears on a board. Advised, not blocked —
+# they can only be set after the item exists.
+board_hygiene_advice() {
+	agentkit_advise_json "FILED, not finished — board metadata is what makes this findable. Before moving on: (1) set the work-item Status off Triage (GitLab: GraphQL statusWidget — boards filter on Status, and a status:: label does not move it); (2) link the parent epic or work item; (3) weight, milestone, assignee, labels; (4) read the item back and verify every field landed — a silent API failure leaves blanks the command line never showed. The complete-work-item-metadata taste is the policy; this reminder exists because it was missed twice."
+}
+
+# An epic is a container: the filed-rather-than-fixed question does not apply,
+# and its fields travel as -f pairs no flag check can read. It gets the body
+# checks and the advisory, not the issue gates.
+if [[ "$CREATION_KIND" == epic ]]; then
+	completeness_checks
+	board_hygiene_advice
+	exit 0
+fi
+
 if echo "$TEXT" | grep -qE "$DISPOSITION_RE"; then
 	completeness_checks
+	board_hygiene_advice
 	exit 0
 fi
 

--- a/plugins-cc/agentkit/hooks/issue-police.sh
+++ b/plugins-cc/agentkit/hooks/issue-police.sh
@@ -23,8 +23,16 @@ STRIPPED=$(echo "$COMMAND" |
 	sed -E "s/\"([^\"\\\\]|\\\\.)*\"/\"\"/g" |
 	sed -E "s/'[^']*'/''/g")
 
+# What matched decides what can be demanded of it: an epic filed over the API
+# carries its fields as -f pairs, so flag requires would false-block it, and
+# the advisory below is its enforcement instead.
+CREATION_KIND=""
+
 is_creation() {
-	echo "$STRIPPED" | grep -qiE '\b(gh|glab)[[:space:]]+issue[[:space:]]+create\b' && return 0
+	echo "$STRIPPED" | grep -qiE '\b(gh|glab)[[:space:]]+issue[[:space:]]+create\b' && {
+		CREATION_KIND="issue"
+		return 0
+	}
 
 	echo "$STRIPPED" | grep -qiE '\b(gh|glab)[[:space:]]+api\b' || return 1
 	echo "$STRIPPED" | grep -qiE '(--method|-X)[[:space:]=]+POST\b' || return 1
@@ -35,7 +43,17 @@ is_creation() {
 	url_part=$(echo "$COMMAND" |
 		sed -E 's/[[:space:]](--field|--raw-field|-f|--input|--body|--body-file|--description-file)[[:space:]=].*//')
 	# Trailing segment only — /issues/7/notes and /issues_statistics create nothing.
-	echo "$url_part" | grep -qE '/issues([^/[:alnum:]_]|$)'
+	echo "$url_part" | grep -qE '/issues([^/[:alnum:]_]|$)' && {
+		CREATION_KIND="issue"
+		return 0
+	}
+	# Epics are work items with the same board obligations, and were the gap
+	# through which a bare epic reached the board unremarked.
+	echo "$url_part" | grep -qE '/epics([^/[:alnum:]_]|$)' && {
+		CREATION_KIND="epic"
+		return 0
+	}
+	return 1
 }
 
 is_creation || exit 0
@@ -204,7 +222,9 @@ Answer each section, delete the ones that genuinely do not apply (and say why), 
 	fi
 
 	require="$(agentkit_forge_config_or issue-police require '')"
-	require_fields "$require"
+	# An epic's fields travel as -f pairs, not flags; requiring flags of it
+	# blocks every epic the API can create. The advisory is its enforcement.
+	[[ "$CREATION_KIND" == epic ]] || require_fields "$require"
 
 	assignee="$(forge_flag_value --assignee -a || true)"
 	[[ -n "$assignee" ]] && refuse_self_assignment "$assignee"
@@ -235,6 +255,13 @@ require_fields() {
 		labels) flag="--label" ;;
 		assignee) flag="--assignee" ;;
 		milestone) flag="--milestone" ;;
+		weight)
+			# A GitLab planning field; gh has no such flag, and a machine-wide
+			# require must not block GitHub repositories for a field their forge
+			# cannot carry.
+			[[ "$(forge_cli || true)" == glab ]] || continue
+			flag="--weight"
+			;;
 		*) continue ;;
 		esac
 		value="$(forge_flag_value "$flag" "${flag:1:2}" || true)"
@@ -318,8 +345,25 @@ forge_labels_glab() {
 	glab label list -R "$LABEL_PROJECT" -F json --per-page 100 2>/dev/null | jq -r '.[].name // empty'
 }
 
+# Filed is not finished: the fields no create flag can carry are exactly the
+# ones that decide whether the item appears on a board. Advised, not blocked —
+# they can only be set after the item exists.
+board_hygiene_advice() {
+	agentkit_advise_json "FILED, not finished — board metadata is what makes this findable. Before moving on: (1) set the work-item Status off Triage (GitLab: GraphQL statusWidget — boards filter on Status, and a status:: label does not move it); (2) link the parent epic or work item; (3) weight, milestone, assignee, labels; (4) read the item back and verify every field landed — a silent API failure leaves blanks the command line never showed. The complete-work-item-metadata taste is the policy; this reminder exists because it was missed twice."
+}
+
+# An epic is a container: the filed-rather-than-fixed question does not apply,
+# and its fields travel as -f pairs no flag check can read. It gets the body
+# checks and the advisory, not the issue gates.
+if [[ "$CREATION_KIND" == epic ]]; then
+	completeness_checks
+	board_hygiene_advice
+	exit 0
+fi
+
 if echo "$TEXT" | grep -qE "$DISPOSITION_RE"; then
 	completeness_checks
+	board_hygiene_advice
 	exit 0
 fi
 

--- a/rules/ssh-first-transport.md
+++ b/rules/ssh-first-transport.md
@@ -1,0 +1,73 @@
+# SSH-First Git Transport
+
+Git transport is SSH. HTTPS-with-a-token is not a fallback to reach for when SSH misbehaves — it
+is an escalation the operator approves, after SSH has actually been exhausted. This rule exists
+because a token push happened before a one-minute diagnosis that would have made it unnecessary.
+
+## 1. Read the failure before changing anything
+
+The error names the problem, and the two problems have disjoint fixes:
+
+- **`Permission denied (publickey)`** — an auth problem. The transport is fine.
+- **Timeout or connection refused** — a network problem. The key is fine.
+
+Switching transport answers neither. Diagnose first; the whole tree below takes under a minute.
+
+## 2. Auth problems: it is about keys
+
+```sh
+ssh -o IdentitiesOnly=yes -i <keyfile> -T git@<host>   # which identity is really offered?
+ssh-keygen -lf <keyfile>.pub                            # fingerprint, to compare with the forge
+```
+
+Verify the key is registered with the forge account the remote expects. If it is missing, adding
+it is an operator decision — say what you found and which key you propose to add.
+
+## 3. Network problems: another port before another protocol
+
+```sh
+nc -z -G 6 <host> 22          # is it this host, or this port anywhere?
+```
+
+Both major providers publish SSH on 443 for firewalled networks — same protocol, same keys,
+different port. This is a designed endpoint, not a workaround:
+
+| Provider | Endpoint |
+| --- | --- |
+| GitHub | `ssh.github.com:443` |
+| gitlab.com | `altssh.gitlab.com:443` |
+| self-hosted GitLab | ask the operator; many publish an alt-ssh port |
+
+Compare against a host that works (`nc -z <corporate-gitlab> 22`): if internal :22 is open while
+the provider's is not, it is the VPN's egress policy, and port 443 is the answer.
+
+## 4. Fix the configuration, not the one command
+
+A working discovery becomes a permanent `~/.ssh/config` entry with a comment saying why, so the
+next session inherits the fix instead of the failure:
+
+```
+Host github-<alias>
+    # VPN drops egress to github.com:22; ssh.github.com:443 is GitHub's
+    # official SSH endpoint for firewalled networks — same protocol, same key.
+    HostName ssh.github.com
+    Port 443
+    User git
+    IdentityFile ~/.ssh/<key>
+    IdentitiesOnly yes
+```
+
+Back up the config before editing it. Verify with `ssh -T git@<alias>` and `git ls-remote`, and
+repoint any branch upstreams that were set against a temporary URL.
+
+## 5. HTTPS is operator-gated
+
+Only when SSH is genuinely unavailable on every port: **stop and ask** before any
+token-over-HTTPS git operation. Never quietly stack `credential.helper` overrides to make a push
+go through — the credential store answering with the wrong account's token is exactly how that
+path fails, and it fails as a push under the wrong identity.
+
+## 6. What this rule does not cover
+
+Forge API CLIs (`gh`, `glab`) speak HTTPS to the REST/GraphQL API. That is not git transport;
+issues, MRs and API reads are unaffected by this rule.


### PR DESCRIPTION
Closes #386
Closes #387

Two enforcement gaps from the same working day, one branch per the one-open-PR convention.

## issue-police (#386)

Three gaps that let a bare epic and under-labelled issues reach the board unremarked, each fixed and behaviourally tested against the hook with a scratch project config:

| test | command shape | expected | got |
| --- | --- | --- | --- |
| T1 | `glab api POST …/epics` with body | advise (was: silence) | advise |
| T2 | `glab issue create` full flags + Disposition | allow + advisory | advise |
| T3 | `POST …/issues/7/notes` | silence (creates nothing) | silence |
| T5 | glab create without `--weight`, require=weight | deny | deny |
| T6 | `gh issue create`, same require | not blocked for weight | advise |
| T7 | no Disposition line | deny (regression guard) | deny |
| T8 | epic with no description | deny (body check applies) | deny |
| T9 | glab create with weight | allow + advisory | advise |

Subtlety: epics are exempt from flag-based `require_fields` — their fields travel as `-f` pairs, so the advisory is their enforcement.

## rules/ssh-first-transport.md (#387)

Always-loaded rule: diagnose SSH failures (auth vs network are disjoint), use the providers' SSH-over-443 endpoints for blocked networks, make the fix permanent in ssh-config, and gate any token-over-HTTPS git operation on the operator. Written from the incident where the diagnosis took a minute and the fallback happened first.