### PR TITLE
fix(pages): derivable share links, honest address bar, top-bar owner shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ release PR — "publish this" authorizes a release, never the tier.
 
 ## [Unreleased]
 
+- Pages: **share links are now derivable and the address bar is honest.** The
+  share token is HMAC(secret, slug:generation) instead of an unrecoverable
+  stored hash, so enabling is idempotent and always hands back the live link,
+  the shell menu and dashboard show it persistently, and rotation is an
+  explicit generation bump (links minted before the scheme keep working until
+  rotated). The owner shell becomes a slim top bar — the content frame starts
+  below it, so the chrome can no longer cover a page's own controls — and
+  rewrites the address bar to the durable share URL when sharing is on (clean
+  page URL when off), so copying what you see always yields a link that works
+  indefinitely, never the personal ten-minute access pass. Owners reopening
+  their own share link get upgraded back into the shell; strangers holding a
+  share link are never walled behind login; signed-in strangers on a private
+  page get an explanation instead of a bare 404 (#402, #403, #404).
+
 - Pages: owners now land on a trusted shell — their page in a sandboxed
   frame, plus a right-edge Share menu that turns the share link on
   (idempotently), rotates it, copies it, or turns it off in place. The menu

--- a/pages/worker/.gitignore
+++ b/pages/worker/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.dev.vars

--- a/pages/worker/README.md
+++ b/pages/worker/README.md
@@ -27,6 +27,7 @@ flowchart LR
 | `DB`                 | D1       | Users, sessions, devices, pages, and grants |
 | `SITE_TOKEN`         | Secret   | Marketing and documentation deployment only |
 | `OIDC_CLIENT_SECRET` | Secret   | Confidential Assay client                   |
+| `SHARE_LINK_KEY`     | Secret   | HMAC key share tokens are derived from      |
 | `ACCOUNT_MODE`       | Variable | `required` fails closed without D1          |
 | `ACCOUNT_URL`        | Variable | Trusted dashboard and account API origin    |
 | `PAGES_URL`          | Variable | Untrusted rendered-page origin              |
@@ -51,6 +52,13 @@ Worker that references a schema migration before the migration has succeeded.
 node node_modules/wrangler/bin/wrangler.js d1 migrations apply agentkit-pages --remote
 node node_modules/wrangler/bin/wrangler.js deploy
 ```
+
+Migration `0006` and the `SHARE_LINK_KEY` secret are hard prerequisites of the current Worker:
+every private-page read selects the share columns, and `required` account mode fails closed with
+`503 share key unconfigured` until the secret is set. Share tokens are
+`HMAC-SHA256(SHARE_LINK_KEY, share:<slug>:<generation>)`, so the key is load-bearing for every
+circulating share link — rotating it invalidates all of them at once; treat rotation as a planned
+migration, never routine hygiene.
 
 New pages are private. An R2 page without a D1 metadata row is treated as a legacy public page so
 the account rollout does not break existing URLs. Claiming legacy ownership is intentionally not

--- a/pages/worker/migrations/0006_share_generation.sql
+++ b/pages/worker/migrations/0006_share_generation.sql
@@ -1,0 +1,6 @@
+-- Derivable share links: the token becomes HMAC(SHARE_LINK_KEY, slug:generation),
+-- so the current link is recomputable on demand instead of unrecoverable after
+-- mint. `share_token_hash` stays for links minted before this scheme; rotating
+-- or disabling clears it.
+ALTER TABLE pages ADD COLUMN share_generation INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE pages ADD COLUMN share_enabled INTEGER NOT NULL DEFAULT 0;

--- a/pages/worker/src/accounts.js
+++ b/pages/worker/src/accounts.js
@@ -51,7 +51,7 @@ export async function consumeDeviceWrite(env, tokenHash, table = "device_write_l
   };
 }
 
-function cookie(request, name) {
+export function cookieValue(request, name) {
   const prefix = `${name}=`;
   for (const part of (request.headers.get("cookie") || "").split(";")) {
     const value = part.trim();
@@ -62,7 +62,7 @@ function cookie(request, name) {
 
 export async function sessionUser(request, env) {
   if (!env.DB) return null;
-  const token = cookie(request, "agentkit_session");
+  const token = cookieValue(request, "agentkit_session");
   if (!token) return null;
   return env.DB.prepare(
     `SELECT users.id, users.email, users.display_name
@@ -73,7 +73,7 @@ export async function sessionUser(request, env) {
 }
 
 export async function endSession(request, env) {
-  const token = cookie(request, "agentkit_session");
+  const token = cookieValue(request, "agentkit_session");
   if (token) {
     await env.DB.prepare("DELETE FROM sessions WHERE token_hash = ?").bind(await sha256(token)).run();
   }

--- a/pages/worker/src/dashboard.js
+++ b/pages/worker/src/dashboard.js
@@ -1,17 +1,27 @@
 import { deviceTokensForUser } from "./accounts.js";
 import { invitesForUserPages, pagesForUser } from "./pages-acl.js";
+import { shareState, shareUrl } from "./share-links.js";
 import { escapeHtml, MARK, shell } from "./ui.js";
 
 function day(seconds) {
   return new Date(seconds * 1000).toISOString().slice(0, 10);
 }
 
+// The link is derivable on demand, so it can sit here permanently instead of
+// the old one-shot "copy it now" reveal. Links from before the derivable
+// scheme cannot be re-displayed; the row says so instead of showing nothing.
 function shareRow(page) {
-  const on = Boolean(page.share_token_hash);
+  const on = shareState(page) !== "off";
   const slug = escapeHtml(page.slug);
+  const detail = page.share_link
+    ? `<a class="link-out mono" href="${escapeHtml(page.share_link)}">${escapeHtml(page.share_link)}</a>`
+    : (on
+      ? `<span class="how">made before links were shown here — turn it off and on for a visible one</span>`
+      : "");
   return `<div class="row">
     <span class="grant">${on ? "Anyone with the link" : "Link sharing is off"}
-      <span class="how">${on ? "no sign-in needed" : "only invited people can open it"}</span></span>
+      <span class="how">${on ? "no sign-in needed" : "only invited people can open it"}</span>
+      ${detail}</span>
     <form method="post" action="/api/pages/${slug}/share">
       <input type="hidden" name="enabled" value="${on ? "false" : "true"}">
       <button class="${on ? "quiet" : ""}">${on ? "Turn off" : "Create a link"}</button>
@@ -30,19 +40,11 @@ function inviteRow(slug, email) {
   </div>`;
 }
 
-function revealRow(url) {
-  return `<div class="row reveal">
-    <span class="grant"><strong>Your sharing link</strong>
-      <span class="how">shown once — copy it now</span>
-      <a class="link-out mono" href="${escapeHtml(url)}">${escapeHtml(url)}</a></span>
-  </div>`;
-}
-
-function pageCard(env, page, invites, flash) {
+function pageCard(env, page, invites) {
   const slug = escapeHtml(page.slug);
   const address = `${env.PAGES_URL}/${page.slug}`;
   const open = `/access?return_to=${encodeURIComponent(address)}`;
-  const shared = Boolean(page.share_token_hash);
+  const shared = shareState(page) !== "off";
   return `<article class="card" id="page-${slug}">
     <div class="card-head">
       <h2><a href="${open}">${escapeHtml(page.title || page.slug)}</a></h2>
@@ -52,7 +54,6 @@ function pageCard(env, page, invites, flash) {
     escapeHtml(address.replace(/^https:\/\//, ""))
   }</a> &middot; updated ${day(page.updated_at)}</p>
     <div class="ledger">
-      ${flash ? revealRow(flash.url) : ""}
       <div class="row">
         <span class="grant">You <span class="how">owner</span></span>
       </div>
@@ -92,12 +93,15 @@ function section(title, count, cards, blank) {
     ${cards || `<div class="blank">${blank}</div>`}`;
 }
 
-export async function dashboard(env, user, flash = null) {
-  const [pages, invites, devices] = await Promise.all([
+export async function dashboard(env, user) {
+  const [bare, invites, devices] = await Promise.all([
     pagesForUser(env, user.id),
     invitesForUserPages(env, user.id),
     deviceTokensForUser(env, user.id),
   ]);
+  const pages = await Promise.all(
+    bare.map(async (page) => ({ ...page, share_link: await shareUrl(env, page) })),
+  );
   const byPage = Map.groupBy(invites, (invite) => invite.page_slug);
   const body = `<header class="top">
       <span class="brand" style="color:var(--accent)">${MARK}<b style="color:var(--text)">agentkit pages</b></span>
@@ -109,9 +113,7 @@ export async function dashboard(env, user, flash = null) {
     section(
       "Pages",
       pages.length,
-      pages.map((page) =>
-        pageCard(env, page, byPage.get(page.slug) || [], flash?.slug === page.slug ? flash : null)
-      ).join(""),
+      pages.map((page) => pageCard(env, page, byPage.get(page.slug) || [])).join(""),
       `<p>Nothing published yet.</p><p class="note">Your agent publishes one for you.</p>
        <code>PUT /api/pages/&lt;slug&gt;</code>`,
     )

--- a/pages/worker/src/dashboard.js
+++ b/pages/worker/src/dashboard.js
@@ -10,8 +10,17 @@ function day(seconds) {
 // The link is derivable on demand, so it can sit here permanently instead of
 // the old one-shot "copy it now" reveal. Links from before the derivable
 // scheme cannot be re-displayed; the row says so instead of showing nothing.
-function shareRow(page) {
-  const on = shareState(page) !== "off";
+// A keyless deployment gets no toggle at all: offering "turn off" for a
+// config error would destroy working share state.
+function shareRow(env, page) {
+  const state = shareState(env, page);
+  if (state === "unavailable") {
+    return `<div class="row">
+    <span class="grant">Sharing unavailable
+      <span class="how">share links are not configured on this deployment — ask the operator to set the share key</span></span>
+  </div>`;
+  }
+  const on = state !== "off";
   const slug = escapeHtml(page.slug);
   const detail = page.share_link
     ? `<a class="link-out mono" href="${escapeHtml(page.share_link)}">${escapeHtml(page.share_link)}</a>`
@@ -44,7 +53,7 @@ function pageCard(env, page, invites) {
   const slug = escapeHtml(page.slug);
   const address = `${env.PAGES_URL}/${page.slug}`;
   const open = `/access?return_to=${encodeURIComponent(address)}`;
-  const shared = shareState(page) !== "off";
+  const shared = shareState(env, page) !== "off";
   return `<article class="card" id="page-${slug}">
     <div class="card-head">
       <h2><a href="${open}">${escapeHtml(page.title || page.slug)}</a></h2>
@@ -58,7 +67,7 @@ function pageCard(env, page, invites) {
         <span class="grant">You <span class="how">owner</span></span>
       </div>
       ${invites.map((invite) => inviteRow(page.slug, invite.email)).join("")}
-      ${shareRow(page)}
+      ${shareRow(env, page)}
     </div>
     <form class="invite" method="post" action="/api/pages/${slug}/invites">
       <input type="email" name="email" required placeholder="name@example.com"

--- a/pages/worker/src/pages-acl.js
+++ b/pages/worker/src/pages-acl.js
@@ -1,12 +1,14 @@
 import { randomToken, sessionUser, sha256 } from "./accounts.js";
+import { shareTokenValid } from "./share-links.js";
 
 const PAGE_ACCESS_TTL_SECONDS = 10 * 60;
 export async function pageRecord(env, slug) {
   if (!env.DB) return null;
   return env.DB.prepare(
-    "SELECT slug, owner_id, visibility, share_token_hash FROM pages WHERE slug = ?",
+    "SELECT slug, owner_id, title, visibility, share_token_hash, share_generation, share_enabled FROM pages WHERE slug = ?",
   ).bind(slug).first();
 }
+
 export async function claimPage(env, slug, userId, title) {
   const existing = await pageRecord(env, slug);
   if (existing && existing.owner_id !== userId) return "forbidden";
@@ -38,13 +40,19 @@ export async function deletePageRecord(env, slug, userId) {
 // other visitor, so nothing owner-only can leak onto their copy of the page.
 export async function pageReadGrant(request, env, page) {
   if (!page || page.visibility === "public") return { allowed: true, owner: false };
-  const share = new URL(request.url).searchParams.get("share");
-  if (share && page.share_token_hash === await sha256(share)) return { allowed: true, owner: false };
-  const access = new URL(request.url).searchParams.get("access");
-  if (!access) return { allowed: false, owner: false };
-  const grant = await ownerByAccess(env, page.slug, access);
-  if (!grant) return { allowed: false, owner: false };
-  return { allowed: true, owner: grant.user_id === page.owner_id };
+  const params = new URL(request.url).searchParams;
+  // An access grant carries more privilege than a share token (it can mark the
+  // visitor as owner), so when both ride the URL the access grant decides.
+  const access = params.get("access");
+  if (access) {
+    const grant = await ownerByAccess(env, page.slug, access);
+    if (grant) return { allowed: true, owner: grant.user_id === page.owner_id };
+  }
+  const share = params.get("share");
+  if (share && await shareTokenValid(env, page, share)) {
+    return { allowed: true, owner: false, viaShare: true };
+  }
+  return { allowed: false, owner: false };
 }
 export async function ownerByAccess(env, slug, token) {
   return env.DB.prepare(
@@ -101,27 +109,6 @@ export async function ownerPage(request, env, slug) {
   if (!user || !page || page.owner_id !== user.id) return null;
   return { user, page };
 }
-// mode: "off" clears; "mint" unconditionally rotates (dashboard and device
-// callers keep their historical semantics); "enable" is idempotent — it never
-// silently kills a link that is already circulating.
-export async function setShareLink(env, slug, mode) {
-  if (mode === "off") {
-    await env.DB.prepare("UPDATE pages SET share_token_hash = NULL WHERE slug = ?").bind(slug).run();
-    return { token: null, already: false };
-  }
-  const token = randomToken();
-  const hash = await sha256(token);
-  if (mode === "enable") {
-    const result = await env.DB.prepare(
-      "UPDATE pages SET share_token_hash = ? WHERE slug = ? AND share_token_hash IS NULL",
-    ).bind(hash, slug).run();
-    if (result.meta.changes === 0) return { token: null, already: true };
-    return { token, already: false };
-  }
-  await env.DB.prepare("UPDATE pages SET share_token_hash = ? WHERE slug = ?")
-    .bind(hash, slug).run();
-  return { token, already: false };
-}
 export async function inviteEmail(env, slug, email) {
   const normalized = email.trim().toLowerCase();
   if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalized)) return false;
@@ -142,7 +129,8 @@ export async function removeInvite(env, slug, email) {
 }
 export async function pagesForUser(env, userId) {
   return (await env.DB.prepare(
-    `SELECT slug, title, visibility, share_token_hash, created_at, updated_at
+    `SELECT slug, title, visibility, share_token_hash, share_generation, share_enabled,
+            created_at, updated_at
        FROM pages WHERE owner_id = ? ORDER BY updated_at DESC`,
   ).bind(userId).all()).results;
 }

--- a/pages/worker/src/share-links.js
+++ b/pages/worker/src/share-links.js
@@ -1,0 +1,81 @@
+import { sha256 } from "./accounts.js";
+
+const encoder = new TextEncoder();
+
+// The share token is derived, not stored: HMAC(SHARE_LINK_KEY, slug:generation),
+// so the server can re-display the current link at any time, "enable" never has
+// to rotate a circulating link just to have something to show, and a database
+// dump alone reveals no share capability. Rotation = bump the generation.
+async function deriveShareToken(env, slug, generation) {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(env.SHARE_LINK_KEY),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const mac = await crypto.subtle.sign("HMAC", key, encoder.encode(`share:${slug}:${generation}`));
+  return btoa(String.fromCharCode(...new Uint8Array(mac).slice(0, 24)))
+    .replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+export function shareCapable(env) {
+  return Boolean(env.SHARE_LINK_KEY);
+}
+
+// "legacy" = a link minted before the derivable scheme: still honored via its
+// stored hash, but not re-displayable. Rotating moves the page onto the scheme.
+export function shareState(page) {
+  if (!page) return "off";
+  if (page.share_enabled) return "on";
+  return page.share_token_hash ? "legacy" : "off";
+}
+
+// The current share URL, or null when sharing is off or legacy.
+export async function shareUrl(env, page) {
+  if (!page || !page.share_enabled || !shareCapable(env)) return null;
+  const token = await deriveShareToken(env, page.slug, page.share_generation);
+  return `${env.PAGES_URL}/${page.slug}?share=${token}`;
+}
+
+// Hash both sides before comparing so string comparison timing reveals nothing.
+export async function shareTokenValid(env, page, presented) {
+  if (!page || !presented) return false;
+  if (page.share_token_hash && page.share_token_hash === await sha256(presented)) return true;
+  if (!page.share_enabled || !shareCapable(env)) return false;
+  const expected = await deriveShareToken(env, page.slug, page.share_generation);
+  return (await sha256(presented)) === (await sha256(expected));
+}
+
+// mode: "off" disables; "rotate" bumps the generation (old link dies, legacy
+// hash cleared); "enable" is idempotent — already-on pages keep their link and
+// get it handed back, which is the whole point of derivable tokens.
+export async function setShareLink(env, slug, mode) {
+  if (mode === "off") {
+    await env.DB.prepare(
+      "UPDATE pages SET share_enabled = 0, share_token_hash = NULL WHERE slug = ?",
+    ).bind(slug).run();
+    return { enabled: false, url: null, already: false };
+  }
+  if (!shareCapable(env)) return { error: "share key unconfigured" };
+  if (mode === "enable") {
+    const turned = await env.DB.prepare(
+      `UPDATE pages SET share_generation = share_generation + 1, share_enabled = 1
+        WHERE slug = ? AND share_enabled = 0 AND share_token_hash IS NULL
+        RETURNING slug, share_generation, share_enabled`,
+    ).bind(slug).first();
+    if (turned) return { enabled: true, url: await shareUrl(env, turned), already: false };
+    const page = await env.DB.prepare(
+      "SELECT slug, share_token_hash, share_generation, share_enabled FROM pages WHERE slug = ?",
+    ).bind(slug).first();
+    if (!page) return { error: "not found" };
+    if (page.share_enabled) return { enabled: true, url: await shareUrl(env, page), already: true };
+    return { enabled: true, url: null, already: true, legacy: true };
+  }
+  const rotated = await env.DB.prepare(
+    `UPDATE pages SET share_generation = share_generation + 1, share_enabled = 1,
+        share_token_hash = NULL WHERE slug = ? RETURNING slug, share_generation, share_enabled`,
+  ).bind(slug).first();
+  if (!rotated) return { error: "not found" };
+  return { enabled: true, url: await shareUrl(env, rotated), already: false };
+}

--- a/pages/worker/src/share-links.js
+++ b/pages/worker/src/share-links.js
@@ -6,15 +6,29 @@ const encoder = new TextEncoder();
 // so the server can re-display the current link at any time, "enable" never has
 // to rotate a circulating link just to have something to show, and a database
 // dump alone reveals no share capability. Rotation = bump the generation.
+let cachedSecret = null;
+let cachedKey = null;
+
+async function hmacKey(env) {
+  if (cachedSecret !== env.SHARE_LINK_KEY) {
+    cachedSecret = env.SHARE_LINK_KEY;
+    cachedKey = await crypto.subtle.importKey(
+      "raw",
+      encoder.encode(env.SHARE_LINK_KEY),
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["sign"],
+    );
+  }
+  return cachedKey;
+}
+
 async function deriveShareToken(env, slug, generation) {
-  const key = await crypto.subtle.importKey(
-    "raw",
-    encoder.encode(env.SHARE_LINK_KEY),
-    { name: "HMAC", hash: "SHA-256" },
-    false,
-    ["sign"],
+  const mac = await crypto.subtle.sign(
+    "HMAC",
+    await hmacKey(env),
+    encoder.encode(`share:${slug}:${generation}`),
   );
-  const mac = await crypto.subtle.sign("HMAC", key, encoder.encode(`share:${slug}:${generation}`));
   return btoa(String.fromCharCode(...new Uint8Array(mac).slice(0, 24)))
     .replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 }
@@ -25,13 +39,16 @@ export function shareCapable(env) {
 
 // "legacy" = a link minted before the derivable scheme: still honored via its
 // stored hash, but not re-displayable. Rotating moves the page onto the scheme.
-export function shareState(page) {
+// "unavailable" = the page says shared but this deployment has no share key —
+// a config error, which must never be presented as a data condition the owner
+// could "fix" destructively.
+export function shareState(env, page) {
   if (!page) return "off";
-  if (page.share_enabled) return "on";
+  if (page.share_enabled) return shareCapable(env) ? "on" : "unavailable";
   return page.share_token_hash ? "legacy" : "off";
 }
 
-// The current share URL, or null when sharing is off or legacy.
+// The current share URL, or null when sharing is off, legacy, or keyless.
 export async function shareUrl(env, page) {
   if (!page || !page.share_enabled || !shareCapable(env)) return null;
   const token = await deriveShareToken(env, page.slug, page.share_generation);
@@ -49,7 +66,8 @@ export async function shareTokenValid(env, page, presented) {
 
 // mode: "off" disables; "rotate" bumps the generation (old link dies, legacy
 // hash cleared); "enable" is idempotent — already-on pages keep their link and
-// get it handed back, which is the whole point of derivable tokens.
+// get it handed back, which is the whole point of derivable tokens. Anything
+// else is refused: the destructive rotation must never be a fall-through.
 export async function setShareLink(env, slug, mode) {
   if (mode === "off") {
     await env.DB.prepare(
@@ -57,20 +75,29 @@ export async function setShareLink(env, slug, mode) {
     ).bind(slug).run();
     return { enabled: false, url: null, already: false };
   }
+  if (mode !== "enable" && mode !== "rotate") return { error: "invalid mode" };
   if (!shareCapable(env)) return { error: "share key unconfigured" };
   if (mode === "enable") {
-    const turned = await env.DB.prepare(
-      `UPDATE pages SET share_generation = share_generation + 1, share_enabled = 1
-        WHERE slug = ? AND share_enabled = 0 AND share_token_hash IS NULL
-        RETURNING slug, share_generation, share_enabled`,
+    const before = await env.DB.prepare(
+      "SELECT share_enabled FROM pages WHERE slug = ?",
     ).bind(slug).first();
-    if (turned) return { enabled: true, url: await shareUrl(env, turned), already: false };
-    const page = await env.DB.prepare(
-      "SELECT slug, share_token_hash, share_generation, share_enabled FROM pages WHERE slug = ?",
+    if (!before) return { error: "not found" };
+    // One statement decides the outcome, so a concurrent off/enable can never
+    // yield a state report that contradicts the row: a legacy hash freezes the
+    // row, anything else ends enabled, and the generation bumps only on a real
+    // off-to-on transition (re-enabling must not resurrect a revoked link).
+    const row = await env.DB.prepare(
+      `UPDATE pages SET
+          share_generation = CASE
+            WHEN share_enabled = 0 AND share_token_hash IS NULL
+            THEN share_generation + 1 ELSE share_generation END,
+          share_enabled = CASE WHEN share_token_hash IS NULL THEN 1 ELSE share_enabled END
+        WHERE slug = ?
+        RETURNING slug, share_token_hash, share_generation, share_enabled`,
     ).bind(slug).first();
-    if (!page) return { error: "not found" };
-    if (page.share_enabled) return { enabled: true, url: await shareUrl(env, page), already: true };
-    return { enabled: true, url: null, already: true, legacy: true };
+    if (!row) return { error: "not found" };
+    if (row.share_token_hash) return { enabled: true, url: null, already: true, legacy: true };
+    return { enabled: true, url: await shareUrl(env, row), already: Boolean(before.share_enabled) };
   }
   const rotated = await env.DB.prepare(
     `UPDATE pages SET share_generation = share_generation + 1, share_enabled = 1,

--- a/pages/worker/src/worker.js
+++ b/pages/worker/src/worker.js
@@ -636,7 +636,8 @@ const OWNER_HINT_COOKIE = "agentkit_owner";
 const OWNER_HINT_MAX_SLUGS = 24;
 
 function ownerHintSlugs(request) {
-  return (cookieValue(request, OWNER_HINT_COOKIE) || "").split("|").filter(Boolean);
+  return (cookieValue(request, OWNER_HINT_COOKIE) || "").split("|")
+    .filter((known) => SLUG_RE.test(known));
 }
 
 function ownerHintCookie(request, slug) {
@@ -740,7 +741,7 @@ html,body{margin:0;height:100%;background:#131417}
 </style></head><body>
 <div id="aks-bar">
 <span id="aks-title">${title}</span>
-<span id="aks-state" class="${state === "off" ? "" : "on"}">${labels[state]}</span>
+<span id="aks-state" class="${state === "on" || state === "legacy" ? "on" : ""}">${labels[state]}</span>
 <button class="aks-b" id="aks-share">Share</button>
 </div>
 <div id="aks-menu" hidden>
@@ -771,7 +772,7 @@ $("content").src="/${slug}?embed=1&access="+encodeURIComponent(q.get("access")||
 var LABELS={on:"Shared by link",legacy:"Shared by link",off:"Private",unavailable:"Sharing unavailable"};
 function render(){
 $("aks-state").textContent=LABELS[state];
-$("aks-state").className=state==="off"?"":"on";
+$("aks-state").className=(state==="on"||state==="legacy")?"on":"";
 $("aks-note").textContent=NOTES[state];
 $("aks-url").hidden=!link;if(link)$("aks-url").textContent=link;
 $("aks-copy").hidden=!link;

--- a/pages/worker/src/worker.js
+++ b/pages/worker/src/worker.js
@@ -1,5 +1,6 @@
 import {
   consumeDeviceWrite,
+  cookieValue,
   deviceCredential,
   endSession,
   revokeDeviceToken,
@@ -16,8 +17,8 @@ import {
   pageRecord,
   pageReadGrant,
   removeInvite,
-  setShareLink,
 } from "./pages-acl.js";
+import { setShareLink, shareState, shareUrl } from "./share-links.js";
 import { dashboard } from "./dashboard.js";
 import { approveDevice, devicePage, pollDevice, startDevice } from "./devices.js";
 import { completeLogin, startLogin } from "./oidc.js";
@@ -326,28 +327,6 @@ function sameOrigin(request) {
   return request.headers.get("origin") === new URL(request.url).origin;
 }
 
-const FLASH_COOKIE = "agentkit_share";
-
-function flashCookie(value, maxAge) {
-  return `${FLASH_COOKIE}=${encodeURIComponent(value)}; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=${maxAge}`;
-}
-
-// Reads the one-shot sharing link back out, so the dashboard can render it
-// once and the next request has nothing left to leak.
-function takeShareFlash(request, env) {
-  const raw = (request.headers.get("cookie") || "")
-    .split(";").map((part) => part.trim())
-    .find((part) => part.startsWith(`${FLASH_COOKIE}=`));
-  if (!raw) return null;
-  const value = decodeURIComponent(raw.slice(FLASH_COOKIE.length + 1));
-  const separator = value.indexOf("|");
-  if (separator < 1) return null;
-  const slug = value.slice(0, separator);
-  const token = value.slice(separator + 1);
-  if (!SLUG_RE.test(slug) || !token) return null;
-  return { slug, url: `${env.PAGES_URL}/${slug}?share=${token}` };
-}
-
 async function requestBody(request) {
   if (request.headers.get("content-type")?.startsWith("application/json")) return request.json();
   return Object.fromEntries(await request.formData());
@@ -370,6 +349,12 @@ async function shareByDevice(request, env, slug, bearer) {
   return rateLimitedShareChange(request, env, slug, credential.tokenHash);
 }
 
+function shareChangeResponse(result) {
+  if (result.error === "not found") return new Response("not found\n", { status: 404 });
+  if (result.error) return new Response(`share links unavailable: ${result.error}\n`, { status: 503 });
+  return Response.json({ ok: true, ...result });
+}
+
 async function rateLimitedShareChange(request, env, slug, limiterKey, limiterTable) {
   const rate = await consumeDeviceWrite(env, limiterKey, limiterTable);
   if (!rate.allowed) {
@@ -380,9 +365,7 @@ async function rateLimitedShareChange(request, env, slug, limiterKey, limiterTab
   }
   const body = await requestBody(request);
   const enabled = body.enabled === true || body.enabled === "true";
-  const { token } = await setShareLink(env, slug, enabled ? "mint" : "off");
-  const url = token ? `${env.PAGES_URL}/${slug}?share=${token}` : null;
-  return Response.json({ ok: true, enabled, url });
+  return shareChangeResponse(await setShareLink(env, slug, enabled ? "enable" : "off"));
 }
 
 async function handleShare(request, env, slug) {
@@ -392,17 +375,13 @@ async function handleShare(request, env, slug) {
   if (!(await ownerPage(request, env, slug))) return new Response("not found\n", { status: 404 });
   const body = await requestBody(request);
   const enabled = body.enabled === true || body.enabled === "true";
-  const { token } = await setShareLink(env, slug, enabled ? "mint" : "off");
-  if (!request.headers.get("content-type")?.startsWith("application/json")) {
-    // The link is handed back through a one-shot cookie rather than the URL:
-    // the dashboard can then show it in place, and the token stays out of the
-    // address bar, browser history and any referrer.
-    const headers = { location: "/dashboard" };
-    if (token) headers["set-cookie"] = flashCookie(`${slug}|${token}`, 120);
-    return new Response(null, { status: 303, headers });
+  const result = await setShareLink(env, slug, enabled ? "enable" : "off");
+  if (!result.error && !request.headers.get("content-type")?.startsWith("application/json")) {
+    // The dashboard shows the derived link persistently, so the form flow just
+    // returns to it — no one-shot reveal cookie needed any more.
+    return new Response(null, { status: 303, headers: { location: "/dashboard" } });
   }
-  const url = token ? `${env.PAGES_URL}/${slug}?share=${token}` : null;
-  return Response.json({ ok: true, enabled, url });
+  return shareChangeResponse(result);
 }
 
 async function handleInvite(request, env, slug) {
@@ -464,6 +443,10 @@ function configuredHost(value) {
   }
 }
 
+// A share token is the one query parameter allowed to round-trip through
+// /access: it lets an owner's browser upgrade a share-link visit to the shell,
+// and lets anyone else fall back to the plain shared page instead of a login
+// wall. Everything else in the query is still rejected.
 function requestedPageTarget(request, env) {
   const raw = new URL(request.url).searchParams.get("return_to");
   if (!raw) return null;
@@ -471,13 +454,28 @@ function requestedPageTarget(request, env) {
     const target = new URL(raw);
     const pagesOrigin = new URL(env.PAGES_URL).origin;
     const slug = target.pathname.replace(/^\/+|\/+$/g, "");
-    if (target.origin !== pagesOrigin || target.search || target.hash || !SLUG_RE.test(slug)) {
+    const extraneous = [...target.searchParams.keys()].some((key) => key !== "share");
+    if (target.origin !== pagesOrigin || extraneous || target.hash || !SLUG_RE.test(slug)) {
       return null;
     }
-    return { target, slug };
+    return { target, slug, share: target.searchParams.get("share") };
   } catch {
     return null;
   }
+}
+
+const PRIVATE_PAGE = `<!doctype html><meta charset="utf-8"><title>Private page</title>
+<body style="font-family:system-ui;display:grid;place-items:center;min-height:90vh">
+<div style="text-align:center;max-width:34rem;padding:0 1rem"><h1 style="letter-spacing:-0.02em">This page is private</h1>
+<p>Your account doesn't have access to it. If someone sent you this link, it was
+probably their personal, time-limited pass — those expire. Ask them for a share
+link instead (the Share menu on the page hands one out that works indefinitely).</p></div>`;
+
+// The plain=1 marker tells the pages host not to bounce this visit back here,
+// which would otherwise loop for a browser holding an owner cookie.
+function backToSharedPage(requested) {
+  requested.target.searchParams.set("plain", "1");
+  return new Response(null, { status: 302, headers: { location: requested.target.toString() } });
 }
 
 async function handlePageAccess(request, env) {
@@ -485,6 +483,7 @@ async function handlePageAccess(request, env) {
   if (!requested) return new Response("invalid page target\n", { status: 400 });
   const user = await sessionUser(request, env);
   if (!user) {
+    if (requested.share) return backToSharedPage(requested);
     const current = new URL(request.url);
     const returnTo = `${current.pathname}${current.search}`;
     return new Response(null, {
@@ -493,7 +492,11 @@ async function handlePageAccess(request, env) {
     });
   }
   const issued = await issuePageAccess(env, requested.slug, user);
-  if (!issued) return new Response("not found\n", { status: 404 });
+  if (!issued) {
+    if (requested.share) return backToSharedPage(requested);
+    return html(403, PRIVATE_PAGE);
+  }
+  requested.target.searchParams.delete("share");
   requested.target.searchParams.set("access", issued.access);
   if (issued.manage) requested.target.searchParams.set("manage", issued.manage);
   return new Response(null, { status: 302, headers: { location: requested.target.toString() } });
@@ -601,16 +604,29 @@ async function handleAccountRequest(request, env, path) {
         headers: { location: "/login?return_to=%2Fdashboard" },
       });
     }
-    const flash = takeShareFlash(request, env);
-    const headers = flash
-      ? { ...UI_HEADERS, "set-cookie": flashCookie("", 0) }
-      : UI_HEADERS;
-    return html(200, await dashboard(env, user, flash), headers);
+    return html(200, await dashboard(env, user), UI_HEADERS);
   }
   if (request.method !== "GET" && request.method !== "HEAD") {
     return new Response("method not allowed\n", { status: 405 });
   }
   return html(404, NOT_FOUND, UI_HEADERS);
+}
+
+// Set whenever this browser has held the owner shell for some page. It is a
+// hint, not a credential: it only decides whether a share-link visit is worth
+// bouncing through /access to see if a session can upgrade it to the shell.
+const OWNER_HINT_COOKIE = "agentkit_owner";
+
+function redirectToAccess(env, request, share) {
+  const target = new URL(request.url);
+  target.search = "";
+  if (share) target.searchParams.set("share", share);
+  return new Response(null, {
+    status: 302,
+    headers: {
+      location: `${env.ACCOUNT_URL}/access?return_to=${encodeURIComponent(target.toString())}`,
+    },
+  });
 }
 
 async function handlePagesRequest(request, env, path) {
@@ -621,23 +637,25 @@ async function handlePagesRequest(request, env, path) {
   if (!SLUG_RE.test(path)) return html(404, NOT_FOUND, PAGE_HEADERS);
   const page = await pageRecord(env, path);
   const grant = await pageReadGrant(request, env, page);
-  if (!grant.allowed) {
-    const target = new URL(request.url);
-    target.search = "";
-    return new Response(null, {
-      status: 302,
-      headers: {
-        location: `${env.ACCOUNT_URL}/access?return_to=${encodeURIComponent(target.toString())}`,
-      },
-    });
-  }
   const url = new URL(request.url);
+  if (!grant.allowed) return redirectToAccess(env, request, null);
   if (url.searchParams.get("embed") === "1") {
     return servePage(env, `pages/${path}/index.html`, EMBED_HEADERS);
   }
+  if (
+    grant.viaShare
+    && url.searchParams.get("plain") !== "1"
+    && cookieValue(request, OWNER_HINT_COOKIE)
+  ) {
+    return redirectToAccess(env, request, url.searchParams.get("share"));
+  }
   const manage = url.searchParams.get("manage");
   if (grant.owner && manage) {
-    return html(200, shellDocument(env, path, page), SHELL_HEADERS);
+    return html(200, await shellDocument(env, path, page), {
+      ...SHELL_HEADERS,
+      "set-cookie":
+        `${OWNER_HINT_COOKIE}=1; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=15552000`,
+    });
   }
   return servePage(env, `pages/${path}/index.html`, PAGE_HEADERS);
 }
@@ -656,64 +674,100 @@ const EMBED_HEADERS = {
     "default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src data:; font-src data:; frame-ancestors 'self'; form-action 'none'; base-uri 'none'",
 };
 
-function shellDocument(env, slug, page) {
+// The owner chrome is a bar with its own strip of the viewport — the content
+// iframe starts below it, so nothing here can ever cover a page's own controls
+// (the floating mid-edge tab this replaces could). The bar also keeps the
+// address bar honest: the durable share URL when sharing is on, the clean page
+// URL when it is off — never the personal, expiring access pass.
+async function shellDocument(env, slug, page) {
   const title = escapeHtmlText(page.title || slug);
   const dashboard = `${env.ACCOUNT_URL}/dashboard#page-${slug}`;
-  const shared = Boolean(page.share_token_hash);
+  const state = shareState(page);
+  const link = await shareUrl(env, page);
+  const labels = {
+    on: "Shared by link",
+    legacy: "Shared by link",
+    off: "Private",
+  };
   return `<!doctype html><html lang="en"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>${title}</title>
 <style>
 [hidden]{display:none!important}
-html,body{margin:0;height:100%}
-#content{position:fixed;inset:0;border:0;width:100%;height:100%}
-#aks{position:fixed;top:40%;right:0;z-index:10;font:13px/1.4 system-ui,sans-serif}
-#aks-tab{writing-mode:vertical-rl;padding:12px 7px;border-radius:8px 0 0 8px;background:#1b1d22;color:#eeeeee;border:1px solid #79a8e7;border-right:0;cursor:pointer;font:600 12px/1 system-ui,sans-serif;letter-spacing:.08em}
-#aks-menu{position:absolute;right:34px;top:0;width:250px;background:#1b1d22;color:#eeeeee;border:1px solid #2a2d34;border-radius:10px;padding:12px 14px;box-shadow:0 6px 24px rgba(0,0,0,.45)}
-#aks-state{font-weight:600;margin-bottom:8px}
+html,body{margin:0;height:100%;background:#131417}
+#content{position:fixed;top:42px;left:0;right:0;bottom:0;border:0;width:100%;height:calc(100% - 42px)}
+#aks-bar{position:fixed;top:0;left:0;right:0;height:42px;z-index:10;display:flex;align-items:center;gap:10px;padding:0 12px;box-sizing:border-box;background:#1b1d22;color:#eee;border-bottom:1px solid #2a2d34;font:13px/1.4 system-ui,sans-serif}
+#aks-title{font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;min-width:0}
+#aks-state{flex:none;font:600 11px/1 system-ui,sans-serif;letter-spacing:.04em;padding:5px 9px;border-radius:99px;border:1px solid #3a3f47;color:#a9b2bf}
+#aks-state.on{border-color:#79a8e7;color:#a8c8f0}
+#aks-share{flex:none;margin-left:auto}
+#aks-menu{position:fixed;top:48px;right:8px;z-index:11;width:280px;background:#1b1d22;color:#eee;border:1px solid #2a2d34;border-radius:10px;padding:12px 14px;box-shadow:0 6px 24px rgba(0,0,0,.45);font:13px/1.4 system-ui,sans-serif}
+#aks-note{color:#a9b2bf;margin-bottom:8px}
 #aks-url{font:11px/1.4 ui-monospace,monospace;word-break:break-all;background:#131417;border:1px solid #2a2d34;border-radius:6px;padding:6px;margin-bottom:8px}
 #aks-err{color:#e06c75;margin-top:8px}
-.aks-b{font:600 12px/1 system-ui,sans-serif;padding:8px 10px;border-radius:7px;border:1px solid #3a3f47;background:#23262d;color:#eeeeee;cursor:pointer;display:block;width:100%;text-align:center;text-decoration:none;box-sizing:border-box}
+.aks-b{font:600 12px/1 system-ui,sans-serif;padding:8px 10px;border-radius:7px;border:1px solid #3a3f47;background:#23262d;color:#eee;cursor:pointer;display:block;width:100%;text-align:center;text-decoration:none;box-sizing:border-box}
 .aks-b:hover{border-color:#79a8e7}
-#aks-menu>div.btns{display:flex;flex-direction:column;gap:6px}
+#aks-bar .aks-b{width:auto;padding:6px 12px}
+#aks-menu .btns{display:flex;flex-direction:column;gap:6px}
 </style></head><body>
-<iframe id="content" title="${title}" sandbox="allow-scripts allow-forms allow-popups allow-modals allow-downloads"></iframe>
-<div id="aks">
-<button id="aks-tab" title="Share settings">SHARE</button>
+<div id="aks-bar">
+<span id="aks-title">${title}</span>
+<span id="aks-state" class="${state === "off" ? "" : "on"}">${labels[state]}</span>
+<button class="aks-b" id="aks-share">Share</button>
+</div>
 <div id="aks-menu" hidden>
-<div id="aks-state">${shared ? "Shared by link" : "Private"}</div>
+<div id="aks-note"></div>
 <div id="aks-url" hidden></div>
 <div class="btns">
-<button class="aks-b" id="aks-on" ${shared ? "hidden" : ""}>Turn share link on</button>
+<button class="aks-b" id="aks-on" hidden>Turn share link on</button>
 <button class="aks-b" id="aks-copy" hidden>Copy link</button>
-<button class="aks-b" id="aks-rotate" ${shared ? "" : "hidden"}>Rotate link (old one dies)</button>
-<button class="aks-b" id="aks-off" ${shared ? "" : "hidden"}>Turn share link off</button>
+<button class="aks-b" id="aks-rotate" hidden>Rotate link (old one dies)</button>
+<button class="aks-b" id="aks-off" hidden>Turn share link off</button>
 <a class="aks-b" href="${dashboard}" target="_blank" rel="noopener">Invites &amp; settings</a>
 </div>
 <div id="aks-err" hidden></div>
-</div></div>
+</div>
+<iframe id="content" title="${title}" sandbox="allow-scripts allow-forms allow-popups allow-modals allow-downloads"></iframe>
 <script>(function(){
 var $=function(id){return document.getElementById(id)};
 var q=new URLSearchParams(location.search);
 var manage=q.get("manage");
-var url=null;
+var state=${JSON.stringify(state)};
+var link=${JSON.stringify(link)};
+var NOTES={
+on:"Anyone with this link can view the page, until you turn it off.",
+legacy:"Shared by a link made before links were recoverable, so it cannot be shown here. Rotate to get a visible link (the old one dies), or turn sharing off.",
+off:"Private. Only you and invited people can open it."};
 $("content").src="/${slug}?embed=1&access="+encodeURIComponent(q.get("access")||"")+location.hash;
-$("aks-tab").addEventListener("click",function(){$("aks-menu").hidden=!$("aks-menu").hidden});
+function render(){
+$("aks-state").textContent=state==="off"?"Private":"Shared by link";
+$("aks-state").className=state==="off"?"":"on";
+$("aks-note").textContent=NOTES[state];
+$("aks-url").hidden=!link;if(link)$("aks-url").textContent=link;
+$("aks-copy").hidden=!link;
+$("aks-on").hidden=state!=="off";
+$("aks-rotate").hidden=state==="off";
+$("aks-off").hidden=state==="off";
+history.replaceState(null,"",(state==="on"&&link?link:"/${slug}")+location.hash);
+}
+render();
+$("aks-share").addEventListener("click",function(){$("aks-menu").hidden=!$("aks-menu").hidden});
 function fail(m){$("aks-err").textContent=m;$("aks-err").hidden=false}
-function state(on){$("aks-state").textContent=on?"Shared by link":"Private";$("aks-on").hidden=on;$("aks-rotate").hidden=!on;$("aks-off").hidden=!on;if(!on){url=null;$("aks-url").hidden=true;$("aks-copy").hidden=true}}
 function act(action){$("aks-err").hidden=true;
 fetch("/api/pages/${slug}/share",{method:"POST",headers:{"authorization":"Bearer "+manage,"content-type":"application/json"},body:JSON.stringify({action:action})})
 .then(function(r){if(r.status===401)throw new Error("Session pass expired - reload the page");if(!r.ok)throw new Error("Share update failed ("+r.status+")");return r.json()})
-.then(function(d){state(d.enabled);if(d.url){url=d.url;$("aks-url").textContent=d.url;$("aks-url").hidden=false;$("aks-copy").hidden=false}
-if(d.already)fail("Already shared - the existing link still works. Use Rotate to replace it.")})
+.then(function(d){
+state=d.enabled?(d.url?"on":"legacy"):"off";
+link=d.url||null;
+render()})
 .catch(function(e){fail(e.message)})}
 $("aks-on").addEventListener("click",function(){act("enable")});
 $("aks-rotate").addEventListener("click",function(){act("rotate")});
 $("aks-off").addEventListener("click",function(){act("off")});
 $("aks-copy").addEventListener("click",function(){
-if(!url)return;
+if(!link)return;
 if(!navigator.clipboard){fail("Clipboard unavailable - copy the link text above by hand");return}
-navigator.clipboard.writeText(url).then(function(){
+navigator.clipboard.writeText(link).then(function(){
 $("aks-copy").textContent="Copied";
 setTimeout(function(){$("aks-copy").textContent="Copy link"},1500);
 }).catch(function(){fail("Copy failed - select the link text above")})});
@@ -725,7 +779,7 @@ function escapeHtmlText(value) {
     .replace(/"/g, "&quot;");
 }
 
-const SHARE_ACTIONS = { enable: "enable", rotate: "mint", off: "off" };
+const SHARE_ACTIONS = { enable: "enable", rotate: "rotate", off: "off" };
 
 async function handleOwnerShare(request, env, slug) {
   if (!sameOrigin(request)) return new Response("forbidden\n", { status: 403 });
@@ -751,10 +805,7 @@ async function handleOwnerShare(request, env, slug) {
       headers: { "retry-after": String(rate.retryAfter) },
     });
   }
-  const { token, already } = await setShareLink(env, slug, mode);
-  const enabled = mode !== "off";
-  const url = token ? `${env.PAGES_URL}/${slug}?share=${token}` : null;
-  return Response.json({ ok: true, enabled, url, already });
+  return shareChangeResponse(await setShareLink(env, slug, mode));
 }
 
 export default {

--- a/pages/worker/src/worker.js
+++ b/pages/worker/src/worker.js
@@ -22,7 +22,7 @@ import { setShareLink, shareState, shareUrl } from "./share-links.js";
 import { dashboard } from "./dashboard.js";
 import { approveDevice, devicePage, pollDevice, startDevice } from "./devices.js";
 import { completeLogin, startLogin } from "./oidc.js";
-import { UI_HEADERS } from "./ui.js";
+import { escapeHtml, UI_HEADERS } from "./ui.js";
 
 const SLUG_RE = /^[a-z0-9][a-z0-9-]{0,63}(\/[a-z0-9][a-z0-9-]{0,63}){0,3}$/;
 const MAX_PAGE_BYTES = 5 * 1024 * 1024;
@@ -97,7 +97,13 @@ const BASE_HEADERS = {
 };
 // Private and legacy page responses both stay out of crawler indexes. Access
 // control happens before this response is built, not through an unguessable URL.
-const PAGE_HEADERS = { ...BASE_HEADERS, "x-robots-tag": "noindex, nofollow" };
+// no-store matters now that share URLs are stable: a cached copy in any
+// URL-keyed intermediary would outlive "turn share link off".
+const PAGE_HEADERS = {
+  ...BASE_HEADERS,
+  "x-robots-tag": "noindex, nofollow",
+  "cache-control": "private, no-store",
+};
 
 // Pagefind fetches index shards, spawns a worker and compiles WebAssembly from
 // bytes, so search cannot run under the marketing pages' `default-src 'none'`.
@@ -455,10 +461,14 @@ function requestedPageTarget(request, env) {
     const pagesOrigin = new URL(env.PAGES_URL).origin;
     const slug = target.pathname.replace(/^\/+|\/+$/g, "");
     const extraneous = [...target.searchParams.keys()].some((key) => key !== "share");
-    if (target.origin !== pagesOrigin || extraneous || target.hash || !SLUG_RE.test(slug)) {
+    const share = target.searchParams.get("share");
+    if (
+      target.origin !== pagesOrigin || extraneous || target.hash || !SLUG_RE.test(slug)
+      || (share !== null && !/^[A-Za-z0-9_-]{1,64}$/.test(share))
+    ) {
       return null;
     }
-    return { target, slug, share: target.searchParams.get("share") };
+    return { target, slug, share };
   } catch {
     return null;
   }
@@ -481,6 +491,12 @@ function backToSharedPage(requested) {
 async function handlePageAccess(request, env) {
   const requested = requestedPageTarget(request, env);
   if (!requested) return new Response("invalid page target\n", { status: 400 });
+  // A page with no record predates accounts and is world-readable — telling a
+  // visitor it is private would be false. Send them straight to it.
+  if (!(await pageRecord(env, requested.slug))) {
+    requested.target.search = "";
+    return new Response(null, { status: 302, headers: { location: requested.target.toString() } });
+  }
   const user = await sessionUser(request, env);
   if (!user) {
     if (requested.share) return backToSharedPage(requested);
@@ -612,10 +628,22 @@ async function handleAccountRequest(request, env, path) {
   return html(404, NOT_FOUND, UI_HEADERS);
 }
 
-// Set whenever this browser has held the owner shell for some page. It is a
-// hint, not a credential: it only decides whether a share-link visit is worth
-// bouncing through /access to see if a session can upgrade it to the shell.
+// Slugs whose owner shell this browser has held — a hint deciding whether a
+// share-link visit is worth bouncing through /access, never a credential.
+// Per-slug so someone else's share link never detours through the account
+// origin, which would put their token in its logs for nothing.
 const OWNER_HINT_COOKIE = "agentkit_owner";
+const OWNER_HINT_MAX_SLUGS = 24;
+
+function ownerHintSlugs(request) {
+  return (cookieValue(request, OWNER_HINT_COOKIE) || "").split("|").filter(Boolean);
+}
+
+function ownerHintCookie(request, slug) {
+  const slugs = [slug, ...ownerHintSlugs(request).filter((known) => known !== slug)]
+    .slice(0, OWNER_HINT_MAX_SLUGS);
+  return `${OWNER_HINT_COOKIE}=${slugs.join("|")}; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=15552000`;
+}
 
 function redirectToAccess(env, request, share) {
   const target = new URL(request.url);
@@ -645,7 +673,7 @@ async function handlePagesRequest(request, env, path) {
   if (
     grant.viaShare
     && url.searchParams.get("plain") !== "1"
-    && cookieValue(request, OWNER_HINT_COOKIE)
+    && ownerHintSlugs(request).includes(path)
   ) {
     return redirectToAccess(env, request, url.searchParams.get("share"));
   }
@@ -653,8 +681,7 @@ async function handlePagesRequest(request, env, path) {
   if (grant.owner && manage) {
     return html(200, await shellDocument(env, path, page), {
       ...SHELL_HEADERS,
-      "set-cookie":
-        `${OWNER_HINT_COOKIE}=1; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=15552000`,
+      "set-cookie": ownerHintCookie(request, path),
     });
   }
   return servePage(env, `pages/${path}/index.html`, PAGE_HEADERS);
@@ -680,14 +707,15 @@ const EMBED_HEADERS = {
 // address bar honest: the durable share URL when sharing is on, the clean page
 // URL when it is off — never the personal, expiring access pass.
 async function shellDocument(env, slug, page) {
-  const title = escapeHtmlText(page.title || slug);
+  const title = escapeHtml(page.title || slug);
   const dashboard = `${env.ACCOUNT_URL}/dashboard#page-${slug}`;
-  const state = shareState(page);
+  const state = shareState(env, page);
   const link = await shareUrl(env, page);
   const labels = {
     on: "Shared by link",
     legacy: "Shared by link",
     off: "Private",
+    unavailable: "Sharing unavailable",
   };
   return `<!doctype html><html lang="en"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -737,20 +765,21 @@ var link=${JSON.stringify(link)};
 var NOTES={
 on:"Anyone with this link can view the page, until you turn it off.",
 legacy:"Shared by a link made before links were recoverable, so it cannot be shown here. Rotate to get a visible link (the old one dies), or turn sharing off.",
-off:"Private. Only you and invited people can open it."};
+off:"Private. Only you and invited people can open it.",
+unavailable:"Share links are not configured on this deployment. Ask the operator to set the share key; nothing here is safe to toggle until then."};
 $("content").src="/${slug}?embed=1&access="+encodeURIComponent(q.get("access")||"")+location.hash;
+var LABELS={on:"Shared by link",legacy:"Shared by link",off:"Private",unavailable:"Sharing unavailable"};
 function render(){
-$("aks-state").textContent=state==="off"?"Private":"Shared by link";
+$("aks-state").textContent=LABELS[state];
 $("aks-state").className=state==="off"?"":"on";
 $("aks-note").textContent=NOTES[state];
 $("aks-url").hidden=!link;if(link)$("aks-url").textContent=link;
 $("aks-copy").hidden=!link;
 $("aks-on").hidden=state!=="off";
-$("aks-rotate").hidden=state==="off";
-$("aks-off").hidden=state==="off";
-history.replaceState(null,"",(state==="on"&&link?link:"/${slug}")+location.hash);
+$("aks-rotate").hidden=state==="off"||state==="unavailable";
+$("aks-off").hidden=state==="off"||state==="unavailable";
+try{history.replaceState(null,"",(state==="on"&&link?link:"/${slug}")+location.hash)}catch(e){}
 }
-render();
 $("aks-share").addEventListener("click",function(){$("aks-menu").hidden=!$("aks-menu").hidden});
 function fail(m){$("aks-err").textContent=m;$("aks-err").hidden=false}
 function act(action){$("aks-err").hidden=true;
@@ -764,6 +793,7 @@ render()})
 $("aks-on").addEventListener("click",function(){act("enable")});
 $("aks-rotate").addEventListener("click",function(){act("rotate")});
 $("aks-off").addEventListener("click",function(){act("off")});
+render();
 $("aks-copy").addEventListener("click",function(){
 if(!link)return;
 if(!navigator.clipboard){fail("Clipboard unavailable - copy the link text above by hand");return}
@@ -772,11 +802,6 @@ $("aks-copy").textContent="Copied";
 setTimeout(function(){$("aks-copy").textContent="Copy link"},1500);
 }).catch(function(){fail("Copy failed - select the link text above")})});
 })()</script></body></html>`;
-}
-
-function escapeHtmlText(value) {
-  return String(value).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
 }
 
 const SHARE_ACTIONS = { enable: "enable", rotate: "rotate", off: "off" };
@@ -823,13 +848,15 @@ export default {
     const accountRequest = accountHost !== null && host === accountHost;
     const pagesRequest = pagesHost !== null && host === pagesHost;
 
-    if (
-      !siteRequest
-      && !docsRequest
-      && env.ACCOUNT_MODE === "required"
-      && (!env.DB || accountHost === null)
-    ) {
-      return new Response("account storage unavailable\n", { status: 503 });
+    if (!siteRequest && !docsRequest && env.ACCOUNT_MODE === "required") {
+      if (!env.DB || accountHost === null) {
+        return new Response("account storage unavailable\n", { status: 503 });
+      }
+      // Without the key every derived share link silently 302s to a login
+      // wall while everything else looks healthy; a 503 at deploy is cheaper.
+      if (!env.SHARE_LINK_KEY) {
+        return new Response("share key unconfigured\n", { status: 503 });
+      }
     }
 
     if (docsRequest) return handleSiteRequest(request, env, path === "" ? "docs" : `docs/${path}`, true);

--- a/plugins-cc/agentkit/skills/publish-page/publish.ts
+++ b/plugins-cc/agentkit/skills/publish-page/publish.ts
@@ -156,7 +156,12 @@ async function flipShare(enabled: boolean): Promise<string | null> {
 
 if (shareOnly) {
   const shareUrl = await flipShare(isShare);
-  console.log(isShare ? shareUrl : `share link revoked for ${slug}`);
+  console.log(
+    isShare
+      ? shareUrl
+        ?? `share link already on for ${slug}, but it predates recoverable links — use the Share menu on the page to rotate it into a visible one`
+      : `share link revoked for ${slug}`,
+  );
   process.exit();
 }
 

--- a/scripts/check-test-slices.ts
+++ b/scripts/check-test-slices.ts
@@ -74,6 +74,7 @@ export const TEST_SLICES = {
     'tests/publish-page/migrations.test.ts',
     'tests/publish-page/pages-police.test.ts',
     'tests/publish-page/publish-freshness.test.ts',
+    'tests/publish-page/share-links.test.ts',
     'tests/publish-page/theme-chrome.test.ts',
     'tests/publish-page/worker.test.ts',
   ],

--- a/skills/publish-page/publish.ts
+++ b/skills/publish-page/publish.ts
@@ -156,7 +156,12 @@ async function flipShare(enabled: boolean): Promise<string | null> {
 
 if (shareOnly) {
   const shareUrl = await flipShare(isShare);
-  console.log(isShare ? shareUrl : `share link revoked for ${slug}`);
+  console.log(
+    isShare
+      ? shareUrl
+        ?? `share link already on for ${slug}, but it predates recoverable links — use the Share menu on the page to rotate it into a visible one`
+      : `share link revoked for ${slug}`,
+  );
   process.exit();
 }
 

--- a/tests/publish-page/account-harness.ts
+++ b/tests/publish-page/account-harness.ts
@@ -1,0 +1,168 @@
+import { Database } from 'bun:sqlite';
+import { readdirSync, readFileSync } from 'node:fs';
+import worker from '../../pages/worker/src/worker.js';
+
+export const openDatabases: Database[] = [];
+export const ACCOUNT_URL = 'https://account.agentkit.sbs';
+export const PAGES_URL = 'https://pages.agentkit.sbs';
+
+export function d1() {
+  const sqlite = new Database(':memory:');
+  // D1 enforces foreign keys on every query; bun:sqlite defaults them off.
+  sqlite.run('PRAGMA foreign_keys = ON');
+  openDatabases.push(sqlite);
+  const migrationsUrl = new URL('../../pages/worker/migrations/', import.meta.url);
+  for (const migration of readdirSync(migrationsUrl).filter((name) => name.endsWith('.sql')).sort()) {
+    sqlite.run(readFileSync(new URL(migration, migrationsUrl), 'utf8'));
+  }
+  return {
+    sqlite,
+    binding: {
+      prepare(sql: string) {
+        let values: unknown[] = [];
+        const statement = {
+          bind(...next: unknown[]) {
+            values = next;
+            return statement;
+          },
+          async first() {
+            return sqlite.query(sql).get(...values);
+          },
+          async all() {
+            return { results: sqlite.query(sql).all(...values) };
+          },
+          async run() {
+            const result = sqlite.query(sql).run(...values);
+            return { success: true, meta: { changes: result.changes } };
+          },
+        };
+        return statement;
+      },
+    },
+  };
+}
+
+export function bucket() {
+  const writes = new Map<string, { body: string }>();
+  return {
+    writes,
+    async get(key: string) {
+      return writes.get(key) ?? null;
+    },
+    async put(key: string, body: ArrayBuffer) {
+      writes.set(key, { body: new TextDecoder().decode(body) });
+    },
+    async head(key: string) {
+      return writes.has(key) ? {} : null;
+    },
+    async delete(key: string) {
+      writes.delete(key);
+    },
+    async list() {
+      return { objects: [], truncated: false };
+    },
+  };
+}
+
+export async function digest(value: string) {
+  const bytes = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value));
+  return [...new Uint8Array(bytes)].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+export async function pkce(value: string) {
+  const bytes = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value));
+  return Buffer.from(bytes).toString('base64url');
+}
+
+export async function accountEnv() {
+  const database = d1();
+  const pages = bucket();
+  const now = Math.floor(Date.now() / 1000);
+  database.sqlite.run(
+    'INSERT INTO users (id, email, display_name, created_at) VALUES (?, ?, ?, ?)',
+    ['user-a', 'owner@example.com', 'Owner', now],
+  );
+  database.sqlite.run(
+    'INSERT INTO users (id, email, display_name, created_at) VALUES (?, ?, ?, ?)',
+    ['user-b', 'other@example.com', 'Other', now],
+  );
+  database.sqlite.run(
+    `INSERT INTO device_tokens (token_hash, user_id, name, scopes, expires_at, created_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    [await digest('device-a'), 'user-a', 'MacBook', 'pages:write pages:delete pages:share', now + 3600, now],
+  );
+  database.sqlite.run(
+    `INSERT INTO device_tokens (token_hash, user_id, name, scopes, expires_at, created_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    [await digest('device-a-legacy'), 'user-a', 'Old MacBook', 'pages:write pages:delete', now + 3600, now],
+  );
+  database.sqlite.run(
+    `INSERT INTO device_tokens (token_hash, user_id, name, scopes, expires_at, created_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    [await digest('device-b'), 'user-b', 'Other Mac', 'pages:write pages:delete', now + 3600, now],
+  );
+  database.sqlite.run(
+    'INSERT INTO sessions (token_hash, user_id, expires_at, created_at) VALUES (?, ?, ?, ?)',
+    [await digest('session-a'), 'user-a', now + 3600, now],
+  );
+  database.sqlite.run(
+    'INSERT INTO sessions (token_hash, user_id, expires_at, created_at) VALUES (?, ?, ?, ?)',
+    [await digest('session-b'), 'user-b', now + 3600, now],
+  );
+  // Loosely typed on purpose: tests override optional Worker vars (rate
+  // limits, quotas, OIDC fetch stubs) that the base literal never carries.
+  const env: Record<string, unknown> = {
+      DB: database.binding,
+      PAGES: pages,
+      SITE_TOKEN: 'site-secret',
+      PUBLISH_TOKEN: 'legacy-shared-secret',
+      ACCOUNT_MODE: 'required',
+      ACCOUNT_URL,
+      PAGES_URL,
+      OIDC_ISSUER: 'https://auth.assay.rs/auth',
+      OIDC_CLIENT_ID: 'agentkit-pages',
+      OIDC_CLIENT_SECRET: 'oidc-secret',
+      SESSION_SECRET: 'session-secret',
+      SHARE_LINK_KEY: 'test-share-key',
+  };
+  return { database, pages, env };
+}
+
+export function signedIn(url: string, session = 'session-a') {
+  return new Request(url, { headers: { cookie: `agentkit_session=${session}` } });
+}
+
+export function accountPost(url: string, body: unknown, session = 'session-a') {
+  return new Request(url, {
+    method: 'POST',
+    headers: {
+      cookie: `agentkit_session=${session}`,
+      'content-type': 'application/json',
+      origin: ACCOUNT_URL,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+export function publish(token: string, body = '<h1>private</h1>', slug = 'private-page', title?: string) {
+  return new Request(`${ACCOUNT_URL}/api/pages/${slug}`, {
+    method: 'PUT',
+    headers: {
+      authorization: `Bearer ${token}`,
+      ...(title ? { 'x-page-title': encodeURIComponent(title) } : {}),
+    },
+    body,
+  });
+}
+
+export async function pageAccessUrl(
+  setup: Awaited<ReturnType<typeof accountEnv>>,
+  slug = 'private-page',
+  session = 'session-a',
+) {
+  const response = await worker.fetch(
+    signedIn(`${ACCOUNT_URL}/access?return_to=${encodeURIComponent(`${PAGES_URL}/${slug}`)}`, session),
+    setup.env,
+  );
+  return { response, location: response.headers.get('location') };
+}

--- a/tests/publish-page/accounts.test.ts
+++ b/tests/publish-page/accounts.test.ts
@@ -1,173 +1,19 @@
-import { Database } from 'bun:sqlite';
 import { afterEach, describe, expect, test } from 'bun:test';
-import { readdirSync, readFileSync } from 'node:fs';
 import { consumeDeviceWrite } from '../../pages/worker/src/accounts.js';
 import worker from '../../pages/worker/src/worker.js';
-
-const openDatabases: Database[] = [];
-const ACCOUNT_URL = 'https://account.agentkit.sbs';
-const PAGES_URL = 'https://pages.agentkit.sbs';
-
-function d1() {
-  const sqlite = new Database(':memory:');
-  // D1 enforces foreign keys on every query; bun:sqlite defaults them off.
-  sqlite.run('PRAGMA foreign_keys = ON');
-  openDatabases.push(sqlite);
-  const migrationsUrl = new URL('../../pages/worker/migrations/', import.meta.url);
-  for (const migration of readdirSync(migrationsUrl).filter((name) => name.endsWith('.sql')).sort()) {
-    sqlite.run(readFileSync(new URL(migration, migrationsUrl), 'utf8'));
-  }
-  return {
-    sqlite,
-    binding: {
-      prepare(sql: string) {
-        let values: unknown[] = [];
-        const statement = {
-          bind(...next: unknown[]) {
-            values = next;
-            return statement;
-          },
-          async first() {
-            return sqlite.query(sql).get(...values);
-          },
-          async all() {
-            return { results: sqlite.query(sql).all(...values) };
-          },
-          async run() {
-            const result = sqlite.query(sql).run(...values);
-            return { success: true, meta: { changes: result.changes } };
-          },
-        };
-        return statement;
-      },
-    },
-  };
-}
-
-function bucket() {
-  const writes = new Map<string, { body: string }>();
-  return {
-    writes,
-    async get(key: string) {
-      return writes.get(key) ?? null;
-    },
-    async put(key: string, body: ArrayBuffer) {
-      writes.set(key, { body: new TextDecoder().decode(body) });
-    },
-    async head(key: string) {
-      return writes.has(key) ? {} : null;
-    },
-    async delete(key: string) {
-      writes.delete(key);
-    },
-    async list() {
-      return { objects: [], truncated: false };
-    },
-  };
-}
-
-async function digest(value: string) {
-  const bytes = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value));
-  return [...new Uint8Array(bytes)].map((byte) => byte.toString(16).padStart(2, '0')).join('');
-}
-
-async function pkce(value: string) {
-  const bytes = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value));
-  return Buffer.from(bytes).toString('base64url');
-}
-
-async function accountEnv() {
-  const database = d1();
-  const pages = bucket();
-  const now = Math.floor(Date.now() / 1000);
-  database.sqlite.run(
-    'INSERT INTO users (id, email, display_name, created_at) VALUES (?, ?, ?, ?)',
-    ['user-a', 'owner@example.com', 'Owner', now],
-  );
-  database.sqlite.run(
-    'INSERT INTO users (id, email, display_name, created_at) VALUES (?, ?, ?, ?)',
-    ['user-b', 'other@example.com', 'Other', now],
-  );
-  database.sqlite.run(
-    `INSERT INTO device_tokens (token_hash, user_id, name, scopes, expires_at, created_at)
-     VALUES (?, ?, ?, ?, ?, ?)`,
-    [await digest('device-a'), 'user-a', 'MacBook', 'pages:write pages:delete pages:share', now + 3600, now],
-  );
-  database.sqlite.run(
-    `INSERT INTO device_tokens (token_hash, user_id, name, scopes, expires_at, created_at)
-     VALUES (?, ?, ?, ?, ?, ?)`,
-    [await digest('device-a-legacy'), 'user-a', 'Old MacBook', 'pages:write pages:delete', now + 3600, now],
-  );
-  database.sqlite.run(
-    `INSERT INTO device_tokens (token_hash, user_id, name, scopes, expires_at, created_at)
-     VALUES (?, ?, ?, ?, ?, ?)`,
-    [await digest('device-b'), 'user-b', 'Other Mac', 'pages:write pages:delete', now + 3600, now],
-  );
-  database.sqlite.run(
-    'INSERT INTO sessions (token_hash, user_id, expires_at, created_at) VALUES (?, ?, ?, ?)',
-    [await digest('session-a'), 'user-a', now + 3600, now],
-  );
-  database.sqlite.run(
-    'INSERT INTO sessions (token_hash, user_id, expires_at, created_at) VALUES (?, ?, ?, ?)',
-    [await digest('session-b'), 'user-b', now + 3600, now],
-  );
-  return {
-    database,
-    pages,
-    env: {
-      DB: database.binding,
-      PAGES: pages,
-      SITE_TOKEN: 'site-secret',
-      PUBLISH_TOKEN: 'legacy-shared-secret',
-      ACCOUNT_MODE: 'required',
-      ACCOUNT_URL,
-      PAGES_URL,
-      OIDC_ISSUER: 'https://auth.assay.rs/auth',
-      OIDC_CLIENT_ID: 'agentkit-pages',
-      OIDC_CLIENT_SECRET: 'oidc-secret',
-      SESSION_SECRET: 'session-secret',
-    },
-  };
-}
-
-function signedIn(url: string, session = 'session-a') {
-  return new Request(url, { headers: { cookie: `agentkit_session=${session}` } });
-}
-
-function accountPost(url: string, body: unknown, session = 'session-a') {
-  return new Request(url, {
-    method: 'POST',
-    headers: {
-      cookie: `agentkit_session=${session}`,
-      'content-type': 'application/json',
-      origin: ACCOUNT_URL,
-    },
-    body: JSON.stringify(body),
-  });
-}
-
-function publish(token: string, body = '<h1>private</h1>', slug = 'private-page', title?: string) {
-  return new Request(`${ACCOUNT_URL}/api/pages/${slug}`, {
-    method: 'PUT',
-    headers: {
-      authorization: `Bearer ${token}`,
-      ...(title ? { 'x-page-title': encodeURIComponent(title) } : {}),
-    },
-    body,
-  });
-}
-
-async function pageAccessUrl(
-  setup: Awaited<ReturnType<typeof accountEnv>>,
-  slug = 'private-page',
-  session = 'session-a',
-) {
-  const response = await worker.fetch(
-    signedIn(`${ACCOUNT_URL}/access?return_to=${encodeURIComponent(`${PAGES_URL}/${slug}`)}`, session),
-    setup.env,
-  );
-  return { response, location: response.headers.get('location') };
-}
+import {
+  ACCOUNT_URL,
+  accountEnv,
+  accountPost,
+  bucket,
+  digest,
+  openDatabases,
+  pageAccessUrl,
+  PAGES_URL,
+  pkce,
+  publish,
+  signedIn,
+} from './account-harness.ts';
 
 afterEach(() => {
   for (const database of openDatabases.splice(0)) database.close();
@@ -495,7 +341,10 @@ describe('private access and sharing', () => {
     expect((await worker.fetch(publish('device-a'), setup.env)).status).toBe(200);
     const target = `${ACCOUNT_URL}/access?return_to=${encodeURIComponent(`${PAGES_URL}/private-page`)}`;
 
-    expect((await worker.fetch(signedIn(target, 'session-b'), setup.env)).status).toBe(404);
+    // Denial explains itself instead of pretending the page does not exist.
+    const denied = await worker.fetch(signedIn(target, 'session-b'), setup.env);
+    expect(denied.status).toBe(403);
+    expect(await denied.text()).toContain('This page is private');
 
     expect((await worker.fetch(
       accountPost(`${ACCOUNT_URL}/api/pages/private-page/invites`, { email: 'other@example.com' }),
@@ -559,7 +408,7 @@ describe('private access and sharing', () => {
 
     const disabled = await worker.fetch(deviceShare('device-a', false), setup.env);
     expect(disabled.status).toBe(200);
-    expect(await disabled.json()).toEqual({ ok: true, enabled: false, url: null });
+    expect(await disabled.json()).toEqual({ ok: true, enabled: false, url: null, already: false });
     expect((await worker.fetch(new Request(url), setup.env)).status).toBe(302);
   });
 
@@ -622,7 +471,7 @@ describe('private access and sharing', () => {
     );
 
     expect(removed.status).toBe(200);
-    expect((await pageAccessUrl(setup, 'private-page', 'session-b')).response.status).toBe(404);
+    expect((await pageAccessUrl(setup, 'private-page', 'session-b')).response.status).toBe(403);
     expect((await worker.fetch(new Request(access.location!), setup.env)).status).toBe(302);
   });
 
@@ -702,7 +551,7 @@ describe('private access and sharing', () => {
     expect(response.status).toBe(403);
   });
 
-  test('the dashboard share form displays the new one-time link', async () => {
+  test('the dashboard share form shows the link persistently, not once', async () => {
     const setup = await accountEnv();
     expect((await worker.fetch(publish('device-a'), setup.env)).status).toBe(200);
     const response = await worker.fetch(
@@ -718,22 +567,15 @@ describe('private access and sharing', () => {
       setup.env,
     );
 
-    // The link comes back through a one-shot cookie and is rendered on the
-    // dashboard itself, so the token never reaches the address bar or history.
+    // The link is derivable on demand, so the form just returns to the
+    // dashboard, which renders it in place — on every load, not via a
+    // one-shot reveal cookie.
     expect(response.status).toBe(303);
-    const flash = response.headers.get('set-cookie') ?? '';
-    expect(flash).toContain('agentkit_share=');
-    expect(flash).toContain('HttpOnly');
-
-    const dashboardResponse = await worker.fetch(
-      new Request(`${ACCOUNT_URL}/dashboard`, {
-        headers: { cookie: `agentkit_session=session-a; ${flash.split(';')[0]}` },
-      }),
-      setup.env,
-    );
-    expect(await dashboardResponse.text()).toContain('https://pages.agentkit.sbs/private-page?share=');
-    // Cleared on the way out, so a reload cannot show it a second time.
-    expect(dashboardResponse.headers.get('set-cookie')).toContain('Max-Age=0');
+    expect(response.headers.get('set-cookie')).toBeNull();
+    const first = await (await worker.fetch(signedIn(`${ACCOUNT_URL}/dashboard`), setup.env)).text();
+    expect(first).toContain('https://pages.agentkit.sbs/private-page?share=');
+    const again = await (await worker.fetch(signedIn(`${ACCOUNT_URL}/dashboard`), setup.env)).text();
+    expect(again).toContain('https://pages.agentkit.sbs/private-page?share=');
   });
 
   test('a cross-origin request cannot change sharing', async () => {
@@ -1213,11 +1055,11 @@ describe('owner share shell and menu', () => {
     expect(first.already).toBe(false);
     expect(await (await worker.fetch(new Request(first.url), setup.env)).text()).toBe('<h1>private</h1>');
 
-    // Enable again: idempotent - the circulating link survives.
+    // Enable again: idempotent - the circulating link survives AND comes back.
     const again = await worker.fetch(shareAction(manage, 'enable'), setup.env);
     const second = await again.json() as { url: string | null; already: boolean };
     expect(second.already).toBe(true);
-    expect(second.url).toBeNull();
+    expect(second.url).toBe(first.url);
     expect((await worker.fetch(new Request(first.url), setup.env)).status).toBe(200);
 
     // Rotate kills the old link and mints a working new one.

--- a/tests/publish-page/share-links.test.ts
+++ b/tests/publish-page/share-links.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import worker from '../../pages/worker/src/worker.js';
+import {
+  ACCOUNT_URL,
+  accountEnv,
+  digest,
+  openDatabases,
+  pageAccessUrl,
+  PAGES_URL,
+  publish,
+  signedIn,
+} from './account-harness.ts';
+
+afterEach(() => {
+  for (const database of openDatabases.splice(0)) database.close();
+});
+
+async function ownerLocation(setup: Awaited<ReturnType<typeof accountEnv>>) {
+  const { location } = await pageAccessUrl(setup);
+  return new URL(location!);
+}
+
+function shareAction(manage: string, action: string, slug = 'private-page') {
+  return new Request(`${PAGES_URL}/api/pages/${slug}/share`, {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${manage}`,
+      'content-type': 'application/json',
+      origin: PAGES_URL,
+    },
+    body: JSON.stringify({ action }),
+  });
+}
+
+async function enabledShareUrl(setup: Awaited<ReturnType<typeof accountEnv>>) {
+  const manage = (await ownerLocation(setup)).searchParams.get('manage')!;
+  const response = await worker.fetch(shareAction(manage, 'enable'), setup.env);
+  const { url } = await response.json() as { url: string };
+  return { manage, url };
+}
+
+async function seedLegacyShare(setup: Awaited<ReturnType<typeof accountEnv>>) {
+  setup.database.sqlite.run(
+    'UPDATE pages SET share_token_hash = ?, share_enabled = 0 WHERE slug = ?',
+    [await digest('legacy-token'), 'private-page'],
+  );
+}
+
+describe('derivable share links', () => {
+  test('required mode fails closed and loud without the share key', async () => {
+    const setup = await accountEnv();
+    delete (setup.env as Record<string, unknown>).SHARE_LINK_KEY;
+    const response = await worker.fetch(new Request(`${PAGES_URL}/private-page`), setup.env);
+    expect(response.status).toBe(503);
+    expect(await response.text()).toContain('share key unconfigured');
+  });
+
+  test('off then on mints a fresh link instead of resurrecting the revoked one', async () => {
+    const setup = await accountEnv();
+    expect((await worker.fetch(publish('device-a'), setup.env)).status).toBe(200);
+    const { manage, url } = await enabledShareUrl(setup);
+
+    await worker.fetch(shareAction(manage, 'off'), setup.env);
+    const back = await (await worker.fetch(shareAction(manage, 'enable'), setup.env)).json() as { url: string };
+    expect(back.url).not.toBe(url);
+    expect((await worker.fetch(new Request(url), setup.env)).status).toBe(302);
+    expect((await worker.fetch(new Request(back.url), setup.env)).status).toBe(200);
+  });
+
+  test('a legacy link keeps working and enable refuses to rotate it', async () => {
+    const setup = await accountEnv();
+    expect((await worker.fetch(publish('device-a'), setup.env)).status).toBe(200);
+    await seedLegacyShare(setup);
+    const legacyUrl = `${PAGES_URL}/private-page?share=legacy-token`;
+    expect((await worker.fetch(new Request(legacyUrl), setup.env)).status).toBe(200);
+
+    const manage = (await ownerLocation(setup)).searchParams.get('manage')!;
+    const kept = await (await worker.fetch(shareAction(manage, 'enable'), setup.env)).json() as {
+      already: boolean;
+      legacy: boolean;
+      url: string | null;
+    };
+    expect(kept).toMatchObject({ already: true, legacy: true, url: null });
+    expect((await worker.fetch(new Request(legacyUrl), setup.env)).status).toBe(200);
+
+    const rotated = await (await worker.fetch(shareAction(manage, 'rotate'), setup.env)).json() as { url: string };
+    expect((await worker.fetch(new Request(legacyUrl), setup.env)).status).toBe(302);
+    expect((await worker.fetch(new Request(rotated.url), setup.env)).status).toBe(200);
+    expect(setup.database.sqlite.query('SELECT share_token_hash FROM pages WHERE slug = ?').get('private-page'))
+      .toEqual({ share_token_hash: null });
+  });
+
+  test('an unknown share action is refused, never treated as rotate', async () => {
+    const setup = await accountEnv();
+    expect((await worker.fetch(publish('device-a'), setup.env)).status).toBe(200);
+    const { manage, url } = await enabledShareUrl(setup);
+    expect((await worker.fetch(shareAction(manage, 'disable'), setup.env)).status).toBe(400);
+    expect((await worker.fetch(new Request(url), setup.env)).status).toBe(200);
+  });
+
+  test('share reads are marked uncacheable so revocation is not outlived', async () => {
+    const setup = await accountEnv();
+    expect((await worker.fetch(publish('device-a'), setup.env)).status).toBe(200);
+    const { url } = await enabledShareUrl(setup);
+    const read = await worker.fetch(new Request(url), setup.env);
+    expect(read.headers.get('cache-control')).toBe('private, no-store');
+  });
+
+  test('an access grant outranks a share token so the owner reaches the shell', async () => {
+    const setup = await accountEnv();
+    expect((await worker.fetch(publish('device-a'), setup.env)).status).toBe(200);
+    const { url } = await enabledShareUrl(setup);
+    const owner = await ownerLocation(setup);
+    owner.searchParams.set('share', new URL(url).searchParams.get('share')!);
+    const response = await worker.fetch(new Request(owner.toString()), setup.env);
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain('<iframe id="content"');
+  });
+});
+
+describe('owner-hint upgrade of share-link visits', () => {
+  test('the shell records its slug in the hint cookie', async () => {
+    const setup = await accountEnv();
+    expect((await worker.fetch(publish('device-a'), setup.env)).status).toBe(200);
+    const shell = await worker.fetch(new Request((await ownerLocation(setup)).toString()), setup.env);
+    const hint = shell.headers.get('set-cookie') ?? '';
+    expect(hint).toContain('agentkit_owner=private-page');
+    expect(hint).toContain('HttpOnly');
+  });
+
+  test('a hinted browser is bounced through /access and back into the shell', async () => {
+    const setup = await accountEnv();
+    expect((await worker.fetch(publish('device-a'), setup.env)).status).toBe(200);
+    const { url } = await enabledShareUrl(setup);
+    const token = new URL(url).searchParams.get('share')!;
+
+    const bounced = await worker.fetch(
+      new Request(url, { headers: { cookie: 'agentkit_owner=private-page' } }),
+      setup.env,
+    );
+    expect(bounced.status).toBe(302);
+    const access = new URL(bounced.headers.get('location')!);
+    expect(access.origin + access.pathname).toBe(`${ACCOUNT_URL}/access`);
+    expect(new URL(access.searchParams.get('return_to')!).searchParams.get('share')).toBe(token);
+
+    const upgraded = await worker.fetch(signedIn(access.toString()), setup.env);
+    expect(upgraded.status).toBe(302);
+    const landing = new URL(upgraded.headers.get('location')!);
+    expect(landing.searchParams.get('share')).toBeNull();
+    expect(landing.searchParams.get('access')).toBeTruthy();
+    expect(landing.searchParams.get('manage')).toBeTruthy();
+  });
+
+  test('plain=1 stops the bounce; a foreign slug hint never starts one', async () => {
+    const setup = await accountEnv();
+    expect((await worker.fetch(publish('device-a'), setup.env)).status).toBe(200);
+    const { url } = await enabledShareUrl(setup);
+
+    const plain = await worker.fetch(
+      new Request(`${url}&plain=1`, { headers: { cookie: 'agentkit_owner=private-page' } }),
+      setup.env,
+    );
+    expect(plain.status).toBe(200);
+
+    const foreign = await worker.fetch(
+      new Request(url, { headers: { cookie: 'agentkit_owner=some-other-page' } }),
+      setup.env,
+    );
+    expect(foreign.status).toBe(200);
+  });
+
+  test('a signed-out hinted browser lands back on the plain page, not a login wall', async () => {
+    const setup = await accountEnv();
+    expect((await worker.fetch(publish('device-a'), setup.env)).status).toBe(200);
+    const { url } = await enabledShareUrl(setup);
+    const bounced = await worker.fetch(
+      new Request(url, { headers: { cookie: 'agentkit_owner=private-page' } }),
+      setup.env,
+    );
+    const denied = await worker.fetch(new Request(bounced.headers.get('location')!), setup.env);
+    expect(denied.status).toBe(302);
+    const back = new URL(denied.headers.get('location')!);
+    expect(back.searchParams.get('plain')).toBe('1');
+    expect((await worker.fetch(new Request(back.toString()), setup.env)).status).toBe(200);
+  });
+
+  test('a keyless dashboard shows sharing as unavailable without a destructive toggle', async () => {
+    const setup = await accountEnv();
+    expect((await worker.fetch(publish('device-a'), setup.env)).status).toBe(200);
+    const { url } = await enabledShareUrl(setup);
+    expect(url).toBeTruthy();
+    (setup.env as Record<string, unknown>).ACCOUNT_MODE = 'optional';
+    delete (setup.env as Record<string, unknown>).SHARE_LINK_KEY;
+    const body = await (await worker.fetch(signedIn(`${ACCOUNT_URL}/dashboard`), setup.env)).text();
+    expect(body).toContain('Sharing unavailable');
+    expect(body).not.toContain('made before links were shown here');
+    expect(body).not.toContain('name="enabled" value="false"');
+  });
+});


### PR DESCRIPTION
Closes #402
Closes #403
Closes #404

## What

- **Share tokens are derived, not stored**: `HMAC-SHA256(SHARE_LINK_KEY, share:<slug>:<generation>)` with a monotonic generation (migration 0006). The current link is recomputable on demand: enable is idempotent AND returns the live URL, the shell menu and dashboard show it persistently, rotation is an explicit generation bump, and links minted before the scheme keep verifying by their stored hash until rotated or turned off.
- **The owner shell is a slim top bar** with its own strip of the viewport — the content iframe starts below it, so owner chrome structurally cannot cover any page's own controls — and it rewrites the address bar to the durable `?share=` URL when sharing is on (clean page URL when off): copying what you see always yields a link that works indefinitely, never the personal ten-minute access pass.
- **Owners reopening their own share link** are upgraded back into the shell via a per-slug hint cookie; strangers holding a share link are bounced back to the plain page instead of a login wall; signed-in strangers on a private page get an explanation instead of a bare 404.
- **Fail-loud**: required mode 503s at the door without `SHARE_LINK_KEY`; a keyless deployment renders 'sharing unavailable' with no destructive toggle. Share reads carry `cache-control: private, no-store`.

## Review

Two-round adversarial security review: round 1 FAIL (red test suite, keyless-deploy failure modes, 7 minors), all findings fixed at mechanism level, round 2 **PASS** with live re-probing — sandboxed-iframe isolation, byte-identical share serving, open-redirect defenses all re-verified intact. Deferred items filed as #405 (no-share /access loop-breaker, pre-existing) and #406 (share-key rotation versioning).

## Tests

`bun test tests/publish-page/`: **321 pass / 0 fail** — harness extracted to `account-harness.ts` (shared), new `share-links.test.ts` covers keyless fail-loud, off→on fresh generation, legacy retention/rotation, unknown-action refusal, no-store reads, access-outranks-share, and the hint-cookie upgrade triangle. Plus 18 headless-Chrome assertions against wrangler dev (top bar, dropdown, address-bar rewrite, no-overlap, mobile, legacy, anonymous).

## Deploy order (load-bearing)

1. `wrangler secret put SHARE_LINK_KEY`  2. `d1 migrations apply --remote` (0006)  3. `wrangler deploy` — per README.

https://claude.ai/code/session_01514GDkBRzjWNWtYyhgnsWx