### PR TITLE
refactor(diagram): one house-root helper for all three post-processors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,10 @@ release PR — "publish this" authorizes a release, never the tier.
   `SvgError` and drops from 19 exports to 15, back under the cap. No rendered output changes: the six
   committed example figures are untouched, and each one's root was reproduced byte-for-byte from a
   reconstructed pre-house input, before and after, alongside a 357-case old-versus-new comparison
-  across the three registers. Two deviations are deliberate and unreachable from any renderer — d2
-  now merges a root style rather than emitting a second `style` attribute, and a `$` in a label is
-  escaped as data rather than read as a replacement pattern that spliced the matched tag back into
-  the attribute.
+  across the three registers. Three deviations are deliberate and unreachable from any renderer — d2
+  now merges a root style rather than emitting a second `style` attribute, a merged style already
+  ending in `;` no longer doubles the separator, and a `$` in a label is escaped as data rather than
+  read as a replacement pattern that spliced the matched tag back into the attribute.
 
 ## v0.8.5 — 2026-09-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ release PR — "publish this" authorizes a release, never the tier.
 
 ## [Unreleased]
 
+- refactor(diagram): **one house-root helper serves all three SVG registers.** `applyHouseAttributes`
+  existed three times, in the d2, draw.io and Excalidraw post-processors, each independently matching
+  the open tag, sizing it from the `viewBox`, stripping `width`/`height`, escaping the `aria-label`
+  through the same three-call chain and rebuilding the tag; d2 and draw.io shared six byte-identical
+  lines. `houseRoot` in the new `scripts/house-root.ts` does that once, and each register passes only
+  what differs: d2's `class="d2"` and source marker, draw.io's plus `dropPriorStyle`, and nothing at
+  all for the sketch register. `SvgError`, `HOUSE_STYLE` and `naturalSize` moved there with it, so the
+  other two registers no longer import the shared contract from the d2 one; `d2-svg.ts` re-exports
+  `SvgError` and drops from 19 exports to 15, back under the cap. No rendered output changes: the six
+  committed example figures are untouched, and each one's root was reproduced byte-for-byte from a
+  reconstructed pre-house input, before and after, alongside a 357-case old-versus-new comparison
+  across the three registers. Two deviations are deliberate and unreachable from any renderer — d2
+  now merges a root style rather than emitting a second `style` attribute, and a `$` in a label is
+  escaped as data rather than read as a replacement pattern that spliced the matched tag back into
+  the attribute.
+
 ## v0.8.5 — 2026-09-04
 
 - fix(publish-page): **figures render at their natural size, capped to the column.** The doc and

--- a/plugins-cc/agentkit/skills/diagram/scripts/d2-svg.ts
+++ b/plugins-cc/agentkit/skills/diagram/scripts/d2-svg.ts
@@ -1,9 +1,13 @@
 // Post-processing and verification for d2 SVG output.
 
+import { houseRoot, SvgError } from "./house-root.ts";
+
+// Callers catch the render error off the register they rendered with, not off
+// the shared root module.
+export { SvgError };
+
 export const D2_PIN = "0.8.2";
 export const SOURCE_MARK = "svg-source:d2";
-
-export class SvgError extends Error {}
 
 // Namespace declarations are identifiers, not fetches; every other absolute
 // URL in the output would be a runtime dependency on the network.
@@ -123,10 +127,6 @@ export function flattenForMarkdown(svg: string): string {
     .join("\n");
 }
 
-// The cap the page applies. It is a maximum, not a width: the natural size
-// below is what a figure narrower than the column renders at.
-export const HOUSE_STYLE = "max-width:100%;height:auto";
-
 const ROOT_TAG_RE = /<svg\b[^>]*>/;
 const STYLE_ATTR_RE = /\s*\bstyle="([^"]*)"/;
 const CAP_DECLS_RE = /max-width:\s*100%\s*;\s*height:\s*auto\s*;?/;
@@ -145,35 +145,8 @@ export function stripHouseCap(svg: string): string {
   return svg.slice(0, open.index) + tag + svg.slice(open.index + open[0].length);
 }
 
