### PR TITLE
fix(ci): pin the docs Go toolchain instead of downloading it per build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,6 +222,11 @@ jobs:
     name: Docs site
     runs-on: ubuntu-24.04
     timeout-minutes: 20
+    env:
+      # Hugo's build fetches Go modules for the Hextra theme; without a pinned
+      # toolchain that silently downloads one through the module proxy on
+      # every build, which is what intermittently fails.
+      GOTOOLCHAIN: local
     steps:
       - name: Check out the commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -230,6 +235,11 @@ jobs:
           # a manual publish from main would show a bare "Latest".
           fetch-tags: true
           fetch-depth: 0
+
+      - name: Install Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: docs/hextra/go.mod
 
       - name: Install pinned Moon, Bun and Node toolchains
         uses: moonrepo/setup-toolchain@261c62cb5b0f580c7be7c8cd0f023a2e96756095 # v0.6.4
@@ -345,6 +355,11 @@ jobs:
     # The publish builds every archived version from its tag and uploads all of
     # them; at the archive cap that is well past the old 20-minute bound.
     timeout-minutes: 45
+    env:
+      # Hugo's build fetches Go modules for the Hextra theme; without a pinned
+      # toolchain that silently downloads one through the module proxy on
+      # every build, which is what intermittently fails.
+      GOTOOLCHAIN: local
     steps:
       - name: Check out the commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -353,6 +368,11 @@ jobs:
           # a manual publish from main would show a bare "Latest".
           fetch-tags: true
           fetch-depth: 0
+
+      - name: Install Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: docs/hextra/go.mod
 
       - name: Install pinned Moon, Bun and Node toolchains
         uses: moonrepo/setup-toolchain@261c62cb5b0f580c7be7c8cd0f023a2e96756095 # v0.6.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ release PR — "publish this" authorizes a release, never the tier.
 
 ## [Unreleased]
 
+- fix(ci): **the docs and docs-publish jobs pin Go via `actions/setup-go` and set
+  `GOTOOLCHAIN=local`**, instead of letting Hugo's Go-module fetch for the Hextra theme
+  silently download `docs/hextra/go.mod`'s toolchain through the module proxy on every
+  build. That download intermittently failed, breaking the docs build and blocking
+  releases; a missing toolchain now fails immediately instead.
+
 - fix(tests): **the mermaid browser test reports Chrome's stderr and retries a stillborn launch.**
   Its launch helper piped the browser's stdout and stderr and read neither, so every sandbox, D-Bus
   or missing-library message Chrome wrote was discarded, and a launch that timed out on CI could say


### PR DESCRIPTION
## Summary

- Hugo's docs build fetches Go modules for the Hextra theme (`docs/hextra/go.mod` declares `go 1.26.3`). Without a pinned toolchain, Go's automatic toolchain switch silently downloads that version through the module proxy on every build, and that download intermittently fails (`go: download go1.26.3 for linux/amd64: toolchain not available`), breaking the docs job and, on a tag push, blocking the release.
- Add `actions/setup-go` (pinned by SHA, `go-version-file: docs/hextra/go.mod`) and set `GOTOOLCHAIN=local` in both the `docs` and `docs-publish` jobs, so a missing toolchain fails immediately and explicitly instead of flaking at runtime.
- Scope is limited to how the toolchain is provisioned; `docs/hextra/go.mod`'s `go 1.26.3` directive is left as-is.

## Test plan

- [x] Verified `.github/workflows/ci.yml` parses as valid YAML.
- [x] Ran `HUGO_BIN=hugo-extended GOTOOLCHAIN=local ./build.sh` locally in `docs/hextra` (host Go is 1.26.3, matching go.mod exactly) — build succeeds, all internal links resolve.
- [ ] CI: docs site job (pending)

Closes #440

https://claude.ai/code/session_01VYrCeSiJ6wzhcE7i6RoxVy