### PR TITLE
feat(pages): in-page share menu for owners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ release PR — "publish this" authorizes a release, never the tier.
 
 ## [Unreleased]
 
+- Pages: the owner Share affordance is now an in-page menu (right-edge tab →
+  toggle/rotate/copy the share link, dashboard link for invites) instead of a
+  dashboard redirect, and moved off the top-right corner where it collided
+  with page and theme controls. Backed by a pages-origin share endpoint
+  authorized by the owner's own access capability; only the owner's response
+  gains `connect-src 'self'` (#400).
+
 - Pages: pages served to their owner now carry a fixed Share button linking to
   that page's card on the account dashboard (`#page-<slug>` anchor, highlighted
   on arrival). Share-link readers, invitees, and legacy pages are served

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,15 @@ release PR — "publish this" authorizes a release, never the tier.
 
 ## [Unreleased]
 
-- Pages: the owner Share affordance is now an in-page menu (right-edge tab →
-  toggle/rotate/copy the share link, dashboard link for invites) instead of a
-  dashboard redirect, and moved off the top-right corner where it collided
-  with page and theme controls. Backed by a pages-origin share endpoint
-  authorized by the owner's own access capability; only the owner's response
-  gains `connect-src 'self'` (#400).
+- Pages: owners now land on a trusted shell — their page in a sandboxed
+  frame, plus a right-edge Share menu that turns the share link on
+  (idempotently), rotates it, copies it, or turns it off in place. The menu
+  is driven by a separate short-lived manage capability the content frame
+  can never read, so page-authored script gets no share authority and no
+  overlay can collide with page controls. Backed by a pages-origin share
+  endpoint (manage-token auth, origin-checked, rate-limited per user) and
+  migrations 0004/0005; the test harness now enforces foreign keys like D1
+  (#400).
 
 - Pages: pages served to their owner now carry a fixed Share button linking to
   that page's card on the account dashboard (`#page-<slug>` anchor, highlighted

--- a/pages/worker/migrations/0004_share_write_limits.sql
+++ b/pages/worker/migrations/0004_share_write_limits.sql
@@ -1,7 +1,7 @@
 -- Rate limiting for share writes authorized by page-access capabilities.
--- Unlike device_write_limits this table has no foreign key: access tokens
--- live in page_access_tokens and expire in minutes, so rows are reaped by
--- window age instead of cascading from a parent credential.
+-- Unlike device_write_limits this table has no foreign key. Keys are hashed
+-- user ids, so the table holds at most one permanently-reused row per user
+-- who has ever used the share menu; nothing needs reaping.
 CREATE TABLE share_write_limits (
   token_hash TEXT PRIMARY KEY,
   window_start INTEGER NOT NULL,

--- a/pages/worker/migrations/0004_share_write_limits.sql
+++ b/pages/worker/migrations/0004_share_write_limits.sql
@@ -1,0 +1,9 @@
+-- Rate limiting for share writes authorized by page-access capabilities.
+-- Unlike device_write_limits this table has no foreign key: access tokens
+-- live in page_access_tokens and expire in minutes, so rows are reaped by
+-- window age instead of cascading from a parent credential.
+CREATE TABLE share_write_limits (
+  token_hash TEXT PRIMARY KEY,
+  window_start INTEGER NOT NULL,
+  request_count INTEGER NOT NULL
+);

--- a/pages/worker/migrations/0005_page_manage_tokens.sql
+++ b/pages/worker/migrations/0005_page_manage_tokens.sql
@@ -1,0 +1,13 @@
+-- Owner-only management capability, minted beside the read capability at
+-- /access. Held by the trusted shell document; the sandboxed content frame
+-- never sees it.
+CREATE TABLE IF NOT EXISTS page_manage_tokens (
+  token_hash TEXT PRIMARY KEY,
+  page_slug TEXT NOT NULL REFERENCES pages(slug) ON DELETE CASCADE,
+  user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  expires_at INTEGER NOT NULL,
+  created_at INTEGER NOT NULL,
+  UNIQUE (page_slug, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS page_manage_tokens_expiry ON page_manage_tokens(expires_at);

--- a/pages/worker/src/accounts.js
+++ b/pages/worker/src/accounts.js
@@ -26,7 +26,10 @@ export async function deviceCredential(env, token) {
   };
 }
 
+const WRITE_LIMIT_TABLES = new Set(["device_write_limits", "share_write_limits"]);
+
 export async function consumeDeviceWrite(env, tokenHash, table = "device_write_limits") {
+  if (!WRITE_LIMIT_TABLES.has(table)) throw new Error(`unknown limiter table: ${table}`);
   const configured = Number(env.WRITE_RATE_LIMIT_PER_MINUTE || 60);
   const limit = Number.isSafeInteger(configured) && configured > 0 ? configured : 60;
   const result = await env.DB.prepare(

--- a/pages/worker/src/accounts.js
+++ b/pages/worker/src/accounts.js
@@ -26,16 +26,16 @@ export async function deviceCredential(env, token) {
   };
 }
 
-export async function consumeDeviceWrite(env, tokenHash) {
+export async function consumeDeviceWrite(env, tokenHash, table = "device_write_limits") {
   const configured = Number(env.WRITE_RATE_LIMIT_PER_MINUTE || 60);
   const limit = Number.isSafeInteger(configured) && configured > 0 ? configured : 60;
   const result = await env.DB.prepare(
-    `INSERT INTO device_write_limits (token_hash, window_start, request_count)
+    `INSERT INTO ${table} (token_hash, window_start, request_count)
      VALUES (?, unixepoch() - (unixepoch() % 60), 1)
      ON CONFLICT(token_hash) DO UPDATE SET
        request_count = CASE
-         WHEN device_write_limits.window_start = excluded.window_start
-         THEN device_write_limits.request_count + 1
+         WHEN window_start = excluded.window_start
+         THEN request_count + 1
          ELSE 1
        END,
        window_start = excluded.window_start

--- a/pages/worker/src/pages-acl.js
+++ b/pages/worker/src/pages-acl.js
@@ -42,13 +42,17 @@ export async function pageReadGrant(request, env, page) {
   if (share && page.share_token_hash === await sha256(share)) return { allowed: true, owner: false };
   const access = new URL(request.url).searchParams.get("access");
   if (!access) return { allowed: false, owner: false };
-  const grant = await env.DB.prepare(
-    `SELECT user_id FROM page_access_tokens
-      WHERE token_hash = ? AND page_slug = ? AND expires_at > ?`,
-  ).bind(await sha256(access), page.slug, Math.floor(Date.now() / 1000)).first();
+  const grant = await ownerByAccess(env, page.slug, access);
   if (!grant) return { allowed: false, owner: false };
   return { allowed: true, owner: grant.user_id === page.owner_id };
 }
+export async function ownerByAccess(env, slug, token) {
+  return env.DB.prepare(
+    `SELECT user_id FROM page_access_tokens
+      WHERE token_hash = ? AND page_slug = ? AND expires_at > ?`,
+  ).bind(await sha256(token), slug, Math.floor(Date.now() / 1000)).first();
+}
+
 async function userCanReadPage(env, user, page) {
   if (!user || !page) return false;
   if (user.id === page.owner_id) return true;

--- a/pages/worker/src/pages-acl.js
+++ b/pages/worker/src/pages-acl.js
@@ -61,36 +61,66 @@ async function userCanReadPage(env, user, page) {
   ).bind(page.slug, user.email.toLowerCase()).first();
   return Boolean(invite);
 }
-export async function issuePageAccess(env, slug, user) {
-  const page = await pageRecord(env, slug);
-  if (!(await userCanReadPage(env, user, page))) return null;
-  const now = Math.floor(Date.now() / 1000);
-  await env.DB.prepare("DELETE FROM page_access_tokens WHERE expires_at <= ?").bind(now).run();
+async function mintCapability(env, table, slug, userId, now) {
+  await env.DB.prepare(`DELETE FROM ${table} WHERE expires_at <= ?`).bind(now).run();
   const token = randomToken();
   await env.DB.prepare(
-    `INSERT INTO page_access_tokens (token_hash, page_slug, user_id, expires_at, created_at)
+    `INSERT INTO ${table} (token_hash, page_slug, user_id, expires_at, created_at)
      VALUES (?, ?, ?, ?, ?)
      ON CONFLICT(page_slug, user_id) DO UPDATE SET
        token_hash = excluded.token_hash,
        expires_at = excluded.expires_at,
        created_at = excluded.created_at`,
-  ).bind(await sha256(token), slug, user.id, now + PAGE_ACCESS_TTL_SECONDS, now).run();
+  ).bind(await sha256(token), slug, userId, now + PAGE_ACCESS_TTL_SECONDS, now).run();
   return token;
+}
+
+// Owners get a second, separately-stored capability for the share menu. Only
+// the trusted shell document ever holds it; the read token alone can never
+// change state.
+export async function issuePageAccess(env, slug, user) {
+  const page = await pageRecord(env, slug);
+  if (!(await userCanReadPage(env, user, page))) return null;
+  const now = Math.floor(Date.now() / 1000);
+  const access = await mintCapability(env, "page_access_tokens", slug, user.id, now);
+  const manage = page && page.owner_id === user.id
+    ? await mintCapability(env, "page_manage_tokens", slug, user.id, now)
+    : null;
+  return { access, manage };
+}
+
+export async function ownerByManage(env, slug, token) {
+  const grant = await env.DB.prepare(
+    `SELECT user_id FROM page_manage_tokens
+      WHERE token_hash = ? AND page_slug = ? AND expires_at > ?`,
+  ).bind(await sha256(token), slug, Math.floor(Date.now() / 1000)).first();
+  return grant ?? null;
 }
 export async function ownerPage(request, env, slug) {
   const [user, page] = await Promise.all([sessionUser(request, env), pageRecord(env, slug)]);
   if (!user || !page || page.owner_id !== user.id) return null;
   return { user, page };
 }
-export async function setShareLink(env, slug, enabled) {
-  if (!enabled) {
+// mode: "off" clears; "mint" unconditionally rotates (dashboard and device
+// callers keep their historical semantics); "enable" is idempotent — it never
+// silently kills a link that is already circulating.
+export async function setShareLink(env, slug, mode) {
+  if (mode === "off") {
     await env.DB.prepare("UPDATE pages SET share_token_hash = NULL WHERE slug = ?").bind(slug).run();
-    return null;
+    return { token: null, already: false };
   }
   const token = randomToken();
+  const hash = await sha256(token);
+  if (mode === "enable") {
+    const result = await env.DB.prepare(
+      "UPDATE pages SET share_token_hash = ? WHERE slug = ? AND share_token_hash IS NULL",
+    ).bind(hash, slug).run();
+    if (result.meta.changes === 0) return { token: null, already: true };
+    return { token, already: false };
+  }
   await env.DB.prepare("UPDATE pages SET share_token_hash = ? WHERE slug = ?")
-    .bind(await sha256(token), slug).run();
-  return token;
+    .bind(hash, slug).run();
+  return { token, already: false };
 }
 export async function inviteEmail(env, slug, email) {
   const normalized = email.trim().toLowerCase();

--- a/pages/worker/src/worker.js
+++ b/pages/worker/src/worker.js
@@ -11,7 +11,7 @@ import {
   deletePageRecord,
   inviteEmail,
   issuePageAccess,
-  ownerByAccess,
+  ownerByManage,
   ownerPage,
   pageRecord,
   pageReadGrant,
@@ -370,8 +370,8 @@ async function shareByDevice(request, env, slug, bearer) {
   return rateLimitedShareChange(request, env, slug, credential.tokenHash);
 }
 
-async function rateLimitedShareChange(request, env, slug, limiterKey) {
-  const rate = await consumeDeviceWrite(env, limiterKey);
+async function rateLimitedShareChange(request, env, slug, limiterKey, limiterTable) {
+  const rate = await consumeDeviceWrite(env, limiterKey, limiterTable);
   if (!rate.allowed) {
     return new Response("share write rate exceeded\n", {
       status: 429,
@@ -380,7 +380,7 @@ async function rateLimitedShareChange(request, env, slug, limiterKey) {
   }
   const body = await requestBody(request);
   const enabled = body.enabled === true || body.enabled === "true";
-  const token = await setShareLink(env, slug, enabled);
+  const { token } = await setShareLink(env, slug, enabled ? "mint" : "off");
   const url = token ? `${env.PAGES_URL}/${slug}?share=${token}` : null;
   return Response.json({ ok: true, enabled, url });
 }
@@ -392,7 +392,7 @@ async function handleShare(request, env, slug) {
   if (!(await ownerPage(request, env, slug))) return new Response("not found\n", { status: 404 });
   const body = await requestBody(request);
   const enabled = body.enabled === true || body.enabled === "true";
-  const token = await setShareLink(env, slug, enabled);
+  const { token } = await setShareLink(env, slug, enabled ? "mint" : "off");
   if (!request.headers.get("content-type")?.startsWith("application/json")) {
     // The link is handed back through a one-shot cookie rather than the URL:
     // the dashboard can then show it in place, and the token stays out of the
@@ -492,9 +492,10 @@ async function handlePageAccess(request, env) {
       headers: { location: `/login?return_to=${encodeURIComponent(returnTo)}` },
     });
   }
-  const token = await issuePageAccess(env, requested.slug, user);
-  if (!token) return new Response("not found\n", { status: 404 });
-  requested.target.searchParams.set("access", token);
+  const issued = await issuePageAccess(env, requested.slug, user);
+  if (!issued) return new Response("not found\n", { status: 404 });
+  requested.target.searchParams.set("access", issued.access);
+  if (issued.manage) requested.target.searchParams.set("manage", issued.manage);
   return new Response(null, { status: 302, headers: { location: requested.target.toString() } });
 }
 
@@ -630,80 +631,131 @@ async function handlePagesRequest(request, env, path) {
       },
     });
   }
-  const response = await servePage(env, `pages/${path}/index.html`, PAGE_HEADERS);
-  if (!grant.owner || response.status !== 200) return response;
-  return withShareMenu(response, env, path, Boolean(page.share_token_hash));
+  const url = new URL(request.url);
+  if (url.searchParams.get("embed") === "1") {
+    return servePage(env, `pages/${path}/index.html`, EMBED_HEADERS);
+  }
+  const manage = url.searchParams.get("manage");
+  if (grant.owner && manage) {
+    return html(200, shellDocument(env, path, page, url.searchParams.get("access")), SHELL_HEADERS);
+  }
+  return servePage(env, `pages/${path}/index.html`, PAGE_HEADERS);
 }
 
-// The owner's copy alone may fetch same-origin: that is what lets the injected
-// menu call the share endpoint. Every other viewer keeps connect-src omitted.
-const OWNER_HEADERS = {
+// The shell is worker-authored, so it alone may fetch same-origin and frame
+// the content. The content keeps the sealed page policy plus permission to be
+// framed by this origin; it still cannot fetch, submit, or read the shell.
+const SHELL_HEADERS = {
   ...PAGE_HEADERS,
-  "content-security-policy": PAGE_HEADERS["content-security-policy"]
-    .replace("img-src data:", "img-src data:; connect-src 'self'"),
+  "content-security-policy":
+    "default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src data:; connect-src 'self'; frame-src 'self'; frame-ancestors 'none'; form-action 'none'; base-uri 'none'",
+};
+const EMBED_HEADERS = {
+  ...PAGE_HEADERS,
+  "content-security-policy":
+    "default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src data:; font-src data:; frame-ancestors 'self'; form-action 'none'; base-uri 'none'",
 };
 
-function shareMenuMarkup(env, slug, shared) {
+function shellDocument(env, slug, page, access) {
+  const title = escapeHtmlText(page.title || slug);
   const dashboard = `${env.ACCOUNT_URL}/dashboard#page-${slug}`;
-  return `<div id="agentkit-share" style="position:fixed;top:40%;right:0;z-index:2147483647;font:13px/1.4 system-ui,sans-serif">
-<button id="aks-tab" title="Share settings" style="writing-mode:vertical-rl;padding:12px 7px;border-radius:8px 0 0 8px;background:#1b1d22;color:#eeeeee;border:1px solid #79a8e7;border-right:0;cursor:pointer;font:600 12px/1 system-ui,sans-serif;letter-spacing:.08em">SHARE</button>
-<div id="aks-menu" hidden style="position:absolute;right:34px;top:0;width:250px;background:#1b1d22;color:#eeeeee;border:1px solid #2a2d34;border-radius:10px;padding:12px 14px;box-shadow:0 6px 24px rgba(0,0,0,.45)">
-<div id="aks-state" style="font-weight:600;margin-bottom:8px">${shared ? "Shared by link" : "Private"}</div>
-<div id="aks-url" hidden style="font:11px/1.4 ui-monospace,monospace;word-break:break-all;background:#131417;border:1px solid #2a2d34;border-radius:6px;padding:6px;margin-bottom:8px"></div>
-<div style="display:flex;flex-direction:column;gap:6px">
+  const shared = Boolean(page.share_token_hash);
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${title}</title>
+<style>
+[hidden]{display:none!important}
+html,body{margin:0;height:100%}
+#content{position:fixed;inset:0;border:0;width:100%;height:100%}
+#aks{position:fixed;top:40%;right:0;z-index:10;font:13px/1.4 system-ui,sans-serif}
+#aks-tab{writing-mode:vertical-rl;padding:12px 7px;border-radius:8px 0 0 8px;background:#1b1d22;color:#eeeeee;border:1px solid #79a8e7;border-right:0;cursor:pointer;font:600 12px/1 system-ui,sans-serif;letter-spacing:.08em}
+#aks-menu{position:absolute;right:34px;top:0;width:250px;background:#1b1d22;color:#eeeeee;border:1px solid #2a2d34;border-radius:10px;padding:12px 14px;box-shadow:0 6px 24px rgba(0,0,0,.45)}
+#aks-state{font-weight:600;margin-bottom:8px}
+#aks-url{font:11px/1.4 ui-monospace,monospace;word-break:break-all;background:#131417;border:1px solid #2a2d34;border-radius:6px;padding:6px;margin-bottom:8px}
+#aks-err{color:#e06c75;margin-top:8px}
+.aks-b{font:600 12px/1 system-ui,sans-serif;padding:8px 10px;border-radius:7px;border:1px solid #3a3f47;background:#23262d;color:#eeeeee;cursor:pointer;display:block;width:100%;text-align:center;text-decoration:none;box-sizing:border-box}
+.aks-b:hover{border-color:#79a8e7}
+#aks-menu>div.btns{display:flex;flex-direction:column;gap:6px}
+</style></head><body>
+<iframe id="content" title="${title}" sandbox="allow-scripts allow-forms allow-popups allow-modals allow-downloads"></iframe>
+<div id="aks">
+<button id="aks-tab" title="Share settings">SHARE</button>
+<div id="aks-menu" hidden>
+<div id="aks-state">${shared ? "Shared by link" : "Private"}</div>
+<div id="aks-url" hidden></div>
+<div class="btns">
 <button class="aks-b" id="aks-on" ${shared ? "hidden" : ""}>Turn share link on</button>
 <button class="aks-b" id="aks-copy" hidden>Copy link</button>
 <button class="aks-b" id="aks-rotate" ${shared ? "" : "hidden"}>Rotate link (old one dies)</button>
 <button class="aks-b" id="aks-off" ${shared ? "" : "hidden"}>Turn share link off</button>
-<a class="aks-b" href="${dashboard}" target="_blank" rel="noopener" style="text-align:center;text-decoration:none">Invites &amp; settings</a>
+<a class="aks-b" href="${dashboard}" target="_blank" rel="noopener">Invites &amp; settings</a>
 </div>
-<div id="aks-err" style="color:#e06c75;margin-top:8px" hidden></div>
+<div id="aks-err" hidden></div>
 </div></div>
-<style>.aks-b{font:600 12px/1 system-ui,sans-serif;padding:8px 10px;border-radius:7px;border:1px solid #3a3f47;background:#23262d;color:#eeeeee;cursor:pointer}.aks-b:hover{border-color:#79a8e7}</style>
 <script>(function(){
 var $=function(id){return document.getElementById(id)};
-var access=new URLSearchParams(location.search).get("access");
+var q=new URLSearchParams(location.search);
+var manage=q.get("manage");
+var access=${JSON.stringify(access)};
 var url=null;
+$("content").src="/${slug}?embed=1&access="+encodeURIComponent(access)+location.hash;
 $("aks-tab").addEventListener("click",function(){$("aks-menu").hidden=!$("aks-menu").hidden});
 function fail(m){$("aks-err").textContent=m;$("aks-err").hidden=false}
 function state(on){$("aks-state").textContent=on?"Shared by link":"Private";$("aks-on").hidden=on;$("aks-rotate").hidden=!on;$("aks-off").hidden=!on;if(!on){url=null;$("aks-url").hidden=true;$("aks-copy").hidden=true}}
-function set(enabled){$("aks-err").hidden=true;
-fetch("/api/pages/${slug}/share",{method:"POST",headers:{"authorization":"Bearer "+access,"content-type":"application/json"},body:JSON.stringify({enabled:enabled})})
-.then(function(r){if(r.status===401)throw new Error("Access pass expired - reload the page");if(!r.ok)throw new Error("Share update failed ("+r.status+")");return r.json()})
-.then(function(d){state(d.enabled);if(d.url){url=d.url;$("aks-url").textContent=d.url;$("aks-url").hidden=false;$("aks-copy").hidden=false}})
+function act(action){$("aks-err").hidden=true;
+fetch("/api/pages/${slug}/share",{method:"POST",headers:{"authorization":"Bearer "+manage,"content-type":"application/json"},body:JSON.stringify({action:action})})
+.then(function(r){if(r.status===401)throw new Error("Session pass expired - reload the page");if(!r.ok)throw new Error("Share update failed ("+r.status+")");return r.json()})
+.then(function(d){state(d.enabled);if(d.url){url=d.url;$("aks-url").textContent=d.url;$("aks-url").hidden=false;$("aks-copy").hidden=false}
+if(d.already)fail("Already shared - the existing link still works. Use Rotate to replace it.")})
 .catch(function(e){fail(e.message)})}
-$("aks-on").addEventListener("click",function(){set(true)});
-$("aks-rotate").addEventListener("click",function(){set(true)});
-$("aks-off").addEventListener("click",function(){set(false)});
-$("aks-copy").addEventListener("click",function(){if(url)navigator.clipboard.writeText(url).then(function(){$("aks-copy").textContent="Copied"})});
-})()</script>`;
+$("aks-on").addEventListener("click",function(){act("enable")});
+$("aks-rotate").addEventListener("click",function(){act("rotate")});
+$("aks-off").addEventListener("click",function(){act("off")});
+$("aks-copy").addEventListener("click",function(){
+if(!url)return;
+if(!navigator.clipboard){fail("Clipboard unavailable - copy the link text above by hand");return}
+navigator.clipboard.writeText(url).then(function(){
+$("aks-copy").textContent="Copied";
+setTimeout(function(){$("aks-copy").textContent="Copy link"},1500);
+}).catch(function(){fail("Copy failed - select the link text above")})});
+})()</script></body></html>`;
 }
 
-async function withShareMenu(response, env, slug, shared) {
-  const body = await response.text();
-  // Appended, never spliced: a literal "</body>" may legally sit inside a
-  // script string or comment, so any rewrite targeting it corrupts the page.
-  // The parser reparents trailing elements back into body regardless.
-  return html(200, body + shareMenuMarkup(env, slug, shared), OWNER_HEADERS);
+function escapeHtmlText(value) {
+  return String(value).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
 }
 
-// The read capability doubles as share authority only when it belongs to the
-// page owner. Blast radius of a hostile page script on the owner's own view:
-// it can flip sharing of ITSELF (the token is page-scoped), which the owner
-// already controls, and it cannot exfiltrate the link (connect-src 'self').
+const SHARE_ACTIONS = { enable: "enable", rotate: "mint", off: "off" };
+
 async function handleOwnerShare(request, env, slug) {
-  if ((request.headers.get("origin") ?? "") !== (env.PAGES_URL || "https://pages.agentkit.sbs")) {
-    return new Response("forbidden\n", { status: 403 });
-  }
+  if (!sameOrigin(request)) return new Response("forbidden\n", { status: 403 });
   if (!SLUG_RE.test(slug) || !env.DB) return new Response("not found\n", { status: 404 });
+  let mode;
+  try {
+    mode = SHARE_ACTIONS[(await requestBody(request)).action];
+  } catch {
+    mode = undefined;
+  }
+  if (!mode) return new Response("invalid action\n", { status: 400 });
   const page = await pageRecord(env, slug);
   if (!page) return new Response("not found\n", { status: 404 });
   const bearer = bearerToken(request);
-  const owner = bearer && await ownerByAccess(env, slug, bearer);
+  const owner = bearer && await ownerByManage(env, slug, bearer);
   if (!owner || owner.user_id !== page.owner_id) {
     return new Response("unauthorized\n", { status: 401 });
   }
-  return rateLimitedShareChange(request, env, slug, await sha256(bearer));
+  const rate = await consumeDeviceWrite(env, await sha256(owner.user_id), "share_write_limits");
+  if (!rate.allowed) {
+    return new Response("share write rate exceeded\n", {
+      status: 429,
+      headers: { "retry-after": String(rate.retryAfter) },
+    });
+  }
+  const { token, already } = await setShareLink(env, slug, mode);
+  const enabled = mode !== "off";
+  const url = token ? `${env.PAGES_URL}/${slug}?share=${token}` : null;
+  return Response.json({ ok: true, enabled, url, already });
 }
 
 export default {

--- a/pages/worker/src/worker.js
+++ b/pages/worker/src/worker.js
@@ -4,12 +4,14 @@ import {
   endSession,
   revokeDeviceToken,
   sessionUser,
+  sha256,
 } from "./accounts.js";
 import {
   claimPage,
   deletePageRecord,
   inviteEmail,
   issuePageAccess,
+  ownerByAccess,
   ownerPage,
   pageRecord,
   pageReadGrant,
@@ -365,9 +367,13 @@ async function shareByDevice(request, env, slug, bearer) {
   if (!page || page.owner_id !== credential.user.id) {
     return new Response("not found\n", { status: 404 });
   }
-  const rate = await consumeDeviceWrite(env, credential.tokenHash);
+  return rateLimitedShareChange(request, env, slug, credential.tokenHash);
+}
+
+async function rateLimitedShareChange(request, env, slug, limiterKey) {
+  const rate = await consumeDeviceWrite(env, limiterKey);
   if (!rate.allowed) {
-    return new Response("device write rate exceeded\n", {
+    return new Response("share write rate exceeded\n", {
       status: 429,
       headers: { "retry-after": String(rate.retryAfter) },
     });
@@ -626,24 +632,78 @@ async function handlePagesRequest(request, env, path) {
   }
   const response = await servePage(env, `pages/${path}/index.html`, PAGE_HEADERS);
   if (!grant.owner || response.status !== 200) return response;
-  return withShareButton(response, env, path);
+  return withShareMenu(response, env, path, Boolean(page.share_token_hash));
 }
 
-// A plain anchor, not a control: the page CSP has no connect-src, so share
-// state can only be changed on the account origin. Injected at serve time
-// rather than publish time so every existing page gets it without a republish.
-const SHARE_BUTTON_STYLE = "position:fixed;top:12px;right:12px;z-index:2147483647;"
-  + "font:600 13px/1 system-ui,sans-serif;padding:8px 14px;border-radius:999px;"
-  + "background:#1b1d22;color:#eeeeee;border:1px solid #79a8e7;text-decoration:none;opacity:.92";
+// The owner's copy alone may fetch same-origin: that is what lets the injected
+// menu call the share endpoint. Every other viewer keeps connect-src omitted.
+const OWNER_HEADERS = {
+  ...PAGE_HEADERS,
+  "content-security-policy": PAGE_HEADERS["content-security-policy"]
+    .replace("img-src data:", "img-src data:; connect-src 'self'"),
+};
 
-async function withShareButton(response, env, slug) {
+function shareMenuMarkup(env, slug, shared) {
+  const dashboard = `${env.ACCOUNT_URL}/dashboard#page-${slug}`;
+  return `<div id="agentkit-share" style="position:fixed;top:40%;right:0;z-index:2147483647;font:13px/1.4 system-ui,sans-serif">
+<button id="aks-tab" title="Share settings" style="writing-mode:vertical-rl;padding:12px 7px;border-radius:8px 0 0 8px;background:#1b1d22;color:#eeeeee;border:1px solid #79a8e7;border-right:0;cursor:pointer;font:600 12px/1 system-ui,sans-serif;letter-spacing:.08em">SHARE</button>
+<div id="aks-menu" hidden style="position:absolute;right:34px;top:0;width:250px;background:#1b1d22;color:#eeeeee;border:1px solid #2a2d34;border-radius:10px;padding:12px 14px;box-shadow:0 6px 24px rgba(0,0,0,.45)">
+<div id="aks-state" style="font-weight:600;margin-bottom:8px">${shared ? "Shared by link" : "Private"}</div>
+<div id="aks-url" hidden style="font:11px/1.4 ui-monospace,monospace;word-break:break-all;background:#131417;border:1px solid #2a2d34;border-radius:6px;padding:6px;margin-bottom:8px"></div>
+<div style="display:flex;flex-direction:column;gap:6px">
+<button class="aks-b" id="aks-on" ${shared ? "hidden" : ""}>Turn share link on</button>
+<button class="aks-b" id="aks-copy" hidden>Copy link</button>
+<button class="aks-b" id="aks-rotate" ${shared ? "" : "hidden"}>Rotate link (old one dies)</button>
+<button class="aks-b" id="aks-off" ${shared ? "" : "hidden"}>Turn share link off</button>
+<a class="aks-b" href="${dashboard}" target="_blank" rel="noopener" style="text-align:center;text-decoration:none">Invites &amp; settings</a>
+</div>
+<div id="aks-err" style="color:#e06c75;margin-top:8px" hidden></div>
+</div></div>
+<style>.aks-b{font:600 12px/1 system-ui,sans-serif;padding:8px 10px;border-radius:7px;border:1px solid #3a3f47;background:#23262d;color:#eeeeee;cursor:pointer}.aks-b:hover{border-color:#79a8e7}</style>
+<script>(function(){
+var $=function(id){return document.getElementById(id)};
+var access=new URLSearchParams(location.search).get("access");
+var url=null;
+$("aks-tab").addEventListener("click",function(){$("aks-menu").hidden=!$("aks-menu").hidden});
+function fail(m){$("aks-err").textContent=m;$("aks-err").hidden=false}
+function state(on){$("aks-state").textContent=on?"Shared by link":"Private";$("aks-on").hidden=on;$("aks-rotate").hidden=!on;$("aks-off").hidden=!on;if(!on){url=null;$("aks-url").hidden=true;$("aks-copy").hidden=true}}
+function set(enabled){$("aks-err").hidden=true;
+fetch("/api/pages/${slug}/share",{method:"POST",headers:{"authorization":"Bearer "+access,"content-type":"application/json"},body:JSON.stringify({enabled:enabled})})
+.then(function(r){if(r.status===401)throw new Error("Access pass expired - reload the page");if(!r.ok)throw new Error("Share update failed ("+r.status+")");return r.json()})
+.then(function(d){state(d.enabled);if(d.url){url=d.url;$("aks-url").textContent=d.url;$("aks-url").hidden=false;$("aks-copy").hidden=false}})
+.catch(function(e){fail(e.message)})}
+$("aks-on").addEventListener("click",function(){set(true)});
+$("aks-rotate").addEventListener("click",function(){set(true)});
+$("aks-off").addEventListener("click",function(){set(false)});
+$("aks-copy").addEventListener("click",function(){if(url)navigator.clipboard.writeText(url).then(function(){$("aks-copy").textContent="Copied"})});
+})()</script>`;
+}
+
+async function withShareMenu(response, env, slug, shared) {
   const body = await response.text();
-  const button = `<a href="${env.ACCOUNT_URL}/dashboard#page-${slug}" target="_blank" rel="noopener"`
-    + ` title="Share settings" style="${SHARE_BUTTON_STYLE}">Share</a>`;
   // Appended, never spliced: a literal "</body>" may legally sit inside a
   // script string or comment, so any rewrite targeting it corrupts the page.
-  // The parser reparents a trailing element back into body regardless.
-  return html(200, body + button, PAGE_HEADERS);
+  // The parser reparents trailing elements back into body regardless.
+  return html(200, body + shareMenuMarkup(env, slug, shared), OWNER_HEADERS);
+}
+
+// The read capability doubles as share authority only when it belongs to the
+// page owner. Blast radius of a hostile page script on the owner's own view:
+// it can flip sharing of ITSELF (the token is page-scoped), which the owner
+// already controls, and it cannot exfiltrate the link (connect-src 'self').
+async function handleOwnerShare(request, env, slug) {
+  if ((request.headers.get("origin") ?? "") !== (env.PAGES_URL || "https://pages.agentkit.sbs")) {
+    return new Response("forbidden\n", { status: 403 });
+  }
+  if (!SLUG_RE.test(slug) || !env.DB) return new Response("not found\n", { status: 404 });
+  const page = await pageRecord(env, slug);
+  if (!page) return new Response("not found\n", { status: 404 });
+  const bearer = bearerToken(request);
+  const owner = bearer && await ownerByAccess(env, slug, bearer);
+  if (!owner || owner.user_id !== page.owner_id) {
+    return new Response("unauthorized\n", { status: 401 });
+  }
+  return rateLimitedShareChange(request, env, slug, await sha256(bearer));
 }
 
 export default {
@@ -686,6 +746,10 @@ export default {
     if (accountRequest) return handleAccountRequest(request, env, path);
 
     if (!pagesRequest) return html(404, NOT_FOUND);
+    const ownerShareMatch = path.match(/^api\/pages\/(.+)\/share$/);
+    if (request.method === "POST" && ownerShareMatch) {
+      return handleOwnerShare(request, env, ownerShareMatch[1]);
+    }
     return handlePagesRequest(request, env, path);
   },
 };

--- a/pages/worker/src/worker.js
+++ b/pages/worker/src/worker.js
@@ -637,7 +637,7 @@ async function handlePagesRequest(request, env, path) {
   }
   const manage = url.searchParams.get("manage");
   if (grant.owner && manage) {
-    return html(200, shellDocument(env, path, page, url.searchParams.get("access")), SHELL_HEADERS);
+    return html(200, shellDocument(env, path, page), SHELL_HEADERS);
   }
   return servePage(env, `pages/${path}/index.html`, PAGE_HEADERS);
 }
@@ -656,7 +656,7 @@ const EMBED_HEADERS = {
     "default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src data:; font-src data:; frame-ancestors 'self'; form-action 'none'; base-uri 'none'",
 };
 
-function shellDocument(env, slug, page, access) {
+function shellDocument(env, slug, page) {
   const title = escapeHtmlText(page.title || slug);
   const dashboard = `${env.ACCOUNT_URL}/dashboard#page-${slug}`;
   const shared = Boolean(page.share_token_hash);
@@ -696,9 +696,8 @@ html,body{margin:0;height:100%}
 var $=function(id){return document.getElementById(id)};
 var q=new URLSearchParams(location.search);
 var manage=q.get("manage");
-var access=${JSON.stringify(access)};
 var url=null;
-$("content").src="/${slug}?embed=1&access="+encodeURIComponent(access)+location.hash;
+$("content").src="/${slug}?embed=1&access="+encodeURIComponent(q.get("access")||"")+location.hash;
 $("aks-tab").addEventListener("click",function(){$("aks-menu").hidden=!$("aks-menu").hidden});
 function fail(m){$("aks-err").textContent=m;$("aks-err").hidden=false}
 function state(on){$("aks-state").textContent=on?"Shared by link":"Private";$("aks-on").hidden=on;$("aks-rotate").hidden=!on;$("aks-off").hidden=!on;if(!on){url=null;$("aks-url").hidden=true;$("aks-copy").hidden=true}}

--- a/tests/publish-page/accounts.test.ts
+++ b/tests/publish-page/accounts.test.ts
@@ -467,8 +467,8 @@ describe('private access and sharing', () => {
     const page = await worker.fetch(new Request(location), setup.env);
     expect(page.status).toBe(200);
     const owned = await page.text();
-    expect(owned).toStartWith('<h1>private</h1><a href=');
-    expect(owned.split('>Share</a>')).toHaveLength(2);
+    expect(owned).toStartWith('<h1>private</h1><div id="agentkit-share"');
+    expect(owned.split('id="agentkit-share"')).toHaveLength(2);
 
     expect((await worker.fetch(
       new Request(location.replace('/private-page?', '/another-page?')),
@@ -513,8 +513,8 @@ describe('private access and sharing', () => {
     expect(response.status).toBe(200);
     // The owner's copy is the exact content plus exactly one appended button.
     const text = await response.text();
-    expect(text).toStartWith('<h1>private</h1><a href=');
-    expect(text.split('>Share</a>')).toHaveLength(2);
+    expect(text).toStartWith('<h1>private</h1><div id="agentkit-share"');
+    expect(text.split('id="agentkit-share"')).toHaveLength(2);
   });
 
   test('a share link grants access and disabling it revokes the old URL', async () => {
@@ -1108,20 +1108,41 @@ describe('Assay OIDC sessions', () => {
   });
 });
 
-describe('owner share button on served pages', () => {
+describe('owner share menu on served pages', () => {
   async function servedBody(setup: Awaited<ReturnType<typeof accountEnv>>, url: string) {
     const response = await worker.fetch(new Request(url), setup.env);
     expect(response.status).toBe(200);
     return response.text();
   }
 
-  test('the owner sees a share button pointing at the dashboard card', async () => {
+  function ownerShare(access: string, enabled: boolean, origin = PAGES_URL, slug = 'private-page') {
+    return new Request(`${PAGES_URL}/api/pages/${slug}/share`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${access}`,
+        'content-type': 'application/json',
+        origin,
+      },
+      body: JSON.stringify({ enabled }),
+    });
+  }
+
+  async function ownerAccessToken(setup: Awaited<ReturnType<typeof accountEnv>>, session = 'session-a') {
+    const { location } = await pageAccessUrl(setup, 'private-page', session);
+    return new URL(location!).searchParams.get('access')!;
+  }
+
+  test('the owner gets the menu; its response alone allows same-origin fetch', async () => {
     const setup = await accountEnv();
     expect((await worker.fetch(publish('device-a'), setup.env)).status).toBe(200);
     const { location } = await pageAccessUrl(setup);
-    const body = await servedBody(setup, location!);
+    const response = await worker.fetch(new Request(location!), setup.env);
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toStartWith('<h1>private</h1>');
+    expect(body.split('id="agentkit-share"')).toHaveLength(2);
     expect(body).toContain(`${ACCOUNT_URL}/dashboard#page-private-page`);
-    expect(body).toContain('>Share</a>');
+    expect(response.headers.get('content-security-policy')).toContain("connect-src 'self'");
   });
 
   test('a literal </body> in page content is never a splice point', async () => {
@@ -1131,10 +1152,10 @@ describe('owner share button on served pages', () => {
     const { location } = await pageAccessUrl(setup);
     const body = await servedBody(setup, location!);
     expect(body).toStartWith(doc);
-    expect(body.split('>Share</a>')).toHaveLength(2);
+    expect(body.split('id="agentkit-share"')).toHaveLength(2);
   });
 
-  test('an invited reader gets the page without the button', async () => {
+  test('an invited reader gets the page without the menu or connect-src', async () => {
     const setup = await accountEnv();
     expect((await worker.fetch(publish('device-a'), setup.env)).status).toBe(200);
     const invite = await worker.fetch(
@@ -1143,11 +1164,12 @@ describe('owner share button on served pages', () => {
     );
     expect([200, 303]).toContain(invite.status);
     const { location } = await pageAccessUrl(setup, 'private-page', 'session-b');
-    const body = await servedBody(setup, location!);
-    expect(body).not.toContain('>Share</a>');
+    const response = await worker.fetch(new Request(location!), setup.env);
+    expect(await response.text()).toBe('<h1>private</h1>');
+    expect(response.headers.get('content-security-policy')).not.toContain('connect-src');
   });
 
-  test('a share-link reader gets the page without the button', async () => {
+  test('a share-link reader gets the page without the menu', async () => {
     const setup = await accountEnv();
     expect((await worker.fetch(publish('device-a'), setup.env)).status).toBe(200);
     const share = await worker.fetch(
@@ -1160,21 +1182,55 @@ describe('owner share button on served pages', () => {
     );
     expect(share.status).toBe(200);
     const { url } = await share.json() as { url: string };
-    const body = await servedBody(setup, url);
-    expect(body).not.toContain('>Share</a>');
+    expect(await servedBody(setup, url)).toBe('<h1>private</h1>');
   });
 
   test('a legacy page with no metadata row is served unmodified', async () => {
     const setup = await accountEnv();
     setup.pages.writes.set('pages/legacy-page/index.html', { body: '<h1>legacy</h1>' });
-    const body = await servedBody(setup, `${PAGES_URL}/legacy-page`);
-    expect(body).toBe('<h1>legacy</h1>');
+    expect(await servedBody(setup, `${PAGES_URL}/legacy-page`)).toBe('<h1>legacy</h1>');
   });
 
-  test('the dashboard card carries the anchor the button targets', async () => {
+  test('the dashboard card carries the anchor the menu links to', async () => {
     const setup = await accountEnv();
     expect((await worker.fetch(publish('device-a'), setup.env)).status).toBe(200);
     const dashboard = await worker.fetch(signedIn(`${ACCOUNT_URL}/dashboard`), setup.env);
     expect(await dashboard.text()).toContain('id="page-private-page"');
+  });
+
+  test('the owner access token can flip the share link from the pages origin', async () => {
+    const setup = await accountEnv();
+    expect((await worker.fetch(publish('device-a'), setup.env)).status).toBe(200);
+    const access = await ownerAccessToken(setup);
+
+    const on = await worker.fetch(ownerShare(access, true), setup.env);
+    expect(on.status).toBe(200);
+    const { enabled, url } = await on.json() as { enabled: boolean; url: string };
+    expect(enabled).toBe(true);
+    expect(await servedBody(setup, url)).toBe('<h1>private</h1>');
+
+    const off = await worker.fetch(ownerShare(access, false), setup.env);
+    expect(off.status).toBe(200);
+    expect((await worker.fetch(new Request(url), setup.env)).status).toBe(302);
+  });
+
+  test('an invitee access token cannot manage sharing', async () => {
+    const setup = await accountEnv();
+    expect((await worker.fetch(publish('device-a'), setup.env)).status).toBe(200);
+    await worker.fetch(
+      accountPost(`${ACCOUNT_URL}/api/pages/private-page/invites`, { email: 'other@example.com' }, 'session-a'),
+      setup.env,
+    );
+    const access = await ownerAccessToken(setup, 'session-b');
+    expect((await worker.fetch(ownerShare(access, true), setup.env)).status).toBe(401);
+  });
+
+  test('an expired or foreign-origin request cannot manage sharing', async () => {
+    const setup = await accountEnv();
+    expect((await worker.fetch(publish('device-a'), setup.env)).status).toBe(200);
+    const access = await ownerAccessToken(setup);
+    expect((await worker.fetch(ownerShare(access, true, 'https://evil.example'), setup.env)).status).toBe(403);
+    setup.database.sqlite.run('UPDATE page_access_tokens SET expires_at = 0');
+    expect((await worker.fetch(ownerShare(access, true), setup.env)).status).toBe(401);
   });
 });

--- a/tests/publish-page/accounts.test.ts
+++ b/tests/publish-page/accounts.test.ts
@@ -10,6 +10,8 @@ const PAGES_URL = 'https://pages.agentkit.sbs';
 
 function d1() {
   const sqlite = new Database(':memory:');
+  // D1 enforces foreign keys on every query; bun:sqlite defaults them off.
+  sqlite.run('PRAGMA foreign_keys = ON');
   openDatabases.push(sqlite);
   const migrationsUrl = new URL('../../pages/worker/migrations/', import.meta.url);
   for (const migration of readdirSync(migrationsUrl).filter((name) => name.endsWith('.sql')).sort()) {
@@ -466,9 +468,12 @@ describe('private access and sharing', () => {
     expect(location).toStartWith(`${PAGES_URL}/private-page?access=`);
     const page = await worker.fetch(new Request(location), setup.env);
     expect(page.status).toBe(200);
-    const owned = await page.text();
-    expect(owned).toStartWith('<h1>private</h1><div id="agentkit-share"');
-    expect(owned.split('id="agentkit-share"')).toHaveLength(2);
+    expect(await page.text()).toContain('<iframe id="content"');
+    const embedded = await worker.fetch(
+      new Request(`${location.split('?')[0]}?embed=1&access=${new URL(location).searchParams.get('access')}`),
+      setup.env,
+    );
+    expect(await embedded.text()).toBe('<h1>private</h1>');
 
     expect((await worker.fetch(
       new Request(location.replace('/private-page?', '/another-page?')),
@@ -511,10 +516,8 @@ describe('private access and sharing', () => {
     const response = await worker.fetch(new Request(access.location!), setup.env);
 
     expect(response.status).toBe(200);
-    // The owner's copy is the exact content plus exactly one appended button.
-    const text = await response.text();
-    expect(text).toStartWith('<h1>private</h1><div id="agentkit-share"');
-    expect(text.split('id="agentkit-share"')).toHaveLength(2);
+    // The owner lands on the shell; the exact content is behind the embed URL.
+    expect(await response.text()).toContain('<iframe id="content"');
   });
 
   test('a share link grants access and disabling it revokes the old URL', async () => {
@@ -1108,68 +1111,73 @@ describe('Assay OIDC sessions', () => {
   });
 });
 
-describe('owner share menu on served pages', () => {
-  async function servedBody(setup: Awaited<ReturnType<typeof accountEnv>>, url: string) {
-    const response = await worker.fetch(new Request(url), setup.env);
-    expect(response.status).toBe(200);
-    return response.text();
+describe('owner share shell and menu', () => {
+  async function ownerLocation(setup: Awaited<ReturnType<typeof accountEnv>>, session = 'session-a') {
+    const { location } = await pageAccessUrl(setup, 'private-page', session);
+    return new URL(location!);
   }
 
-  function ownerShare(access: string, enabled: boolean, origin = PAGES_URL, slug = 'private-page') {
+  function shareAction(manage: string, action: string, origin = PAGES_URL, slug = 'private-page') {
     return new Request(`${PAGES_URL}/api/pages/${slug}/share`, {
       method: 'POST',
       headers: {
-        authorization: `Bearer ${access}`,
+        authorization: `Bearer ${manage}`,
         'content-type': 'application/json',
         origin,
       },
-      body: JSON.stringify({ enabled }),
+      body: JSON.stringify({ action }),
     });
   }
 
-  async function ownerAccessToken(setup: Awaited<ReturnType<typeof accountEnv>>, session = 'session-a') {
-    const { location } = await pageAccessUrl(setup, 'private-page', session);
-    return new URL(location!).searchParams.get('access')!;
-  }
-
-  test('the owner gets the menu; its response alone allows same-origin fetch', async () => {
+  test('the owner gets the shell: sandboxed frame, no same-origin escape, shell CSP', async () => {
     const setup = await accountEnv();
     expect((await worker.fetch(publish('device-a'), setup.env)).status).toBe(200);
-    const { location } = await pageAccessUrl(setup);
-    const response = await worker.fetch(new Request(location!), setup.env);
+    const location = await ownerLocation(setup);
+    expect(location.searchParams.get('manage')).toBeTruthy();
+    const response = await worker.fetch(new Request(location.toString()), setup.env);
     expect(response.status).toBe(200);
     const body = await response.text();
-    expect(body).toStartWith('<h1>private</h1>');
-    expect(body.split('id="agentkit-share"')).toHaveLength(2);
+    expect(body).toContain('sandbox="allow-scripts allow-forms allow-popups allow-modals allow-downloads"');
+    expect(body).not.toContain('allow-same-origin');
     expect(body).toContain(`${ACCOUNT_URL}/dashboard#page-private-page`);
-    expect(response.headers.get('content-security-policy')).toContain("connect-src 'self'");
+    // The manage token never appears in the shell body - the script reads it
+    // from its own URL, which the sandboxed frame cannot see.
+    expect(body).not.toContain(location.searchParams.get('manage')!);
+    const csp = response.headers.get('content-security-policy')!;
+    expect(csp).toContain("connect-src 'self'");
+    expect(csp).toContain("frame-src 'self'");
   });
 
-  test('a literal </body> in page content is never a splice point', async () => {
+  test('the embed variant serves the exact content, framable by self only, sealed CSP', async () => {
     const setup = await accountEnv();
     const doc = '<script>var s = "</body>";</script><h1>private</h1>';
     expect((await worker.fetch(publish('device-a', doc), setup.env)).status).toBe(200);
-    const { location } = await pageAccessUrl(setup);
-    const body = await servedBody(setup, location!);
-    expect(body).toStartWith(doc);
-    expect(body.split('id="agentkit-share"')).toHaveLength(2);
+    const location = await ownerLocation(setup);
+    const embed = await worker.fetch(
+      new Request(`${PAGES_URL}/private-page?embed=1&access=${location.searchParams.get('access')}`),
+      setup.env,
+    );
+    expect(await embed.text()).toBe(doc);
+    const csp = embed.headers.get('content-security-policy')!;
+    expect(csp).toContain("frame-ancestors 'self'");
+    expect(csp).not.toContain('connect-src');
   });
 
-  test('an invited reader gets the page without the menu or connect-src', async () => {
+  test('an invited reader gets plain content: no shell, no manage param, sealed CSP', async () => {
     const setup = await accountEnv();
     expect((await worker.fetch(publish('device-a'), setup.env)).status).toBe(200);
-    const invite = await worker.fetch(
+    await worker.fetch(
       accountPost(`${ACCOUNT_URL}/api/pages/private-page/invites`, { email: 'other@example.com' }, 'session-a'),
       setup.env,
     );
-    expect([200, 303]).toContain(invite.status);
-    const { location } = await pageAccessUrl(setup, 'private-page', 'session-b');
-    const response = await worker.fetch(new Request(location!), setup.env);
+    const location = await ownerLocation(setup, 'session-b');
+    expect(location.searchParams.get('manage')).toBeNull();
+    const response = await worker.fetch(new Request(location.toString()), setup.env);
     expect(await response.text()).toBe('<h1>private</h1>');
     expect(response.headers.get('content-security-policy')).not.toContain('connect-src');
   });
 
-  test('a share-link reader gets the page without the menu', async () => {
+  test('share-link readers and legacy pages are served byte-identical plain content', async () => {
     const setup = await accountEnv();
     expect((await worker.fetch(publish('device-a'), setup.env)).status).toBe(200);
     const share = await worker.fetch(
@@ -1180,15 +1188,10 @@ describe('owner share menu on served pages', () => {
       }),
       setup.env,
     );
-    expect(share.status).toBe(200);
     const { url } = await share.json() as { url: string };
-    expect(await servedBody(setup, url)).toBe('<h1>private</h1>');
-  });
-
-  test('a legacy page with no metadata row is served unmodified', async () => {
-    const setup = await accountEnv();
+    expect(await (await worker.fetch(new Request(url), setup.env)).text()).toBe('<h1>private</h1>');
     setup.pages.writes.set('pages/legacy-page/index.html', { body: '<h1>legacy</h1>' });
-    expect(await servedBody(setup, `${PAGES_URL}/legacy-page`)).toBe('<h1>legacy</h1>');
+    expect(await (await worker.fetch(new Request(`${PAGES_URL}/legacy-page`), setup.env)).text()).toBe('<h1>legacy</h1>');
   });
 
   test('the dashboard card carries the anchor the menu links to', async () => {
@@ -1198,39 +1201,62 @@ describe('owner share menu on served pages', () => {
     expect(await dashboard.text()).toContain('id="page-private-page"');
   });
 
-  test('the owner access token can flip the share link from the pages origin', async () => {
+  test('the manage token drives enable-idempotent, rotate, and off', async () => {
     const setup = await accountEnv();
     expect((await worker.fetch(publish('device-a'), setup.env)).status).toBe(200);
-    const access = await ownerAccessToken(setup);
+    const manage = (await ownerLocation(setup)).searchParams.get('manage')!;
 
-    const on = await worker.fetch(ownerShare(access, true), setup.env);
+    const on = await worker.fetch(shareAction(manage, 'enable'), setup.env);
     expect(on.status).toBe(200);
-    const { enabled, url } = await on.json() as { enabled: boolean; url: string };
-    expect(enabled).toBe(true);
-    expect(await servedBody(setup, url)).toBe('<h1>private</h1>');
+    const first = await on.json() as { enabled: boolean; url: string; already: boolean };
+    expect(first.enabled).toBe(true);
+    expect(first.already).toBe(false);
+    expect(await (await worker.fetch(new Request(first.url), setup.env)).text()).toBe('<h1>private</h1>');
 
-    const off = await worker.fetch(ownerShare(access, false), setup.env);
-    expect(off.status).toBe(200);
-    expect((await worker.fetch(new Request(url), setup.env)).status).toBe(302);
+    // Enable again: idempotent - the circulating link survives.
+    const again = await worker.fetch(shareAction(manage, 'enable'), setup.env);
+    const second = await again.json() as { url: string | null; already: boolean };
+    expect(second.already).toBe(true);
+    expect(second.url).toBeNull();
+    expect((await worker.fetch(new Request(first.url), setup.env)).status).toBe(200);
+
+    // Rotate kills the old link and mints a working new one.
+    const rotated = await (await worker.fetch(shareAction(manage, 'rotate'), setup.env)).json() as { url: string };
+    expect((await worker.fetch(new Request(first.url), setup.env)).status).toBe(302);
+    expect((await worker.fetch(new Request(rotated.url), setup.env)).status).toBe(200);
+
+    const off = await worker.fetch(shareAction(manage, 'off'), setup.env);
+    expect((await off.json() as { enabled: boolean }).enabled).toBe(false);
+    expect((await worker.fetch(new Request(rotated.url), setup.env)).status).toBe(302);
   });
 
-  test('an invitee access token cannot manage sharing', async () => {
+  test('a read access token is never share authority', async () => {
     const setup = await accountEnv();
     expect((await worker.fetch(publish('device-a'), setup.env)).status).toBe(200);
-    await worker.fetch(
-      accountPost(`${ACCOUNT_URL}/api/pages/private-page/invites`, { email: 'other@example.com' }, 'session-a'),
-      setup.env,
-    );
-    const access = await ownerAccessToken(setup, 'session-b');
-    expect((await worker.fetch(ownerShare(access, true), setup.env)).status).toBe(401);
+    const access = (await ownerLocation(setup)).searchParams.get('access')!;
+    expect((await worker.fetch(shareAction(access, 'enable'), setup.env)).status).toBe(401);
   });
 
-  test('an expired or foreign-origin request cannot manage sharing', async () => {
+  test('a manage token is bound to its page: cross-slug use fails', async () => {
     const setup = await accountEnv();
     expect((await worker.fetch(publish('device-a'), setup.env)).status).toBe(200);
-    const access = await ownerAccessToken(setup);
-    expect((await worker.fetch(ownerShare(access, true, 'https://evil.example'), setup.env)).status).toBe(403);
-    setup.database.sqlite.run('UPDATE page_access_tokens SET expires_at = 0');
-    expect((await worker.fetch(ownerShare(access, true), setup.env)).status).toBe(401);
+    expect((await worker.fetch(publish('device-a', '<h1>b</h1>', 'second-page'), setup.env)).status).toBe(200);
+    const manage = (await ownerLocation(setup)).searchParams.get('manage')!;
+    expect((await worker.fetch(shareAction(manage, 'enable', PAGES_URL, 'second-page'), setup.env)).status).toBe(401);
+  });
+
+  test('expired manage, foreign origin, and malformed bodies are refused', async () => {
+    const setup = await accountEnv();
+    expect((await worker.fetch(publish('device-a'), setup.env)).status).toBe(200);
+    const manage = (await ownerLocation(setup)).searchParams.get('manage')!;
+    expect((await worker.fetch(shareAction(manage, 'enable', 'https://evil.example'), setup.env)).status).toBe(403);
+    const bad = new Request(`${PAGES_URL}/api/pages/private-page/share`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${manage}`, 'content-type': 'application/json', origin: PAGES_URL },
+      body: 'not json',
+    });
+    expect((await worker.fetch(bad, setup.env)).status).toBe(400);
+    setup.database.sqlite.run('UPDATE page_manage_tokens SET expires_at = 0');
+    expect((await worker.fetch(shareAction(manage, 'enable'), setup.env)).status).toBe(401);
   });
 });


### PR DESCRIPTION
Closes #400. **Rewritten after a DON'T-SHIP review of the first approach** — two gating findings: the rate-limiter FK made every share write throw under D1 (masked by the harness running SQLite with foreign keys off), and `connect-src 'self'` on an injected in-document menu handed page-authored script a self-publish primitive (CSP never restricted script navigation, so the isolation argument was wrong).

**Shipped design — the artifact model:** owners landing via /access now get a worker-authored **shell**: their page in an iframe sandboxed **without** `allow-same-origin` (parent-DOM reach throws SecurityError — verified in a real browser), and a right-edge SHARE tab opening an in-page menu: turn the share link on (idempotent — never silently rotates a circulating link), rotate (explicit), copy, turn off, invites → dashboard. The menu is driven by a second short-lived **manage capability** (migration 0005) carried only in the shell URL, which the sandboxed content can never read. Share-link readers, invitees, and legacy pages are served byte-identical plain content with the sealed CSP.

Endpoint: `POST /api/pages/:slug/share` on the pages origin — manage-token auth (page-bound), `sameOrigin`, body parsed before any charge (400 on bad JSON), rate-limited per user into FK-free `share_write_limits` (migration 0004). Harness now runs `PRAGMA foreign_keys = ON` to match D1.

**Verification:** 310/310 tests (sandbox attrs, per-viewer CSP, cross-slug token binding, read-token-vs-manage separation, idempotent enable/rotate/off round-trip against live share URLs, malformed-body 400) + full browser end-to-end against the real worker: enable → anonymous context reads the minted link (200); off → anonymous bounced to the access gate. Screenshots in review thread. Second adversarial review pass requested.