### PR TITLE
chore: cut v0.8.6 — one house-root helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ release PR — "publish this" authorizes a release, never the tier.
 
 ## [Unreleased]
 
+## v0.8.6 — 2026-09-04
+
 - refactor(diagram): **one house-root helper serves all three SVG registers.** `applyHouseAttributes`
   existed three times, in the d2, draw.io and Excalidraw post-processors, each independently matching
   the open tag, sizing it from the `viewBox`, stripping `width`/`height`, escaping the `aria-label`


### PR DESCRIPTION
## Summary
- Moves the Unreleased entry under `v0.8.6 — 2026-09-04`: #457, one house-root helper for the three SVG post-processors, with the `$`-in-label escaping fix and the style-separator normalisation it carried.
- Tag `v0.8.6` follows the merge, signed, and the release job publishes it.

## Test plan
- [x] Unreleased lists exactly the PRs merged since v0.8.5
- [ ] CI on the cut, tag pushed, release published, installed here

https://claude.ai/code/session_01BdVLyWdh7LD29hiyT8qF5q