### PR TITLE
chore: cut v0.8.1 — the police read the command line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,17 @@ release PR — "publish this" authorizes a release, never the tier.
 
 ## [Unreleased]
 
+## v0.8.1 — 2026-09-01
+
 - feat(hooks): **prose-police reads inline forge text too.** A second registration as a
   PreToolUse Bash guard runs the same pattern scan over the inline `--body`, `--description`,
   `--title`, `--notes`, `--message`, and `--comment` values of `gh`/`glab` commands, the REST
   `--field body=…` spellings, and the contents of a readable `--body-file` (stdin `-` is not
   readable and passes). Scanning is scoped to the simple command whose head is `gh`/`glab` — a
   commit message or curl payload sharing the line is not forge text, and prose that merely
-  quotes a forge command is not a forge command. Same off switches; fails open without
-  `python3`, matching issue-police.
+  quotes a forge command is not a forge command. The deny report's quoting advice is arm-aware,
+  so it never prescribes backticks inside a double-quoted shell body. Same off switches; fails
+  open without `python3`, matching issue-police.
 
 ## v0.8.0 — 2026-09-01
 


### PR DESCRIPTION
Release commit for v0.8.1 (patch — closes a coverage gap in the shipped prose-police feature; the codified default tier). Ships the inline gh/glab body scanning from #418 (closes the #413 scope). Tag v0.8.1 follows on the squash.

https://claude.ai/code/session_01JbJqcjuiwFLifkWjgepa5Q