-
-const VIEWBOX_RE = /\bviewBox="([\d.eE+-]+)[,\s]+([\d.eE+-]+)[,\s]+([\d.eE+-]+)[,\s]+([\d.eE+-]+)"/;
-
-// Rounded up rather than truncated: a fractional viewBox truncated down clips
-// the last row of pixels wherever the SVG is used without CSS.
-export function naturalSize(tag: string): { width: number; height: number } {
-  const box = tag.match(VIEWBOX_RE);
-  if (!box) throw new SvgError("cannot size the root — no viewBox on the rendered SVG");
-  const width = Math.ceil(Number(box[3]));
-  const height = Math.ceil(Number(box[4]));
-  if (!(width > 0) || !(height > 0)) {
-    throw new SvgError(`viewBox does not describe a positive size: ${box[0]}`);
-  }
-  return { width, height };
-}
-
 export function applyHouseAttributes(svg: string, ariaLabel: string): string {
-  const open = svg.match(/^<svg\b[^>]*>/);
-  if (!open) throw new SvgError("output does not start with an <svg> tag");
-  let tag = open[0];
-  const { width, height } = naturalSize(tag);
-  if (/\bwidth=/.test(tag)) tag = tag.replace(/\s*\bwidth="[^"]*"/, "");
-  if (/\bheight=/.test(tag)) tag = tag.replace(/\s*\bheight="[^"]*"/, "");
-  const escaped = ariaLabel.replaceAll("&", "&amp;").replaceAll('"', "&quot;").replaceAll("<", "&lt;");
-  tag = tag.replace(
-    /^<svg\b/,
-    `<svg class="d2" role="img" aria-label="${escaped}" width="${width}" height="${height}" style="${HOUSE_STYLE}"`,
-  );
-  return `<!-- ${SOURCE_MARK} -->\n${tag}${svg.slice(open[0].length)}`;
+  return houseRoot(svg, { label: ariaLabel, className: "d2", sourceMark: SOURCE_MARK });
 }
 
 // Ink for a re-inlined monochrome mark. Against the d2 node fills a single grey

