### PR TITLE
chore: cut v0.8.8 — the editor gate and its docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ release PR — "publish this" authorizes a release, never the tier.
 
 ## [Unreleased]
 
+## v0.8.8 — 2026-09-07
+
 - docs(editor-police): **the docs site covers the editor gate.** A cookbook recipe, "Name the
   person at the keyboard", walks through the roster, the refusal, the one-question prompt, the
   trailer and a handover with the hook's real output; the hook reference gains its row and its


### PR DESCRIPTION
Turns the Unreleased heading into `v0.8.8 — 2026-09-07`. Carries #469 (editor-police hook, wiki-editor tool and skill) and #472 (its cookbook recipe and reference entries).

Tier: **patch**, on the owner's explicit word on 2026-09-07: "please make it a patch . dont need it to be minor."

After the squash lands: `git tag -s v0.8.8 <squash> && git push origin v0.8.8`; the tag run publishes the docs site, the worker, the marketing site and the GitHub Release.

https://claude.ai/code/session_01Mjdg7U93LrFhrwbgJTghB8