### PR TITLE
pages: a pages:share device scope lets the publisher flip share links

### DIFF
--- a/docs/hextra/content/cookbook/publish-a-page.md
+++ b/docs/hextra/content/cookbook/publish-a-page.md
@@ -45,7 +45,7 @@ It prints the live URL, `https://pages.agentkit.sbs/<slug>`.
 
 On the first publish, the command opens `account.agentkit.sbs/device` and prints a short code. Sign in
 with Assay and approve that device. The resulting credential belongs only to that account and device;
-it grants `pages:write` and `pages:delete` for 90 days, and later publishes reuse it. A rejected or
+it grants `pages:write`, `pages:delete` and `pages:share` for 90 days, and later publishes reuse it. A rejected or
 expired credential starts the device flow again. New pages are private and appear at
 `https://account.agentkit.sbs/dashboard`,
 where the owner can create a revocable sharing link or invite another verified Assay email.

--- a/docs/hextra/content/guide/concepts/pages.md
+++ b/docs/hextra/content/guide/concepts/pages.md
@@ -86,7 +86,7 @@ waiting for it to expire.
 | Credential      | Grants                                                             | Storage                                               |
 | --------------- | ------------------------------------------------------------------ | ----------------------------------------------------- |
 | slug key        | Derives a URL from a name; no network access                       | Local file, mode `0600`                               |
-| device token    | `pages:write` / `pages:delete` for owned pages; expires in 90 days | Local file, mode `0600`; SHA-256 hash in D1           |
+| device token    | `pages:write` / `pages:delete` / `pages:share` for owned pages; expires in 90 days | Local file, mode `0600`; SHA-256 hash in D1           |
 | browser session | Account dashboard and access-broker requests                       | Host-only secure HTTP-only cookie; SHA-256 hash in D1 |
 | page capability | Read access to one page for ten minutes                            | URL parameter; SHA-256 hash and expiry in D1          |
 | sharing token   | Read access to one page until its owner disables the link          | URL shown once; SHA-256 hash in D1                    |

--- a/pages/worker/src/devices.js
+++ b/pages/worker/src/devices.js
@@ -5,7 +5,7 @@ const DEVICE_TTL_SECONDS = 600;
 const DEFAULT_TOKEN_TTL_SECONDS = 90 * 24 * 60 * 60;
 const POLL_INTERVAL_SECONDS = 5;
 const CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