--- a/plugins-cc/agentkit/skills/diagram/scripts/drawio-render.ts
+++ b/plugins-cc/agentkit/skills/diagram/scripts/drawio-render.ts
@@ -4,7 +4,7 @@
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { basename, join, resolve } from "node:path";
-import { flattenForMarkdown, SvgError, verifySelfContained } from "./d2-svg.ts";
+import { flattenForMarkdown, verifySelfContained } from "./d2-svg.ts";
 import {
   DrawioError,
   INSTALL_HINT,
@@ -23,6 +23,7 @@ import {
   screenSource,
   stripPrologue,
 } from "./drawio-svg.ts";
+import { SvgError } from "./house-root.ts";
 
 function fail(msg: string): never {
   console.error(`drawio-render: ${msg}`);

--- a/plugins-cc/agentkit/skills/diagram/scripts/drawio-svg.ts
+++ b/plugins-cc/agentkit/skills/diagram/scripts/drawio-svg.ts
@@ -1,6 +1,6 @@
 // Post-processing and source screening for draw.io SVG output.
 
-import { HOUSE_STYLE, naturalSize, SvgError } from "./d2-svg.ts";
+import { houseRoot, SvgError } from "./house-root.ts";
 
 export const DRAWIO_PIN = "31.3.2";
 export const SOURCE_MARK = "svg-source:drawio";
@@ -35,25 +35,16 @@ export function plateBackground(svg: string, fill = PLATE): string {
   return tag + rect + svg.slice(root[0].length);
 }
 
+// draw.io is the one register that discards the style it arrives with: its own
+// root style only paints a transparent backdrop, which the figure island already
+// supplies.
 export function applyHouseAttributes(svg: string, ariaLabel: string): string {
-  const open = svg.match(/^<svg\b[^>]*>/);
-  if (!open) throw new SvgError("output does not start with an <svg> tag");
-  let tag = open[0];
-  // draw.io's own root style only paints a transparent backdrop, which the
-  // figure island already supplies; left in place it becomes a second style
-  // attribute on the tag and the house sizing silently loses to it.
-  const { width, height } = naturalSize(tag);
-  tag = tag.replace(/\s*\bwidth="[^"]*"/, "").replace(/\s*\bheight="[^"]*"/, "")
-    .replace(/\s*\bstyle="[^"]*"/, "");
-  const escaped = ariaLabel.replaceAll("&", "&amp;").replaceAll('"', "&quot;").replaceAll(
-    "<",
-    "&lt;",
-  );
-  tag = tag.replace(
-    /^<svg\b/,
-    `<svg class="drawio" role="img" aria-label="${escaped}" width="${width}" height="${height}" style="${HOUSE_STYLE}"`,
-  );
-  return `<!-- ${SOURCE_MARK} -->\n${tag}${svg.slice(open[0].length)}`;
+  return houseRoot(svg, {
+    label: ariaLabel,
+    className: "drawio",
+    sourceMark: SOURCE_MARK,
+    dropPriorStyle: true,
+  });
 }
 
 // draw.io salts gradient ids with a fresh nanoid per render and emits mxCell ids

--- a/plugins-cc/agentkit/skills/diagram/scripts/excalidraw-svg.ts
+++ b/plugins-cc/agentkit/skills/diagram/scripts/excalidraw-svg.ts
@@ -1,9 +1,9 @@
 // Post-processing for Excalidraw SVG output.
 
-import { HOUSE_STYLE, naturalSize, SvgError } from "./d2-svg.ts";
+import { houseRoot, SvgError } from "./house-root.ts";
 
-// Every register throws the one error type; the sketch scripts import it from
-// here, which is where it lived before the root contract became shared.
+// Every register throws the one error type, and the sketch scripts catch it off
+// this module rather than off the shared root contract it is declared in.
 export { SvgError };
 
 // A baked-ink sketch has no ground of its own once inlined into a
@@ -29,25 +29,6 @@ export function resolveBackground(explicit: string | undefined, sceneColor: unkn
   return color;
 }
 
-// The same root every register ships: the natural size the page caps against,
-// the viewBox the lightbox expands from, and the label a screen reader reads.
-// Excalidraw writes the size and the viewBox; the rest is added here so the
-// sketch register is not the one that has to be fixed up by hand.
 export function applyHouseAttributes(svg: string, ariaLabel: string): string {
-  const open = svg.match(/^<svg\b[^>]*>/);
-  if (!open) throw new SvgError("output does not start with an <svg> tag");
-  let tag = open[0];
-  const { width, height } = naturalSize(tag);
-  // Excalidraw ships no root style today, but two style attributes on one tag
-  // is not a merge — the browser reads the first and the cap would be dead.
-  const prior = tag.match(/\bstyle="([^"]*)"/)?.[1];
-  tag = tag.replace(/\s*\bwidth="[^"]*"/, "").replace(/\s*\bheight="[^"]*"/, "")
-    .replace(/\s*\bstyle="[^"]*"/, "");
-  const style = prior ? `${prior};${HOUSE_STYLE}` : HOUSE_STYLE;
-  const escaped = ariaLabel.replaceAll("&", "&amp;").replaceAll('"', "&quot;").replaceAll("<", "&lt;");
-  tag = tag.replace(
-    /^<svg\b/,
-    `<svg role="img" aria-label="${escaped}" width="${width}" height="${height}" style="${style}"`,
-  );
-  return tag + svg.slice(open[0].length);
+  return houseRoot(svg, { label: ariaLabel });
 }

--- a/plugins-cc/agentkit/skills/diagram/scripts/house-root.ts
+++ b/plugins-cc/agentkit/skills/diagram/scripts/house-root.ts
@@ -4,13 +4,13 @@ export class SvgError extends Error {}
 
 // The cap the page applies. It is a maximum, not a width: the natural size
 // below is what a figure narrower than the column renders at.
-export const HOUSE_STYLE = "max-width:100%;height:auto";
+const HOUSE_STYLE = "max-width:100%;height:auto";
 
 const VIEWBOX_RE = /\bviewBox="([\d.eE+-]+)[,\s]+([\d.eE+-]+)[,\s]+([\d.eE+-]+)[,\s]+([\d.eE+-]+)"/;
 
 // Rounded up rather than truncated: a fractional viewBox truncated down clips
 // the last row of pixels wherever the SVG is used without CSS.
-export function naturalSize(tag: string): { width: number; height: number } {
+function naturalSize(tag: string): { width: number; height: number } {
   const box = tag.match(VIEWBOX_RE);
   if (!box) throw new SvgError("cannot size the root — no viewBox on the rendered SVG");
   const width = Math.ceil(Number(box[3]));
@@ -35,8 +35,10 @@ export function houseRoot(svg: string, spec: HouseRoot): string {
   if (!open) throw new SvgError("output does not start with an <svg> tag");
   const { width, height } = naturalSize(open[0]);
   // Two style attributes on one tag is not a merge — the browser reads the
-  // first, and the cap would be dead markup.
-  const prior = spec.dropPriorStyle ? undefined : open[0].match(/\bstyle="([^"]*)"/)?.[1];
+  // first, and the cap would be dead markup. The separator is normalised because
+  // a renderer style already ending in `;` would otherwise produce `;;`.
+  const declared = spec.dropPriorStyle ? undefined : open[0].match(/\bstyle="([^"]*)"/)?.[1];
+  const prior = declared?.replace(/;\s*$/, "");
   const style = prior ? `${prior};${HOUSE_STYLE}` : HOUSE_STYLE;
   const label = spec.label.replaceAll("&", "&amp;").replaceAll('"', "&quot;").replaceAll("<", "&lt;");
   const className = spec.className ? `class="${spec.className}" ` : "";
@@ -54,4 +56,3 @@ export function houseRoot(svg: string, spec: HouseRoot): string {
   const mark = spec.sourceMark ? `<!-- ${spec.sourceMark} -->\n` : "";
   return `${mark}${tag}${svg.slice(open[0].length)}`;
 }
-

--- a/plugins-cc/agentkit/skills/diagram/scripts/house-root.ts
+++ b/plugins-cc/agentkit/skills/diagram/scripts/house-root.ts
@@ -1,0 +1,57 @@
+// The root contract every SVG register ships, and the error type they all throw.
+
+export class SvgError extends Error {}
+
+// The cap the page applies. It is a maximum, not a width: the natural size
+// below is what a figure narrower than the column renders at.
+export const HOUSE_STYLE = "max-width:100%;height:auto";
+
+const VIEWBOX_RE = /\bviewBox="([\d.eE+-]+)[,\s]+([\d.eE+-]+)[,\s]+([\d.eE+-]+)[,\s]+([\d.eE+-]+)"/;
+
+// Rounded up rather than truncated: a fractional viewBox truncated down clips
+// the last row of pixels wherever the SVG is used without CSS.
+export function naturalSize(tag: string): { width: number; height: number } {
+  const box = tag.match(VIEWBOX_RE);
+  if (!box) throw new SvgError("cannot size the root — no viewBox on the rendered SVG");
+  const width = Math.ceil(Number(box[3]));
+  const height = Math.ceil(Number(box[4]));
+  if (!(width > 0) || !(height > 0)) {
+    throw new SvgError(`viewBox does not describe a positive size: ${box[0]}`);
+  }
+  return { width, height };
+}
+
+export interface HouseRoot {
+  label: string;
+  className?: string;
+  sourceMark?: string;
+  dropPriorStyle?: boolean;
+}
+
+// The root every register ships: the natural size the page caps against, the
+// viewBox the lightbox expands from, and the label a screen reader reads.
+export function houseRoot(svg: string, spec: HouseRoot): string {
+  const open = svg.match(/^<svg\b[^>]*>/);
+  if (!open) throw new SvgError("output does not start with an <svg> tag");
+  const { width, height } = naturalSize(open[0]);
+  // Two style attributes on one tag is not a merge — the browser reads the
+  // first, and the cap would be dead markup.
+  const prior = spec.dropPriorStyle ? undefined : open[0].match(/\bstyle="([^"]*)"/)?.[1];
+  const style = prior ? `${prior};${HOUSE_STYLE}` : HOUSE_STYLE;
+  const label = spec.label.replaceAll("&", "&amp;").replaceAll('"', "&quot;").replaceAll("<", "&lt;");
+  const className = spec.className ? `class="${spec.className}" ` : "";
+  const tag = open[0]
+    .replace(/\s*\bwidth="[^"]*"/, "")
+    .replace(/\s*\bheight="[^"]*"/, "")
+    .replace(/\s*\bstyle="[^"]*"/, "")
+    // A label is data, and `$&` in a replacement string is not: as a literal it
+    // would splice the matched tag back into the attribute it just escaped.
+    .replace(
+      /^<svg\b/,
+      () =>
+        `<svg ${className}role="img" aria-label="${label}" width="${width}" height="${height}" style="${style}"`,
+    );
+  const mark = spec.sourceMark ? `<!-- ${spec.sourceMark} -->\n` : "";
+  return `${mark}${tag}${svg.slice(open[0].length)}`;
+}
+

--- a/scripts/check-test-slices.ts
+++ b/scripts/check-test-slices.ts
@@ -11,6 +11,7 @@ export const TEST_SLICES = {
     'tests/diagram/extract-cli.test.ts',
     'tests/diagram/extract-model.test.ts',
     'tests/diagram/extract-sources.test.ts',
+    'tests/diagram/house-root.test.ts',
     'tests/diagram/icons.test.ts',
     'tests/diagram/layout.test.ts',
     'tests/diagram/lockfile.test.ts',

--- a/skills/diagram/scripts/d2-svg.ts
+++ b/skills/diagram/scripts/d2-svg.ts
@@ -1,9 +1,13 @@
 // Post-processing and verification for d2 SVG output.
 
+import { houseRoot, SvgError } from "./house-root.ts";
+
+// Callers catch the render error off the register they rendered with, not off
+// the shared root module.
+export { SvgError };
+
 export const D2_PIN = "0.8.2";
 export const SOURCE_MARK = "svg-source:d2";
-
-export class SvgError extends Error {}
 
 // Namespace declarations are identifiers, not fetches; every other absolute
 // URL in the output would be a runtime dependency on the network.
@@ -123,10 +127,6 @@ export function flattenForMarkdown(svg: string): string {
     .join("\n");
 }
 
-// The cap the page applies. It is a maximum, not a width: the natural size
-// below is what a figure narrower than the column renders at.
-export const HOUSE_STYLE = "max-width:100%;height:auto";
-
 const ROOT_TAG_RE = /<svg\b[^>]*>/;
 const STYLE_ATTR_RE = /\s*\bstyle="([^"]*)"/;
 const CAP_DECLS_RE = /max-width:\s*100%\s*;\s*height:\s*auto\s*;?/;
