### PR TITLE
test(hooks): kill the three surviving prose-police mutants

### DIFF
--- a/tests/hooks/prose-police.test.ts
+++ b/tests/hooks/prose-police.test.ts
@@ -85,6 +85,7 @@ describe('prose-police hook', () => {
       '/tmp/repo/rules/writing-discipline.md',
       '/tmp/repo/skills/humanize/SKILL.md',
       '/tmp/repo/docs/prose-police.md',
+      '/tmp/repo/instructions/anti-glaze.md',
     ]) {
       expect(run(slop, path).out).toBe('');
     }
@@ -117,6 +118,26 @@ describe('prose-police hook', () => {
 
   test('short edits are never density-checked', () => {
     expect(flagged(run('a — b — c — d — e\n').out)).toBe(false);
+  });
+
+  test('the word floor is pinned from below: 4 dashes under 150 words stays silent', () => {
+    const words = (n: number) => Array.from({ length: n }, (_, i) => `word${i}`).join(' ');
+    const fourDashesUnderFloor = Array.from({ length: 5 }, () => words(19)).join(' — ') + '.\n';
+    expect(flagged(run(fourDashesUnderFloor).out)).toBe(false);
+  });
+
+  test('missing jq fails open, as the FAQ promises', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'agentkit-prose-nojq-'));
+    const r = spawnSync('/bin/bash', [hook], {
+      input: JSON.stringify({
+        tool_name: 'Write',
+        tool_input: { file_path: '/tmp/prose-subject/doc.md', content: 'We delve into a rich tapestry.\n' },
+      }),
+      encoding: 'utf-8',
+      env: { PATH: '', HOME: dir, XDG_CONFIG_HOME: dir },
+    });
+    rmSync(dir, { recursive: true, force: true });
+    expect(r.status).toBe(0);
   });
 
   test('long dash-free prose does not kill the hook under pipefail', () => {


### PR DESCRIPTION
Closes #415.

The #412 review's final mutation matrix left three LOW structural survivors. This adds the reviewer's own verified fixtures:

- **Word floor pinned from below**: four em dashes over 99 words must stay silent — `MIN_WORDS_FOR_DENSITY` 150→60 now fails exactly one test.
- **anti-glaze exemption**: one path added to the exemption array — deleting the exemption now fails.
- **missing-jq fail-open**: PATH-stripped spawn asserts exit 0, backing the FAQ's documented contract — deleting the guard now fails.

Each mutant was re-applied and confirmed to produce exactly one failure before restoring. Tests only; the hook is untouched.

https://claude.ai/code/session_01JbJqcjuiwFLifkWjgepa5Q