### PR TITLE
chore: cut v0.8.4 — no loose ends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ release PR — "publish this" authorizes a release, never the tier.
 
 ## [Unreleased]
 
+## v0.8.4 — 2026-09-03
+
 - feat(hooks): **`issue-police` gates the `Disposition:` value, not just its presence.** An issue
   filed with `Disposition: follow-up`, `later`, `tech debt`, or any other label passed as if it were
   an answer used to clear the hook; only `in-progress`, `owner-deferred`, `owner-request`, and


### PR DESCRIPTION
Patch release carrying #446 (closes #428 #431 #432 #435 #436 #439 #447: theme selector and CSS scoping, sketch background, lockfile range check, git-tracked mirror parity, review-police probe "did not answer", D2_BIN through the bounded env, --disable-gpu test, skill typecheck gate) and #445 (closes #444: issue-police gates the Disposition value; No Deferred Findings rule). Patch tier per the changelog rule.

https://claude.ai/code/session_01VYrCeSiJ6wzhcE7i6RoxVy