@@ -145,35 +145,8 @@ export function stripHouseCap(svg: string): string {
   return svg.slice(0, open.index) + tag + svg.slice(open.index + open[0].length);
 }
 
-
-const VIEWBOX_RE = /\bviewBox="([\d.eE+-]+)[,\s]+([\d.eE+-]+)[,\s]+([\d.eE+-]+)[,\s]+([\d.eE+-]+)"/;
-
-// Rounded up rather than truncated: a fractional viewBox truncated down clips
-// the last row of pixels wherever the SVG is used without CSS.
-export function naturalSize(tag: string): { width: number; height: number } {
-  const box = tag.match(VIEWBOX_RE);
-  if (!box) throw new SvgError("cannot size the root — no viewBox on the rendered SVG");
-  const width = Math.ceil(Number(box[3]));
-  const height = Math.ceil(Number(box[4]));
-  if (!(width > 0) || !(height > 0)) {
-    throw new SvgError(`viewBox does not describe a positive size: ${box[0]}`);
-  }
-  return { width, height };
-}
-
 export function applyHouseAttributes(svg: string, ariaLabel: string): string {
-  const open = svg.match(/^<svg\b[^>]*>/);
-  if (!open) throw new SvgError("output does not start with an <svg> tag");
-  let tag = open[0];
-  const { width, height } = naturalSize(tag);
-  if (/\bwidth=/.test(tag)) tag = tag.replace(/\s*\bwidth="[^"]*"/, "");
-  if (/\bheight=/.test(tag)) tag = tag.replace(/\s*\bheight="[^"]*"/, "");
-  const escaped = ariaLabel.replaceAll("&", "&amp;").replaceAll('"', "&quot;").replaceAll("<", "&lt;");
-  tag = tag.replace(
-    /^<svg\b/,
-    `<svg class="d2" role="img" aria-label="${escaped}" width="${width}" height="${height}" style="${HOUSE_STYLE}"`,
-  );
-  return `<!-- ${SOURCE_MARK} -->\n${tag}${svg.slice(open[0].length)}`;
+  return houseRoot(svg, { label: ariaLabel, className: "d2", sourceMark: SOURCE_MARK });
 }
 
 // Ink for a re-inlined monochrome mark. Against the d2 node fills a single grey

