### PR TITLE
chore: cut v0.8.5 — figures at natural size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ release PR — "publish this" authorizes a release, never the tier.
 
 ## [Unreleased]
 
+## v0.8.5 — 2026-09-04
+
 - fix(publish-page): **figures render at their natural size, capped to the column.** The doc and
   deck themes sized every `.figure > svg` with `width: 100%`, and the diagram skill told the author
   to replace the renderer's `width`/`height` with `width="100%"` — so any figure narrower than the


### PR DESCRIPTION
## Summary
- Moves the Unreleased entries under a `v0.8.5 — 2026-09-04` heading: #450 (review-police probe diagnostics), #452 (review-police test split under the file cap), #454 (figures render at natural size, capped to the column).
- Tag `v0.8.5` follows the merge, signed, and the release job publishes it.

## Test plan
- [x] Unreleased section lists exactly the PRs merged since v0.8.4
- [ ] CI on the cut, tag pushed, release published, installed here and `~/.claude/skills/diagram` matches the tag

https://claude.ai/code/session_01BdVLyWdh7LD29hiyT8qF5q