-const ALLOWED_SCOPES = ["pages:write", "pages:delete"];
+const ALLOWED_SCOPES = ["pages:write", "pages:delete", "pages:share"];
 
 function requestedScopes(value) {
   if (value === undefined || value === null) return ALLOWED_SCOPES;

--- a/pages/worker/src/worker.js
+++ b/pages/worker/src/worker.js
@@ -349,7 +349,37 @@ async function requestBody(request) {
   return Object.fromEntries(await request.formData());
 }
 
+// A device holding `pages:share` may flip the link over the API; a browser
+// session stays same-origin. The scope is separate from `pages:write` because
+// enabling a share link changes who can READ the page, which a stolen publish
+// token must not be able to do.
+async function shareByDevice(request, env, slug, bearer) {
+  const credential = await deviceCredential(env, bearer);
+  if (!credential) return new Response("unauthorized\n", { status: 401 });
+  if (!credential.scopes.includes("pages:share")) {
+    return new Response("insufficient scope: pages:share\n", { status: 403 });
+  }
+  const page = await pageRecord(env, slug);
+  if (!page || page.owner_id !== credential.user.id) {
+    return new Response("not found\n", { status: 404 });
+  }
+  const rate = await consumeDeviceWrite(env, credential.tokenHash);
+  if (!rate.allowed) {
+    return new Response("device write rate exceeded\n", {
+      status: 429,
+      headers: { "retry-after": String(rate.retryAfter) },
+    });
+  }
+  const body = await requestBody(request);
+  const enabled = body.enabled === true || body.enabled === "true";
+  const token = await setShareLink(env, slug, enabled);
+  const url = token ? `${env.PAGES_URL}/${slug}?share=${token}` : null;
+  return Response.json({ ok: true, enabled, url });
+}
+
 async function handleShare(request, env, slug) {
+  const bearer = bearerToken(request);
+  if (bearer) return shareByDevice(request, env, slug, bearer);
   if (!sameOrigin(request)) return new Response("forbidden\n", { status: 403 });
   if (!(await ownerPage(request, env, slug))) return new Response("not found\n", { status: 404 });
   const body = await requestBody(request);

--- a/plugins-cc/agentkit/skills/publish-page/SKILL.md
+++ b/plugins-cc/agentkit/skills/publish-page/SKILL.md
@@ -27,6 +27,9 @@ an artifact: decide, publish, hand back the URL.
 ```bash
 bun <skill-dir>/publish.ts --name <name> --file <content-file> [--template doc|deck|raw] [--title "Title"]
 bun <skill-dir>/publish.ts --name <name> --delete    # remove a page you published
+bun <skill-dir>/publish.ts --name <name> --file <f> --share   # publish + turn on the share link
+bun <skill-dir>/publish.ts --name <name> --share     # share an already-published page
+bun <skill-dir>/publish.ts --name <name> --unshare   # revoke the share link
 ```
 
 5. **Verify before reporting**: load the printed URL in headless Chromium at
@@ -250,16 +253,20 @@ slide with nothing but a kicker and an `h2` above them.
 
 - Device token: `~/.config/agentkit/pages-token`. First use starts the bounded device flow at
   `account.agentkit.sbs/device`, signs in through Assay, and stores the token with mode `0600`.
-  The credential grants `pages:write` and `pages:delete`, expires after 90 days,
+  The credential grants `pages:write`, `pages:delete` and `pages:share`, expires after 90 days,
   and is replaced through the same device flow when the service rejects it.
 - Themes are bundled with the skill; if a clone of `gitlab.com/agentkit/agentkit-pages`
   exists at `~/code/agentkit-pages` (override: `AGENTKIT_PAGES_REPO`), the publish
   archives `src/` + `dist/` there only with explicit `--git` — otherwise it
   serves only. Repository archival has its own visibility and is never implied
   by a private page. Endpoint override: `AGENTKIT_PAGES_ENDPOINT`.
-- New pages are **private by default**. Owners manage revocable sharing links and
-  verified-email invites, and revoke publishing devices at
-  `https://account.agentkit.sbs/dashboard`. Rendered pages stay on the separate
+- New pages are **private by default**. `--share` turns on the page's revocable
+  share link and prints it — anyone holding the URL can read the page with no
+  sign-in; `--unshare` kills it instantly. The same links, verified-email
+  invites, and device revocation are also owner-managed at
+  `https://account.agentkit.sbs/dashboard`. A device token minted before the
+  `pages:share` scope existed gets a 403 with the fix (delete the token file,
+  re-run to re-authorize). Rendered pages stay on the separate
   `pages.agentkit.sbs` origin so their inline JavaScript cannot read the account dashboard. Pages from
   before the accounts migration remain public until claimed or removed.
 - A device can perform at most 60 publish/delete operations per minute. A

--- a/plugins-cc/agentkit/skills/publish-page/auth.ts
+++ b/plugins-cc/agentkit/skills/publish-page/auth.ts
@@ -36,7 +36,7 @@ export async function loadOrAuthorize(options: AuthorizationOptions): Promise<st
     headers: { "content-type": "application/json" },
     body: JSON.stringify({
       device_name: options.deviceName ?? hostname(),
-      scopes: ["pages:write", "pages:delete"],
+      scopes: ["pages:write", "pages:delete", "pages:share"],
     }),
   });
   if (!started.ok) throw new Error(`device authorization failed: HTTP ${started.status}`);

--- a/plugins-cc/agentkit/skills/publish-page/publish.ts
+++ b/plugins-cc/agentkit/skills/publish-page/publish.ts
@@ -26,6 +26,9 @@ function arg(name: string): string | undefined {
 const explicitSlug = arg("slug");
 const name = arg("name");
 const isDelete = process.argv.includes("--delete");
+const isShare = process.argv.includes("--share");
+const isUnshare = process.argv.includes("--unshare");
+if (isShare && isUnshare) fail("--share and --unshare are mutually exclusive");
 const file = arg("file");
 const template = arg("template") ?? "doc";
 let noGit = !shouldCommitCanonical(process.argv);
@@ -37,8 +40,9 @@ if (name && !/^[a-z0-9][a-z0-9-]{0,63}$/.test(name)) {
   fail(`invalid name "${name}" (lowercase a-z0-9-)`);
 }
 if (!["doc", "deck", "raw"].includes(template)) fail(`unknown template "${template}"`);
-if (!isDelete && !file) fail("--file is required");
-if (!isDelete && !existsSync(file!)) fail(`no such file: ${file}`);
+const shareOnly = (isShare || isUnshare) && !file;
+if (!isDelete && !shareOnly && !file) fail("--file is required");
+if (!isDelete && !shareOnly && !existsSync(file!)) fail(`no such file: ${file}`);
 
 const endpoint = process.env.AGENTKIT_PAGES_ENDPOINT ?? "https://account.agentkit.sbs";
 const endpointHost = new URL(endpoint).hostname;
@@ -123,6 +127,37 @@ function commitScoped(message: string, paths: string[]) {
     );
     process.exitCode = 1;
   }
