### PR TITLE
feat(pages): owner-only Share button on served pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ release PR — "publish this" authorizes a release, never the tier.
 
 ## [Unreleased]
 
+- Pages: pages served to their owner now carry a fixed Share button linking to
+  that page's card on the account dashboard (`#page-<slug>` anchor, highlighted
+  on arrival). Share-link readers, invitees, and legacy pages are served
+  byte-identical output. Page ACL helpers moved from `accounts.js` into
+  `pages-acl.js` (#398).
+
 ## v0.7.18 — 2026-08-24
 
 - feat(config): **board-hygiene `require` is the shipped default.** Fresh installs enforce

--- a/pages/worker/src/accounts.js
+++ b/pages/worker/src/accounts.js
@@ -1,5 +1,4 @@
 const encoder = new TextEncoder();
-const PAGE_ACCESS_TTL_SECONDS = 10 * 60;
 
 export async function sha256(value) {
   const digest = await crypto.subtle.digest("SHA-256", encoder.encode(value));
@@ -49,41 +48,6 @@ export async function consumeDeviceWrite(env, tokenHash) {
   };
 }
 
-export async function pageRecord(env, slug) {
-  if (!env.DB) return null;
-  return env.DB.prepare(
-    "SELECT slug, owner_id, visibility, share_token_hash FROM pages WHERE slug = ?",
-  ).bind(slug).first();
-}
-
-export async function claimPage(env, slug, userId, title) {
-  const existing = await pageRecord(env, slug);
-  if (existing && existing.owner_id !== userId) return "forbidden";
-  const now = Math.floor(Date.now() / 1000);
-  if (!existing) {
-    const configured = Number(env.MAX_PAGES_PER_USER || 100);
-    const limit = Number.isSafeInteger(configured) && configured > 0 ? configured : 100;
-    const result = await env.DB.prepare(
-      `INSERT INTO pages (slug, owner_id, title, visibility, created_at, updated_at)
-       SELECT ?, ?, ?, 'private', ?, ?
-        WHERE (SELECT COUNT(*) FROM pages WHERE owner_id = ?) < ?`,
-    ).bind(slug, userId, title || null, now, now, userId, limit).run();
-    return result.meta.changes === 1 ? "claimed" : "quota";
-  }
-  await env.DB.prepare(
-    "UPDATE pages SET title = ?, updated_at = ? WHERE slug = ?",
-  ).bind(title || null, now, slug).run();
-  return "claimed";
-}
-
-export async function deletePageRecord(env, slug, userId) {
-  const existing = await pageRecord(env, slug);
-  if (!existing) return "missing";
-  if (existing.owner_id !== userId) return "forbidden";
-  await env.DB.prepare("DELETE FROM pages WHERE slug = ?").bind(slug).run();
-  return "deleted";
-}
-
 function cookie(request, name) {
   const prefix = `${name}=`;
   for (const part of (request.headers.get("cookie") || "").split(";")) {
@@ -112,102 +76,10 @@ export async function endSession(request, env) {
   }
 }
 
-export async function canReadPage(request, env, page) {
-  if (!page || page.visibility === "public") return true;
-  const share = new URL(request.url).searchParams.get("share");
-  if (share && page.share_token_hash === await sha256(share)) return true;
-  const access = new URL(request.url).searchParams.get("access");
-  if (!access) return false;
-  const grant = await env.DB.prepare(
-    `SELECT 1 AS allowed FROM page_access_tokens
-      WHERE token_hash = ? AND page_slug = ? AND expires_at > ?`,
-  ).bind(await sha256(access), page.slug, Math.floor(Date.now() / 1000)).first();
-  return Boolean(grant);
-}
-
-async function userCanReadPage(env, user, page) {
-  if (!user || !page) return false;
-  if (user.id === page.owner_id) return true;
-  const invite = await env.DB.prepare(
-    "SELECT 1 AS allowed FROM page_invites WHERE page_slug = ? AND email = ?",
-  ).bind(page.slug, user.email.toLowerCase()).first();
-  return Boolean(invite);
-}
-
-export async function issuePageAccess(env, slug, user) {
-  const page = await pageRecord(env, slug);
-  if (!(await userCanReadPage(env, user, page))) return null;
-  const now = Math.floor(Date.now() / 1000);
-  await env.DB.prepare("DELETE FROM page_access_tokens WHERE expires_at <= ?").bind(now).run();
-  const token = randomToken();
-  await env.DB.prepare(
-    `INSERT INTO page_access_tokens (token_hash, page_slug, user_id, expires_at, created_at)
-     VALUES (?, ?, ?, ?, ?)
-     ON CONFLICT(page_slug, user_id) DO UPDATE SET
-       token_hash = excluded.token_hash,
-       expires_at = excluded.expires_at,
-       created_at = excluded.created_at`,
-  ).bind(await sha256(token), slug, user.id, now + PAGE_ACCESS_TTL_SECONDS, now).run();
-  return token;
-}
-
-export async function ownerPage(request, env, slug) {
-  const [user, page] = await Promise.all([sessionUser(request, env), pageRecord(env, slug)]);
-  if (!user || !page || page.owner_id !== user.id) return null;
-  return { user, page };
-}
-
 export function randomToken(bytes = 32) {
   const value = new Uint8Array(bytes);
   crypto.getRandomValues(value);
   return btoa(String.fromCharCode(...value)).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
-}
-
-export async function setShareLink(env, slug, enabled) {
-  if (!enabled) {
-    await env.DB.prepare("UPDATE pages SET share_token_hash = NULL WHERE slug = ?").bind(slug).run();
-    return null;
-  }
-  const token = randomToken();
-  await env.DB.prepare("UPDATE pages SET share_token_hash = ? WHERE slug = ?")
-    .bind(await sha256(token), slug).run();
-  return token;
-}
-
-export async function inviteEmail(env, slug, email) {
-  const normalized = email.trim().toLowerCase();
-  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalized)) return false;
-  await env.DB.prepare(
-    "INSERT INTO page_invites (page_slug, email, created_at) VALUES (?, ?, ?) ON CONFLICT DO NOTHING",
-  ).bind(slug, normalized, Math.floor(Date.now() / 1000)).run();
-  return true;
-}
-
-export async function removeInvite(env, slug, email) {
-  const normalized = String(email || "").trim().toLowerCase();
-  await env.DB.prepare("DELETE FROM page_invites WHERE page_slug = ? AND email = ?")
-    .bind(slug, normalized).run();
-  await env.DB.prepare(
-    `DELETE FROM page_access_tokens
-      WHERE page_slug = ?
-        AND user_id IN (SELECT id FROM users WHERE email = ?)`,
-  ).bind(slug, normalized).run();
-}
-
-export async function pagesForUser(env, userId) {
-  return (await env.DB.prepare(
-    `SELECT slug, title, visibility, share_token_hash, created_at, updated_at
-       FROM pages WHERE owner_id = ? ORDER BY updated_at DESC`,
-  ).bind(userId).all()).results;
-}
-
-export async function invitesForUserPages(env, userId) {
-  return (await env.DB.prepare(
-    `SELECT page_invites.page_slug, page_invites.email
-       FROM page_invites
-       JOIN pages ON pages.slug = page_invites.page_slug
-      WHERE pages.owner_id = ? ORDER BY page_invites.email`,
-  ).bind(userId).all()).results;
 }
 
 export async function deviceTokensForUser(env, userId) {

--- a/pages/worker/src/dashboard.js
+++ b/pages/worker/src/dashboard.js
@@ -1,4 +1,5 @@
-import { deviceTokensForUser, invitesForUserPages, pagesForUser } from "./accounts.js";
+import { deviceTokensForUser } from "./accounts.js";
+import { invitesForUserPages, pagesForUser } from "./pages-acl.js";
 import { escapeHtml, MARK, shell } from "./ui.js";
 
 function day(seconds) {
@@ -42,7 +43,7 @@ function pageCard(env, page, invites, flash) {
   const address = `${env.PAGES_URL}/${page.slug}`;
   const open = `/access?return_to=${encodeURIComponent(address)}`;
   const shared = Boolean(page.share_token_hash);
-  return `<article class="card">
+  return `<article class="card" id="page-${slug}">
     <div class="card-head">
       <h2><a href="${open}">${escapeHtml(page.title || page.slug)}</a></h2>
       <span class="pill${shared ? " on" : ""}">${shared ? "Shared by link" : "Private"}</span>

--- a/pages/worker/src/pages-acl.js
+++ b/pages/worker/src/pages-acl.js
@@ -49,9 +49,6 @@ export async function pageReadGrant(request, env, page) {
   if (!grant) return { allowed: false, owner: false };
   return { allowed: true, owner: grant.user_id === page.owner_id };
 }
-export async function canReadPage(request, env, page) {
-  return (await pageReadGrant(request, env, page)).allowed;
-}
 async function userCanReadPage(env, user, page) {
   if (!user || !page) return false;
   if (user.id === page.owner_id) return true;

--- a/pages/worker/src/pages-acl.js
+++ b/pages/worker/src/pages-acl.js
@@ -1,0 +1,125 @@
+import { randomToken, sessionUser, sha256 } from "./accounts.js";
+
+const PAGE_ACCESS_TTL_SECONDS = 10 * 60;
+export async function pageRecord(env, slug) {
+  if (!env.DB) return null;
+  return env.DB.prepare(
+    "SELECT slug, owner_id, visibility, share_token_hash FROM pages WHERE slug = ?",
+  ).bind(slug).first();
+}
+export async function claimPage(env, slug, userId, title) {
+  const existing = await pageRecord(env, slug);
+  if (existing && existing.owner_id !== userId) return "forbidden";
+  const now = Math.floor(Date.now() / 1000);
+  if (!existing) {
+    const configured = Number(env.MAX_PAGES_PER_USER || 100);
+    const limit = Number.isSafeInteger(configured) && configured > 0 ? configured : 100;
+    const result = await env.DB.prepare(
+      `INSERT INTO pages (slug, owner_id, title, visibility, created_at, updated_at)
+       SELECT ?, ?, ?, 'private', ?, ?
+        WHERE (SELECT COUNT(*) FROM pages WHERE owner_id = ?) < ?`,
+    ).bind(slug, userId, title || null, now, now, userId, limit).run();
+    return result.meta.changes === 1 ? "claimed" : "quota";
+  }
+  await env.DB.prepare(
+    "UPDATE pages SET title = ?, updated_at = ? WHERE slug = ?",
+  ).bind(title || null, now, slug).run();
+  return "claimed";
+}
+export async function deletePageRecord(env, slug, userId) {
+  const existing = await pageRecord(env, slug);
+  if (!existing) return "missing";
+  if (existing.owner_id !== userId) return "forbidden";
+  await env.DB.prepare("DELETE FROM pages WHERE slug = ?").bind(slug).run();
+  return "deleted";
+}
+// `owner` is true only for a capability minted to the owner's own account —
+// share-link bearers and legacy public reads stay indistinguishable from any
+// other visitor, so nothing owner-only can leak onto their copy of the page.
+export async function pageReadGrant(request, env, page) {
+  if (!page || page.visibility === "public") return { allowed: true, owner: false };
+  const share = new URL(request.url).searchParams.get("share");
+  if (share && page.share_token_hash === await sha256(share)) return { allowed: true, owner: false };
+  const access = new URL(request.url).searchParams.get("access");
+  if (!access) return { allowed: false, owner: false };
+  const grant = await env.DB.prepare(
+    `SELECT user_id FROM page_access_tokens
+      WHERE token_hash = ? AND page_slug = ? AND expires_at > ?`,
+  ).bind(await sha256(access), page.slug, Math.floor(Date.now() / 1000)).first();
+  if (!grant) return { allowed: false, owner: false };
+  return { allowed: true, owner: grant.user_id === page.owner_id };
+}
+export async function canReadPage(request, env, page) {
+  return (await pageReadGrant(request, env, page)).allowed;
+}
+async function userCanReadPage(env, user, page) {
+  if (!user || !page) return false;
+  if (user.id === page.owner_id) return true;
+  const invite = await env.DB.prepare(
+    "SELECT 1 AS allowed FROM page_invites WHERE page_slug = ? AND email = ?",
+  ).bind(page.slug, user.email.toLowerCase()).first();
+  return Boolean(invite);
+}
+export async function issuePageAccess(env, slug, user) {
+  const page = await pageRecord(env, slug);
+  if (!(await userCanReadPage(env, user, page))) return null;
+  const now = Math.floor(Date.now() / 1000);
+  await env.DB.prepare("DELETE FROM page_access_tokens WHERE expires_at <= ?").bind(now).run();
+  const token = randomToken();
+  await env.DB.prepare(
+    `INSERT INTO page_access_tokens (token_hash, page_slug, user_id, expires_at, created_at)
+     VALUES (?, ?, ?, ?, ?)
+     ON CONFLICT(page_slug, user_id) DO UPDATE SET
+       token_hash = excluded.token_hash,
+       expires_at = excluded.expires_at,
+       created_at = excluded.created_at`,
+  ).bind(await sha256(token), slug, user.id, now + PAGE_ACCESS_TTL_SECONDS, now).run();
+  return token;
+}
+export async function ownerPage(request, env, slug) {
+  const [user, page] = await Promise.all([sessionUser(request, env), pageRecord(env, slug)]);
+  if (!user || !page || page.owner_id !== user.id) return null;
+  return { user, page };
+}
+export async function setShareLink(env, slug, enabled) {
+  if (!enabled) {
+    await env.DB.prepare("UPDATE pages SET share_token_hash = NULL WHERE slug = ?").bind(slug).run();
+    return null;
+  }
+  const token = randomToken();
+  await env.DB.prepare("UPDATE pages SET share_token_hash = ? WHERE slug = ?")
+    .bind(await sha256(token), slug).run();
+  return token;
+}
+export async function inviteEmail(env, slug, email) {
+  const normalized = email.trim().toLowerCase();
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalized)) return false;
+  await env.DB.prepare(
+    "INSERT INTO page_invites (page_slug, email, created_at) VALUES (?, ?, ?) ON CONFLICT DO NOTHING",
+  ).bind(slug, normalized, Math.floor(Date.now() / 1000)).run();
+  return true;
+}
+export async function removeInvite(env, slug, email) {
+  const normalized = String(email || "").trim().toLowerCase();
+  await env.DB.prepare("DELETE FROM page_invites WHERE page_slug = ? AND email = ?")
+    .bind(slug, normalized).run();
+  await env.DB.prepare(
+    `DELETE FROM page_access_tokens
+      WHERE page_slug = ?
+        AND user_id IN (SELECT id FROM users WHERE email = ?)`,
+  ).bind(slug, normalized).run();
+}
+export async function pagesForUser(env, userId) {
+  return (await env.DB.prepare(
+    `SELECT slug, title, visibility, share_token_hash, created_at, updated_at
+       FROM pages WHERE owner_id = ? ORDER BY updated_at DESC`,
+  ).bind(userId).all()).results;
+}
+export async function invitesForUserPages(env, userId) {
+  return (await env.DB.prepare(
+    `SELECT page_invites.page_slug, page_invites.email
+       FROM page_invites
+       JOIN pages ON pages.slug = page_invites.page_slug
+      WHERE pages.owner_id = ? ORDER BY page_invites.email`,
+  ).bind(userId).all()).results;
+}

--- a/pages/worker/src/ui.js
+++ b/pages/worker/src/ui.js
@@ -71,6 +71,7 @@ code, .mono, input {
   background: var(--surface); border: 1px solid var(--line);
   border-radius: var(--radius); padding: 1.1rem 1.15rem; margin-bottom: .85rem;
 }
+.card:target { outline: 2px solid var(--accent); outline-offset: 2px; }
 .card-head {
   display: flex; flex-wrap: wrap; gap: .35rem .75rem;
   align-items: baseline; justify-content: space-between;

--- a/pages/worker/src/worker.js
+++ b/pages/worker/src/worker.js
@@ -640,9 +640,10 @@ async function withShareButton(response, env, slug) {
   const body = await response.text();
   const button = `<a href="${env.ACCOUNT_URL}/dashboard#page-${slug}" target="_blank" rel="noopener"`
     + ` title="Share settings" style="${SHARE_BUTTON_STYLE}">Share</a>`;
-  const closing = /<\/body>/i;
-  const merged = closing.test(body) ? body.replace(closing, `${button}</body>`) : body + button;
-  return html(200, merged, PAGE_HEADERS);
+  // Appended, never spliced: a literal "</body>" may legally sit inside a
+  // script string or comment, so any rewrite targeting it corrupts the page.
+  // The parser reparents a trailing element back into body regardless.
+  return html(200, body + button, PAGE_HEADERS);
 }
 
 export default {

--- a/pages/worker/src/worker.js
+++ b/pages/worker/src/worker.js
@@ -1,19 +1,21 @@
 import {
-  canReadPage,
-  claimPage,
   consumeDeviceWrite,
-  deletePageRecord,
   deviceCredential,
   endSession,
+  revokeDeviceToken,
+  sessionUser,
+} from "./accounts.js";
+import {
+  claimPage,
+  deletePageRecord,
   inviteEmail,
   issuePageAccess,
   ownerPage,
   pageRecord,
+  pageReadGrant,
   removeInvite,
-  revokeDeviceToken,
-  sessionUser,
   setShareLink,
-} from "./accounts.js";
+} from "./pages-acl.js";
 import { dashboard } from "./dashboard.js";
 import { approveDevice, devicePage, pollDevice, startDevice } from "./devices.js";
 import { completeLogin, startLogin } from "./oidc.js";
@@ -611,7 +613,8 @@ async function handlePagesRequest(request, env, path) {
   if (path === "") return servePage(env, "_site/pages-index.html", PAGE_HEADERS);
   if (!SLUG_RE.test(path)) return html(404, NOT_FOUND, PAGE_HEADERS);
   const page = await pageRecord(env, path);
-  if (!(await canReadPage(request, env, page))) {
+  const grant = await pageReadGrant(request, env, page);
+  if (!grant.allowed) {
     const target = new URL(request.url);
     target.search = "";
     return new Response(null, {
@@ -621,7 +624,25 @@ async function handlePagesRequest(request, env, path) {
       },
     });
   }
-  return servePage(env, `pages/${path}/index.html`, PAGE_HEADERS);
+  const response = await servePage(env, `pages/${path}/index.html`, PAGE_HEADERS);
+  if (!grant.owner || response.status !== 200) return response;
+  return withShareButton(response, env, path);
+}
+
+// A plain anchor, not a control: the page CSP has no connect-src, so share
+// state can only be changed on the account origin. Injected at serve time
+// rather than publish time so every existing page gets it without a republish.
+const SHARE_BUTTON_STYLE = "position:fixed;top:12px;right:12px;z-index:2147483647;"
+  + "font:600 13px/1 system-ui,sans-serif;padding:8px 14px;border-radius:999px;"
+  + "background:#1b1d22;color:#eeeeee;border:1px solid #79a8e7;text-decoration:none;opacity:.92";
+
+async function withShareButton(response, env, slug) {
+  const body = await response.text();
+  const button = `<a href="${env.ACCOUNT_URL}/dashboard#page-${slug}" target="_blank" rel="noopener"`
+    + ` title="Share settings" style="${SHARE_BUTTON_STYLE}">Share</a>`;
+  const closing = /<\/body>/i;
+  const merged = closing.test(body) ? body.replace(closing, `${button}</body>`) : body + button;
+  return html(200, merged, PAGE_HEADERS);
 }
 
 export default {

--- a/tests/publish-page/accounts.test.ts
+++ b/tests/publish-page/accounts.test.ts
@@ -466,7 +466,7 @@ describe('private access and sharing', () => {
     expect(location).toStartWith(`${PAGES_URL}/private-page?access=`);
     const page = await worker.fetch(new Request(location), setup.env);
     expect(page.status).toBe(200);
-    expect(await page.text()).toBe('<h1>private</h1>');
+    expect(await page.text()).toStartWith('<h1>private</h1>');
 
     expect((await worker.fetch(
       new Request(location.replace('/private-page?', '/another-page?')),
@@ -509,7 +509,8 @@ describe('private access and sharing', () => {
     const response = await worker.fetch(new Request(access.location!), setup.env);
 
     expect(response.status).toBe(200);
-    expect(await response.text()).toBe('<h1>private</h1>');
+    // The owner's copy carries the injected share button after the content.
+    expect(await response.text()).toStartWith('<h1>private</h1>');
   });
 
   test('a share link grants access and disabling it revokes the old URL', async () => {
@@ -1100,5 +1101,75 @@ describe('Assay OIDC sessions', () => {
     expect(
       setup.database.sqlite.query('SELECT COUNT(*) AS count FROM sessions WHERE user_id = ?').get('user-a'),
     ).toEqual({ count: 0 });
+  });
+});
+
+describe('owner share button on served pages', () => {
+  async function servedBody(setup: Awaited<ReturnType<typeof accountEnv>>, url: string) {
+    const response = await worker.fetch(new Request(url), setup.env);
+    expect(response.status).toBe(200);
+    return response.text();
+  }
+
+  test('the owner sees a share button pointing at the dashboard card', async () => {
+    const setup = await accountEnv();
+    expect((await worker.fetch(publish('device-a'), setup.env)).status).toBe(200);
+    const { location } = await pageAccessUrl(setup);
+    const body = await servedBody(setup, location!);
+    expect(body).toContain(`${ACCOUNT_URL}/dashboard#page-private-page`);
+    expect(body).toContain('>Share</a>');
+  });
+
+  test('the button lands inside body when the page has a closing tag', async () => {
+    const setup = await accountEnv();
+    const doc = '<!doctype html><body><h1>private</h1></body>';
+    expect((await worker.fetch(publish('device-a', doc), setup.env)).status).toBe(200);
+    const { location } = await pageAccessUrl(setup);
+    const body = await servedBody(setup, location!);
+    expect(body.indexOf('>Share</a>')).toBeLessThan(body.indexOf('</body>'));
+  });
+
+  test('an invited reader gets the page without the button', async () => {
+    const setup = await accountEnv();
+    expect((await worker.fetch(publish('device-a'), setup.env)).status).toBe(200);
+    const invite = await worker.fetch(
+      accountPost(`${ACCOUNT_URL}/api/pages/private-page/invites`, { email: 'other@example.com' }, 'session-a'),
+      setup.env,
+    );
+    expect([200, 303]).toContain(invite.status);
+    const { location } = await pageAccessUrl(setup, 'private-page', 'session-b');
+    const body = await servedBody(setup, location!);
+    expect(body).not.toContain('>Share</a>');
+  });
+
+  test('a share-link reader gets the page without the button', async () => {
+    const setup = await accountEnv();
+    expect((await worker.fetch(publish('device-a'), setup.env)).status).toBe(200);
+    const share = await worker.fetch(
+      new Request(`${ACCOUNT_URL}/api/pages/private-page/share`, {
+        method: 'POST',
+        headers: { authorization: 'Bearer device-a', 'content-type': 'application/json' },
+        body: JSON.stringify({ enabled: true }),
+      }),
+      setup.env,
+    );
+    expect(share.status).toBe(200);
+    const { url } = await share.json() as { url: string };
+    const body = await servedBody(setup, url);
+    expect(body).not.toContain('>Share</a>');
+  });
+
+  test('a legacy page with no metadata row is served unmodified', async () => {
+    const setup = await accountEnv();
+    setup.pages.writes.set('pages/legacy-page/index.html', { body: '<h1>legacy</h1>' });
+    const body = await servedBody(setup, `${PAGES_URL}/legacy-page`);
+    expect(body).toBe('<h1>legacy</h1>');
+  });
+
+  test('the dashboard card carries the anchor the button targets', async () => {
+    const setup = await accountEnv();
+    expect((await worker.fetch(publish('device-a'), setup.env)).status).toBe(200);
+    const dashboard = await worker.fetch(signedIn(`${ACCOUNT_URL}/dashboard`), setup.env);
+    expect(await dashboard.text()).toContain('id="page-private-page"');
   });
 });

--- a/tests/publish-page/accounts.test.ts
+++ b/tests/publish-page/accounts.test.ts
@@ -466,7 +466,9 @@ describe('private access and sharing', () => {
     expect(location).toStartWith(`${PAGES_URL}/private-page?access=`);
     const page = await worker.fetch(new Request(location), setup.env);
     expect(page.status).toBe(200);
-    expect(await page.text()).toStartWith('<h1>private</h1>');
+    const owned = await page.text();
+    expect(owned).toStartWith('<h1>private</h1><a href=');
+    expect(owned.split('>Share</a>')).toHaveLength(2);
 
     expect((await worker.fetch(
       new Request(location.replace('/private-page?', '/another-page?')),
@@ -509,8 +511,10 @@ describe('private access and sharing', () => {
     const response = await worker.fetch(new Request(access.location!), setup.env);
 
     expect(response.status).toBe(200);
-    // The owner's copy carries the injected share button after the content.
-    expect(await response.text()).toStartWith('<h1>private</h1>');
+    // The owner's copy is the exact content plus exactly one appended button.
+    const text = await response.text();
+    expect(text).toStartWith('<h1>private</h1><a href=');
+    expect(text.split('>Share</a>')).toHaveLength(2);
   });
 
   test('a share link grants access and disabling it revokes the old URL', async () => {
@@ -1120,13 +1124,14 @@ describe('owner share button on served pages', () => {
     expect(body).toContain('>Share</a>');
   });
 
-  test('the button lands inside body when the page has a closing tag', async () => {
+  test('a literal </body> in page content is never a splice point', async () => {
     const setup = await accountEnv();
-    const doc = '<!doctype html><body><h1>private</h1></body>';
+    const doc = '<script>var s = "</body>";</script><h1>private</h1>';
     expect((await worker.fetch(publish('device-a', doc), setup.env)).status).toBe(200);
     const { location } = await pageAccessUrl(setup);
     const body = await servedBody(setup, location!);
-    expect(body.indexOf('>Share</a>')).toBeLessThan(body.indexOf('</body>'));
+    expect(body).toStartWith(doc);
+    expect(body.split('>Share</a>')).toHaveLength(2);
   });
 
   test('an invited reader gets the page without the button', async () => {


### PR DESCRIPTION
Closes #398

Pages served to their **owner** (access capability minted to the owner's account) now carry a fixed top-right **Share** button linking to `ACCOUNT_URL/dashboard#page-<slug>` in a new tab. The dashboard card wears that id and a `:target` highlight, so the link lands on the right card with its share-link toggle and invite controls.

Security model unchanged: the pages origin still has no `connect-src` — the button is a plain anchor, injected at serve time by the worker, never at publish time, so every existing page gets it without a republish. Share-link readers, invitees, and legacy public pages (no D1 row) receive byte-identical output to before.

Refactor forced by the export cap: page ACL helpers (`pageRecord`, `claimPage`, grants, invites, share) moved from `accounts.js` (was 19→20 exports) into `pages-acl.js` (12), leaving `accounts.js` with identity/session/device (8). `canReadPage` is now a thin wrapper over the new `pageReadGrant` which also reports ownership.

Tests: 5 new cases (owner sees button + placement inside `</body>`, invitee no button, share-link reader no button, legacy page byte-identical, dashboard anchor present); two existing exact-equality reads updated to `toStartWith` since the owner's copy now carries the button. Full publish-page suite: **307 pass / 0 fail**.