--- a/skills/diagram/scripts/drawio-render.ts
+++ b/skills/diagram/scripts/drawio-render.ts
@@ -4,7 +4,7 @@
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { basename, join, resolve } from "node:path";
-import { flattenForMarkdown, SvgError, verifySelfContained } from "./d2-svg.ts";
+import { flattenForMarkdown, verifySelfContained } from "./d2-svg.ts";
 import {
   DrawioError,
   INSTALL_HINT,
@@ -23,6 +23,7 @@ import {
   screenSource,
   stripPrologue,
 } from "./drawio-svg.ts";
+import { SvgError } from "./house-root.ts";
 
 function fail(msg: string): never {
   console.error(`drawio-render: ${msg}`);

--- a/skills/diagram/scripts/drawio-svg.ts
+++ b/skills/diagram/scripts/drawio-svg.ts
@@ -1,6 +1,6 @@
 // Post-processing and source screening for draw.io SVG output.
 
-import { HOUSE_STYLE, naturalSize, SvgError } from "./d2-svg.ts";
+import { houseRoot, SvgError } from "./house-root.ts";
 
 export const DRAWIO_PIN = "31.3.2";
 export const SOURCE_MARK = "svg-source:drawio";
@@ -35,25 +35,16 @@ export function plateBackground(svg: string, fill = PLATE): string {
   return tag + rect + svg.slice(root[0].length);
 }
 
+// draw.io is the one register that discards the style it arrives with: its own
+// root style only paints a transparent backdrop, which the figure island already
+// supplies.
 export function applyHouseAttributes(svg: string, ariaLabel: string): string {
-  const open = svg.match(/^<svg\b[^>]*>/);
-  if (!open) throw new SvgError("output does not start with an <svg> tag");
-  let tag = open[0];
-  // draw.io's own root style only paints a transparent backdrop, which the
-  // figure island already supplies; left in place it becomes a second style
-  // attribute on the tag and the house sizing silently loses to it.
-  const { width, height } = naturalSize(tag);
-  tag = tag.replace(/\s*\bwidth="[^"]*"/, "").replace(/\s*\bheight="[^"]*"/, "")
-    .replace(/\s*\bstyle="[^"]*"/, "");
-  const escaped = ariaLabel.replaceAll("&", "&amp;").replaceAll('"', "&quot;").replaceAll(
-    "<",
-    "&lt;",
-  );
-  tag = tag.replace(
-    /^<svg\b/,
-    `<svg class="drawio" role="img" aria-label="${escaped}" width="${width}" height="${height}" style="${HOUSE_STYLE}"`,
-  );
-  return `<!-- ${SOURCE_MARK} -->\n${tag}${svg.slice(open[0].length)}`;
+  return houseRoot(svg, {
+    label: ariaLabel,
+    className: "drawio",
+    sourceMark: SOURCE_MARK,
+    dropPriorStyle: true,
+  });
 }
 
 // draw.io salts gradient ids with a fresh nanoid per render and emits mxCell ids

--- a/skills/diagram/scripts/excalidraw-svg.ts
+++ b/skills/diagram/scripts/excalidraw-svg.ts
@@ -1,9 +1,9 @@
 // Post-processing for Excalidraw SVG output.
 
-import { HOUSE_STYLE, naturalSize, SvgError } from "./d2-svg.ts";
+import { houseRoot, SvgError } from "./house-root.ts";
 
-// Every register throws the one error type; the sketch scripts import it from
-// here, which is where it lived before the root contract became shared.
+// Every register throws the one error type, and the sketch scripts catch it off
+// this module rather than off the shared root contract it is declared in.
 export { SvgError };
 
 // A baked-ink sketch has no ground of its own once inlined into a
@@ -29,25 +29,6 @@ export function resolveBackground(explicit: string | undefined, sceneColor: unkn
   return color;
 }
 
-// The same root every register ships: the natural size the page caps against,
-// the viewBox the lightbox expands from, and the label a screen reader reads.
-// Excalidraw writes the size and the viewBox; the rest is added here so the
-// sketch register is not the one that has to be fixed up by hand.
 export function applyHouseAttributes(svg: string, ariaLabel: string): string {
-  const open = svg.match(/^<svg\b[^>]*>/);
-  if (!open) throw new SvgError("output does not start with an <svg> tag");
-  let tag = open[0];
-  const { width, height } = naturalSize(tag);
-  // Excalidraw ships no root style today, but two style attributes on one tag
-  // is not a merge — the browser reads the first and the cap would be dead.
-  const prior = tag.match(/\bstyle="([^"]*)"/)?.[1];
-  tag = tag.replace(/\s*\bwidth="[^"]*"/, "").replace(/\s*\bheight="[^"]*"/, "")
-    .replace(/\s*\bstyle="[^"]*"/, "");
-  const style = prior ? `${prior};${HOUSE_STYLE}` : HOUSE_STYLE;
-  const escaped = ariaLabel.replaceAll("&", "&amp;").replaceAll('"', "&quot;").replaceAll("<", "&lt;");
-  tag = tag.replace(
-    /^<svg\b/,
-    `<svg role="img" aria-label="${escaped}" width="${width}" height="${height}" style="${style}"`,
-  );
-  return tag + svg.slice(open[0].length);
+  return houseRoot(svg, { label: ariaLabel });
 }

--- a/skills/diagram/scripts/house-root.ts
+++ b/skills/diagram/scripts/house-root.ts
@@ -4,13 +4,13 @@ export class SvgError extends Error {}
 
 // The cap the page applies. It is a maximum, not a width: the natural size
 // below is what a figure narrower than the column renders at.
-export const HOUSE_STYLE = "max-width:100%;height:auto";
+const HOUSE_STYLE = "max-width:100%;height:auto";
 
 const VIEWBOX_RE = /\bviewBox="([\d.eE+-]+)[,\s]+([\d.eE+-]+)[,\s]+([\d.eE+-]+)[,\s]+([\d.eE+-]+)"/;
 
 // Rounded up rather than truncated: a fractional viewBox truncated down clips
 // the last row of pixels wherever the SVG is used without CSS.
-export function naturalSize(tag: string): { width: number; height: number } {
+function naturalSize(tag: string): { width: number; height: number } {
   const box = tag.match(VIEWBOX_RE);
   if (!box) throw new SvgError("cannot size the root — no viewBox on the rendered SVG");
   const width = Math.ceil(Number(box[3]));
@@ -35,8 +35,10 @@ export function houseRoot(svg: string, spec: HouseRoot): string {
   if (!open) throw new SvgError("output does not start with an <svg> tag");
   const { width, height } = naturalSize(open[0]);
   // Two style attributes on one tag is not a merge — the browser reads the
-  // first, and the cap would be dead markup.
-  const prior = spec.dropPriorStyle ? undefined : open[0].match(/\bstyle="([^"]*)"/)?.[1];
+  // first, and the cap would be dead markup. The separator is normalised because
+  // a renderer style already ending in `;` would otherwise produce `;;`.
+  const declared = spec.dropPriorStyle ? undefined : open[0].match(/\bstyle="([^"]*)"/)?.[1];
+  const prior = declared?.replace(/;\s*$/, "");
   const style = prior ? `${prior};${HOUSE_STYLE}` : HOUSE_STYLE;
   const label = spec.label.replaceAll("&", "&amp;").replaceAll('"', "&quot;").replaceAll("<", "&lt;");
   const className = spec.className ? `class="${spec.className}" ` : "";
@@ -54,4 +56,3 @@ export function houseRoot(svg: string, spec: HouseRoot): string {
   const mark = spec.sourceMark ? `<!-- ${spec.sourceMark} -->\n` : "";
   return `${mark}${tag}${svg.slice(open[0].length)}`;
 }
-

--- a/skills/diagram/scripts/house-root.ts
+++ b/skills/diagram/scripts/house-root.ts
@@ -1,0 +1,57 @@
+// The root contract every SVG register ships, and the error type they all throw.
+
+export class SvgError extends Error {}
+
+// The cap the page applies. It is a maximum, not a width: the natural size
+// below is what a figure narrower than the column renders at.
+export const HOUSE_STYLE = "max-width:100%;height:auto";
+
+const VIEWBOX_RE = /\bviewBox="([\d.eE+-]+)[,\s]+([\d.eE+-]+)[,\s]+([\d.eE+-]+)[,\s]+([\d.eE+-]+)"/;
+
+// Rounded up rather than truncated: a fractional viewBox truncated down clips
+// the last row of pixels wherever the SVG is used without CSS.
+export function naturalSize(tag: string): { width: number; height: number } {
+  const box = tag.match(VIEWBOX_RE);
+  if (!box) throw new SvgError("cannot size the root — no viewBox on the rendered SVG");
+  const width = Math.ceil(Number(box[3]));
+  const height = Math.ceil(Number(box[4]));
+  if (!(width > 0) || !(height > 0)) {
+    throw new SvgError(`viewBox does not describe a positive size: ${box[0]}`);
+  }
+  return { width, height };
+}
+
+export interface HouseRoot {
+  label: string;
+  className?: string;
+  sourceMark?: string;
+  dropPriorStyle?: boolean;
+}
+
+// The root every register ships: the natural size the page caps against, the
+// viewBox the lightbox expands from, and the label a screen reader reads.
+export function houseRoot(svg: string, spec: HouseRoot): string {
+  const open = svg.match(/^<svg\b[^>]*>/);
+  if (!open) throw new SvgError("output does not start with an <svg> tag");
+  const { width, height } = naturalSize(open[0]);
+  // Two style attributes on one tag is not a merge — the browser reads the
+  // first, and the cap would be dead markup.
+  const prior = spec.dropPriorStyle ? undefined : open[0].match(/\bstyle="([^"]*)"/)?.[1];
+  const style = prior ? `${prior};${HOUSE_STYLE}` : HOUSE_STYLE;
+  const label = spec.label.replaceAll("&", "&amp;").replaceAll('"', "&quot;").replaceAll("<", "&lt;");
+  const className = spec.className ? `class="${spec.className}" ` : "";
+  const tag = open[0]
+    .replace(/\s*\bwidth="[^"]*"/, "")
+    .replace(/\s*\bheight="[^"]*"/, "")
+    .replace(/\s*\bstyle="[^"]*"/, "")
+    // A label is data, and `$&` in a replacement string is not: as a literal it
+    // would splice the matched tag back into the attribute it just escaped.
+    .replace(
+      /^<svg\b/,
+      () =>
+        `<svg ${className}role="img" aria-label="${label}" width="${width}" height="${height}" style="${style}"`,
+    );
+  const mark = spec.sourceMark ? `<!-- ${spec.sourceMark} -->\n` : "";
+  return `${mark}${tag}${svg.slice(open[0].length)}`;
+}
+

--- a/tests/diagram/d2-svg.test.ts
+++ b/tests/diagram/d2-svg.test.ts
@@ -156,6 +156,14 @@ describe('house attributes', () => {
   test('input that is not an svg is refused', () => {
     expect(() => applyHouseAttributes('<html></html>', 'x')).toThrow(SvgError);
   });
+
+  test('a root style the renderer already set is merged, not duplicated', () => {
+    // d2 writes no root style today, so this is the contract the shared helper
+    // holds rather than a shape any current export produces.
+    const out = applyHouseAttributes('<svg style="color:red" viewBox="0 0 10 20"></svg>', 'x');
+    expect(out).toContain('style="color:red;max-width:100%;height:auto"');
+    expect([...out.matchAll(/\bstyle="/g)]).toHaveLength(1);
+  });
 });
 
 describe('self-containment verification', () => {

--- a/tests/diagram/house-root.test.ts
+++ b/tests/diagram/house-root.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'bun:test';
+import { houseRoot } from '../../skills/diagram/scripts/house-root.ts';
+
+describe('the house root every register shares', () => {
+  test('the class and the source marker are the register\'s to add, not the root\'s', () => {
+    const bare = houseRoot('<svg viewBox="0 0 10 20"></svg>', { label: 'x' });
+    expect(bare).toStartWith('<svg role="img" aria-label="x" width="10" height="20"');
+    expect(bare).not.toContain('class=');
+    const marked = houseRoot('<svg viewBox="0 0 10 20"></svg>', {
+      label: 'x',
+      className: 'reg',
+      sourceMark: 'svg-source:reg',
+    });
+    expect(marked).toStartWith('<!-- svg-source:reg -->\n<svg class="reg" role="img"');
+  });
+
+  test('dropPriorStyle is what separates draw.io from the other two registers', () => {
+    const input = '<svg style="color:red" viewBox="0 0 10 20"></svg>';
+    expect(houseRoot(input, { label: 'x' })).toContain('style="color:red;max-width:100%;height:auto"');
+    expect(houseRoot(input, { label: 'x', dropPriorStyle: true }))
+      .toContain('style="max-width:100%;height:auto"');
+  });
+
+  test('a dollar sign in a label is data, not a replacement pattern', () => {
+    // $& in a replacement string splices the matched <svg back into the
+    // aria-label — the same break the label escaping exists to stop.
+    const out = houseRoot('<svg viewBox="0 0 10 20"></svg>', { label: "costs $& and $' and $`" });
+    expect(out).toContain('aria-label="costs $&amp; and $\' and $`"');
+  });
+});

--- a/tests/diagram/house-root.test.ts
+++ b/tests/diagram/house-root.test.ts
@@ -21,6 +21,12 @@ describe('the house root every register shares', () => {
       .toContain('style="max-width:100%;height:auto"');
   });
 
+  test('a prior style ending in a semicolon does not double the separator', () => {
+    const out = houseRoot('<svg style="color:red;" viewBox="0 0 10 20"></svg>', { label: 'x' });
+    expect(out).toContain('style="color:red;max-width:100%;height:auto"');
+    expect(out).not.toContain(';;');
+  });
+
   test('a dollar sign in a label is data, not a replacement pattern', () => {
     // $& in a replacement string splices the matched <svg back into the
     // aria-label — the same break the label escaping exists to stop.


### PR DESCRIPTION
## Summary

`applyHouseAttributes` existed three times, once per SVG register, each independently matching the
open tag, sizing it from the `viewBox`, stripping `width`/`height`, escaping the `aria-label` through
the same three-call `replaceAll` chain and rebuilding the tag. The d2 and draw.io copies shared six
byte-identical lines.

`houseRoot` does all of that once. Each register now passes only what genuinely differs:

| register | class | source marker | prior root style |
| --- | --- | --- | --- |
| d2 | `d2` | `svg-source:d2` | merged |
| draw.io | `drawio` | `svg-source:drawio` | dropped |
| Excalidraw | none | none | merged |

**Where it lives, and why.** A new `skills/diagram/scripts/house-root.ts` rather than `d2-svg.ts`,
for two reasons the task named as the trigger. Adding the helper and its options interface to
`d2-svg.ts` would have taken it to 19 exports, past the 15 the coding standards cap at; it now sits
at 15. And the dependency direction read wrong: `drawio-svg.ts` and `excalidraw-svg.ts` were already
importing `HOUSE_STYLE`, `naturalSize` and `SvgError` from the *d2 register*, so the shared root
contract was living inside one of the three things sharing it. Those three moved into `house-root.ts`
with the new helper. `d2-svg.ts` re-exports `SvgError` so `d2-render.ts` and its tests keep catching
the render error off the register they render with.

`stripHouseCap` stays in `d2-svg.ts`. It is the inverse of the cap and arguably belongs beside it,
but it is not duplicated, so moving it would churn `d2-render.ts`, `render.ts` and a test that spans
both functions for no dedup gain.

**Three deliberate deviations**, all stated rather than smuggled, and none reachable from any
renderer this repo drives:

1. **d2 now merges a pre-existing root style** instead of leaving it in place and emitting a second
   `style` attribute. The fork was accidental: draw.io and Excalidraw both handle the case, d2 was
   the copy that never did, and two `style` attributes on one tag means the browser reads the first
   and the house cap is dead markup. No d2 export carries a root style — all four committed d2
   examples show a bare `<svg xmlns … preserveAspectRatio viewBox>` root, with the class carrier on
   an inner `<svg>` — so this changes no output.
2. **A merged style already ending in `;` no longer doubles the separator.** `style="color:red;"`
   produced `color:red;;max-width:100%…`. Normalised before the cap is appended.
3. **A `$` in a label is escaped as data.** All three copies interpolated the escaped label into a
   `String.replace` *replacement string*, where `$&` and `` $` `` are substitution patterns. A label
   containing `$'` spliced the matched `<svg` tag back into the `aria-label` and broke straight out
   of the attribute — the exact failure the escaping above it exists to prevent. The shared helper
   uses a replacement function instead. Surfaced while consolidating; fixed here rather than filed.

Refs #456

## Test plan

**Behaviour lock, captured before refactoring and re-run after.**

- Every committed example figure's root was reproduced byte-for-byte by the refactored register, from
  an input reconstructed from the shipped tag with the raw `width`/`height` restored (`100%` for d2,
  `966px`/`562px` for draw.io) and draw.io's own `background-color` root style put back so the drop
  path is exercised. All six match, source-marker comment included.
- 357 old-versus-new comparisons: three registers over 17 root tags (fractional and comma-separated
  viewBoxes, `px` and `%` sizes, exponent notation, zero and missing viewBox, non-SVG input, a root
  carrying one style and a root carrying two) crossed with 7 labels. Zero unintended differences; the
  60 differences all fall in the two categories above.
- `git status` shows no example SVG changed.

**Gates.**

- `bun test tests/diagram tests/publish-page`: 759 pass, 0 fail, 27 files. The 754 on `main` plus the
  5 tests added here; no case deleted or renamed.
- `scripts/preflight`: all checks passed, including plugin-mirror byte-identity for the touched skill
  files.
- `bunx tsc --noEmit -p skills/diagram`: clean.

**Tests added** (5): four in a new `tests/diagram/house-root.test.ts` exercising the helper directly
(class and source marker are the register's to add; `dropPriorStyle` is the whole difference between
draw.io and the other two; a trailing `;` does not double the separator; a `$` label survives
verbatim), and one in `d2-svg.test.ts` locking the d2 style merge. `tests/diagram/house-root.test.ts`
is registered in the `diagram` slice.

**Review fixes** (second commit `58d7cb3`): `HOUSE_STYLE` and `naturalSize` lose their `export` (only
`houseRoot` reads them, and nothing outside the module imported either); the `;;` separator is
normalised; `drawio-render.ts` takes `SvgError` from `house-root.ts` rather than `d2-svg.ts`, closing
the last wrong-direction import; the trailing blank line is gone. `dprint check` covers only
markdown, JSON, TOML and YAML in this repo, so the touched `.ts` files are outside its scope; the
only touched file it formats is `CHANGELOG.md`, which is clean. The pinned 0.55.2 binary is not on
this host's PATH; `bunx dprint` resolves 0.57.0.

https://claude.ai/code/session_01BdVLyWdh7LD29hiyT8qF5q