+}
+
+async function flipShare(enabled: boolean): Promise<string | null> {
+  let res: Response;
+  try {
+    res = await fetchWithDeviceAuthorization({ endpoint, tokenPath }, (token) =>
+      fetch(`${endpoint}/api/pages/${slug}/share`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+        body: JSON.stringify({ enabled }),
+      }));
+  } catch (error) {
+    fail((error as Error).message);
+  }
+  if (res!.status === 403) {
+    // Tokens minted before the pages:share scope existed cannot flip links.
+    fail(
+      "this device token predates the pages:share scope — remove "
+        + tokenPath
+        + " and re-run to authorize a fresh token, then retry",
+    );
+  }
+  if (!res!.ok) fail(await deviceRequestError(enabled ? "share" : "unshare", res!));
+  const { url: shareUrl } = (await res!.json()) as { url: string | null };
+  return shareUrl;
+}
+
+if (shareOnly) {
+  const shareUrl = await flipShare(isShare);
+  console.log(isShare ? shareUrl : `share link revoked for ${slug}`);
+  process.exit();
 }
 
 if (isDelete) {
@@ -259,4 +294,9 @@ if (!noGit) {
   commitScoped(`pages: publish ${pageLabel}`, [`src/${slug}`, `dist/${slug}`]);
 }
 
+if (isShare || isUnshare) {
+  const shareUrl = await flipShare(isShare);
+  if (isShare && shareUrl) console.log(`share: ${shareUrl}`);
+  if (isUnshare) console.error("share link revoked");
+}
 console.log(url);

--- a/skills/publish-page/SKILL.md
+++ b/skills/publish-page/SKILL.md
@@ -27,6 +27,9 @@ an artifact: decide, publish, hand back the URL.
 ```bash
 bun <skill-dir>/publish.ts --name <name> --file <content-file> [--template doc|deck|raw] [--title "Title"]
 bun <skill-dir>/publish.ts --name <name> --delete    # remove a page you published
+bun <skill-dir>/publish.ts --name <name> --file <f> --share   # publish + turn on the share link
+bun <skill-dir>/publish.ts --name <name> --share     # share an already-published page
+bun <skill-dir>/publish.ts --name <name> --unshare   # revoke the share link
 ```
 
 5. **Verify before reporting**: load the printed URL in headless Chromium at
@@ -250,16 +253,20 @@ slide with nothing but a kicker and an `h2` above them.
 
 - Device token: `~/.config/agentkit/pages-token`. First use starts the bounded device flow at
   `account.agentkit.sbs/device`, signs in through Assay, and stores the token with mode `0600`.
-  The credential grants `pages:write` and `pages:delete`, expires after 90 days,
+  The credential grants `pages:write`, `pages:delete` and `pages:share`, expires after 90 days,
   and is replaced through the same device flow when the service rejects it.
 - Themes are bundled with the skill; if a clone of `gitlab.com/agentkit/agentkit-pages`
   exists at `~/code/agentkit-pages` (override: `AGENTKIT_PAGES_REPO`), the publish
   archives `src/` + `dist/` there only with explicit `--git` — otherwise it
   serves only. Repository archival has its own visibility and is never implied
   by a private page. Endpoint override: `AGENTKIT_PAGES_ENDPOINT`.
-- New pages are **private by default**. Owners manage revocable sharing links and
-  verified-email invites, and revoke publishing devices at
-  `https://account.agentkit.sbs/dashboard`. Rendered pages stay on the separate
+- New pages are **private by default**. `--share` turns on the page's revocable
+  share link and prints it — anyone holding the URL can read the page with no
+  sign-in; `--unshare` kills it instantly. The same links, verified-email
+  invites, and device revocation are also owner-managed at
+  `https://account.agentkit.sbs/dashboard`. A device token minted before the
+  `pages:share` scope existed gets a 403 with the fix (delete the token file,
+  re-run to re-authorize). Rendered pages stay on the separate
   `pages.agentkit.sbs` origin so their inline JavaScript cannot read the account dashboard. Pages from
   before the accounts migration remain public until claimed or removed.
 - A device can perform at most 60 publish/delete operations per minute. A

--- a/skills/publish-page/auth.ts
+++ b/skills/publish-page/auth.ts
@@ -36,7 +36,7 @@ export async function loadOrAuthorize(options: AuthorizationOptions): Promise<st
     headers: { "content-type": "application/json" },
     body: JSON.stringify({
       device_name: options.deviceName ?? hostname(),
-      scopes: ["pages:write", "pages:delete"],
+      scopes: ["pages:write", "pages:delete", "pages:share"],
     }),
   });
   if (!started.ok) throw new Error(`device authorization failed: HTTP ${started.status}`);

