### PR TITLE
feat(pages): for generated slugs, the page URL is the share link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ release PR — "publish this" authorizes a release, never the tier.
 
 ## [Unreleased]
 
+- Pages: **for generated slugs, the page URL is the share link.** Default
+  publishes get HMAC-derived hex slugs that are already unguessable, so when
+  sharing is on, the bare page URL serves to anyone — no `?share=` token to
+  copy, lose, or explain; the shell, dashboard, and CLI hand back the bare
+  URL, and legacy-shared generated slugs shed their "unrecoverable link"
+  state. Readable custom slugs are guessable, so they keep requiring the
+  derived token; private pages of every slug shape stay private.
+
 - Pages: **share links are now derivable and the address bar is honest.** The
   share token is HMAC(secret, slug:generation) instead of an unrecoverable
   stored hash, so enabling is idempotent and always hands back the live link,

--- a/pages/worker/src/pages-acl.js
+++ b/pages/worker/src/pages-acl.js
@@ -1,5 +1,5 @@
 import { randomToken, sessionUser, sha256 } from "./accounts.js";
-import { shareTokenValid } from "./share-links.js";
+import { bareShared, shareTokenValid } from "./share-links.js";
 
 const PAGE_ACCESS_TTL_SECONDS = 10 * 60;
 export async function pageRecord(env, slug) {
@@ -52,6 +52,8 @@ export async function pageReadGrant(request, env, page) {
   if (share && await shareTokenValid(env, page, share)) {
     return { allowed: true, owner: false, viaShare: true };
   }
+  // viaShare so an owner's own browser still upgrades this visit to the shell.
+  if (bareShared(page)) return { allowed: true, owner: false, viaShare: true };
   return { allowed: false, owner: false };
 }
 export async function ownerByAccess(env, slug, token) {

--- a/pages/worker/src/share-links.js
+++ b/pages/worker/src/share-links.js
@@ -37,6 +37,18 @@ export function shareCapable(env) {
   return Boolean(env.SHARE_LINK_KEY);
 }
 
+// The default publish flow derives slugs as HMAC hex[20] — an 80-bit secret in
+// its own right. For those pages "sharing on" means the page URL itself is the
+// link: no token to lose, nothing to explain. Readable custom slugs are
+// guessable, so they keep requiring the derived token.
+const GENERATED_SLUG_RE = /^[0-9a-f]{20}$/;
+
+export function bareShared(page) {
+  if (!page) return false;
+  if (!page.share_enabled && !page.share_token_hash) return false;
+  return GENERATED_SLUG_RE.test(page.slug);
+}
+
 // "legacy" = a link minted before the derivable scheme: still honored via its
 // stored hash, but not re-displayable. Rotating moves the page onto the scheme.
 // "unavailable" = the page says shared but this deployment has no share key —
@@ -48,8 +60,10 @@ export function shareState(env, page) {
   return page.share_token_hash ? "legacy" : "off";
 }
 
-// The current share URL, or null when sharing is off, legacy, or keyless.
+// The current share URL: the bare page URL when the slug is its own secret,
+// the derived-token URL otherwise, null when sharing is off, legacy, or keyless.
 export async function shareUrl(env, page) {
+  if (bareShared(page)) return `${env.PAGES_URL}/${page.slug}`;
   if (!page || !page.share_enabled || !shareCapable(env)) return null;
   const token = await deriveShareToken(env, page.slug, page.share_generation);
   return `${env.PAGES_URL}/${page.slug}?share=${token}`;
@@ -96,7 +110,10 @@ export async function setShareLink(env, slug, mode) {
         RETURNING slug, share_token_hash, share_generation, share_enabled`,
     ).bind(slug).first();
     if (!row) return { error: "not found" };
-    if (row.share_token_hash) return { enabled: true, url: null, already: true, legacy: true };
+    if (row.share_token_hash) {
+      const legacyUrl = await shareUrl(env, row);
+      return { enabled: true, url: legacyUrl, already: true, legacy: !legacyUrl };
+    }
     return { enabled: true, url: await shareUrl(env, row), already: Boolean(before.share_enabled) };
   }
   const rotated = await env.DB.prepare(

--- a/pages/worker/src/share-links.js
+++ b/pages/worker/src/share-links.js
@@ -56,6 +56,8 @@ export function bareShared(page) {
 // could "fix" destructively.
 export function shareState(env, page) {
   if (!page) return "off";
+  // Bare sharing works without the HMAC key, so it can never be "unavailable".
+  if (bareShared(page)) return "on";
   if (page.share_enabled) return shareCapable(env) ? "on" : "unavailable";
   return page.share_token_hash ? "legacy" : "off";
 }

--- a/pages/worker/src/worker.js
+++ b/pages/worker/src/worker.js
@@ -715,10 +715,7 @@ async function shellDocument(env, slug, page) {
   const title = escapeHtml(page.title || slug);
   const dashboard = `${env.ACCOUNT_URL}/dashboard#page-${slug}`;
   const link = await shareUrl(env, page);
-  // A legacy page with a showable bare link has nothing legacy-shaped left to
-  // explain — it presents as plainly shared.
-  const rawState = shareState(env, page);
-  const state = rawState === "legacy" && link ? "on" : rawState;
+  const state = shareState(env, page);
   const labels = {
     on: "Shared by link",
     legacy: "Shared by link",

--- a/pages/worker/src/worker.js
+++ b/pages/worker/src/worker.js
@@ -18,7 +18,7 @@ import {
   pageReadGrant,
   removeInvite,
 } from "./pages-acl.js";
-import { setShareLink, shareState, shareUrl } from "./share-links.js";
+import { bareShared, setShareLink, shareState, shareUrl } from "./share-links.js";
 import { dashboard } from "./dashboard.js";
 import { approveDevice, devicePage, pollDevice, startDevice } from "./devices.js";
 import { completeLogin, startLogin } from "./oidc.js";
@@ -493,13 +493,17 @@ async function handlePageAccess(request, env) {
   if (!requested) return new Response("invalid page target\n", { status: 400 });
   // A page with no record predates accounts and is world-readable — telling a
   // visitor it is private would be false. Send them straight to it.
-  if (!(await pageRecord(env, requested.slug))) {
+  const record = await pageRecord(env, requested.slug);
+  if (!record) {
     requested.target.search = "";
     return new Response(null, { status: 302, headers: { location: requested.target.toString() } });
   }
+  // A bare-shared page is readable without any grant, so nobody who cannot
+  // sign in (or is not invited) should ever hit a wall on the way to it.
+  const openToAll = requested.share || bareShared(record);
   const user = await sessionUser(request, env);
   if (!user) {
-    if (requested.share) return backToSharedPage(requested);
+    if (openToAll) return backToSharedPage(requested);
     const current = new URL(request.url);
     const returnTo = `${current.pathname}${current.search}`;
     return new Response(null, {
@@ -509,7 +513,7 @@ async function handlePageAccess(request, env) {
   }
   const issued = await issuePageAccess(env, requested.slug, user);
   if (!issued) {
-    if (requested.share) return backToSharedPage(requested);
+    if (openToAll) return backToSharedPage(requested);
     return html(403, PRIVATE_PAGE);
   }
   requested.target.searchParams.delete("share");
@@ -710,8 +714,11 @@ const EMBED_HEADERS = {
 async function shellDocument(env, slug, page) {
   const title = escapeHtml(page.title || slug);
   const dashboard = `${env.ACCOUNT_URL}/dashboard#page-${slug}`;
-  const state = shareState(env, page);
   const link = await shareUrl(env, page);
+  // A legacy page with a showable bare link has nothing legacy-shaped left to
+  // explain — it presents as plainly shared.
+  const rawState = shareState(env, page);
+  const state = rawState === "legacy" && link ? "on" : rawState;
   const labels = {
     on: "Shared by link",
     legacy: "Shared by link",
@@ -777,7 +784,7 @@ $("aks-note").textContent=NOTES[state];
 $("aks-url").hidden=!link;if(link)$("aks-url").textContent=link;
 $("aks-copy").hidden=!link;
 $("aks-on").hidden=state!=="off";
-$("aks-rotate").hidden=state==="off"||state==="unavailable";
+$("aks-rotate").hidden=state==="off"||state==="unavailable"||(link&&link.indexOf("?share=")<0);
 $("aks-off").hidden=state==="off"||state==="unavailable";
 try{history.replaceState(null,"",(state==="on"&&link?link:"/${slug}")+location.hash)}catch(e){}
 }

--- a/plugins-cc/agentkit/skills/publish-page/publish.ts
+++ b/plugins-cc/agentkit/skills/publish-page/publish.ts
@@ -36,6 +36,15 @@ if (!explicitSlug && !name) fail("--name (cryptic URL, default) or --slug (reada
 if (explicitSlug && !SLUG_RE.test(explicitSlug)) {
   fail(`invalid slug "${explicitSlug}" (lowercase a-z0-9-, max 4 segments)`);
 }
+// The worker treats a 20-hex slug as a generated (unguessable) one and lets
+// the bare URL serve the page whenever sharing is on. An explicit slug of
+// that shape opts into the same rule with entropy the server cannot vouch for.
+if (explicitSlug && /^[0-9a-f]{20}$/.test(explicitSlug)) {
+  console.error(
+    `warning: --slug ${explicitSlug} looks like a generated slug; if sharing is enabled, `
+      + "this URL alone grants access - anyone who knows the identifier can read the page",
+  );
+}
 if (name && !/^[a-z0-9][a-z0-9-]{0,63}$/.test(name)) {
   fail(`invalid name "${name}" (lowercase a-z0-9-)`);
 }

--- a/skills/publish-page/publish.ts
+++ b/skills/publish-page/publish.ts
@@ -36,6 +36,15 @@ if (!explicitSlug && !name) fail("--name (cryptic URL, default) or --slug (reada
 if (explicitSlug && !SLUG_RE.test(explicitSlug)) {
   fail(`invalid slug "${explicitSlug}" (lowercase a-z0-9-, max 4 segments)`);
 }
+// The worker treats a 20-hex slug as a generated (unguessable) one and lets
+// the bare URL serve the page whenever sharing is on. An explicit slug of
+// that shape opts into the same rule with entropy the server cannot vouch for.
+if (explicitSlug && /^[0-9a-f]{20}$/.test(explicitSlug)) {
+  console.error(
+    `warning: --slug ${explicitSlug} looks like a generated slug; if sharing is enabled, `
+      + "this URL alone grants access - anyone who knows the identifier can read the page",
+  );
+}
 if (name && !/^[a-z0-9][a-z0-9-]{0,63}$/.test(name)) {
   fail(`invalid name "${name}" (lowercase a-z0-9-)`);
 }

--- a/tests/publish-page/share-links.test.ts
+++ b/tests/publish-page/share-links.test.ts
@@ -197,3 +197,92 @@ describe('owner-hint upgrade of share-link visits', () => {
     expect(body).not.toContain('name="enabled" value="false"');
   });
 });
+
+describe('bare share URLs for generated slugs', () => {
+  const GENERATED = 'abc123abc123abc123ab';
+
+  test('sharing on makes the bare page URL itself serve to anyone', async () => {
+    const setup = await accountEnv();
+    expect((await worker.fetch(publish('device-a', '<h1>bare</h1>', GENERATED), setup.env)).status).toBe(200);
+    expect((await worker.fetch(new Request(`${PAGES_URL}/${GENERATED}`), setup.env)).status).toBe(302);
+
+    const manage = new URL((await pageAccessUrl(setup, GENERATED)).location!).searchParams.get('manage')!;
+    const on = await (await worker.fetch(shareAction(manage, 'enable', GENERATED), setup.env)).json() as { url: string };
+    expect(on.url).toBe(`${PAGES_URL}/${GENERATED}`);
+
+    const read = await worker.fetch(new Request(`${PAGES_URL}/${GENERATED}`), setup.env);
+    expect(read.status).toBe(200);
+    expect(await read.text()).toBe('<h1>bare</h1>');
+
+    await worker.fetch(shareAction(manage, 'off', GENERATED), setup.env);
+    expect((await worker.fetch(new Request(`${PAGES_URL}/${GENERATED}`), setup.env)).status).toBe(302);
+  });
+
+  test('a readable custom slug keeps requiring the share token when shared', async () => {
+    const setup = await accountEnv();
+    expect((await worker.fetch(publish('device-a'), setup.env)).status).toBe(200);
+    const { url } = await enabledShareUrl(setup);
+    expect(url).toContain('?share=');
+    expect((await worker.fetch(new Request(`${PAGES_URL}/private-page`), setup.env)).status).toBe(302);
+    expect((await worker.fetch(new Request(url), setup.env)).status).toBe(200);
+  });
+
+  test('a hinted owner browser on the bare URL is upgraded to the shell', async () => {
+    const setup = await accountEnv();
+    expect((await worker.fetch(publish('device-a', '<h1>bare</h1>', GENERATED), setup.env)).status).toBe(200);
+    const manage = new URL((await pageAccessUrl(setup, GENERATED)).location!).searchParams.get('manage')!;
+    await worker.fetch(shareAction(manage, 'enable', GENERATED), setup.env);
+
+    const bounced = await worker.fetch(
+      new Request(`${PAGES_URL}/${GENERATED}`, { headers: { cookie: `agentkit_owner=${GENERATED}` } }),
+      setup.env,
+    );
+    expect(bounced.status).toBe(302);
+    const upgraded = await worker.fetch(signedIn(bounced.headers.get('location')!), setup.env);
+    expect(upgraded.status).toBe(302);
+    expect(new URL(upgraded.headers.get('location')!).searchParams.get('manage')).toBeTruthy();
+  });
+
+  test('a hinted but signed-out browser falls back to the plain page, not login', async () => {
+    const setup = await accountEnv();
+    expect((await worker.fetch(publish('device-a', '<h1>bare</h1>', GENERATED), setup.env)).status).toBe(200);
+    const manage = new URL((await pageAccessUrl(setup, GENERATED)).location!).searchParams.get('manage')!;
+    await worker.fetch(shareAction(manage, 'enable', GENERATED), setup.env);
+
+    const bounced = await worker.fetch(
+      new Request(`${PAGES_URL}/${GENERATED}`, { headers: { cookie: `agentkit_owner=${GENERATED}` } }),
+      setup.env,
+    );
+    const back = await worker.fetch(new Request(bounced.headers.get('location')!), setup.env);
+    expect(back.status).toBe(302);
+    const landing = new URL(back.headers.get('location')!);
+    expect(landing.searchParams.get('plain')).toBe('1');
+    expect((await worker.fetch(new Request(landing.toString()), setup.env)).status).toBe(200);
+  });
+
+  test('a legacy-shared generated slug serves bare and shows its bare link', async () => {
+    const setup = await accountEnv();
+    expect((await worker.fetch(publish('device-a', '<h1>bare</h1>', GENERATED), setup.env)).status).toBe(200);
+    setup.database.sqlite.run(
+      'UPDATE pages SET share_token_hash = ?, share_enabled = 0 WHERE slug = ?',
+      [await digest('legacy-token'), GENERATED],
+    );
+    expect((await worker.fetch(new Request(`${PAGES_URL}/${GENERATED}`), setup.env)).status).toBe(200);
+    expect((await worker.fetch(new Request(`${PAGES_URL}/${GENERATED}?share=legacy-token`), setup.env)).status).toBe(200);
+
+    const manage = new URL((await pageAccessUrl(setup, GENERATED)).location!).searchParams.get('manage')!;
+    const kept = await (await worker.fetch(shareAction(manage, 'enable', GENERATED), setup.env)).json() as {
+      url: string | null;
+      legacy?: boolean;
+    };
+    expect(kept.url).toBe(`${PAGES_URL}/${GENERATED}`);
+    expect(kept.legacy).toBeFalsy();
+  });
+
+  test('a private generated slug stays private', async () => {
+    const setup = await accountEnv();
+    expect((await worker.fetch(publish('device-a', '<h1>bare</h1>', GENERATED), setup.env)).status).toBe(200);
+    expect((await worker.fetch(new Request(`${PAGES_URL}/${GENERATED}`), setup.env)).status).toBe(302);
+    expect((await worker.fetch(new Request(`${PAGES_URL}/${GENERATED}?share=guess`), setup.env)).status).toBe(302);
+  });
+});

--- a/tests/publish-page/share-links.test.ts
+++ b/tests/publish-page/share-links.test.ts
@@ -279,6 +279,20 @@ describe('bare share URLs for generated slugs', () => {
     expect(kept.legacy).toBeFalsy();
   });
 
+  test('a signed-in stranger heading for a bare-shared page lands on it, not a 403', async () => {
+    const setup = await accountEnv();
+    expect((await worker.fetch(publish('device-a', '<h1>bare</h1>', GENERATED), setup.env)).status).toBe(200);
+    const manage = new URL((await pageAccessUrl(setup, GENERATED)).location!).searchParams.get('manage')!;
+    await worker.fetch(shareAction(manage, 'enable', GENERATED), setup.env);
+
+    const target = `${ACCOUNT_URL}/access?return_to=${encodeURIComponent(`${PAGES_URL}/${GENERATED}`)}`;
+    const bounced = await worker.fetch(signedIn(target, 'session-b'), setup.env);
+    expect(bounced.status).toBe(302);
+    const landing = new URL(bounced.headers.get('location')!);
+    expect(landing.searchParams.get('plain')).toBe('1');
+    expect((await worker.fetch(new Request(landing.toString()), setup.env)).status).toBe(200);
+  });
+
   test('a private generated slug stays private', async () => {
     const setup = await accountEnv();
     expect((await worker.fetch(publish('device-a', '<h1>bare</h1>', GENERATED), setup.env)).status).toBe(200);


### PR DESCRIPTION
The owner's original ask: copying the page URL you're looking at should just work. Default publishes derive slugs as HMAC hex[20] — already an ~80-bit secret — so when sharing is on, the bare page URL now serves to anyone. The shell address bar, dashboard, and device API all hand back the bare URL; Rotate hides when there's no token to rotate; legacy-shared generated slugs shed the unrecoverable-link state. Readable custom slugs (guessable) keep requiring the derived `?share=` token; private pages stay private in every slug shape. /access bounces anyone it cannot grant toward a bare-shared page back to the page instead of a login wall.

Accepted trade-off (owner-decided): revocation for generated slugs is on/off only — a leaked bare URL can't be rotated away without turning sharing off.

Tests: 6 new bare-share tests; suite 327/0. Adversarial review round on the diff in flight; merge gated on its PASS.

https://claude.ai/code/session_01514GDkBRzjWNWtYyhgnsWx