### PR TITLE
fix(themes): theme scripts survive the owner shell's sandboxed frame

### DIFF
--- a/plugins-cc/agentkit/skills/publish-page/themes/deck.html
+++ b/plugins-cc/agentkit/skills/publish-page/themes/deck.html
@@ -6,7 +6,10 @@
 <title>{{TITLE}}</title>
 <script>
   (() => {
-    const saved = localStorage.getItem("agentkit-theme");
+    // localStorage throws in a sandboxed (opaque-origin) frame, such as the
+    // owner shell's content frame - fall through to the default theme there.
+    let saved = null;
+    try { saved = localStorage.getItem("agentkit-theme"); } catch {}
     if (saved === "light" || saved === "dark") document.documentElement.dataset.theme = saved;
   })();
 </script>
@@ -387,7 +390,9 @@
     const html = document.documentElement;
     const next = html.dataset.theme === "light" ? "dark" : "light";
     html.dataset.theme = next;
-    localStorage.setItem("agentkit-theme", next);
+    // The flip and the re-theme event must survive a sandboxed frame where
+    // storage throws; persistence is best-effort there.
+    try { localStorage.setItem("agentkit-theme", next); } catch {}
     dispatchEvent(new CustomEvent("agentkit-theme", { detail: next }));
   });
   const slides = [...document.querySelectorAll(".slide")];

--- a/plugins-cc/agentkit/skills/publish-page/themes/doc.html
+++ b/plugins-cc/agentkit/skills/publish-page/themes/doc.html
@@ -6,7 +6,10 @@
 <title>{{TITLE}}</title>
 <script>
   (() => {
-    const saved = localStorage.getItem("agentkit-theme");
+    // localStorage throws in a sandboxed (opaque-origin) frame, such as the
+    // owner shell's content frame - fall through to the default theme there.
+    let saved = null;
+    try { saved = localStorage.getItem("agentkit-theme"); } catch {}
     if (saved === "light" || saved === "dark") document.documentElement.dataset.theme = saved;
   })();
 </script>
@@ -409,7 +412,9 @@
     const html = document.documentElement;
     const next = html.dataset.theme === "light" ? "dark" : "light";
     html.dataset.theme = next;
-    localStorage.setItem("agentkit-theme", next);
+    // The flip and the re-theme event must survive a sandboxed frame where
+    // storage throws; persistence is best-effort there.
+    try { localStorage.setItem("agentkit-theme", next); } catch {}
     dispatchEvent(new CustomEvent("agentkit-theme", { detail: next }));
   });
 

--- a/skills/publish-page/themes/deck.html
+++ b/skills/publish-page/themes/deck.html
@@ -6,7 +6,10 @@
 <title>{{TITLE}}</title>
 <script>
   (() => {
-    const saved = localStorage.getItem("agentkit-theme");
+    // localStorage throws in a sandboxed (opaque-origin) frame, such as the
+    // owner shell's content frame - fall through to the default theme there.
+    let saved = null;
+    try { saved = localStorage.getItem("agentkit-theme"); } catch {}
     if (saved === "light" || saved === "dark") document.documentElement.dataset.theme = saved;
   })();
 </script>
@@ -387,7 +390,9 @@
     const html = document.documentElement;
     const next = html.dataset.theme === "light" ? "dark" : "light";
     html.dataset.theme = next;
-    localStorage.setItem("agentkit-theme", next);
+    // The flip and the re-theme event must survive a sandboxed frame where
+    // storage throws; persistence is best-effort there.
+    try { localStorage.setItem("agentkit-theme", next); } catch {}
     dispatchEvent(new CustomEvent("agentkit-theme", { detail: next }));
   });
   const slides = [...document.querySelectorAll(".slide")];

--- a/skills/publish-page/themes/doc.html
+++ b/skills/publish-page/themes/doc.html
@@ -6,7 +6,10 @@
 <title>{{TITLE}}</title>
 <script>
   (() => {
-    const saved = localStorage.getItem("agentkit-theme");
+    // localStorage throws in a sandboxed (opaque-origin) frame, such as the
+    // owner shell's content frame - fall through to the default theme there.
+    let saved = null;
+    try { saved = localStorage.getItem("agentkit-theme"); } catch {}
     if (saved === "light" || saved === "dark") document.documentElement.dataset.theme = saved;
   })();
 </script>
@@ -409,7 +412,9 @@
     const html = document.documentElement;
     const next = html.dataset.theme === "light" ? "dark" : "light";
     html.dataset.theme = next;
-    localStorage.setItem("agentkit-theme", next);
+    // The flip and the re-theme event must survive a sandboxed frame where
+    // storage throws; persistence is best-effort there.
+    try { localStorage.setItem("agentkit-theme", next); } catch {}
     dispatchEvent(new CustomEvent("agentkit-theme", { detail: next }));
   });
 


### PR DESCRIPTION
Skill+plugin mirror of agentkit-pages!7 (canonical 01252d4). In the owner shell the content iframe is opaque-origin, so localStorage throws: saved-theme restore died and the toggle's setItem threw before the agentkit-theme event, leaving mermaid un-re-themed. Both guarded; flip and event always run. Verified in a headless shell session: zero pageerrors, toggle flips. Canonical deck light-palette drift is pre-existing (#276), deliberately not imported.

https://claude.ai/code/session_01514GDkBRzjWNWtYyhgnsWx