--- a/skills/publish-page/publish.ts
+++ b/skills/publish-page/publish.ts
@@ -26,6 +26,9 @@ function arg(name: string): string | undefined {
 const explicitSlug = arg("slug");
 const name = arg("name");
 const isDelete = process.argv.includes("--delete");
+const isShare = process.argv.includes("--share");
+const isUnshare = process.argv.includes("--unshare");
+if (isShare && isUnshare) fail("--share and --unshare are mutually exclusive");
 const file = arg("file");
 const template = arg("template") ?? "doc";
 let noGit = !shouldCommitCanonical(process.argv);
@@ -37,8 +40,9 @@ if (name && !/^[a-z0-9][a-z0-9-]{0,63}$/.test(name)) {
   fail(`invalid name "${name}" (lowercase a-z0-9-)`);
 }
 if (!["doc", "deck", "raw"].includes(template)) fail(`unknown template "${template}"`);
-if (!isDelete && !file) fail("--file is required");
-if (!isDelete && !existsSync(file!)) fail(`no such file: ${file}`);
+const shareOnly = (isShare || isUnshare) && !file;
+if (!isDelete && !shareOnly && !file) fail("--file is required");
+if (!isDelete && !shareOnly && !existsSync(file!)) fail(`no such file: ${file}`);
 
 const endpoint = process.env.AGENTKIT_PAGES_ENDPOINT ?? "https://account.agentkit.sbs";
 const endpointHost = new URL(endpoint).hostname;
@@ -123,6 +127,37 @@ function commitScoped(message: string, paths: string[]) {
     );
     process.exitCode = 1;
   }
