### PR TITLE
chore: cut v0.8.3 — the session checks back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ release PR — "publish this" authorizes a release, never the tier.
 
 ## [Unreleased]
 
+## v0.8.3 — 2026-09-03
+
 - feat(hooks): **`wait-police` refuses to end a turn while delegated work runs unpolled.** A
   session that delegates and then waits on the completion message alone can idle for hours with the
   work already finished, because a notification can be dropped, delayed past a session-limit


### PR DESCRIPTION
Patch release carrying #442 (wait-police hook, wait-for, wait-discipline; closes #437), #434 (browser-launch evidence + retry; closes #430), #441 (pinned Go toolchain for the docs build; closes #440). Patch tier per the changelog rule.

https://claude.ai/code/session_01VYrCeSiJ6wzhcE7i6RoxVy