### PR TITLE
chore: cut v0.8.7 — figures fit the screen, renderers orient themselves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ release PR — "publish this" authorizes a release, never the tier.
 
 ## [Unreleased]
 
+## v0.8.7 — 2026-09-04
+
 - feat(publish-page): **figures fit the screen by default, with per-figure zoom and full-screen
   controls.** v0.8.5 stopped stretching a figure to the column but left nothing bounding its height,
   so a 717x1292 sketch rendered at natural size and a 1221x1787 D2 figure at 977x1430 — 1.4 and 1.6


### PR DESCRIPTION
## Summary
- Moves the Unreleased entries under `v0.8.7 — 2026-09-04`: #461 (figures fit the screen by default, zoom and full-screen controls) and #462 (renderers pick a column-friendly orientation when none is set).
- Tag `v0.8.7` follows the merge, signed; the release job publishes it.

## Test plan
- [x] Unreleased lists exactly the PRs merged since v0.8.6
- [ ] CI on the cut, tag pushed, release published, installed here

https://claude.ai/code/session_01BdVLyWdh7LD29hiyT8qF5q