+}
+
+async function flipShare(enabled: boolean): Promise<string | null> {
+  let res: Response;
+  try {
+    res = await fetchWithDeviceAuthorization({ endpoint, tokenPath }, (token) =>
+      fetch(`${endpoint}/api/pages/${slug}/share`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+        body: JSON.stringify({ enabled }),
+      }));
+  } catch (error) {
+    fail((error as Error).message);
+  }
+  if (res!.status === 403) {
+    // Tokens minted before the pages:share scope existed cannot flip links.
+    fail(
+      "this device token predates the pages:share scope — remove "
+        + tokenPath
+        + " and re-run to authorize a fresh token, then retry",
+    );
+  }
+  if (!res!.ok) fail(await deviceRequestError(enabled ? "share" : "unshare", res!));
+  const { url: shareUrl } = (await res!.json()) as { url: string | null };
+  return shareUrl;
+}
+
+if (shareOnly) {
+  const shareUrl = await flipShare(isShare);
+  console.log(isShare ? shareUrl : `share link revoked for ${slug}`);
+  process.exit();
 }
 
 if (isDelete) {
@@ -259,4 +294,9 @@ if (!noGit) {
   commitScoped(`pages: publish ${pageLabel}`, [`src/${slug}`, `dist/${slug}`]);
 }
 
+if (isShare || isUnshare) {
+  const shareUrl = await flipShare(isShare);
+  if (isShare && shareUrl) console.log(`share: ${shareUrl}`);
+  if (isUnshare) console.error("share link revoked");
+}
 console.log(url);

--- a/tests/publish-page/accounts.test.ts
+++ b/tests/publish-page/accounts.test.ts
@@ -89,7 +89,12 @@ async function accountEnv() {
   database.sqlite.run(
     `INSERT INTO device_tokens (token_hash, user_id, name, scopes, expires_at, created_at)
      VALUES (?, ?, ?, ?, ?, ?)`,
-    [await digest('device-a'), 'user-a', 'MacBook', 'pages:write pages:delete', now + 3600, now],
+    [await digest('device-a'), 'user-a', 'MacBook', 'pages:write pages:delete pages:share', now + 3600, now],
+  );
+  database.sqlite.run(
+    `INSERT INTO device_tokens (token_hash, user_id, name, scopes, expires_at, created_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    [await digest('device-a-legacy'), 'user-a', 'Old MacBook', 'pages:write pages:delete', now + 3600, now],
   );
   database.sqlite.run(
     `INSERT INTO device_tokens (token_hash, user_id, name, scopes, expires_at, created_at)
@@ -525,6 +530,51 @@ describe('private access and sharing', () => {
     );
     expect(disabled.status).toBe(200);
     expect((await worker.fetch(new Request(url), setup.env)).status).toBe(302);
+  });
+
+  const deviceShare = (token: string, enabled: boolean, slug = 'private-page') =>
+    new Request(`${ACCOUNT_URL}/api/pages/${slug}/share`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+      body: JSON.stringify({ enabled }),
+    });
+
+  test('a pages:share device token flips the link and gets the URL back', async () => {
+    const setup = await accountEnv();
+    expect((await worker.fetch(publish('device-a'), setup.env)).status).toBe(200);
+
+    const enabled = await worker.fetch(deviceShare('device-a', true), setup.env);
+    expect(enabled.status).toBe(200);
+    const { url } = await enabled.json() as { url: string };
+    expect(url).toStartWith(`${PAGES_URL}/private-page?share=`);
+    expect((await worker.fetch(new Request(url), setup.env)).status).toBe(200);
+
+    const disabled = await worker.fetch(deviceShare('device-a', false), setup.env);
+    expect(disabled.status).toBe(200);
+    expect(await disabled.json()).toEqual({ ok: true, enabled: false, url: null });
+    expect((await worker.fetch(new Request(url), setup.env)).status).toBe(302);
+  });
+
+  test('a device token without pages:share is refused by name', async () => {
+    const setup = await accountEnv();
+    expect((await worker.fetch(publish('device-a'), setup.env)).status).toBe(200);
+
+    const refused = await worker.fetch(deviceShare('device-a-legacy', true), setup.env);
+    expect(refused.status).toBe(403);
+    expect(await refused.text()).toContain('pages:share');
+  });
+
+  test('a device cannot share a page its user does not own', async () => {
+    const setup = await accountEnv();
+    expect((await worker.fetch(publish('device-a'), setup.env)).status).toBe(200);
+    setup.database.sqlite.run(
+      `INSERT INTO device_tokens (token_hash, user_id, name, scopes, expires_at, created_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      [await digest('device-b-share'), 'user-b', 'Other Mac', 'pages:write pages:delete pages:share',
+        Math.floor(Date.now() / 1000) + 3600, Math.floor(Date.now() / 1000)],
+    );
+
+    expect((await worker.fetch(deviceShare('device-b-share', true), setup.env)).status).toBe(404);
   });
 
   test('an invited Assay email can obtain page-scoped access after signing in', async () => {

--- a/tests/publish-page/device-login.test.ts
+++ b/tests/publish-page/device-login.test.ts
@@ -82,7 +82,7 @@ describe('publish-page device login', () => {
     expect(messages.join('\n')).toContain('ABCD-2345');
     expect(authorizationBodies[0]).toEqual({
       device_name: 'Test Mac',
-      scopes: ['pages:write', 'pages:delete'],
+      scopes: ['pages:write', 'pages:delete', 'pages:share'],
     });
     expect(await readFile(path, 'utf8')).toBe('new-device-token\n');
     expect((await stat(path)).mode & 0o777).toBe(0o600);


### PR DESCRIPTION
Closes #394

## What

- **Worker**: `POST /api/pages/:slug/share` now also accepts a bearer device credential carrying the new `pages:share` scope — owner-checked via the page record, device write rate limit applied, JSON in/out. Browser same-origin path unchanged.
- **Scope**: `pages:share` added to `ALLOWED_SCOPES`; freshly minted device tokens carry it by default. Tokens minted before the scope get `403 insufficient scope: pages:share`.
- **Skill**: `publish.ts --share` / `--unshare` — with `--file` it flips the link right after the publish; standalone with `--name` it flips an existing page. The 403 prints the exact re-auth remedy.
- **Docs**: SKILL.md, concepts/pages.md, cookbook. `plugins-cc` copy synced.

## Why the separate scope

Enabling a share link changes who can *read* the page. A stolen publish token being able to expose private pages is exactly the escalation the scoped-token design exists to prevent, so share is its own grant rather than riding `pages:write`.

## Tests

`bun test tests/publish-page/` — 177 pass, including new: device flips link and revocation kills the URL, missing scope refused by name, cross-owner share 404s.

## Deploy

Worker deploys on tag or manual dispatch of the publish job — will dispatch after merge and verify live end-to-end.